### PR TITLE
feat: Add liseur-sync personal series management support

### DIFF
--- a/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/31.json
+++ b/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/31.json
@@ -1,0 +1,996 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 31,
+    "identityHash": "a8e9ceea47516386e8ed9fa52b6059bc",
+    "entities": [
+      {
+        "tableName": "reading_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `total_progression` REAL, `reading_speed` REAL, `reading_seconds_per_position` REAL, `reading_pace_samples` INTEGER NOT NULL DEFAULT 0, `reading_pace_elapsed_ms` INTEGER NOT NULL DEFAULT 0, `reading_pace_evidence` REAL NOT NULL DEFAULT 0, `updated_at` INTEGER NOT NULL, `status` TEXT, `synced_at` INTEGER, `local_revision` INTEGER NOT NULL DEFAULT 0, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `agreed_account` TEXT, `pending_progression` REAL, `pending_status` TEXT, `pending_updated_at` INTEGER, `pending_account` TEXT, `owner_account` TEXT, `remote_updated_at` INTEGER, `finished_override` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSpeed",
+            "columnName": "reading_speed",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSecondsPerPosition",
+            "columnName": "reading_seconds_per_position",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingPaceSamples",
+            "columnName": "reading_pace_samples",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceElapsedMs",
+            "columnName": "reading_pace_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceEvidence",
+            "columnName": "reading_pace_evidence",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localRevision",
+            "columnName": "local_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "agreedAccount",
+            "columnName": "agreed_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingAccount",
+            "columnName": "pending_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ownerAccount",
+            "columnName": "owner_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "finishedOverride",
+            "columnName": "finished_override",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `cover_path` TEXT, `source` TEXT, `added_at` INTEGER NOT NULL, `last_opened_at` INTEGER, `local_uri` TEXT, `remote_uuid` TEXT, `remote_book_id` INTEGER, `cover_url` TEXT, `download_href` TEXT, `download_state` TEXT NOT NULL, `remote_updated_at` INTEGER, `downloaded_at` INTEGER, `file_modified_at` INTEGER, `work_id` TEXT, `finished_at` INTEGER, `archived_at` INTEGER, `remote_page_count` INTEGER, `series_name` TEXT, `series_index` REAL, `file_series_name` TEXT, `file_series_index` REAL, `series_id` TEXT, `series_checked` INTEGER NOT NULL, `catalog_series_name` TEXT, `catalog_series_index` REAL, `catalog_folder_id` TEXT, `catalog_series_source` TEXT, `user_series_name` TEXT, `user_series_index` REAL, `series_override` INTEGER NOT NULL, `user_series_updated_at` INTEGER, `series_index_override` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "last_opened_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localUri",
+            "columnName": "local_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUuid",
+            "columnName": "remote_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteBookId",
+            "columnName": "remote_book_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadHref",
+            "columnName": "download_href",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadState",
+            "columnName": "download_state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloaded_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finished_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archived_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remotePageCount",
+            "columnName": "remote_page_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fileSeriesName",
+            "columnName": "file_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileSeriesIndex",
+            "columnName": "file_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesChecked",
+            "columnName": "series_checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSeriesName",
+            "columnName": "catalog_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesIndex",
+            "columnName": "catalog_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "catalogFolderId",
+            "columnName": "catalog_folder_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesSource",
+            "columnName": "catalog_series_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesName",
+            "columnName": "user_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesIndex",
+            "columnName": "user_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesOverridden",
+            "columnName": "series_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userSeriesUpdatedAt",
+            "columnName": "user_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "indexOverridden",
+            "columnName": "series_index_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_books_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_books_url` ON `${TABLE_NAME}` (`url`)"
+          },
+          {
+            "name": "index_books_series_name",
+            "unique": false,
+            "columnNames": [
+              "series_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_series_name` ON `${TABLE_NAME}` (`series_name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "library_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `added_at` INTEGER NOT NULL, PRIMARY KEY(`url`))",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "url"
+          ]
+        }
+      },
+      {
+        "tableName": "remote_server",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `kind` TEXT NOT NULL, `base_url` TEXT NOT NULL, `username` TEXT, `password_cipher` TEXT, `api_key_cipher` TEXT, `account_id` TEXT, `user_id` INTEGER, `kobo_token` TEXT, `can_download` INTEGER NOT NULL, `can_manage_library` INTEGER NOT NULL, `can_admin` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `catalog_synced_at` INTEGER, `position_synced_at` INTEGER, `sync_token` TEXT, `liseur_token_cipher` TEXT, `liseur_account_id` TEXT, `sync_cursor_seq` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "passwordCipher",
+            "columnName": "password_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiKeyCipher",
+            "columnName": "api_key_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "koboTokenCipher",
+            "columnName": "kobo_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "canDownload",
+            "columnName": "can_download",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canManageLibrary",
+            "columnName": "can_manage_library",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canAdmin",
+            "columnName": "can_admin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSyncedAt",
+            "columnName": "catalog_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "positionSyncedAt",
+            "columnName": "position_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncToken",
+            "columnName": "sync_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurTokenCipher",
+            "columnName": "liseur_token_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurAccountId",
+            "columnName": "liseur_account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncCursorSeq",
+            "columnName": "sync_cursor_seq",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `book_id` TEXT NOT NULL, `kind` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `text` TEXT, `note` TEXT, `tint` TEXT, `chapter` TEXT, `position` INTEGER, `total_progression` REAL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tint",
+            "columnName": "tint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapter",
+            "columnName": "chapter",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_typography",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `font` TEXT NOT NULL, `font_size` REAL NOT NULL, `line_height` REAL, `page_margins` REAL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "font",
+            "columnName": "font",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "font_size",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineHeight",
+            "columnName": "line_height",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pageMargins",
+            "columnName": "page_margins",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `book_url` TEXT NOT NULL, `started_at` INTEGER NOT NULL, `ended_at` INTEGER, `last_checkpoint_at` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `start_progression` REAL, `end_progression` REAL, `uploaded_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "ended_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastCheckpointAt",
+            "columnName": "last_checkpoint_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startProgression",
+            "columnName": "start_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "endProgression",
+            "columnName": "end_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "uploadedAt",
+            "columnName": "uploaded_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_sessions_book_url",
+            "unique": false,
+            "columnNames": [
+              "book_url"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_book_url` ON `${TABLE_NAME}` (`book_url`)"
+          },
+          {
+            "name": "index_reading_sessions_started_at",
+            "unique": false,
+            "columnNames": [
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_started_at` ON `${TABLE_NAME}` (`started_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_peer_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `pending_progression` REAL, `pending_status` TEXT, `pending_updated_at` INTEGER, `has_pending` INTEGER NOT NULL DEFAULT 0, `remote_updated_at` INTEGER, `synced_at` INTEGER, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasPending",
+            "columnName": "has_pending",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_peer_state_peer_id",
+            "unique": false,
+            "columnNames": [
+              "peer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_peer_state_peer_id` ON `${TABLE_NAME}` (`peer_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_fingerprint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `sha256` TEXT NOT NULL, `partial_md5` TEXT NOT NULL, `file_size` INTEGER NOT NULL, `file_modified_at` INTEGER, `computed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256",
+            "columnName": "sha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partialMd5",
+            "columnName": "partial_md5",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "computedAt",
+            "columnName": "computed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "work_alias",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_id` TEXT NOT NULL, `confidence` TEXT NOT NULL, `confirmed` INTEGER NOT NULL, `seeded` INTEGER NOT NULL DEFAULT 0, `source_sent` INTEGER NOT NULL DEFAULT 0, `edition_sha` TEXT, `resolved_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confirmed",
+            "columnName": "confirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seeded",
+            "columnName": "seeded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceSent",
+            "columnName": "source_sent",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "editionSha",
+            "columnName": "edition_sha",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resolvedAt",
+            "columnName": "resolved_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "work_ambiguity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_ids` TEXT NOT NULL, `noticed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workIds",
+            "columnName": "work_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noticedAt",
+            "columnName": "noticed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_extra",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`series_id` TEXT NOT NULL, `summary` TEXT, `status` TEXT, `total_book_count` INTEGER, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`series_id`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalBookCount",
+            "columnName": "total_book_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "series_id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a8e9ceea47516386e8ed9fa52b6059bc')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -28,6 +28,7 @@ import com.chmouel.liseur.data.liseursync.LiseurSyncFileSource
 import com.chmouel.liseur.data.liseursync.LiseurSyncInsights
 import com.chmouel.liseur.data.liseursync.LiseurSyncPositionSync
 import com.chmouel.liseur.data.liseursync.LiseurSyncServerSetup
+import com.chmouel.liseur.data.liseursync.LiseurSyncSeriesClient
 import com.chmouel.liseur.data.liseursync.WorkResolver
 import com.chmouel.liseur.data.remote.RemoteAccountRepository
 import com.chmouel.liseur.data.remote.RemoteCatalogRepository
@@ -237,6 +238,9 @@ class AppContainer(context: Context) {
             ServerKind.CALIBRE to koboSync,
             ServerKind.KOMGA to komgaSync,
             ServerKind.LISEUR_SYNC to liseurSync,
+        ),
+        seriesClaims = mapOf(
+            ServerKind.LISEUR_SYNC to LiseurSyncSeriesClient(),
         ),
         // calibre-web is the only one that deletes. Komga treats it as
         // an administrator's job, and a liseur-sync book is a file in a

--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -570,6 +570,7 @@ private fun LibraryRoute(
             SeriesAssignDialog(
                 book = book,
                 seriesNames = state.seriesNames,
+                canResetSharedSeries = state.canResetSharedSeries,
                 onConfirm = { name, index ->
                     viewModel.setBookSeries(book, name, index)
                     seriesSheetRefile = null

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/Book.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/Book.kt
@@ -114,6 +114,10 @@ data class Book(
     @ColumnInfo(name = "catalog_series_name") val catalogSeriesName: String? = null,
     /** The catalog's series index. */
     @ColumnInfo(name = "catalog_series_index") val catalogSeriesIndex: Double? = null,
+    /** The watched folder that named this catalog row, for liseur-sync series writes. */
+    @ColumnInfo(name = "catalog_folder_id") val catalogFolderId: String? = null,
+    /** Whether the catalog series came from the folder, shared layer or personal layer. */
+    @ColumnInfo(name = "catalog_series_source") val catalogSeriesSource: String? = null,
     /**
      * The series the reader filed the book under themselves, null when
      * they filed it under none.
@@ -137,6 +141,8 @@ data class Book(
      * without also freezing the name the server gave it.
      */
     @ColumnInfo(name = "series_override") val seriesOverridden: Boolean = false,
+    /** When this device last changed its personal series claim. */
+    @ColumnInfo(name = "user_series_updated_at") val userSeriesUpdatedAt: Long? = null,
     /**
      * Whether the reader has set this book's place in its series by
      * hand, by typing a number or by dragging the shelf into order.
@@ -196,6 +202,9 @@ interface BookDao {
     @Query("SELECT * FROM books WHERE url = :url")
     suspend fun getByUrl(url: String): Book?
 
+    @Query("SELECT * FROM books WHERE url IN (:urls)")
+    suspend fun getByUrls(urls: List<String>): List<Book>
+
     /** Puts a book away, or brings it back to the shelf. */
     @Query("UPDATE books SET archived_at = :archivedAt WHERE url = :url")
     suspend fun setArchived(url: String, archivedAt: Long?)
@@ -216,6 +225,7 @@ interface BookDao {
         "UPDATE books SET remote_uuid = NULL, remote_book_id = NULL, cover_url = NULL, " +
             "download_href = NULL, remote_updated_at = NULL, remote_page_count = NULL, " +
             "catalog_series_name = NULL, catalog_series_index = NULL, " +
+            "catalog_folder_id = NULL, catalog_series_source = NULL, " +
             "series_name = CASE WHEN series_override = 1 THEN user_series_name " +
             "ELSE file_series_name END, " +
             "series_index = CASE " +
@@ -239,6 +249,7 @@ interface BookDao {
         "UPDATE books SET remote_uuid = NULL, remote_book_id = NULL, cover_url = NULL, " +
             "download_href = NULL, remote_updated_at = NULL, remote_page_count = NULL, " +
             "catalog_series_name = NULL, catalog_series_index = NULL, " +
+            "catalog_folder_id = NULL, catalog_series_source = NULL, " +
             "series_name = CASE WHEN series_override = 1 THEN user_series_name " +
             "ELSE file_series_name END, " +
             "series_index = CASE " +
@@ -391,13 +402,33 @@ interface BookDao {
         SET user_series_name = :name,
             user_series_index = CASE WHEN :name IS NULL THEN NULL ELSE :index END,
             series_override = 1,
+            user_series_updated_at = :updatedAt,
             series_index_override = 1,
             series_name = :name,
-            series_index = CASE WHEN :name IS NULL THEN NULL ELSE :index END
+            series_index = CASE WHEN :name IS NULL THEN NULL ELSE :index END,
+            series_id = NULL
         WHERE url = :url
         """,
     )
-    suspend fun setSeriesOverride(url: String, name: String?, index: Double?)
+    suspend fun setSeriesOverride(
+        url: String,
+        name: String?,
+        index: Double?,
+        updatedAt: Long = System.currentTimeMillis(),
+    )
+
+    /**
+     * Records the server's own id for the series this book now sits in.
+     *
+     * [setSeriesOverride] clears the id rather than keeping the old one,
+     * because a book refiled by hand is no longer in the series the last
+     * refresh named, and renumbering a shelf sends this id: a stale one
+     * would renumber — and quietly re-file into — the previous series.
+     * Null until the claim reaches the server, which is the safe way
+     * round, since a shelf with no id simply cannot be pushed.
+     */
+    @Query("UPDATE books SET series_id = :seriesId WHERE url = :url")
+    suspend fun setRemoteSeriesId(url: String, seriesId: String?)
 
     /**
      * Hands the book back to whoever described it, for when the reader
@@ -409,7 +440,8 @@ interface BookDao {
         SET user_series_name = NULL,
             user_series_index = NULL,
             series_override = 0,
-            series_index_override = 0,
+        user_series_updated_at = :updatedAt,
+        series_index_override = 0,
             series_name = COALESCE(catalog_series_name, file_series_name),
             series_index = CASE
                 WHEN COALESCE(catalog_series_name, file_series_name) IS NULL THEN NULL
@@ -418,7 +450,7 @@ interface BookDao {
         WHERE url = :url
         """,
     )
-    suspend fun clearSeriesOverride(url: String)
+    suspend fun clearSeriesOverride(url: String, updatedAt: Long = System.currentTimeMillis())
 
     /**
      * Forgets that this book was ever opened, for when the file at a path
@@ -461,19 +493,26 @@ interface BookDao {
             remote_page_count = :remotePageCount,
             catalog_series_name = :catalogSeriesName,
             catalog_series_index = :catalogSeriesIndex,
+            catalog_folder_id = :catalogFolderId,
+            catalog_series_source = :catalogSeriesSource,
+            user_series_name = :userSeriesName,
+            user_series_index = :userSeriesIndex,
+            series_override = :seriesOverridden,
+            series_index_override = :indexOverridden,
+            user_series_updated_at = :userSeriesUpdatedAt,
             series_name = CASE
-                WHEN series_override = 1 THEN user_series_name
+                WHEN :seriesOverridden = 1 THEN :userSeriesName
                 ELSE COALESCE(:catalogSeriesName, file_series_name)
             END,
             series_index = CASE
                 -- Same ladder as series_name above, so that a number
                 -- never outlives the name it counts within.
                 WHEN (CASE
-                    WHEN series_override = 1 THEN user_series_name
+                    WHEN :seriesOverridden = 1 THEN :userSeriesName
                     ELSE COALESCE(:catalogSeriesName, file_series_name)
                 END) IS NULL THEN NULL
-                WHEN series_index_override = 1 THEN user_series_index
-                WHEN series_override = 1 THEN NULL
+                WHEN :indexOverridden = 1 THEN :userSeriesIndex
+                WHEN :seriesOverridden = 1 THEN NULL
                 ELSE COALESCE(:catalogSeriesIndex, file_series_index)
             END,
             series_id = :seriesId
@@ -492,6 +531,13 @@ interface BookDao {
         remotePageCount: Int?,
         catalogSeriesName: String?,
         catalogSeriesIndex: Double?,
+        catalogFolderId: String?,
+        catalogSeriesSource: String?,
+        userSeriesName: String?,
+        userSeriesIndex: Double?,
+        seriesOverridden: Boolean,
+        indexOverridden: Boolean,
+        userSeriesUpdatedAt: Long?,
         seriesId: String?,
     )
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
@@ -22,7 +22,7 @@ import androidx.sqlite.execSQL
         WorkAmbiguity::class,
         SeriesExtra::class,
     ],
-    version = 30,
+    version = 31,
     exportSchema = true,
 )
 abstract class LiseurDatabase : RoomDatabase() {
@@ -880,6 +880,27 @@ abstract class LiseurDatabase : RoomDatabase() {
         }
 
         /**
+         * Caches liseur-sync series-claim metadata beside the local
+         * override, so offline edits and catalog refreshes can reconcile
+         * instead of racing two separate answers on screen.
+         */
+        val MIGRATION_30_31 = object : Migration(30, 31) {
+            override fun migrate(connection: SQLiteConnection) {
+                connection.execSQL("ALTER TABLE `books` ADD COLUMN `catalog_folder_id` TEXT")
+                connection.execSQL("ALTER TABLE `books` ADD COLUMN `catalog_series_source` TEXT")
+                connection.execSQL("ALTER TABLE `books` ADD COLUMN `user_series_updated_at` INTEGER")
+                connection.execSQL(
+                    "ALTER TABLE `remote_server` ADD COLUMN `can_manage_library` " +
+                        "INTEGER NOT NULL DEFAULT 0",
+                )
+                connection.execSQL(
+                    "ALTER TABLE `remote_server` ADD COLUMN `can_admin` " +
+                        "INTEGER NOT NULL DEFAULT 0",
+                )
+            }
+        }
+
+        /**
          * Every migration, in order, as one list so that what the app
          * runs and what the tests replay cannot drift apart.
          */
@@ -913,6 +934,7 @@ abstract class LiseurDatabase : RoomDatabase() {
             MIGRATION_27_28,
             MIGRATION_28_29,
             MIGRATION_29_30,
+            MIGRATION_30_31,
         )
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/RemoteServer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/RemoteServer.kt
@@ -43,6 +43,8 @@ data class RemoteServer(
     @ColumnInfo(name = "user_id") val userId: Int?,
     @ColumnInfo(name = "kobo_token") val koboTokenCipher: String?,
     @ColumnInfo(name = "can_download") val canDownload: Boolean,
+    @ColumnInfo(name = "can_manage_library") val canManageLibrary: Boolean = false,
+    @ColumnInfo(name = "can_admin") val canAdmin: Boolean = false,
     @ColumnInfo(name = "added_at") val addedAt: Long,
     @ColumnInfo(name = "catalog_synced_at") val catalogSyncedAt: Long?,
     @ColumnInfo(name = "position_synced_at") val positionSyncedAt: Long?,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/SeriesOrder.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/SeriesOrder.kt
@@ -45,11 +45,12 @@ abstract class SeriesOrderDao {
         UPDATE books
         SET user_series_index = :index,
             series_index_override = 1,
+            user_series_updated_at = :updatedAt,
             series_index = CASE WHEN series_name IS NULL THEN NULL ELSE :index END
         WHERE url = :url
         """,
     )
-    protected abstract suspend fun setIndexOverride(url: String, index: Double?)
+    protected abstract suspend fun setIndexOverride(url: String, index: Double?, updatedAt: Long)
 
     /**
      * Gives the numbering of these books back to their sources.
@@ -98,7 +99,8 @@ abstract class SeriesOrderDao {
     @Transaction
     open suspend fun renumber(key: String, urlsInOrder: List<String>): Boolean {
         if (!stillHolds(key, urlsInOrder)) return false
-        urlsInOrder.forEachIndexed { i, url -> setIndexOverride(url, (i + 1).toDouble()) }
+        val now = System.currentTimeMillis()
+        urlsInOrder.forEachIndexed { i, url -> setIndexOverride(url, (i + 1).toDouble(), now) }
         return true
     }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncApi.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncApi.kt
@@ -25,18 +25,20 @@ object LiseurSyncApi {
     const val SCOPE_SYNC = "sync"
     const val SCOPE_INSIGHTS = "read-insights"
     const val SCOPE_LIBRARY_READ = "library-read"
+    const val SCOPE_LIBRARY_MANAGE = "library-manage"
 
     /**
      * Every scope a full account wants, in one mint.
      *
-     * There is no scope for writing to the catalog: books reach a
-     * liseur-sync server by being put in a folder it watches, so the
-     * app only ever reads.
+     * Books still reach a liseur-sync server only by being put in a
+     * watched folder. The one catalog thing the app can now write is a
+     * reader's claim about which series a book belongs to.
      */
     val SCOPES_FULL = listOf(
         SCOPE_SYNC,
         SCOPE_INSIGHTS,
         SCOPE_LIBRARY_READ,
+        SCOPE_LIBRARY_MANAGE,
     )
 
     fun url(baseUrl: String, path: String): String = RemoteUrl.api(baseUrl, path)
@@ -80,6 +82,19 @@ object LiseurSyncApi {
     /** The book itself. */
     fun book(baseUrl: String, bookId: String): String =
         url(baseUrl, "/v1/books/$bookId")
+
+    fun bookSeries(baseUrl: String, bookId: String): String =
+        url(baseUrl, "/v1/books/$bookId/series")
+
+    fun bookSeries(baseUrl: String, bookId: String, scope: String): String =
+        url(
+            baseUrl,
+            "/v1/books/$bookId/series?scope=" +
+                java.net.URLEncoder.encode(scope, "UTF-8"),
+        )
+
+    fun seriesOrder(baseUrl: String, folder: String, seriesId: String): String =
+        url(baseUrl, "$FOLDERS/$folder/entities/series/$seriesId/order")
 
     fun bookCover(baseUrl: String, bookId: String): String =
         url(baseUrl, "/v1/books/$bookId/cover")

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncApi.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncApi.kt
@@ -93,8 +93,8 @@ object LiseurSyncApi {
                 java.net.URLEncoder.encode(scope, "UTF-8"),
         )
 
-    fun seriesOrder(baseUrl: String, folder: String, seriesId: String): String =
-        url(baseUrl, "$FOLDERS/$folder/entities/series/$seriesId/order")
+    fun seriesOrder(baseUrl: String, seriesId: String): String =
+        url(baseUrl, "/v1/entities/series/$seriesId/order")
 
     fun bookCover(baseUrl: String, bookId: String): String =
         url(baseUrl, "/v1/books/$bookId/cover")

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncCatalogClient.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncCatalogClient.kt
@@ -5,6 +5,7 @@ import com.chmouel.liseur.data.remote.CatalogSource
 import com.chmouel.liseur.data.remote.CatalogWalk
 import com.chmouel.liseur.data.remote.RemoteBook
 import com.chmouel.liseur.data.remote.RemoteCredentials
+import com.chmouel.liseur.data.remote.RemoteSeriesMembership
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.ensureActive
 import org.json.JSONArray
@@ -133,7 +134,8 @@ internal fun books(array: JSONArray?): List<RemoteBook> =
 private fun book(json: JSONObject): RemoteBook? {
     val id = json.optString("book_id").takeIf { it.isNotEmpty() } ?: return null
     val title = json.optString("title").takeIf { it.isNotEmpty() } ?: return null
-    val series = json.optJSONArray("series")?.optJSONObject(0)
+    val memberships = series(json.optJSONArray("series"))
+    val series = memberships.firstOrNull()
     // A book the last complete pass did not find keeps its place and its
     // reading history — a disconnected disk is not a deleted book — but
     // there are no bytes to fetch, so it is offered without a download.
@@ -146,12 +148,28 @@ private fun book(json: JSONObject): RemoteBook? {
         downloadHref = if (present) "/v1/books/$id/download" else null,
         sizeBytes = json.optLong("size_bytes").takeIf { it > 0 },
         updatedAt = SyncOps.parseTime(json.optString("updated_at")),
-        seriesName = series?.optString("name")?.takeIf { it.isNotEmpty() },
-        seriesIndex = series?.takeIf { it.has("position") }?.optDouble("position"),
-        seriesId = series?.optString("id")?.takeIf { it.isNotEmpty() },
+        seriesName = series?.name,
+        seriesIndex = series?.position,
+        seriesId = series?.id,
+        series = memberships,
+        seriesSource = series?.source,
+        folderId = json.optString("folder_id").takeIf { it.isNotEmpty() },
         sha256 = json.optString("sha256").takeIf { it.isNotEmpty() },
     )
 }
+
+internal fun series(array: JSONArray?): List<RemoteSeriesMembership> =
+    (0 until (array?.length() ?: 0)).mapNotNull { index ->
+        array?.optJSONObject(index)?.let { json ->
+            val name = json.optString("name").takeIf { it.isNotEmpty() } ?: return@mapNotNull null
+            RemoteSeriesMembership(
+                id = json.optString("id").takeIf { it.isNotEmpty() },
+                name = name,
+                position = json.takeIf { it.has("position") }?.optDouble("position"),
+                source = json.optString("source").takeIf { it.isNotEmpty() },
+            )
+        }
+    }
 
 private fun authors(contributors: JSONArray?): String? {
     val names = (0 until (contributors?.length() ?: 0)).mapNotNull { index ->

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncHttp.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncHttp.kt
@@ -69,6 +69,36 @@ class LiseurSyncHttp(private val http: RemoteHttp = RemoteHttp()) {
         expected,
     )
 
+    suspend fun put(
+        url: String,
+        credentials: RemoteCredentials?,
+        json: JSONObject,
+        expected: Set<Int> = emptySet(),
+    ): JSONObject = send(
+        Request.Builder().url(url).put(json.toString().toRequestBody(JSON)),
+        credentials,
+        expected,
+    )
+
+    suspend fun delete(
+        url: String,
+        credentials: RemoteCredentials?,
+        expected: Set<Int> = emptySet(),
+    ): JSONObject = send(Request.Builder().url(url).delete(), credentials, expected)
+
+    suspend fun putNoContent(
+        url: String,
+        credentials: RemoteCredentials?,
+        json: JSONObject,
+        expected: Set<Int> = emptySet(),
+    ) {
+        sendMaybeEmpty(
+            Request.Builder().url(url).put(json.toString().toRequestBody(JSON)),
+            credentials,
+            expected,
+        )
+    }
+
     /**
      * Runs a request and insists on JSON back.
      *
@@ -90,6 +120,21 @@ class LiseurSyncHttp(private val http: RemoteHttp = RemoteHttp()) {
             }
             if (!response.isSuccessful) throw failureFor(response, text)
             parseOrNull(text) ?: throw RemoteHttpFailure(SyncFailure.Malformed)
+        }
+    }
+
+    private suspend fun sendMaybeEmpty(
+        builder: Request.Builder,
+        credentials: RemoteCredentials?,
+        expected: Set<Int>,
+    ) = withContext(Dispatchers.IO) {
+        val request = builder.also { credentials?.signInto(it) }.build()
+        http.client.newCall(request).execute().use { response ->
+            val text = response.body?.string().orEmpty()
+            if (response.code in expected) {
+                throw LiseurSyncRejection(response.code, parseOrNull(text))
+            }
+            if (!response.isSuccessful) throw failureFor(response, text)
         }
     }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSeriesClient.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSeriesClient.kt
@@ -58,12 +58,14 @@ class LiseurSyncSeriesClient(
         booksInOrder: List<Book>,
     ): Boolean {
         val first = booksInOrder.firstOrNull() ?: return false
-        val folder = first.catalogFolderId ?: return false
         val seriesId = first.seriesId ?: return false
         // The server places a book it finds unplaced, so the wrong id
         // here would not merely misnumber the shelf, it would refile
-        // every book on it. A shelf whose books disagree about which
-        // series they are in is not one this route can speak for.
+        // every book on it — and a series id now names a shelf across
+        // the whole library, so a stale one can reach a folder this
+        // reader was not even looking at. A shelf whose books disagree
+        // about which series they are in is not one this route can
+        // speak for.
         if (booksInOrder.any { it.seriesId != seriesId }) return false
         val order = JSONArray().also { array ->
             booksInOrder.forEachIndexed { index, book ->
@@ -72,7 +74,7 @@ class LiseurSyncSeriesClient(
             }
         }
         val body = JSONObject().put("scope", PERSONAL).put("order", order)
-        http.putNoContent(LiseurSyncApi.seriesOrder(baseUrl, folder, seriesId), credentials, body)
+        http.putNoContent(LiseurSyncApi.seriesOrder(baseUrl, seriesId), credentials, body)
         return true
     }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSeriesClient.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSeriesClient.kt
@@ -1,0 +1,92 @@
+package com.chmouel.liseur.data.liseursync
+
+import com.chmouel.liseur.data.db.Book
+import com.chmouel.liseur.data.remote.RemoteCredentials
+import com.chmouel.liseur.data.remote.SeriesClaimSync
+import com.chmouel.liseur.data.remote.SeriesLayers
+import org.json.JSONArray
+import org.json.JSONObject
+
+class LiseurSyncSeriesClient(
+    private val http: LiseurSyncHttp = LiseurSyncHttp(),
+) : SeriesClaimSync {
+
+    override suspend fun setPersonalSeries(
+        baseUrl: String,
+        credentials: RemoteCredentials,
+        book: Book,
+        name: String?,
+        index: Double?,
+    ): SeriesLayers? {
+        val id = book.remoteUuid ?: return null
+        val item = name?.let {
+            JSONObject().put("name", it).also { json ->
+                if (index != null) json.put("position", index)
+            }
+        }
+        val body = JSONObject()
+            .put("scope", PERSONAL)
+            .put("series", JSONArray().also { array -> if (item != null) array.put(item) })
+        return layers(http.put(LiseurSyncApi.bookSeries(baseUrl, id), credentials, body))
+    }
+
+    override suspend fun resetPersonalSeries(
+        baseUrl: String,
+        credentials: RemoteCredentials,
+        book: Book,
+    ): SeriesLayers? = resetSeries(baseUrl, credentials, book, PERSONAL)
+
+    override suspend fun resetSharedSeries(
+        baseUrl: String,
+        credentials: RemoteCredentials,
+        book: Book,
+    ): SeriesLayers? = resetSeries(baseUrl, credentials, book, SHARED)
+
+    private suspend fun resetSeries(
+        baseUrl: String,
+        credentials: RemoteCredentials,
+        book: Book,
+        scope: String,
+    ): SeriesLayers? {
+        val id = book.remoteUuid ?: return null
+        return layers(http.delete(LiseurSyncApi.bookSeries(baseUrl, id, scope), credentials))
+    }
+
+    override suspend fun reorderPersonalSeries(
+        baseUrl: String,
+        credentials: RemoteCredentials,
+        booksInOrder: List<Book>,
+    ): Boolean {
+        val first = booksInOrder.firstOrNull() ?: return false
+        val folder = first.catalogFolderId ?: return false
+        val seriesId = first.seriesId ?: return false
+        // The server places a book it finds unplaced, so the wrong id
+        // here would not merely misnumber the shelf, it would refile
+        // every book on it. A shelf whose books disagree about which
+        // series they are in is not one this route can speak for.
+        if (booksInOrder.any { it.seriesId != seriesId }) return false
+        val order = JSONArray().also { array ->
+            booksInOrder.forEachIndexed { index, book ->
+                val id = book.remoteUuid ?: return false
+                array.put(JSONObject().put("book_id", id).put("position", index + 1.0))
+            }
+        }
+        val body = JSONObject().put("scope", PERSONAL).put("order", order)
+        http.putNoContent(LiseurSyncApi.seriesOrder(baseUrl, folder, seriesId), credentials, body)
+        return true
+    }
+
+    companion object {
+        const val PERSONAL = "personal"
+        const val SHARED = "shared"
+
+        fun layers(json: JSONObject): SeriesLayers = SeriesLayers(
+            bookId = json.optString("book_id"),
+            source = json.optString("source").takeIf { it.isNotEmpty() },
+            series = series(json.optJSONArray("series")),
+            folder = series(json.optJSONArray("folder")),
+            shared = json.optJSONArray("shared")?.let(::series),
+            personal = json.optJSONArray("personal")?.let(::series),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncServerSetup.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncServerSetup.kt
@@ -98,9 +98,13 @@ class LiseurSyncServerSetup(
         if (LiseurSyncApi.SCOPE_SYNC !in scopes) {
             throw InsufficientScopes()
         }
+        val isAdmin = "admin" in scopes
         return ServerCapabilities(
             baseUrl = baseUrl,
-            canDownload = LiseurSyncApi.SCOPE_LIBRARY_READ in scopes,
+            canDownload = LiseurSyncApi.SCOPE_LIBRARY_READ in scopes ||
+                LiseurSyncApi.SCOPE_LIBRARY_MANAGE in scopes || isAdmin,
+            canManageLibrary = LiseurSyncApi.SCOPE_LIBRARY_MANAGE in scopes || isAdmin,
+            canAdmin = isAdmin,
             accountId = answer.optString("device_id").takeIf { it.isNotEmpty() },
             displayName = answer.optString("name").ifEmpty { "liseur-sync" },
             liseurToken = credentials.token,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepository.kt
@@ -315,6 +315,8 @@ class RemoteAccountRepository(
                 koboTokenCipher = RemoteServer.seal(capabilities.koboToken)
                     ?: existing?.koboTokenCipher,
                 canDownload = capabilities.canDownload,
+                canManageLibrary = capabilities.canManageLibrary,
+                canAdmin = capabilities.canAdmin,
                 addedAt = existing?.addedAt ?: System.currentTimeMillis(),
                 catalogSyncedAt = existing?.catalogSyncedAt,
                 positionSyncedAt = existing?.positionSyncedAt,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteBook.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteBook.kt
@@ -49,6 +49,12 @@ data class RemoteBook(
      * about the series; it never decides which books belong together.
      */
     val seriesId: String? = null,
+    /** Every series membership the server sent, in its own order. */
+    val series: List<RemoteSeriesMembership> = emptyList(),
+    /** Where the first effective series membership came from, if known. */
+    val seriesSource: String? = series.firstOrNull()?.source,
+    /** liseur-sync's watched folder id, needed when renumbering a series. */
+    val folderId: String? = null,
     /**
      * The digest of the file's content, when the server publishes one.
      *
@@ -58,4 +64,11 @@ data class RemoteBook(
      * it again, and it is never an address of anything on the server.
      */
     val sha256: String? = null,
+)
+
+data class RemoteSeriesMembership(
+    val id: String?,
+    val name: String,
+    val position: Double?,
+    val source: String?,
 )

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepository.kt
@@ -236,7 +236,7 @@ class RemoteCatalogRepository(
             // reading positions hang off; the catalog's spelling of the
             // identity belongs to rows the catalog itself introduced.
             val rowUrl = existing?.takeIf { it.id != 0L }?.url ?: url
-            val merged = mergeCatalogEntry(remote, existing, rowUrl, baseUrl, now)
+            val merged = mergeCatalogEntry(remote, existing, rowUrl, baseUrl, now, kind)
             known.remember(merged)
             // Nothing the catalog owns has moved, so writing the row back
             // would only tell the library to sort itself again.
@@ -260,7 +260,14 @@ class RemoteCatalogRepository(
                 remotePageCount = book.remotePageCount,
                 catalogSeriesName = remote.seriesName,
                 catalogSeriesIndex = remote.seriesIndex,
-                seriesId = remote.seriesId,
+                catalogFolderId = remote.folderId,
+                catalogSeriesSource = remote.seriesSource,
+                userSeriesName = book.userSeriesName,
+                userSeriesIndex = book.userSeriesIndex,
+                seriesOverridden = book.seriesOverridden,
+                indexOverridden = book.indexOverridden,
+                userSeriesUpdatedAt = book.userSeriesUpdatedAt,
+                seriesId = book.seriesId,
             )
         }
         if (inserts.isNotEmpty()) bookDao.upsertAll(inserts.values.toList())
@@ -374,6 +381,7 @@ internal fun mergeCatalogEntry(
     url: String,
     baseUrl: String,
     now: Long,
+    kind: ServerKind = ServerKind.KOMGA,
 ): Book {
     val book = existing ?: Book(
         url = url,
@@ -395,17 +403,44 @@ internal fun mergeCatalogEntry(
         catalog = SeriesMetadata(remote.seriesName, remote.seriesIndex, remote.seriesId),
         file = SeriesMetadata(book.fileSeriesName, book.fileSeriesIndex),
     )
+    val catalogAt = remote.updatedAt ?: 0L
+    val localClaimAt = book.userSeriesUpdatedAt
+    val serverPersonalWins = kind == ServerKind.LISEUR_SYNC &&
+        (localClaimAt == null || catalogAt >= localClaimAt)
+    val userSeriesName = when {
+        serverPersonalWins && remote.seriesSource == "personal" -> remote.seriesName
+        serverPersonalWins -> null
+        else -> book.userSeriesName
+    }
+    val userSeriesIndex = when {
+        serverPersonalWins && remote.seriesSource == "personal" -> remote.seriesIndex
+        serverPersonalWins -> null
+        else -> book.userSeriesIndex
+    }
+    val seriesOverridden = when {
+        serverPersonalWins -> remote.seriesSource == "personal"
+        else -> book.seriesOverridden
+    }
+    val indexOverridden = when {
+        serverPersonalWins -> remote.seriesSource == "personal"
+        else -> book.indexOverridden
+    }
+    val userSeriesUpdatedAt = when {
+        serverPersonalWins && remote.seriesSource == "personal" -> catalogAt
+        serverPersonalWins -> null
+        else -> book.userSeriesUpdatedAt
+    }
     // The reader outranks the feed. Worked out here as well as in the
     // update statement, so that a book they refiled compares equal to
     // the row already stored and the sync leaves it alone entirely.
     val filed = effectiveSeries(
-        name = if (book.seriesOverridden) {
-            SeriesOverride(book.userSeriesName, book.userSeriesIndex)
+        name = if (seriesOverridden) {
+            SeriesOverride(userSeriesName, userSeriesIndex)
         } else {
             null
         },
-        index = book.userSeriesIndex,
-        indexOverridden = book.indexOverridden,
+        index = userSeriesIndex,
+        indexOverridden = indexOverridden,
         source = series,
     )
     return book.copy(
@@ -420,8 +455,15 @@ internal fun mergeCatalogEntry(
         remotePageCount = remote.pageCount,
         seriesName = filed.name,
         seriesIndex = filed.index,
-        seriesId = series.id,
+        seriesId = if (seriesOverridden) book.seriesId else series.id,
         catalogSeriesName = remote.seriesName,
         catalogSeriesIndex = remote.seriesIndex,
+        catalogFolderId = remote.folderId,
+        catalogSeriesSource = remote.seriesSource,
+        userSeriesName = userSeriesName,
+        userSeriesIndex = userSeriesIndex,
+        seriesOverridden = seriesOverridden,
+        indexOverridden = indexOverridden,
+        userSeriesUpdatedAt = userSeriesUpdatedAt,
     )
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteRouter.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteRouter.kt
@@ -16,6 +16,7 @@ class RemoteRouter(
     private val catalogs: Map<ServerKind, CatalogSource>,
     private val files: Map<ServerKind, FileSource>,
     private val positions: Map<ServerKind, PositionSync>,
+    private val seriesClaims: Map<ServerKind, SeriesClaimSync> = emptyMap(),
     /**
      * Which kinds can delete a book on the server at all. Absent from
      * the map means the action is never offered for that kind.
@@ -44,6 +45,9 @@ class RemoteRouter(
 
     /** The deleter for a server already in hand, when the kind has one. */
     fun deleterFor(kind: ServerKind): BookDeleter? = deleters[kind]
+
+    /** The series-claim writer for a server already in hand, when it has one. */
+    fun seriesClaimsFor(kind: ServerKind): SeriesClaimSync? = seriesClaims[kind]
 }
 
 /**

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteSources.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteSources.kt
@@ -90,6 +90,10 @@ data class ServerCapabilities(
     val baseUrl: String,
     /** Whether this account may fetch book files at all. */
     val canDownload: Boolean,
+    /** Whether the account can write liseur-sync personal series claims. */
+    val canManageLibrary: Boolean = false,
+    /** Whether the account can also write the shared catalog layer. */
+    val canAdmin: Boolean = false,
     /** Who the server says we are, for telling two logins apart. */
     val accountId: String?,
     /** The display name to show for the account. */
@@ -180,4 +184,41 @@ interface BookDeleter {
         credentials: RemoteCredentials,
         book: Book,
     ): ServerDeleteResult
+}
+
+data class SeriesLayers(
+    val bookId: String,
+    val source: String?,
+    val series: List<RemoteSeriesMembership>,
+    val folder: List<RemoteSeriesMembership>,
+    val shared: List<RemoteSeriesMembership>?,
+    val personal: List<RemoteSeriesMembership>?,
+)
+
+interface SeriesClaimSync {
+    suspend fun setPersonalSeries(
+        baseUrl: String,
+        credentials: RemoteCredentials,
+        book: Book,
+        name: String?,
+        index: Double?,
+    ): SeriesLayers?
+
+    suspend fun resetPersonalSeries(
+        baseUrl: String,
+        credentials: RemoteCredentials,
+        book: Book,
+    ): SeriesLayers?
+
+    suspend fun resetSharedSeries(
+        baseUrl: String,
+        credentials: RemoteCredentials,
+        book: Book,
+    ): SeriesLayers?
+
+    suspend fun reorderPersonalSeries(
+        baseUrl: String,
+        credentials: RemoteCredentials,
+        booksInOrder: List<Book>,
+    ): Boolean
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
@@ -677,6 +677,7 @@ fun LibraryScreen(
         SeriesAssignDialog(
             book = book,
             seriesNames = state.seriesNames,
+            canResetSharedSeries = state.canResetSharedSeries,
             onConfirm = { name, index ->
                 onSetSeries(book, name, index)
                 editSeriesOf = null

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryViewModel.kt
@@ -1,6 +1,7 @@
 package com.chmouel.liseur.ui.library
 
 import android.net.Uri
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
@@ -68,6 +69,7 @@ import com.chmouel.liseur.domain.LibraryFilterOption
 import com.chmouel.liseur.domain.LibraryFilters
 import com.chmouel.liseur.domain.displayAuthor
 import com.chmouel.liseur.domain.displayTitle
+import java.io.IOException
 import kotlinx.coroutines.launch
 
 data class ContinueReading(val book: Book, val progression: Double?)
@@ -156,6 +158,8 @@ data class LibraryUiState(
      * liseur-sync book is a file in a folder the server only reads.
      */
     val canDeleteFromServer: Boolean = false,
+    /** Whether a shared liseur-sync series claim can be cleared. */
+    val canResetSharedSeries: Boolean = false,
     val refreshing: Boolean = false,
     val sort: LibrarySort = LibrarySort.Default,
     val sortReversed: Boolean = false,
@@ -436,6 +440,7 @@ class LibraryViewModel(
                 canDownload = server?.canDownload != false,
                 canDeleteFromServer = server != null &&
                     router.deleterFor(server.kind) != null,
+                canResetSharedSeries = server?.kind == ServerKind.LISEUR_SYNC && server.canAdmin,
                 refreshing = refreshing || catalogStatus is CatalogStatus.Refreshing,
                 sort = settings.librarySort,
                 sortReversed = settings.librarySortReversed,
@@ -697,13 +702,63 @@ class LibraryViewModel(
      */
     fun setBookSeries(book: Book, name: String?, index: Double?) {
         viewModelScope.launch {
-            bookDao.setSeriesOverride(book.url, name?.trim()?.takeIf { it.isNotEmpty() }, index)
+            val clean = name?.trim()?.takeIf { it.isNotEmpty() }
+            bookDao.setSeriesOverride(book.url, clean, index)
+            pushSeriesClaim(book, clean, index)
         }
     }
 
     /** Gives the book back to whatever the server or the file said. */
     fun resetBookSeries(book: Book) {
-        viewModelScope.launch { bookDao.clearSeriesOverride(book.url) }
+        viewModelScope.launch {
+            bookDao.clearSeriesOverride(book.url)
+            resetSeriesClaim(book)
+        }
+    }
+
+    private suspend fun pushSeriesClaim(book: Book, name: String?, index: Double?) {
+        val server = account.current()?.takeIf {
+            it.kind == ServerKind.LISEUR_SYNC && it.canManageLibrary
+        } ?: return
+        val credentials = server.credentials ?: return
+        val claims = router.seriesClaimsFor(server.kind) ?: return
+        try {
+            val layers = claims.setPersonalSeries(server.baseUrl, credentials, book, name, index)
+            bookDao.setRemoteSeriesId(
+                book.url,
+                layers?.personal?.firstOrNull()?.id,
+            )
+        } catch (e: IOException) {
+            // The local row is the offline cache, and leaving it in
+            // place is what keeps the reader's edit on screen. It is not
+            // queued: nothing re-pushes it, so a claim made offline
+            // reaches the server only when the reader edits again, and
+            // a catalog refresh whose `updated_at` is newer will take it
+            // back. There is no outbox in this app to hang it on —
+            // positions carry their own pending state rather than a
+            // general one — and inventing one for series alone would be
+            // the wrong place to start.
+            Log.i(TAG, "Could not push the series claim", e)
+        }
+    }
+
+    private suspend fun resetSeriesClaim(book: Book) {
+        val server = account.current()?.takeIf {
+            it.kind == ServerKind.LISEUR_SYNC && it.canManageLibrary
+        } ?: return
+        val credentials = server.credentials ?: return
+        val claims = router.seriesClaimsFor(server.kind) ?: return
+        try {
+            if (!book.seriesOverridden && book.catalogSeriesSource == "shared" && server.canAdmin) {
+                claims.resetSharedSeries(server.baseUrl, credentials, book)
+                catalog.refresh()
+            } else {
+                claims.resetPersonalSeries(server.baseUrl, credentials, book)
+                catalog.refresh()
+            }
+        } catch (e: IOException) {
+            Log.i(TAG, "Could not reset the series claim", e)
+        }
     }
 
     /**
@@ -769,6 +824,7 @@ class LibraryViewModel(
         viewModelScope.launch {
             val committed = seriesOrderDao.renumber(draft.key, numbering.map { (url, _) -> url })
             if (committed) {
+                pushSeriesOrder(numbering.map { (url, _) -> url })
                 _reorder.value = null
             } else {
                 // Not a guess at what the reader meant for books they
@@ -794,6 +850,22 @@ class LibraryViewModel(
         }
     }
 
+    private suspend fun pushSeriesOrder(urlsInOrder: List<String>) {
+        val server = account.current()?.takeIf {
+            it.kind == ServerKind.LISEUR_SYNC && it.canManageLibrary
+        } ?: return
+        val credentials = server.credentials ?: return
+        val claims = router.seriesClaimsFor(server.kind) ?: return
+        val byUrl = bookDao.getByUrls(urlsInOrder).associateBy { it.url }
+        val books = urlsInOrder.mapNotNull(byUrl::get)
+        if (books.size != urlsInOrder.size) return
+        try {
+            claims.reorderPersonalSeries(server.baseUrl, credentials, books)
+        } catch (e: IOException) {
+            Log.i(TAG, "Could not push the series order", e)
+        }
+    }
+
     /** Marks a message as shown. */
     fun noticeShown(id: Long) = notices.shown(id)
 
@@ -807,6 +879,8 @@ class LibraryViewModel(
     }
 
     companion object {
+        private const val TAG = "LibraryViewModel"
+
         val Factory: ViewModelProvider.Factory = viewModelFactory {
             initializer {
                 val container = checkNotNull(this[APPLICATION_KEY]).container

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/SeriesUi.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/SeriesUi.kt
@@ -354,6 +354,7 @@ internal fun SeriesSummaryLine(shelf: SeriesShelf, modifier: Modifier = Modifier
 internal fun SeriesAssignDialog(
     book: Book,
     seriesNames: List<String>,
+    canResetSharedSeries: Boolean = false,
     onConfirm: (String?, Double?) -> Unit,
     onReset: () -> Unit,
     onDismiss: () -> Unit,
@@ -367,6 +368,7 @@ internal fun SeriesAssignDialog(
 
     val typed = name.text.trim()
     val choices = remember(typed, seriesNames) { seriesChoices(typed, seriesNames) }
+    val sourceLabel = seriesSourceLabel(book)
 
     val pick: (String) -> Unit = { chosen ->
         // Tapping the series already picked unpicks it, which is how a
@@ -395,6 +397,16 @@ internal fun SeriesAssignDialog(
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
                     )
+                }
+                sourceLabel?.let { label ->
+                    item {
+                        Text(
+                            text = label,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(top = 8.dp),
+                        )
+                    }
                 }
                 item {
                     OutlinedTextField(
@@ -470,7 +482,9 @@ internal fun SeriesAssignDialog(
                     }
                 }
                 // Only worth offering once there is something to undo.
-                if (book.seriesOverridden) {
+                if (book.seriesOverridden ||
+                    (canResetSharedSeries && book.catalogSeriesSource == "shared")
+                ) {
                     item {
                         TextButton(
                             onClick = onReset,
@@ -538,6 +552,15 @@ private fun SeriesChoiceRow(name: String, selected: Boolean, onClick: () -> Unit
             overflow = TextOverflow.Ellipsis,
         )
     }
+}
+
+@Composable
+private fun seriesSourceLabel(book: Book): String? = when {
+    book.seriesOverridden -> stringResource(R.string.series_source_personal)
+    book.catalogSeriesSource == "folder" -> stringResource(R.string.series_source_folder)
+    book.catalogSeriesSource == "shared" -> stringResource(R.string.series_source_shared)
+    book.catalogSeriesSource == "personal" -> stringResource(R.string.series_source_personal)
+    else -> null
 }
 
 /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,9 @@
     <string name="series_assign_volume">Book number (optional)</string>
     <string name="series_assign_reset">Restore the original series</string>
     <string name="series_assign_hint">Leave the name empty to take this book out of its series.</string>
+    <string name="series_source_folder">Series from the watched folder</string>
+    <string name="series_source_shared">Series corrected by the library admin</string>
+    <string name="series_source_personal">Your personal series claim</string>
     <string name="next_in_series">Next: %1$s</string>
     <string name="next_in_series_numbered">Next: #%1$s %2$s</string>
     <string name="clear">Clear</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/SeriesMetadataDaoTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/SeriesMetadataDaoTest.kt
@@ -380,6 +380,7 @@ class SeriesMetadataDaoTest {
     }
 
     private suspend fun refreshCatalog(seriesName: String?, seriesIndex: Double?) {
+        val existing = db.bookDao().getByUrl(BOOK_URL)
         db.bookDao().updateCatalogFields(
             url = BOOK_URL,
             title = "A Book",
@@ -392,6 +393,13 @@ class SeriesMetadataDaoTest {
             remotePageCount = null,
             catalogSeriesName = seriesName,
             catalogSeriesIndex = seriesIndex,
+            catalogFolderId = null,
+            catalogSeriesSource = null,
+            userSeriesName = existing?.userSeriesName,
+            userSeriesIndex = existing?.userSeriesIndex,
+            seriesOverridden = existing?.seriesOverridden ?: false,
+            indexOverridden = existing?.indexOverridden ?: false,
+            userSeriesUpdatedAt = existing?.userSeriesUpdatedAt,
             seriesId = null,
         )
     }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncCatalogClientTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncCatalogClientTest.kt
@@ -130,7 +130,9 @@ class LiseurSyncCatalogClientTest {
                     "contributors":[
                         {"id":"a-1","name":"Pierce Brown","role":"author"},
                         {"id":"a-2","name":"calibre","role":"bkp"}],
-                    "series":[{"id":"s-1","name":"Red Rising","position":4.5}]}]}
+                    "series":[
+                        {"id":"s-1","name":"Red Rising","position":4.5,"source":"shared"},
+                        {"id":"s-2","name":"Solar War","position":1,"source":"folder"}]}]}
                 """.trimIndent(),
             ),
         )
@@ -143,6 +145,10 @@ class LiseurSyncCatalogClientTest {
         assertEquals("Red Rising", book.seriesName)
         assertEquals(4.5, book.seriesIndex!!, 0.0)
         assertEquals("s-1", book.seriesId)
+        assertEquals("shared", book.seriesSource)
+        assertEquals("f-1", book.folderId)
+        assertEquals(listOf("Red Rising", "Solar War"), book.series.map { it.name })
+        assertEquals(listOf("shared", "folder"), book.series.map { it.source })
         assertEquals(1126528L, book.sizeBytes)
         assertEquals("ab12", book.sha256)
         assertEquals("/v1/books/b-1/cover", book.coverHref)
@@ -151,6 +157,92 @@ class LiseurSyncCatalogClientTest {
             SyncOps.parseTime("2026-08-15T08:30:34.105Z"),
             book.updatedAt,
         )
+    }
+
+    @Test
+    fun `personal series writes use the liseur-sync layer routes`() = runTest {
+        server.enqueue(
+            json(
+                """{"book_id":"b-1","source":"personal",
+                    "series":[{"id":"s-1","name":"Murderbot","position":2,"source":"personal"}],
+                    "folder":[{"id":"s-2","name":"Old","source":"folder"}],
+                    "shared":null,
+                    "personal":[{"id":"s-1","name":"Murderbot","position":2,"source":"personal"}]}
+                """.trimIndent(),
+            ),
+        )
+        server.enqueue(
+            json(
+                """{"book_id":"b-1","source":"folder",
+                    "series":[{"id":"s-2","name":"Old","source":"folder"}],
+                    "folder":[{"id":"s-2","name":"Old","source":"folder"}],
+                    "shared":null,"personal":null}
+                """.trimIndent(),
+            ),
+        )
+
+        val book = com.chmouel.liseur.data.db.Book(
+            url = "liseur-sync:b-1",
+            title = "Exit Strategy",
+            author = null,
+            coverPath = null,
+            source = null,
+            addedAt = 0,
+            lastOpenedAt = null,
+            remoteUuid = "b-1",
+        )
+        val client = LiseurSyncSeriesClient()
+
+        val written = client.setPersonalSeries(BASE, credentials, book, "Murderbot", 2.0)
+        val reset = client.resetPersonalSeries(BASE, credentials, book)
+
+        assertEquals("personal", written?.source)
+        assertEquals("Murderbot", written?.personal?.single()?.name)
+        assertEquals(null, reset?.personal)
+        val put = server.takeRequest()
+        assertEquals("PUT", put.method)
+        assertEquals("/v1/books/b-1/series", put.target)
+        assertTrue(put.body?.utf8()?.contains(""""scope":"personal"""") == true)
+        val delete = server.takeRequest()
+        assertEquals("DELETE", delete.method)
+        assertEquals("/v1/books/b-1/series?scope=personal", delete.target)
+    }
+
+    /**
+     * The server places a book the renumbering finds unplaced, so a
+     * shelf sent under the wrong series id would not merely misnumber
+     * it, it would refile every book on it. A shelf whose books do not
+     * agree which series they are in is refused rather than guessed at,
+     * and a book refiled by hand has no id at all until its claim has
+     * been accepted.
+     */
+    @Test
+    fun `renumbering is refused when the shelf does not agree on a series`() = runTest {
+        val client = LiseurSyncSeriesClient()
+        fun volume(id: String, series: String?) = com.chmouel.liseur.data.db.Book(
+            url = "liseur-sync:$id",
+            title = id,
+            author = null,
+            coverPath = null,
+            source = null,
+            addedAt = 0,
+            lastOpenedAt = null,
+            remoteUuid = id,
+            catalogFolderId = "f-1",
+            seriesId = series,
+        )
+
+        assertFalse(
+            client.reorderPersonalSeries(
+                BASE, credentials, listOf(volume("b-1", "s-1"), volume("b-2", "s-2")),
+            ),
+        )
+        assertFalse(
+            client.reorderPersonalSeries(
+                BASE, credentials, listOf(volume("b-1", null), volume("b-2", "s-1")),
+            ),
+        )
+        assertEquals(0, server.requestCount)
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncCatalogClientTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncCatalogClientTest.kt
@@ -228,7 +228,6 @@ class LiseurSyncCatalogClientTest {
             addedAt = 0,
             lastOpenedAt = null,
             remoteUuid = id,
-            catalogFolderId = "f-1",
             seriesId = series,
         )
 
@@ -243,6 +242,19 @@ class LiseurSyncCatalogClientTest {
             ),
         )
         assertEquals(0, server.requestCount)
+
+        // A shelf that does agree renumbers through the library-wide
+        // route: a series id names one shelf everywhere, so the folder
+        // a volume was found in has no part in the address.
+        server.enqueue(MockResponse(code = 204))
+        assertTrue(
+            client.reorderPersonalSeries(
+                BASE, credentials, listOf(volume("b-1", "s-1"), volume("b-2", "s-1")),
+            ),
+        )
+        val put = server.takeRequest()
+        assertEquals("PUT", put.method)
+        assertEquals("/v1/entities/series/s-1/order", put.target)
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncServerSetupTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncServerSetupTest.kt
@@ -47,7 +47,7 @@ class LiseurSyncServerSetupTest {
         server.enqueue(
             json(
                 """{"token_id":"t-1","device_id":"d-1","scopes":["sync","read-insights",
-                    "library-read"],"secret":"device-secret"}
+                    "library-read","library-manage"],"secret":"device-secret"}
                 """.trimIndent(),
             ),
         )
@@ -56,7 +56,7 @@ class LiseurSyncServerSetupTest {
         server.enqueue(
             json(
                 """{"id":"t-1","device_id":"d-1","name":"Test phone",
-                    "scopes":["sync","read-insights","library-read"],
+                    "scopes":["sync","read-insights","library-read","library-manage"],
                     "account_id":"acc-9"}
                 """.trimIndent(),
             ),
@@ -69,22 +69,20 @@ class LiseurSyncServerSetupTest {
         assertEquals("d-1", capabilities.accountId)
         assertEquals("acc-9", capabilities.liseurAccountId)
         assertTrue(capabilities.canDownload)
+        assertTrue(capabilities.canManageLibrary)
         assertEquals("ada", capabilities.displayName)
 
         // The password went to the login route and nowhere else, and
-        // the mint asked for everything in one token.
+        // the mint asked for every reader-facing scope in one token.
         val login = server.takeRequest()
         assertTrue(login.target!!.endsWith("/v1/login"))
         val minted = server.takeRequest()
         assertTrue(minted.target!!.endsWith("/v1/tokens"))
         val body = JSONObject(minted.body!!.utf8())
-        // Reading and syncing is all the app does: there is no scope
-        // here for writing to the catalog, so there is nothing a server
-        // might refuse and no second mint to fall back to.
         val asked = body.getJSONArray("scopes")
-        assertEquals(3, asked.length())
+        assertEquals(4, asked.length())
         assertEquals(
-            setOf("sync", "read-insights", "library-read"),
+            setOf("sync", "read-insights", "library-read", "library-manage"),
             (0 until asked.length()).map { asked.getString(it) }.toSet(),
         )
         assertTrue(server.takeRequest().target!!.endsWith("/v1/token"))
@@ -121,6 +119,41 @@ class LiseurSyncServerSetupTest {
         assertTrue(
             (result as SetupResult.Failure).reason is SetupFailure.InsufficientScopes,
         )
+    }
+
+    @Test
+    fun `admin scope implies library-manage and library-read`() = runTest {
+        server.enqueue(
+            json(
+                """{"id":"t-a","device_id":"d-a","name":"Admin",
+                    "scopes":["sync","admin"]}
+                """.trimIndent(),
+            ),
+        )
+
+        val result = connect(RemoteCredentials.Bearer("admin-token"))
+
+        val capabilities = (result as SetupResult.Success).capabilities
+        assertTrue(capabilities.canAdmin)
+        assertTrue(capabilities.canManageLibrary)
+        assertTrue(capabilities.canDownload)
+    }
+
+    @Test
+    fun `library-manage scope implies library-read`() = runTest {
+        server.enqueue(
+            json(
+                """{"id":"t-m","device_id":"d-m","name":"Manager",
+                    "scopes":["sync","library-manage"]}
+                """.trimIndent(),
+            ),
+        )
+
+        val result = connect(RemoteCredentials.Bearer("manage-token"))
+
+        val capabilities = (result as SetupResult.Success).capabilities
+        assertTrue(capabilities.canManageLibrary)
+        assertTrue(capabilities.canDownload)
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepositoryTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepositoryTest.kt
@@ -54,22 +54,28 @@ class RemoteCatalogRepositoryTest {
         CredentialCipher.keyForTesting = null
     }
 
-    private suspend fun connect() {
+    private suspend fun connect(kind: ServerKind = ServerKind.KOMGA) {
         db.remoteServerDao().upsert(
             RemoteServer(
-                kind = ServerKind.KOMGA,
+                kind = kind,
                 baseUrl = "https://books.example",
                 username = "reader",
                 passwordCipher = null,
-                apiKeyCipher = RemoteServer.seal("a-key"),
+                apiKeyCipher = if (kind == ServerKind.KOMGA) RemoteServer.seal("a-key") else null,
                 accountId = "u1",
                 userId = null,
                 koboTokenCipher = null,
                 canDownload = true,
+                canManageLibrary = kind == ServerKind.LISEUR_SYNC,
                 addedAt = 0L,
                 catalogSyncedAt = null,
                 positionSyncedAt = null,
                 syncToken = null,
+                liseurTokenCipher = if (kind == ServerKind.LISEUR_SYNC) {
+                    RemoteServer.seal("token")
+                } else {
+                    null
+                },
             ),
         )
     }
@@ -98,7 +104,7 @@ class RemoteCatalogRepositoryTest {
     private fun repository(catalog: CatalogSource) = RemoteCatalogRepository(
         router = RemoteRouter(
             serverDao = db.remoteServerDao(),
-            catalogs = mapOf(ServerKind.KOMGA to catalog),
+            catalogs = mapOf(ServerKind.KOMGA to catalog, ServerKind.LISEUR_SYNC to catalog),
             files = emptyMap(),
             positions = emptyMap(),
         ),
@@ -139,7 +145,7 @@ class RemoteCatalogRepositoryTest {
     private fun repository(catalog: CatalogSource, bookDao: BookDao) = RemoteCatalogRepository(
         router = RemoteRouter(
             serverDao = db.remoteServerDao(),
-            catalogs = mapOf(ServerKind.KOMGA to catalog),
+            catalogs = mapOf(ServerKind.KOMGA to catalog, ServerKind.LISEUR_SYNC to catalog),
             files = emptyMap(),
             positions = emptyMap(),
         ),
@@ -164,6 +170,50 @@ class RemoteCatalogRepositoryTest {
         updatedAt = null,
         pageCount = null,
     )
+
+    @Test
+    fun `liseur-sync personal series becomes the local override`() = runTest {
+        connect(ServerKind.LISEUR_SYNC)
+        val remote = book("b1").copy(
+            updatedAt = 20,
+            seriesName = "Imperial Radch",
+            seriesIndex = 2.0,
+            seriesId = "s1",
+            seriesSource = "personal",
+            folderId = "f1",
+        )
+
+        assertEquals(true, repository(FakeCatalog { onPage -> onPage(listOf(remote)) }).refresh().completed)
+
+        val stored = db.bookDao().allOnce().single()
+        assertEquals("Imperial Radch", stored.userSeriesName)
+        assertEquals(2.0, stored.userSeriesIndex!!, 0.0)
+        assertEquals(true, stored.seriesOverridden)
+        assertEquals("personal", stored.catalogSeriesSource)
+        assertEquals("f1", stored.catalogFolderId)
+    }
+
+    @Test
+    fun `non liseur-sync catalog refresh keeps a local series override local`() = runTest {
+        connect(ServerKind.KOMGA)
+        repository(FakeCatalog { onPage -> onPage(listOf(book("b1"))) }).refresh()
+        val url = db.bookDao().allOnce().single().url
+        db.bookDao().setSeriesOverride(url, "My Shelf", 7.0, updatedAt = 30)
+
+        val remote = book("b1").copy(
+            updatedAt = 40,
+            seriesName = "Server Shelf",
+            seriesIndex = 1.0,
+            seriesId = "ks1",
+        )
+        repository(FakeCatalog { onPage -> onPage(listOf(remote)) }).refresh()
+
+        val stored = db.bookDao().allOnce().single()
+        assertEquals("My Shelf", stored.seriesName)
+        assertEquals("My Shelf", stored.userSeriesName)
+        assertEquals("Server Shelf", stored.catalogSeriesName)
+        assertEquals(true, stored.seriesOverridden)
+    }
 
     @Test
     fun `a refused sign-in is reported as such, not as being offline`() = runTest {


### PR DESCRIPTION
* Added schema and database migration for 31.
* Implemented client and server setup for liseur-sync series claims.
* Updated series assignment UI to support resetting shared series.

Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>
