### PR TITLE
feat: Add setting to choose between built-in or external dictionary

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -248,6 +248,9 @@ private fun LiseurApp(settings: AppSettings) {
                 onVolumeKeys = { scope.launch { repository.setVolumeKeysTurnPages(it) } },
                 onEInkMode = { scope.launch { repository.setEInkMode(it) } },
                 onResumeLastBook = { scope.launch { repository.setResumeLastBook(it) } },
+                onDefinitionTarget = {
+                    scope.launch { repository.setDefinitionTarget(it) }
+                },
                 onDictionaryLookup = {
                     scope.launch { repository.setDictionaryLookupEnabled(it) }
                 },

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
@@ -59,6 +59,20 @@ enum class EInkMode(val id: String) {
     }
 }
 
+/** Where the Define action sends selected text. */
+enum class DefinitionTarget(val id: String) {
+    BUILT_IN("built_in"),
+    EXTERNAL_APP("external_app"),
+    ;
+
+    companion object {
+        val Default = BUILT_IN
+
+        fun fromId(id: String?): DefinitionTarget =
+            entries.firstOrNull { it.id == id } ?: Default
+    }
+}
+
 /**
  * Settings that belong to the app rather than to a book.
  *
@@ -71,6 +85,8 @@ enum class EInkMode(val id: String) {
  * @param librarySort How the library grid is arranged.
  * @param librarySortReversed The library order read back to front.
  * @param eInkMode Whether to drop animation for an electronic paper screen.
+ * @param definitionTarget Whether Define opens Liseur's definition card or
+ *   sends the text to another app.
  * @param dictionaryLookupEnabled Whether Define may ask a dictionary server
  *   for a definition. Off until asked for, because that server is the one
  *   thing the app talks to that the reader did not choose themselves.
@@ -86,6 +102,7 @@ data class AppSettings(
     val librarySort: LibrarySort = LibrarySort.Default,
     val librarySortReversed: Boolean = false,
     val eInkMode: EInkMode = EInkMode.Default,
+    val definitionTarget: DefinitionTarget = DefinitionTarget.Default,
     val dictionaryLookupEnabled: Boolean = false,
     val dictionaryBaseUrl: String = DictionaryUrl.DEFAULT_BASE_URL,
 )
@@ -105,6 +122,7 @@ class AppSettingsRepository(private val context: Context) {
         val LIBRARY_SORT = stringPreferencesKey("library_sort")
         val LIBRARY_SORT_REVERSED = booleanPreferencesKey("library_sort_reversed")
         val EINK_MODE = stringPreferencesKey("eink_mode")
+        val DEFINITION_TARGET = stringPreferencesKey("definition_target")
         val DICTIONARY_ENABLED = booleanPreferencesKey("dictionary_lookup_enabled")
         val DICTIONARY_BASE_URL = stringPreferencesKey("dictionary_base_url")
         val ACCOUNT_LOST = booleanPreferencesKey("calibre_account_lost_to_restore")
@@ -134,6 +152,7 @@ class AppSettingsRepository(private val context: Context) {
             librarySort = LibrarySort.fromId(p[Keys.LIBRARY_SORT]),
             librarySortReversed = p[Keys.LIBRARY_SORT_REVERSED] ?: false,
             eInkMode = EInkMode.fromId(p[Keys.EINK_MODE]),
+            definitionTarget = DefinitionTarget.fromId(p[Keys.DEFINITION_TARGET]),
             dictionaryLookupEnabled = p[Keys.DICTIONARY_ENABLED] ?: false,
             dictionaryBaseUrl = p[Keys.DICTIONARY_BASE_URL]?.let(DictionaryUrl::normalise)
                 ?: DictionaryUrl.DEFAULT_BASE_URL,
@@ -168,6 +187,10 @@ class AppSettingsRepository(private val context: Context) {
 
     suspend fun setEInkMode(mode: EInkMode) {
         context.appSettingsStore.edit { it[Keys.EINK_MODE] = mode.id }
+    }
+
+    suspend fun setDefinitionTarget(target: DefinitionTarget) {
+        context.appSettingsStore.edit { it[Keys.DEFINITION_TARGET] = target.id }
     }
 
     suspend fun setDictionaryLookupEnabled(enabled: Boolean) {

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -72,6 +72,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.IntOffset
 import com.chmouel.liseur.R
 import com.chmouel.liseur.data.db.BookAnnotation
+import com.chmouel.liseur.data.settings.DefinitionTarget
 import com.chmouel.liseur.reader.annotations.BookmarkRibbon
 import com.chmouel.liseur.reader.annotations.DECORATION_GROUP
 import com.chmouel.liseur.reader.annotations.HighlightTint
@@ -457,7 +458,7 @@ fun ReaderScreen(
         SelectionPopup(
             offset = active.popupOffset(),
             activeTint = active.existing?.tint?.let(HighlightTint::fromName),
-            actions = remember(active) {
+            actions = remember(active, dictionary) {
                 SelectionActions(
                     onHighlight = { tint ->
                         onAnnotationAction.highlight(active.locator, tint, active.existing?.id)
@@ -475,7 +476,12 @@ fun ReaderScreen(
                         selection = null
                     },
                     onLookUp = {
-                        defineWord = active.text
+                        when (dictionary.target) {
+                            DefinitionTarget.BUILT_IN -> defineWord = active.text
+                            DefinitionTarget.EXTERNAL_APP -> {
+                                context.lookUpExternally(active.text, dictionary.baseUrl)
+                            }
+                        }
                         navigator?.clearSelection()
                         selection = null
                     },

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -23,6 +23,7 @@ import com.chmouel.liseur.data.db.ReadingProgressDao
 import com.chmouel.liseur.data.library.LocalLibraryRepository
 import com.chmouel.liseur.data.library.ReadingSessionManager
 import com.chmouel.liseur.data.settings.AppSettingsRepository
+import com.chmouel.liseur.data.settings.DefinitionTarget
 import com.chmouel.liseur.data.settings.FooterMode
 import com.chmouel.liseur.data.settings.ReaderFont
 import com.chmouel.liseur.data.settings.ReaderPreferencesRepository
@@ -100,19 +101,27 @@ class ReaderViewModel(
     private val sessions = sessionManager.recorder(bookId)
 
     /**
-     * What the definition card needs to know before it may fetch anything.
+     * What the Define action needs before it opens a card or another app.
      *
+     * @param target Where the Define action sends selected text.
      * @param enabled Whether the reader has agreed to online lookups.
      * @param baseUrl The dictionary site they chose.
      */
     data class DictionarySettings(
+        val target: DefinitionTarget = DefinitionTarget.Default,
         val enabled: Boolean = false,
         val baseUrl: String = DictionaryUrl.DEFAULT_BASE_URL,
     )
 
     /** The dictionary's opt-in state, watched so the card reacts to it. */
     val dictionary: StateFlow<DictionarySettings> = appSettings.settings
