### PR TITLE
feat: Group book series on library shelf

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -251,6 +251,11 @@ private fun LiseurApp(settings: AppSettings) {
                 onEInkMode = { scope.launch { repository.setEInkMode(it) } },
                 onResumeLastBook = { scope.launch { repository.setResumeLastBook(it) } },
                 onKeepScreenOn = { scope.launch { repository.setKeepScreenOn(it) } },
+                onGroupSeries = { grouped ->
+                    scope.launch {
+                        repository.editLibraryFilters { it.copy(groupBySeries = grouped) }
+                    }
+                },
                 onDefinitionTarget = {
                     scope.launch { repository.setDefinitionTarget(it) }
                 },

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
@@ -164,7 +164,7 @@ class AppSettingsRepository(private val context: Context) {
             librarySortReversed = p[Keys.LIBRARY_SORT_REVERSED] ?: false,
             libraryFilters = LibraryFilters(
                 options = LibraryFilters.parse(p[Keys.LIBRARY_FILTERS]),
-                groupBySeries = p[Keys.LIBRARY_GROUP_BY_SERIES] ?: false,
+                groupBySeries = p[Keys.LIBRARY_GROUP_BY_SERIES] ?: true,
             ),
             eInkMode = EInkMode.fromId(p[Keys.EINK_MODE]),
             definitionTarget = DefinitionTarget.fromId(p[Keys.DEFINITION_TARGET]),
@@ -223,7 +223,7 @@ class AppSettingsRepository(private val context: Context) {
             val filters = edit(
                 LibraryFilters(
                     options = LibraryFilters.parse(p[Keys.LIBRARY_FILTERS]),
-                    groupBySeries = p[Keys.LIBRARY_GROUP_BY_SERIES] ?: false,
+                    groupBySeries = p[Keys.LIBRARY_GROUP_BY_SERIES] ?: true,
                 ),
             )
             p[Keys.LIBRARY_FILTERS] = filters.serialise()

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/LibraryShelf.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/LibraryShelf.kt
@@ -1,0 +1,155 @@
+package com.chmouel.liseur.domain
+
+import com.chmouel.liseur.data.db.Book
+
+/**
+ * One card on the grouped shelf: a book on its own, or a series
+ * standing for its volumes.
+ *
+ * The grouped view is one grid, not a series section over a book
+ * section: a series files under its name between the standalones the
+ * way it would on a wooden shelf, so the reader scans one alphabet, one
+ * recency, not two.
+ */
+sealed interface ShelfEntry {
+    /** Stable identity for the grid, distinct across the two kinds. */
+    val gridKey: String
+
+    data class Single(val book: Book) : ShelfEntry {
+        override val gridKey: String get() = "book:${book.id}"
+    }
+
+    data class Pile(val shelf: SeriesShelf) : ShelfEntry {
+        override val gridKey: String get() = "series:${shelf.key}"
+    }
+}
+
+/**
+ * Folds a library into the entries the grouped shelf draws: one pile
+ * per series in [shelves], one single for every book that belongs to
+ * none of them, the whole lot in the asked-for order.
+ *
+ * A book whose series is on the shelf disappears into its pile — the
+ * pile is where it is now found — while a book naming a series too
+ * small to show ([worthShowing]) stays out as a single, wearing its
+ * series line but not a card of its own.
+ *
+ * [books] and [shelves] arrive already narrowed by search and filters,
+ * each by its own rules: a series survives a search any volume matches,
+ * a book survives on its own name. The fold here must not re-litigate
+ * that, only merge and order.
+ */
+fun mixedShelf(
+    books: List<Book>,
+    shelves: List<SeriesShelf>,
+    sort: LibrarySort,
+    reversed: Boolean = false,
+    readAt: Map<String, Long> = emptyMap(),
+): List<ShelfEntry> {
+    val shown = shelves.mapTo(mutableSetOf()) { it.key }
+    val entries = shelves.map<SeriesShelf, ShelfEntry> { ShelfEntry.Pile(it) } +
+        books.filter { seriesKey(it.seriesName) !in shown }.map { ShelfEntry.Single(it) }
+    return entries.sortedWith(entryComparator(sort, reversed, readAt))
+}
+
+/** The string an entry files under: a book by its title, a pile by its name. */
+private fun ShelfEntry.nameKey(): String = when (this) {
+    is ShelfEntry.Single -> sortKey(book.title)
+    is ShelfEntry.Pile -> sortKey(shelf.name)
+}
+
+private fun ShelfEntry.authorName(): String? = when (this) {
+    is ShelfEntry.Single -> book.displayAuthor
+    is ShelfEntry.Pile -> shelf.author
+}
+
+/**
+ * A pile is as recent as its most recent volume in the best rank any
+ * volume holds — the same rule [SeriesShelf.arrangedBy] uses, so
+ * turning grouping on does not reshuffle what "recent" means.
+ */
+private fun ShelfEntry.recentRank(readAt: Map<String, Long>): Int = when (this) {
+    is ShelfEntry.Single -> book.recentRank(readAt[book.url])
+    is ShelfEntry.Pile ->
+        shelf.volumes.minOfOrNull { it.book.recentRank(readAt[it.book.url]) } ?: 2
+}
+
+private fun ShelfEntry.recentAt(readAt: Map<String, Long>): Long = when (this) {
+    is ShelfEntry.Single -> book.recentAt(readAt[book.url])
+    is ShelfEntry.Pile -> {
+        val rank = recentRank(readAt)
+        shelf.volumes.asSequence()
+            .filter { it.book.recentRank(readAt[it.book.url]) == rank }
+            .maxOfOrNull { it.book.recentAt(readAt[it.book.url]) }
+            ?: 0L
+    }
+}
+
+/** A pile joined the library when its newest volume did. */
+private fun ShelfEntry.addedAt(): Long = when (this) {
+    is ShelfEntry.Single -> book.addedAt
+    is ShelfEntry.Pile -> shelf.volumes.maxOfOrNull { it.book.addedAt } ?: 0L
+}
+
+/** The series an entry files under for [LibrarySort.SERIES], or "". */
+private fun ShelfEntry.seriesSortKey(): String = when (this) {
+    is ShelfEntry.Single -> seriesKey(book.seriesName)
+    is ShelfEntry.Pile -> shelf.key
+}
+
+/**
+ * Orders [ShelfEntry]s the way [arrangedBy] orders books and
+ * [SeriesShelf.arrangedBy] orders shelves, so the mixed grid agrees
+ * with both of the views it replaces. Every order finishes on the name
+ * and then the key, so equal entries keep their places between
+ * launches.
+ */
+private fun entryComparator(
+    sort: LibrarySort,
+    reversed: Boolean,
+    readAt: Map<String, Long>,
+): Comparator<ShelfEntry> {
+    val byName = compareBy<ShelfEntry>({ it.nameKey() }, { it.gridKey })
+
+    return when (sort) {
+        LibrarySort.RECENT -> {
+            val recent = compareBy<ShelfEntry> { it.recentRank(readAt) }
+                .thenByDescending { it.recentAt(readAt) }
+            (if (reversed) recent.reversed() else recent).then(byName)
+        }
+
+        LibrarySort.TITLE ->
+            if (reversed) byName.reversed() else byName
+
+        LibrarySort.AUTHOR -> {
+            val named = compareBy<ShelfEntry> { sortKey(it.authorName()) }
+            val ordered = if (reversed) named.reversed() else named
+            compareBy<ShelfEntry> { if (it.authorName().isNullOrBlank()) 1 else 0 }
+                .then(ordered)
+                .then(byName)
+        }
+
+        LibrarySort.ADDED -> {
+            val added = compareByDescending<ShelfEntry> { it.addedAt() }
+            (if (reversed) added.reversed() else added).then(byName)
+        }
+
+        LibrarySort.SERIES -> {
+            // A pile *is* its series; a single with a series name files
+            // under it too, and a book with none files last, as the
+            // plain shelf has always had it. Reversing reads the series
+            // back to front but never a series' own volumes backwards.
+            val bySeries = compareBy<ShelfEntry> { it.seriesSortKey() }
+            val ordered = if (reversed) {
+                compareByDescending<ShelfEntry> { it.seriesSortKey() }
+            } else {
+                bySeries
+            }
+            compareBy<ShelfEntry> { if (it.seriesSortKey().isEmpty()) 1 else 0 }
+                .then(ordered)
+                .thenBy { (it as? ShelfEntry.Single)?.book?.seriesIndex == null }
+                .thenBy { (it as? ShelfEntry.Single)?.book?.seriesIndex ?: 0.0 }
+                .then(byName)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
@@ -78,6 +78,7 @@ import com.chmouel.liseur.domain.LibraryFilterOption
 import com.chmouel.liseur.domain.LibraryFilters
 import com.chmouel.liseur.domain.LibrarySort
 import com.chmouel.liseur.domain.SeriesShelf
+import com.chmouel.liseur.domain.ShelfEntry
 import com.chmouel.liseur.domain.displayAuthor
 import com.chmouel.liseur.domain.displayTitle
 import androidx.compose.material3.IconButton
@@ -918,14 +919,27 @@ private fun BookGrid(
             }
         }
         if (state.filters.groupBySeries) {
-            items(state.shelfSeries, key = { it.key }) { shelf ->
-                SeriesStackCard(
-                    shelf = shelf,
-                    onClick = { onSeriesSelected(shelf) },
-                    // A pile has no actions of its own on the shelf; the
-                    // long press opens it, which is where they live.
-                    onLongClick = { onSeriesSelected(shelf) },
-                )
+            items(state.shelfEntries, key = { it.gridKey }) { entry ->
+                when (entry) {
+                    is ShelfEntry.Pile -> SeriesStackCard(
+                        shelf = entry.shelf,
+                        onClick = { onSeriesSelected(entry.shelf) },
+                        // A pile has no actions of its own on the shelf;
+                        // the long press opens it, which is where they
+                        // live.
+                        onLongClick = { onSeriesSelected(entry.shelf) },
+                    )
+                    is ShelfEntry.Single -> BookCard(
+                        book = entry.book,
+                        progress = state.downloads[entry.book.url],
+                        // A single here is a book whose series is not on
+                        // the shelf; a pile it belonged to would have
+                        // swallowed it.
+                        inASeries = false,
+                        onClick = { onBookSelected(entry.book) },
+                        onLongClick = { onBookLongPress(entry.book) },
+                    )
+                }
             }
         } else {
             items(state.books, key = { it.id }) { book ->
@@ -1605,11 +1619,12 @@ private fun FilterMenu(
     val filters = state.filters
     val active = LibraryFilterOption.entries.filter { it in filters.options }
     val grouped = stringResource(R.string.filter_group_series)
+    // The grouping is a view mode with a home in Settings, not a
+    // narrowing, so it does not belong in the summary: on by default,
+    // it would caption every library ever opened.
     val summary = when {
-        active.isEmpty() && !filters.groupBySeries -> stringResource(R.string.filter_menu)
-        else -> (if (filters.groupBySeries) listOf(grouped) else emptyList())
-            .plus(active.map { it.label() })
-            .joinToString(" · ")
+        active.isEmpty() -> stringResource(R.string.filter_menu)
+        else -> active.map { it.label() }.joinToString(" · ")
     }
 
     Box(modifier = modifier) {
@@ -1686,7 +1701,10 @@ private fun FilterMenu(
                     onToggle = { onToggleFilter(LibraryFilterOption.ARCHIVED) },
                 )
             }
-            if (!filters.isEmpty) {
+            // On the options, not on [LibraryFilters.isEmpty]: the
+            // grouping no longer clears, so an offer keyed to it would
+            // sit there doing nothing.
+            if (filters.options.isNotEmpty()) {
                 HorizontalDivider()
                 DropdownMenuItem(
                     text = { Text(stringResource(R.string.filter_clear)) },

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryViewModel.kt
@@ -37,6 +37,8 @@ import com.chmouel.liseur.domain.SeriesShelf
 import com.chmouel.liseur.domain.asPickOption
 import com.chmouel.liseur.domain.groupedIntoSeries
 import com.chmouel.liseur.domain.matchesLibrarySearch
+import com.chmouel.liseur.domain.ShelfEntry
+import com.chmouel.liseur.domain.mixedShelf
 import com.chmouel.liseur.domain.movedItem
 import com.chmouel.liseur.domain.renumbered
 import com.chmouel.liseur.domain.seriesKey
@@ -158,6 +160,12 @@ data class LibraryUiState(
      * take the screen they are standing on with it.
      */
     val shelfSeries: List<SeriesShelf> = emptyList(),
+    /**
+     * The grouped grid itself: series piles and standalone books in one
+     * order. Empty unless the grouping is on, because it is only built
+     * for the grid that draws it.
+     */
+    val shelfEntries: List<ShelfEntry> = emptyList(),
     val continueReading: ContinueReading? = null,
     val catalogStatus: CatalogStatus = CatalogStatus.Idle,
     val downloads: Map<String, DownloadProgress> = emptyMap(),
@@ -406,11 +414,6 @@ class LibraryViewModel(
 
             val filteredBooks = sortedBooks
                 .filter { filters.accepts(it, progressions[it.url]) }
-                // Whether a book's series is big enough to be shown is a
-                // property of the group, which [LibraryFilters.accepts]
-                // cannot see from one book. It is applied here, where
-                // the grouping is already in hand.
-                .filter { !filters.groupBySeries || seriesKey(it.seriesName) in shownSeries }
                 .filter { book ->
                     survivesLibrarySearch(
                         query,
@@ -444,17 +447,30 @@ class LibraryViewModel(
                 readAt,
             )
 
+            // A series stands for its volumes, so it survives a
+            // narrowing as long as one of them does: asking for
+            // unread books should leave a part-read series on the
+            // shelf rather than hide the volume that has not been
+            // started.
+            val narrowedSeries = arrangedSeries.filter { shelf ->
+                shelf.volumes.any { filters.accepts(it.book, progressions[it.book.url]) }
+            }
+
             LibraryUiState(
                 loading = false,
                 books = filteredBooks,
                 series = arrangedSeries,
-                // A series stands for its volumes, so it survives a
-                // narrowing as long as one of them does: asking for
-                // unread books should leave a part-read series on the
-                // shelf rather than hide the volume that has not been
-                // started.
-                shelfSeries = arrangedSeries.filter { shelf ->
-                    shelf.volumes.any { filters.accepts(it.book, progressions[it.book.url]) }
+                shelfSeries = narrowedSeries,
+                shelfEntries = if (filters.groupBySeries) {
+                    mixedShelf(
+                        books = filteredBooks,
+                        shelves = narrowedSeries,
+                        sort = settings.librarySort,
+                        reversed = settings.librarySortReversed,
+                        readAt = readAt,
+                    )
+                } else {
+                    emptyList()
                 },
                 continueReading = recent,
                 catalogStatus = catalogStatus,
@@ -510,12 +526,14 @@ class LibraryViewModel(
     fun clearFilters() {
         // The archive is a place rather than a narrowing, so Clear
         // widens the shelf you are standing on instead of walking you
-        // off it without asking.
+        // off it without asking. The grouping survives too: it is a view
+        // mode with a home in Settings, not a filter to be cleared.
         editFilters { stored ->
             LibraryFilters(
                 options = stored.options.filterTo(mutableSetOf()) {
                     it.group == FilterGroup.PLACE
                 },
+                groupBySeries = stored.groupBySeries,
             )
         }
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/SeriesUi.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/SeriesUi.kt
@@ -121,10 +121,11 @@ internal fun SeriesIndexRibbon(index: Double?, modifier: Modifier = Modifier) {
 /**
  * A whole series as one card: a pile of books rather than a book.
  *
- * The cover shown is the volume you would open next, and behind it two
- * offset slivers stand for the rest of the pile — which is what makes a
- * series legible at shelf-scanning speed, before any of the text is
- * read. The count sits on the corner, and a rail along the bottom fills
+ * The cover shown is the volume you would open next, and behind it the
+ * real covers of the other volumes peek out, stepped and faded — which
+ * is what makes a series legible at shelf-scanning speed, before any of
+ * the text is read. The count sits on the corner, and a rail along the
+ * bottom fills
  * in a segment per volume finished, so how far through a series you are
  * is answerable without opening it.
  *
@@ -166,26 +167,50 @@ internal fun SeriesStackCard(
                 // the card next to it.
                 .aspectRatio(2f / 3f * 0.92f),
         ) {
-            // The two behind, furthest first. Insets rather than
-            // rotations: a fan of tilted covers looks like a mistake at
-            // this size, and a stepped pile reads instantly.
+            // The volumes the pile is made of, peeking out behind the
+            // front cover: their real artwork, furthest first, each
+            // faded towards the surface so the front cover stays the
+            // loudest thing on the card. Insets rather than rotations: a
+            // fan of tilted covers looks like a mistake at this size,
+            // and a stepped pile reads instantly.
+            val backers = shelf.volumes
+                .map { it.book }
+                .filter { it.id != shelf.cover.id }
+                .take(2)
+            val shape = RoundedCornerShape(10.dp)
+            val surface = MaterialTheme.colorScheme.surface
             repeat(2) { layer ->
                 val depth = (2 - layer)
+                val backer = backers.getOrNull(depth - 1)
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(start = (depth * 5).dp, bottom = (depth * 5).dp)
                         .padding(start = (10 - depth * 5).dp, top = (10 - depth * 5).dp)
-                        .clip(RoundedCornerShape(10.dp))
+                        .clip(shape)
                         .background(
                             if (eInk) Color.Transparent
                             else MaterialTheme.colorScheme.surfaceVariant,
                         )
                         .border(
                             BorderStroke(1.dp, outline.copy(alpha = if (eInk) 0.9f else 0.5f)),
-                            RoundedCornerShape(10.dp),
+                            shape,
                         ),
-                )
+                ) {
+                    // On e-paper the pile stays an outline: the fade
+                    // relies on translucency, which sixteen greys and no
+                    // compositing to speak of turn into smudge.
+                    if (backer != null && !eInk) {
+                        BookCover(book = backer, modifier = Modifier.fillMaxSize())
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(
+                                    surface.copy(alpha = if (depth == 2) 0.55f else 0.35f),
+                                ),
+                        )
+                    }
+                }
             }
             BookCover(
                 book = shelf.cover,

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
@@ -88,6 +88,7 @@ fun SettingsScreen(
     onEInkMode: (EInkMode) -> Unit,
     onResumeLastBook: (Boolean) -> Unit,
     onKeepScreenOn: (Boolean) -> Unit,
+    onGroupSeries: (Boolean) -> Unit,
     onDefinitionTarget: (DefinitionTarget) -> Unit,
     onDictionaryLookup: (Boolean) -> Unit,
     onDictionaryBaseUrl: (String) -> Unit,
@@ -223,6 +224,15 @@ fun SettingsScreen(
                             )
                         } ?: stringResource(R.string.settings_account_detail),
                         onClick = onOpenAccount,
+                    )
+                }
+
+                SettingsGroup(stringResource(R.string.settings_library)) {
+                    SwitchRow(
+                        title = stringResource(R.string.settings_group_series),
+                        subtitle = stringResource(R.string.settings_group_series_detail),
+                        checked = settings.libraryFilters.groupBySeries,
+                        onCheckedChange = onGroupSeries,
                     )
                 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -328,6 +328,8 @@
     <string name="settings_dictionary_site_invalid">Needs to be an https address, like https://fr.wiktionary.org</string>
     <string name="settings_dictionary_site_reset">Use the default</string>
     <string name="settings_library">Library</string>
+    <string name="settings_group_series">Group series</string>
+    <string name="settings_group_series_detail">Show the books of a series as one pile on the shelf, alongside your other books.</string>
     <string name="settings_remote_library">Remote libraries</string>
     <string name="settings_export_import">Export and import</string>
     <string name="settings_library_help_title">Book servers</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/LibraryShelfTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/LibraryShelfTest.kt
@@ -1,0 +1,182 @@
+package com.chmouel.liseur.domain
+
+import com.chmouel.liseur.data.db.Book
+import com.chmouel.liseur.data.db.DownloadState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LibraryShelfTest {
+
+    private fun book(
+        title: String,
+        series: String? = null,
+        index: Double? = null,
+        author: String? = "Someone",
+        addedAt: Long = 0,
+        lastOpenedAt: Long? = null,
+        state: DownloadState = DownloadState.DOWNLOADED,
+    ) = Book(
+        url = "https://example.test/$title",
+        title = title,
+        author = author,
+        coverPath = null,
+        source = null,
+        addedAt = addedAt,
+        lastOpenedAt = lastOpenedAt,
+        downloadState = state,
+        seriesName = series,
+        seriesIndex = index,
+    )
+
+    private fun List<ShelfEntry>.names(): List<String> = map {
+        when (it) {
+            is ShelfEntry.Single -> it.book.title
+            is ShelfEntry.Pile -> it.shelf.name
+        }
+    }
+
+    private fun shelves(books: List<Book>): List<SeriesShelf> =
+        books.groupedIntoSeries().worthShowing()
+
+    @Test
+    fun `a series files between the standalones under its name`() {
+        val books = listOf(
+            book("Anna Karenina"),
+            book("Leviathan Wakes", series = "The Expanse", index = 1.0),
+            book("Caliban's War", series = "The Expanse", index = 2.0),
+            book("Zorba the Greek"),
+        )
+        val entries = mixedShelf(books, shelves(books), LibrarySort.TITLE)
+
+        assertEquals(
+            listOf("Anna Karenina", "The Expanse", "Zorba the Greek"),
+            entries.names(),
+        )
+        assertTrue(entries[1] is ShelfEntry.Pile)
+    }
+
+    @Test
+    fun `a book whose series is on the shelf is folded into its pile`() {
+        val books = listOf(
+            book("Leviathan Wakes", series = "The Expanse", index = 1.0),
+            book("Caliban's War", series = "The Expanse", index = 2.0),
+        )
+        val entries = mixedShelf(books, shelves(books), LibrarySort.TITLE)
+
+        assertEquals(1, entries.size)
+        assertTrue(entries.single() is ShelfEntry.Pile)
+    }
+
+    @Test
+    fun `a book of a series too small to show stays a single`() {
+        val books = listOf(
+            book("Dune", series = "Dune Chronicles", index = 1.0),
+            book("Emma"),
+        )
+        // No shelf worth showing: Dune Chronicles has one volume.
+        val entries = mixedShelf(books, shelves(books), LibrarySort.TITLE)
+
+        assertEquals(listOf("Dune", "Emma"), entries.names())
+        assertTrue(entries.all { it is ShelfEntry.Single })
+    }
+
+    @Test
+    fun `title order reversed reads back to front`() {
+        val books = listOf(
+            book("Anna Karenina"),
+            book("Leviathan Wakes", series = "The Expanse", index = 1.0),
+            book("Caliban's War", series = "The Expanse", index = 2.0),
+            book("Zorba the Greek"),
+        )
+        val entries = mixedShelf(books, shelves(books), LibrarySort.TITLE, reversed = true)
+
+        assertEquals(
+            listOf("Zorba the Greek", "The Expanse", "Anna Karenina"),
+            entries.names(),
+        )
+    }
+
+    @Test
+    fun `recent order lifts the pile with the volume being read`() {
+        val books = listOf(
+            book("Anna Karenina", lastOpenedAt = 50),
+            book("Leviathan Wakes", series = "The Expanse", index = 1.0, lastOpenedAt = 100),
+            book("Caliban's War", series = "The Expanse", index = 2.0),
+            book("Zorba the Greek", state = DownloadState.REMOTE),
+        )
+        val entries = mixedShelf(books, shelves(books), LibrarySort.RECENT)
+
+        assertEquals(
+            listOf("The Expanse", "Anna Karenina", "Zorba the Greek"),
+            entries.names(),
+        )
+    }
+
+    @Test
+    fun `added order dates a pile by its newest volume`() {
+        val books = listOf(
+            book("Anna Karenina", addedAt = 500),
+            book("Leviathan Wakes", series = "The Expanse", index = 1.0, addedAt = 100),
+            book("Caliban's War", series = "The Expanse", index = 2.0, addedAt = 900),
+        )
+        val entries = mixedShelf(books, shelves(books), LibrarySort.ADDED)
+
+        assertEquals(listOf("The Expanse", "Anna Karenina"), entries.names())
+    }
+
+    @Test
+    fun `author order files the authorless last`() {
+        val books = listOf(
+            book("Orphan", author = null),
+            book("Leviathan Wakes", series = "The Expanse", index = 1.0, author = "James Corey"),
+            book("Caliban's War", series = "The Expanse", index = 2.0, author = "James Corey"),
+            book("Anna Karenina", author = "Leo Tolstoy"),
+        )
+        val entries = mixedShelf(books, shelves(books), LibrarySort.AUTHOR)
+
+        assertEquals(
+            listOf("The Expanse", "Anna Karenina", "Orphan"),
+            entries.names(),
+        )
+    }
+
+    @Test
+    fun `series order puts the seriesless last and keeps small series filed`() {
+        val books = listOf(
+            book("Emma"),
+            book("Leviathan Wakes", series = "The Expanse", index = 1.0),
+            book("Caliban's War", series = "The Expanse", index = 2.0),
+            book("Dune", series = "Dune Chronicles", index = 1.0),
+        )
+        val entries = mixedShelf(books, shelves(books), LibrarySort.SERIES)
+
+        assertEquals(listOf("Dune", "The Expanse", "Emma"), entries.names())
+    }
+
+    @Test
+    fun `a filtered-out volume does not resurface as a single`() {
+        val all = listOf(
+            book("Leviathan Wakes", series = "The Expanse", index = 1.0),
+            book("Caliban's War", series = "The Expanse", index = 2.0),
+        )
+        // The filter kept only one volume, but the pile is still shown:
+        // the survivor must fold into it, not stand beside it.
+        val entries = mixedShelf(all.take(1), shelves(all), LibrarySort.TITLE)
+
+        assertEquals(1, entries.size)
+        assertTrue(entries.single() is ShelfEntry.Pile)
+    }
+
+    @Test
+    fun `grid keys are distinct across kinds`() {
+        val books = listOf(
+            book("Emma"),
+            book("Leviathan Wakes", series = "The Expanse", index = 1.0),
+            book("Caliban's War", series = "The Expanse", index = 2.0),
+        )
+        val entries = mixedShelf(books, shelves(books), LibrarySort.TITLE)
+
+        assertEquals(entries.size, entries.map { it.gridKey }.toSet().size)
+    }
+}


### PR DESCRIPTION

This pull request introduces a major update to how the library shelf is displayed and managed, focusing on grouping books by series as a default, improving the UI for grouped series, and clarifying the distinction between view modes and filters. The key changes include a new `ShelfEntry` abstraction for unified shelf rendering, a new algorithm for mixing standalone books and series in the grid, UI improvements for series piles, and updates to settings and filter logic.

**Library shelf grouping and display:**

* Introduced the `ShelfEntry` sealed interface and the `mixedShelf` function in `LibraryShelf.kt` to represent and order both standalone books and series piles in a single, unified grid. This enables a mixed view where series and single books are interleaved according to the chosen sort order.
* Updated the `LibraryViewModel` and `LibraryUiState` to compute and expose `shelfEntries` when grouping is enabled, using the new `mixedShelf` logic, and to ensure series piles and standalone books are displayed together. [[1]](diffhunk://#diff-bd3bd7e1c539f3aeae6066d9beb3a627a231de6bacdc6eb72790245d35361589R163-R168) [[2]](diffhunk://#diff-bd3bd7e1c539f3aeae6066d9beb3a627a231de6bacdc6eb72790245d35361589L409-L413) [[3]](diffhunk://#diff-bd3bd7e1c539f3aeae6066d9beb3a627a231de6bacdc6eb72790245d35361589L447-R473)
* Modified the `BookGrid` UI in `LibraryScreen.kt` to render the new `ShelfEntry` types, showing either a `SeriesStackCard` for a series pile or a `BookCard` for a standalone book.

**Settings and filter behavior:**

* Added a new toggle in the Settings screen for grouping books by series, with grouping now enabled by default for new users. Grouping is now treated as a view mode rather than a filter, so it is not cleared with other filters and does not appear in filter summaries. [[1]](diffhunk://#diff-35ab09f0dd2c16760942462b262b7d55c958395bb721177e1a152967688263a2R254-R258) [[2]](diffhunk://#diff-c4f0c74bcc5b5d00e45525d57386a83258ebfdf6473dac366d5d716ab0204231R91) [[3]](diffhunk://#diff-c4f0c74bcc5b5d00e45525d57386a83258ebfdf6473dac366d5d716ab0204231R230-R238) [[4]](diffhunk://#diff-2f1b6c7604cd27c6d12cc515936aaecc53983f475fe2282c97624d89628938beL167-R167) [[5]](diffhunk://#diff-2f1b6c7604cd27c6d12cc515936aaecc53983f475fe2282c97624d89628938beL226-R226) [[6]](diffhunk://#diff-bd3bd7e1c539f3aeae6066d9beb3a627a231de6bacdc6eb72790245d35361589L513-R536) [[7]](diffhunk://#diff-14c62fd194c48b52b419319e6db83155e6d332bf0e589f40781f6526f0731bbfR1622-R1627) [[8]](diffhunk://#diff-14c62fd194c48b52b419319e6db83155e6d332bf0e589f40781f6526f0731bbfL1689-R1707)

**UI improvements for series piles:**

* Enhanced the `SeriesStackCard` to show the real covers of other volumes in the pile, stepped and faded behind the main cover, for better visual clarity and legibility. [[1]](diffhunk://#diff-f58e145c6c1133e63901c3a7fd5584cb6b324af42cd0b7c294d577d230af6901L124-R128) [[2]](diffhunk://#diff-f58e145c6c1133e63901c3a7fd5584cb6b324af42cd0b7c294d577d230af6901L169-R214)

**Other minor changes:**

* Updated imports and refactored code to support the new abstractions and logic. [[1]](diffhunk://#diff-14c62fd194c48b52b419319e6db83155e6d332bf0e589f40781f6526f0731bbfR81) [[2]](diffhunk://#diff-bd3bd7e1c539f3aeae6066d9beb3a627a231de6bacdc6eb72790245d35361589R40-R41)

These changes collectively provide a more intuitive and visually appealing library shelf, with improved handling of series and clearer separation between filtering and view modes.

<img width="946" height="2115" alt="image" src="https://github.com/user-attachments/assets/9e7506c1-eb22-4c81-a99f-a52fbe4995e9" />