-        .map { DictionarySettings(it.dictionaryLookupEnabled, it.dictionaryBaseUrl) }
+        .map {
+            DictionarySettings(
+                it.definitionTarget,
+                it.dictionaryLookupEnabled,
+                it.dictionaryBaseUrl,
+            )
+        }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), DictionarySettings())
 
     /** Turns online definitions on, from the card that asked for them. */

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/TextIntents.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/TextIntents.kt
@@ -34,14 +34,13 @@ fun Context.lookUpExternally(text: String, dictionaryBaseUrl: String) {
         putExtra(Intent.EXTRA_PROCESS_TEXT, word)
         putExtra(Intent.EXTRA_PROCESS_TEXT_READONLY, true)
     }
-    // A chooser with nothing in it still opens, so ask first rather than
-    // showing the reader an empty sheet when no dictionary is installed.
+    // Ask first so devices without a handler fall back to the browser.
     if (packageManager.queryIntentActivities(process, 0).isEmpty()) {
         openDictionaryEntry(word, dictionaryBaseUrl)
         return
     }
     try {
-        startActivity(Intent.createChooser(process, null))
+        startActivity(process)
     } catch (_: ActivityNotFoundException) {
         openDictionaryEntry(word, dictionaryBaseUrl)
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
@@ -68,6 +68,7 @@ import com.chmouel.liseur.data.settings.AppSettings
 import com.chmouel.liseur.data.ConnectionsState
 import com.chmouel.liseur.data.library.Inspection
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.chmouel.liseur.data.settings.DefinitionTarget
 import com.chmouel.liseur.data.settings.EInkMode
 import com.chmouel.liseur.data.settings.ThemeMode
 import com.chmouel.liseur.domain.DictionaryUrl
@@ -87,6 +88,7 @@ fun SettingsScreen(
     onVolumeKeys: (Boolean) -> Unit,
     onEInkMode: (EInkMode) -> Unit,
     onResumeLastBook: (Boolean) -> Unit,
+    onDefinitionTarget: (DefinitionTarget) -> Unit,
     onDictionaryLookup: (Boolean) -> Unit,
     onDictionaryBaseUrl: (String) -> Unit,
     onOpenAccount: () -> Unit,
@@ -261,18 +263,28 @@ fun SettingsScreen(
                 }
 
                 SettingsGroup(stringResource(R.string.settings_dictionary)) {
-                    SwitchRow(
-                        title = stringResource(R.string.settings_dictionary_lookup),
-                        subtitle = stringResource(R.string.settings_dictionary_lookup_detail),
-                        checked = settings.dictionaryLookupEnabled,
-                        onCheckedChange = onDictionaryLookup,
+                    ChipRow(
+                        title = stringResource(R.string.settings_define_with),
+                        options = DefinitionTarget.entries,
+                        selected = settings.definitionTarget,
+                        label = { stringResource(it.label) },
+                        onSelected = onDefinitionTarget,
                     )
-                    if (settings.dictionaryLookupEnabled) {
+                    if (settings.definitionTarget == DefinitionTarget.BUILT_IN) {
                         RowDivider()
-                        DictionarySiteRow(
-                            baseUrl = settings.dictionaryBaseUrl,
-                            onBaseUrl = onDictionaryBaseUrl,
+                        SwitchRow(
+                            title = stringResource(R.string.settings_dictionary_lookup),
+                            subtitle = stringResource(R.string.settings_dictionary_lookup_detail),
+                            checked = settings.dictionaryLookupEnabled,
+                            onCheckedChange = onDictionaryLookup,
                         )
+                        if (settings.dictionaryLookupEnabled) {
+                            RowDivider()
+                            DictionarySiteRow(
+                                baseUrl = settings.dictionaryBaseUrl,
+                                onBaseUrl = onDictionaryBaseUrl,
+                            )
+                        }
                     }
                 }
 
@@ -351,6 +363,12 @@ private val EInkMode.label: Int
         EInkMode.AUTO -> R.string.eink_auto
         EInkMode.ON -> R.string.eink_on
         EInkMode.OFF -> R.string.eink_off
+    }
+
+private val DefinitionTarget.label: Int
+    get() = when (this) {
+        DefinitionTarget.BUILT_IN -> R.string.definition_target_builtin
+        DefinitionTarget.EXTERNAL_APP -> R.string.definition_target_external
     }
 
 /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,7 +214,7 @@
     <string name="dictionary_not_found">No entry for “%1$s”.</string>
     <string name="dictionary_failed">Could not reach the dictionary.</string>
     <string name="dictionary_failed_reason">Could not reach the dictionary: %1$s</string>
-    <string name="dictionary_other_app">Dictionary app</string>
+    <string name="dictionary_other_app">Open in app</string>
     <string name="dictionary_open_full_entry">Full entry</string>
     <string name="dictionary_disabled_explanation">Definitions are off. Turning them on lets Liseur send the word you tapped, and nothing else, to %1$s. A dictionary app on your phone works without any of that.</string>
     <string name="dictionary_enable">Turn on definitions</string>
@@ -249,6 +249,9 @@
     <string name="eink_on">On</string>
     <string name="eink_off">Off</string>
     <string name="settings_dictionary">Dictionary</string>
+    <string name="settings_define_with">Define with</string>
+    <string name="definition_target_builtin">Built-in</string>
+    <string name="definition_target_external">External app</string>
     <string name="settings_dictionary_lookup">Look up definitions online</string>
     <string name="settings_dictionary_lookup_detail">Off by default. When on, defining a word sends that word to the site below — the only place Liseur talks to besides your own book server.</string>
     <string name="settings_dictionary_site">Dictionary site</string>


### PR DESCRIPTION
Added a setting allowing readers to select whether word definitions
open in the built-in card or send text to an external dictionary
app. Readers using standalone dictionary apps previously had to open
the built-in card first before delegating to another application.

Fixes #3

