### PR TITLE
feat: Add per-book scroll reading mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,29 @@ An open-source EPUB reader and [calibre-web](https://github.com/janeczku/calibre
 
 ## About Liseur
 
-[Liseur](#whats-in-a-name) is designed to get out of the way and let you read. Pages open cleanly from edge to edge with the Readium engine, set in open typefaces like Literata, Vollkorn, Atkinson Hyperlegible, and Inter, or whatever quirky typography the publisher insisted on. Four dedicated reading themes (Light, Sepia, Dark, and true OLED Black) let you settle into a story at 2 a.m. without being blinded by your phone. Margins, line spacing, brightness, and page turns stay quietly out of your way. A discreet footer shows the time remaining in the chapter (just enough to convince yourself that one more chapter won't hurt), while highlights, margin notes, bookmarks, and instant dictionary lookups remain right under your fingers when you stumble upon a word you pretend to know.
+[Liseur](#whats-in-a-name) is designed to get out of the way and let you read.
+Pages open cleanly from edge to edge with the Readium engine, set in open
+typefaces like Literata, Vollkorn, Atkinson Hyperlegible, and Inter, or
+whatever quirky typography the publisher insisted on. Four dedicated reading
+themes (Light, Sepia, Dark, and true OLED Black) let you settle into a story at
+2 a.m. without being blinded by your phone. Margins, line spacing, brightness,
+and page turns stay quietly out of your way. Prefer one long scroll to turning
+pages? Switch it on for the whole library, or for the one book that wants it,
+and keep scrolling past the end of a chapter to fall into the next one.
+
+A discreet footer shows the time remaining in the chapter (just enough to
+convince yourself that one more chapter won't hurt), while highlights, margin
+notes, bookmarks, and instant dictionary lookups remain right under your
+fingers when you stumble upon a word you pretend to know.
 
 Your library gathers onto a single shelf, whether your books live in messy folders on your phone or on a self-hosted [calibre-web](https://github.com/janeczku/calibre-web), [Komga](https://komga.org) or [liseur-sync](https://github.com/chmouel/liseur-sync) server. Books that belong to a series politely group into compact stacks that track your reading order, your progress, and the missing volumes you still need to hunt down. When you reach the final page of a novel, the next volume is already sitting there, gently enabling your binge-reading habits.
 
 When you switch between devices, you have the choice to have your place travel with you across your devices. Two-way synchronization with [calibre-web](https://github.com/janeczku/calibre-web), [Komga](https://komga.org) and [liseur-sync](https://github.com/chmouel/liseur-sync) keeps your progress aligned — down to the exact sentence on Komga and liseur-sync, so you never have to play the guessing game of where you were. liseur-sync goes one further: standalone EPUB files that never came from a catalog sync their position too, matched by the file itself. Its books come from folders it watches on the server, so anything you drop there shows up on the shelf.
 
-Everything runs privately and without distraction. There are no trackers, no analytics, no ads, and no attempts to sell you a monthly subscription for books you already own. Liseur only talks to the book servers and dictionary sources you choose to add.
+Everything runs privately and without distraction. There are no trackers, no
+analytics, no ads, and no attempts to sell you a monthly subscription for books
+you already own. Liseur only talks to the book servers and dictionary sources
+you choose to add.
 
 ## Install
 
@@ -76,7 +92,7 @@ See [DEVELOPER.md](DEVELOPER.md) for build instructions and architecture notes.
 
 ## What's in a name?
 
-**Liseur** ([li.zœʁ], *lee-ZUR*) is the French word for an avid reader or book lover. It sounds dignified, which is useful when you are caught reading under the covers well past bedtime.
+**Liseur** ([li.zœʁ], *lee-ZUR*) is the French word for an avid reader or book lover. It sounds dignified just like the English word *leisure*, which is exactly what you should be doing when you curl up with a good book.
 
 ## Author
 

--- a/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/34.json
+++ b/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/34.json
@@ -1,0 +1,1061 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 34,
+    "identityHash": "1898d1f633a2ec70e0126b0a3853347b",
+    "entities": [
+      {
+        "tableName": "reading_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `total_progression` REAL, `reading_speed` REAL, `reading_seconds_per_position` REAL, `reading_pace_samples` INTEGER NOT NULL DEFAULT 0, `reading_pace_elapsed_ms` INTEGER NOT NULL DEFAULT 0, `reading_pace_evidence` REAL NOT NULL DEFAULT 0, `updated_at` INTEGER NOT NULL, `status` TEXT, `synced_at` INTEGER, `local_revision` INTEGER NOT NULL DEFAULT 0, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `agreed_account` TEXT, `pending_progression` REAL, `pending_status` TEXT, `pending_updated_at` INTEGER, `pending_account` TEXT, `owner_account` TEXT, `remote_updated_at` INTEGER, `finished_override` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSpeed",
+            "columnName": "reading_speed",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSecondsPerPosition",
+            "columnName": "reading_seconds_per_position",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingPaceSamples",
+            "columnName": "reading_pace_samples",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceElapsedMs",
+            "columnName": "reading_pace_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceEvidence",
+            "columnName": "reading_pace_evidence",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localRevision",
+            "columnName": "local_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "agreedAccount",
+            "columnName": "agreed_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingAccount",
+            "columnName": "pending_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ownerAccount",
+            "columnName": "owner_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "finishedOverride",
+            "columnName": "finished_override",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `cover_path` TEXT, `source` TEXT, `added_at` INTEGER NOT NULL, `last_opened_at` INTEGER, `local_uri` TEXT, `remote_uuid` TEXT, `remote_book_id` INTEGER, `cover_url` TEXT, `download_href` TEXT, `download_state` TEXT NOT NULL, `remote_updated_at` INTEGER, `downloaded_at` INTEGER, `file_modified_at` INTEGER, `work_id` TEXT, `finished_at` INTEGER, `archived_at` INTEGER, `remote_page_count` INTEGER, `series_name` TEXT, `series_index` REAL, `file_series_name` TEXT, `file_series_index` REAL, `series_id` TEXT, `series_checked` INTEGER NOT NULL, `catalog_series_name` TEXT, `catalog_series_index` REAL, `catalog_folder_id` TEXT, `catalog_series_source` TEXT, `user_series_name` TEXT, `user_series_index` REAL, `series_override` INTEGER NOT NULL, `user_series_updated_at` INTEGER, `series_claim_pending` INTEGER NOT NULL, `series_claim_reset` INTEGER NOT NULL, `personal_series_updated_at` INTEGER, `series_index_override` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "last_opened_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localUri",
+            "columnName": "local_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUuid",
+            "columnName": "remote_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteBookId",
+            "columnName": "remote_book_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadHref",
+            "columnName": "download_href",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadState",
+            "columnName": "download_state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloaded_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finished_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archived_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remotePageCount",
+            "columnName": "remote_page_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fileSeriesName",
+            "columnName": "file_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileSeriesIndex",
+            "columnName": "file_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesChecked",
+            "columnName": "series_checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSeriesName",
+            "columnName": "catalog_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesIndex",
+            "columnName": "catalog_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "catalogFolderId",
+            "columnName": "catalog_folder_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesSource",
+            "columnName": "catalog_series_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesName",
+            "columnName": "user_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesIndex",
+            "columnName": "user_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesOverridden",
+            "columnName": "series_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userSeriesUpdatedAt",
+            "columnName": "user_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesClaimPending",
+            "columnName": "series_claim_pending",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesClaimReset",
+            "columnName": "series_claim_reset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personalSeriesUpdatedAt",
+            "columnName": "personal_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "indexOverridden",
+            "columnName": "series_index_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_books_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_books_url` ON `${TABLE_NAME}` (`url`)"
+          },
+          {
+            "name": "index_books_series_name",
+            "unique": false,
+            "columnNames": [
+              "series_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_series_name` ON `${TABLE_NAME}` (`series_name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "library_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `added_at` INTEGER NOT NULL, PRIMARY KEY(`url`))",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "url"
+          ]
+        }
+      },
+      {
+        "tableName": "remote_server",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `kind` TEXT NOT NULL, `base_url` TEXT NOT NULL, `username` TEXT, `password_cipher` TEXT, `api_key_cipher` TEXT, `account_id` TEXT, `user_id` INTEGER, `kobo_token` TEXT, `can_download` INTEGER NOT NULL, `can_manage_library` INTEGER NOT NULL, `can_admin` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `catalog_synced_at` INTEGER, `position_synced_at` INTEGER, `sync_token` TEXT, `liseur_token_cipher` TEXT, `liseur_account_id` TEXT, `sync_cursor_seq` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "passwordCipher",
+            "columnName": "password_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiKeyCipher",
+            "columnName": "api_key_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "koboTokenCipher",
+            "columnName": "kobo_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "canDownload",
+            "columnName": "can_download",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canManageLibrary",
+            "columnName": "can_manage_library",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canAdmin",
+            "columnName": "can_admin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSyncedAt",
+            "columnName": "catalog_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "positionSyncedAt",
+            "columnName": "position_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncToken",
+            "columnName": "sync_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurTokenCipher",
+            "columnName": "liseur_token_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurAccountId",
+            "columnName": "liseur_account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncCursorSeq",
+            "columnName": "sync_cursor_seq",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `book_id` TEXT NOT NULL, `kind` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `text` TEXT, `note` TEXT, `tint` TEXT, `chapter` TEXT, `position` INTEGER, `total_progression` REAL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tint",
+            "columnName": "tint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapter",
+            "columnName": "chapter",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_typography",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `font` TEXT NOT NULL, `font_size` REAL NOT NULL, `line_height` REAL, `page_margins` REAL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "font",
+            "columnName": "font",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "font_size",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineHeight",
+            "columnName": "line_height",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pageMargins",
+            "columnName": "page_margins",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_screen",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `keep_screen_on` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keepScreenOn",
+            "columnName": "keep_screen_on",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_reading_mode",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `scroll` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scroll",
+            "columnName": "scroll",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `book_url` TEXT NOT NULL, `started_at` INTEGER NOT NULL, `ended_at` INTEGER, `last_checkpoint_at` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `start_progression` REAL, `end_progression` REAL, `uploaded_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "ended_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastCheckpointAt",
+            "columnName": "last_checkpoint_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startProgression",
+            "columnName": "start_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "endProgression",
+            "columnName": "end_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "uploadedAt",
+            "columnName": "uploaded_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_sessions_book_url",
+            "unique": false,
+            "columnNames": [
+              "book_url"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_book_url` ON `${TABLE_NAME}` (`book_url`)"
+          },
+          {
+            "name": "index_reading_sessions_started_at",
+            "unique": false,
+            "columnNames": [
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_started_at` ON `${TABLE_NAME}` (`started_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_peer_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `pending_progression` REAL, `pending_status` TEXT, `pending_updated_at` INTEGER, `has_pending` INTEGER NOT NULL DEFAULT 0, `remote_updated_at` INTEGER, `synced_at` INTEGER, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasPending",
+            "columnName": "has_pending",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_peer_state_peer_id",
+            "unique": false,
+            "columnNames": [
+              "peer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_peer_state_peer_id` ON `${TABLE_NAME}` (`peer_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_fingerprint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `sha256` TEXT NOT NULL, `partial_md5` TEXT NOT NULL, `file_size` INTEGER NOT NULL, `file_modified_at` INTEGER, `computed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256",
+            "columnName": "sha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partialMd5",
+            "columnName": "partial_md5",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "computedAt",
+            "columnName": "computed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "work_alias",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_id` TEXT NOT NULL, `confidence` TEXT NOT NULL, `confirmed` INTEGER NOT NULL, `seeded` INTEGER NOT NULL DEFAULT 0, `source_sent` INTEGER NOT NULL DEFAULT 0, `edition_sha` TEXT, `resolved_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confirmed",
+            "columnName": "confirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seeded",
+            "columnName": "seeded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceSent",
+            "columnName": "source_sent",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "editionSha",
+            "columnName": "edition_sha",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resolvedAt",
+            "columnName": "resolved_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "work_ambiguity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_ids` TEXT NOT NULL, `noticed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workIds",
+            "columnName": "work_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noticedAt",
+            "columnName": "noticed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_extra",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`series_id` TEXT NOT NULL, `summary` TEXT, `status` TEXT, `total_book_count` INTEGER, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`series_id`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalBookCount",
+            "columnName": "total_book_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "series_id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1898d1f633a2ec70e0126b0a3853347b')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -256,6 +256,7 @@ private fun LiseurApp(settings: AppSettings) {
                         repository.editLibraryFilters { it.copy(groupBySeries = grouped) }
                     }
                 },
+                onScrollMode = { scope.launch { repository.setScrollMode(it) } },
                 onDefinitionTarget = {
                     scope.launch { repository.setDefinitionTarget(it) }
                 },

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/BookReadingMode.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/BookReadingMode.kt
@@ -1,0 +1,44 @@
+package com.chmouel.liseur.data.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * One book's own answer to whether it is read by scrolling.
+ *
+ * Turning pages or scrolling is mostly a habit, which is why Settings
+ * answers it for the whole library. Some books ask for the other one all
+ * the same: a technical manual read by hunting through it scrolls, a
+ * novel read straight through turns pages. Flipping the switch inside a
+ * book sets that book apart without moving the rest.
+ *
+ * A row means the book has been answered for, and it stays answered for:
+ * the app-wide setting can change afterwards without undoing a switch
+ * flipped by hand. No row means the book follows the app-wide setting,
+ * and keeps following it as that setting changes.
+ */
+@Entity(tableName = "book_reading_mode")
+data class BookReadingMode(
+    @PrimaryKey @ColumnInfo(name = "book_url") val bookUrl: String,
+    @ColumnInfo(name = "scroll") val scroll: Boolean,
+)
+
+/**
+ * Whether this book is read by scrolling, given what the app-wide
+ * setting says for everything that has not been answered for.
+ */
+fun BookReadingMode?.scrollsWith(global: Boolean): Boolean = this?.scroll ?: global
+
+@Dao
+interface BookReadingModeDao {
+    @Query("SELECT * FROM book_reading_mode WHERE book_url = :bookUrl")
+    fun observe(bookUrl: String): Flow<BookReadingMode?>
+
+    @Upsert
+    suspend fun upsert(mode: BookReadingMode)
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
@@ -16,6 +16,7 @@ import androidx.sqlite.execSQL
         BookAnnotation::class,
         BookTypography::class,
         BookScreen::class,
+        BookReadingMode::class,
         ReadingSession::class,
         SyncPeerState::class,
         BookFingerprintRow::class,
@@ -23,7 +24,7 @@ import androidx.sqlite.execSQL
         WorkAmbiguity::class,
         SeriesExtra::class,
     ],
-    version = 33,
+    version = 34,
     exportSchema = true,
 )
 abstract class LiseurDatabase : RoomDatabase() {
@@ -39,6 +40,7 @@ abstract class LiseurDatabase : RoomDatabase() {
     abstract fun annotationDao(): BookAnnotationDao
     abstract fun typographyDao(): BookTypographyDao
     abstract fun bookScreenDao(): BookScreenDao
+    abstract fun bookReadingModeDao(): BookReadingModeDao
     abstract fun seriesExtraDao(): SeriesExtraDao
 
     companion object {
@@ -942,6 +944,24 @@ abstract class LiseurDatabase : RoomDatabase() {
         }
 
         /**
+         * Lets a single book be read by scrolling, or by turning pages,
+         * against whatever the app-wide setting says.
+         */
+        val MIGRATION_33_34 = object : Migration(33, 34) {
+            override fun migrate(connection: SQLiteConnection) {
+                connection.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `book_reading_mode` (
+                        `book_url` TEXT NOT NULL,
+                        `scroll` INTEGER NOT NULL,
+                        PRIMARY KEY(`book_url`)
+                    )
+                    """.trimIndent(),
+                )
+            }
+        }
+
+        /**
          * Every migration, in order, as one list so that what the app
          * runs and what the tests replay cannot drift apart.
          */
@@ -978,6 +998,7 @@ abstract class LiseurDatabase : RoomDatabase() {
             MIGRATION_30_31,
             MIGRATION_31_32,
             MIGRATION_32_33,
+            MIGRATION_33_34,
         )
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
@@ -86,6 +86,9 @@ enum class DefinitionTarget(val id: String) {
  * @param keepScreenOn The screen stays awake while a book is open. Off
  *   until asked for: it costs battery, and it overrides a device setting
  *   the reader chose themselves.
+ * @param scrollMode Books are read by scrolling rather than by turning
+ *   pages. The default for the whole library; a book read the other way
+ *   is set apart from inside it.
  * @param librarySort How the library grid is arranged.
  * @param librarySortReversed The library order read back to front.
  * @param libraryFilters What the library grid is narrowed to.
@@ -105,6 +108,7 @@ data class AppSettings(
     val volumeKeysTurnPages: Boolean = true,
     val resumeLastBook: Boolean = true,
     val keepScreenOn: Boolean = false,
+    val scrollMode: Boolean = false,
     val librarySort: LibrarySort = LibrarySort.Default,
     val librarySortReversed: Boolean = false,
     val libraryFilters: LibraryFilters = LibraryFilters.None,
@@ -127,6 +131,7 @@ class AppSettingsRepository(private val context: Context) {
         val VOLUME_KEYS = booleanPreferencesKey("volume_keys_turn_pages")
         val RESUME_LAST_BOOK = booleanPreferencesKey("resume_last_book")
         val KEEP_SCREEN_ON = booleanPreferencesKey("keep_screen_on")
+        val SCROLL_MODE = booleanPreferencesKey("scroll_mode")
         val LIBRARY_SORT = stringPreferencesKey("library_sort")
         val LIBRARY_SORT_REVERSED = booleanPreferencesKey("library_sort_reversed")
         val LIBRARY_FILTERS = stringPreferencesKey("library_filters")
@@ -160,6 +165,7 @@ class AppSettingsRepository(private val context: Context) {
             volumeKeysTurnPages = p[Keys.VOLUME_KEYS] ?: true,
             resumeLastBook = p[Keys.RESUME_LAST_BOOK] ?: true,
             keepScreenOn = p[Keys.KEEP_SCREEN_ON] ?: false,
+            scrollMode = p[Keys.SCROLL_MODE] ?: false,
             librarySort = LibrarySort.fromId(p[Keys.LIBRARY_SORT]),
             librarySortReversed = p[Keys.LIBRARY_SORT_REVERSED] ?: false,
             libraryFilters = LibraryFilters(
@@ -194,6 +200,10 @@ class AppSettingsRepository(private val context: Context) {
 
     suspend fun setKeepScreenOn(enabled: Boolean) {
         context.appSettingsStore.edit { it[Keys.KEEP_SCREEN_ON] = enabled }
+    }
+
+    suspend fun setScrollMode(enabled: Boolean) {
+        context.appSettingsStore.edit { it[Keys.SCROLL_MODE] = enabled }
     }
 
     suspend fun setLibrarySort(sort: LibrarySort) {

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
@@ -115,14 +115,24 @@ class ReaderActivity : FragmentActivity() {
                             // Rotating a tablet into a narrow window is the
                             // same event, which is why the width goes through
                             // effectiveFor() rather than being read once.
+                            //
+                            // Scrolling is a key for the same reason: whether
+                            // page turns are disabled is fixed when the
+                            // navigator is configured, and turning scrolling on
+                            // has to take the sideways chapter jumps with it.
                             val prefs by viewModel.prefs.collectAsStateWithLifecycle()
+                            val scrollMode by viewModel.scrollMode.collectAsStateWithLifecycle()
                             val columnMode = prefs.columnMode.effectiveFor(widthClass())
-                            remember(s.navigatorFactory, columnMode) {
+                            remember(s.navigatorFactory, columnMode, scrollMode) {
                                 s.navigatorFactory.createFragmentFactory(
                                     initialLocator = viewModel.lastLocator ?: s.initialLocator,
-                                    initialPreferences = prefs.toEpubPreferences(columnMode),
+                                    initialPreferences = prefs.toEpubPreferences(
+                                        columnMode = columnMode,
+                                        scroll = scrollMode,
+                                    ),
                                     configuration = epubNavigatorConfiguration(
                                         columnMode = columnMode,
+                                        scroll = scrollMode,
                                         onTextSelected = viewModel::onTextSelected,
                                     ),
                                 ).also { supportFragmentManager.fragmentFactory = it }
@@ -144,6 +154,8 @@ class ReaderActivity : FragmentActivity() {
                                 onNavigatorChanged = { navigator = it },
                                 keepScreenOnFlow = viewModel.keepScreenOn,
                                 onKeepScreenOnChanged = viewModel::setKeepScreenOn,
+                                scrollModeFlow = viewModel.scrollMode,
+                                onScrollModeChanged = viewModel::setScrollMode,
                                 onPageTurnerChanged = { pageTurner = it },
                                 onChromeVisibleChanged = { chromeVisible = it },
                                 onPrefsAction = remember {

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapper.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapper.kt
@@ -21,14 +21,22 @@ import org.readium.r2.navigator.preferences.FontFamily
 import org.readium.r2.navigator.preferences.Theme
 import org.readium.r2.shared.ExperimentalReadiumApi
 
-/** Maps the app's reading preferences onto Readium's EPUB preferences. */
+/**
+ * Maps the app's reading preferences onto Readium's EPUB preferences.
+ *
+ * [scroll] is not part of [ReaderPrefs]: it is answered per book against
+ * an app-wide default, so it arrives from the reader's own flow rather
+ * than from the shared reading settings.
+ */
 @OptIn(ExperimentalReadiumApi::class)
 fun ReaderPrefs.toEpubPreferences(
     columnMode: ColumnMode = this.columnMode,
+    scroll: Boolean = false,
 ): EpubPreferences =
     EpubPreferences(
         fontFamily = font.cssName?.let { FontFamily(it) },
         fontSize = fontSize,
+        scroll = scroll,
         theme = when (theme) {
             ReaderTheme.LIGHT -> Theme.LIGHT
             ReaderTheme.SEPIA -> Theme.SEPIA
@@ -122,14 +130,21 @@ fun ColumnMode.effectiveFor(widthClass: WidthClass): ColumnMode = when {
  * The system's own selection menu is refused so the app can put its own
  * bar next to the words instead: the platform bar floats where it likes,
  * offers actions a book has no use for, and cannot show highlight colours.
+ *
+ * [scroll] switches off Readium's page turns, which in a scrolled book
+ * are a whole chapter at a time: a sideways swipe would throw the reader
+ * out of the chapter they are in the middle of, and the volume keys are
+ * given a screenful of scrolling instead (see `PageTurner`).
  */
 @OptIn(ExperimentalReadiumApi::class)
 fun epubNavigatorConfiguration(
     columnMode: ColumnMode = ColumnMode.Default,
+    scroll: Boolean = false,
     onTextSelected: () -> Unit = {},
 ): EpubNavigatorFragment.Configuration =
     EpubNavigatorFragment.Configuration {
         servedAssets = listOf("fonts/.*")
+        disablePageTurnsWhileScrolling = scroll
         readiumCssRsProperties = when (columnMode) {
             ColumnMode.AUTO -> RsProperties()
             ColumnMode.ONE -> RsProperties(colCount = ColCount.ONE)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -14,16 +14,14 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.navigationBarsIgnoringVisibility
-import androidx.compose.foundation.layout.systemBarsIgnoringVisibility
-import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -100,6 +98,7 @@ import com.chmouel.liseur.reader.chrome.PageTurnOverlay
 import com.chmouel.liseur.reader.chrome.PageTurner
 import com.chmouel.liseur.reader.chrome.ReaderTapZones
 import com.chmouel.liseur.reader.chrome.ReadingFooter
+import com.chmouel.liseur.reader.chrome.ScrollEdgeTurner
 import com.chmouel.liseur.reader.chrome.ReadingScrubber
 import com.chmouel.liseur.reader.chrome.ContentsScreen
 import com.chmouel.liseur.reader.chrome.TypographySheet
@@ -160,6 +159,8 @@ fun ReaderScreen(
     onEnableDictionary: () -> Unit,
     keepScreenOnFlow: StateFlow<Boolean>,
     onKeepScreenOnChanged: (Boolean) -> Unit,
+    scrollModeFlow: StateFlow<Boolean>,
+    onScrollModeChanged: (Boolean) -> Unit,
     goTo: SharedFlow<Locator>,
     onBookSyncAction: ReaderBookSyncActions,
     onBack: () -> Unit,
@@ -174,6 +175,8 @@ fun ReaderScreen(
     val chromeVisibleNow by rememberUpdatedState(chromeVisible)
     val prefs by prefsFlow.collectAsStateWithLifecycle()
     val keepScreenOn by keepScreenOnFlow.collectAsStateWithLifecycle()
+    val scrollMode by scrollModeFlow.collectAsStateWithLifecycle()
+    val scrollModeNow by rememberUpdatedState(scrollMode)
     val columnMode = prefs.columnMode.effectiveFor(widthClass())
 
     // The activity decides what a keyboard's arrows mean, and the
@@ -206,8 +209,11 @@ fun ReaderScreen(
             // which is the one thing electronic paper cannot draw: it
             // arrives as a trail of half-erased pages. The instant jump
             // the preference already had is what e-paper wants anyway.
+            // A scrolled book has no page to lift off, and reads the same
+            // answer as whether its scrolling glides or jumps.
             isAnimated = { prefsFlow.value.pageTurnAnimation && !eInkNow },
             isEffectSuppressed = { chromeVisibleNow },
+            isScrolling = { scrollModeNow },
         )
     }
 
@@ -228,13 +234,15 @@ fun ReaderScreen(
     // The column mode is filtered through the window width for the same
     // reason it is in ReaderActivity: a narrow window cannot carry a
     // choice made on a wide one, and the control to undo it is hidden.
-    LaunchedEffect(navigator, columnMode) {
+    LaunchedEffect(navigator, columnMode, scrollMode) {
         val nav = navigator ?: return@LaunchedEffect
         // The factory already built this navigator with the current
         // preferences. Submitting that same value once more reflows the
         // freshly opened book and emits a second restoration locator,
         // which must not be recorded as a page the reader turned.
-        prefsFlow.drop(1).collect { nav.submitPreferences(it.toEpubPreferences(columnMode)) }
+        prefsFlow.drop(1).collect {
+            nav.submitPreferences(it.toEpubPreferences(columnMode, scrollMode))
+        }
     }
 
     // Picking the selection up from the navigator when it tells us the
@@ -282,20 +290,30 @@ fun ReaderScreen(
         val nav = navigator
         pageTurner.navigator = nav
         pageTurner.window = (view.context as? Activity)?.window
+        pageTurner.publication = publication
         onPageTurnerChanged(if (nav != null) pageTurner else null)
-        val listener = nav?.let {
-            ReaderTapZones(
-                navigator = it,
-                isChromeVisible = { chromeVisibleNow },
-                onTurnPage = pageTurner::turn,
-                onShowChrome = { chromeVisible = true },
-                onHideChrome = { chromeVisible = false },
-            ).also(it::addInputListener)
+        val listeners = nav?.let {
+            listOf(
+                ReaderTapZones(
+                    navigator = it,
+                    isChromeVisible = { chromeVisibleNow },
+                    isScrolling = { scrollModeNow },
+                    onTurnPage = pageTurner::turn,
+                    onShowChrome = { chromeVisible = true },
+                    onHideChrome = { chromeVisible = false },
+                ),
+                ScrollEdgeTurner(
+                    navigator = it,
+                    isScrolling = { scrollModeNow },
+                    onStepChapter = { forward -> pageTurner.stepChapter(forward) },
+                ),
+            ).onEach(it::addInputListener)
         }
         onDispose {
-            if (nav != null && listener != null) nav.removeInputListener(listener)
+            if (nav != null) listeners?.forEach(nav::removeInputListener)
             pageTurner.navigator = null
             pageTurner.window = null
+            pageTurner.publication = null
             onPageTurnerChanged(null)
             onNavigatorChanged(null)
         }
@@ -310,26 +328,51 @@ fun ReaderScreen(
             .fillMaxSize()
             .background(prefs.theme.background),
     ) {
-        // The page keeps its own breathing room: Readium's own padding
-        // is switched off (see dimens.xml) because it is applied after
-        // the page is laid out, which cuts the last line in half.
+        // The page runs the whole screen in both modes. Readium's own
+        // padding is switched off (see dimens.xml) because it is applied
+        // after the page is laid out, which cuts the last line in half;
+        // the small margin here is applied before the page loads, and is
+        // the only thing between the text and the edges of the screen.
         //
-        // The bars and the cutout are measured *ignoring visibility*, so
-        // hiding the chrome does not change the height Readium paginates
-        // against. Otherwise every page would be re-laid-out on each tap,
-        // and a line would end up hidden under the gesture bar or the
-        // notch — close enough to fit that the page becomes scrollable by
-        // a few pixels, which is exactly the itch we are scratching.
+        // The system bars used to be inset out of the way. They are
+        // hidden while reading, so all that space bought was a band of
+        // background at the top and bottom of every page. They are not
+        // inset now, and because the layout no longer depends on where
+        // the bars are, showing and hiding the chrome cannot reflow the
+        // page either, which was the other half of what the insets were
+        // for.
+        //
+        // The camera hole is the one thing still kept clear of a page
+        // that is turned, because a line behind it is a line that never
+        // comes back. The inset is the hole's own height on the hole's
+        // own edge — zero on a phone that has none, which is all the
+        // detection this needs, and no more than the hardware costs on a
+        // phone that has one.
+        //
+        // A scrolled book refuses even that: it has no last line to
+        // protect, and whatever the hole covers is a moment's scrolling
+        // away.
         // Keyed on the column mode: the count is part of the ReadiumCSS
         // properties the navigator is constructed with and cannot be
         // changed on a live fragment, so the fragment is rebuilt instead.
         // The factory hands it lastLocator, so the page stays where it was.
-        key(columnMode) {
+        //
+        // Scrolling is keyed for the same reason: whether a sideways
+        // swipe turns a page is fixed at construction too, and it has to
+        // stop turning them when the pages become one long column.
+        key(columnMode, scrollMode) {
             AndroidFragment<EpubNavigatorFragment>(
                 modifier = Modifier
                     .fillMaxSize()
-                    .windowInsetsPadding(readerInsets())
-                    .padding(top = 12.dp, bottom = 26.dp),
+                    .then(
+                        if (scrollMode) {
+                            Modifier
+                        } else {
+                            Modifier
+                                .windowInsetsPadding(WindowInsets.displayCutout)
+                                .padding(top = 12.dp, bottom = 26.dp)
+                        },
+                    ),
             ) { fragment ->
                 navigator = fragment
                 fragment.view?.let(::consumeInsetsForReadium)
@@ -409,7 +452,10 @@ fun ReaderScreen(
                         }
                     },
                 )
-            } else if (jumpBack == null && catchUp == null && nextUp == null) {
+            } else if (!scrollMode && jumpBack == null && catchUp == null && nextUp == null) {
+                // A scrolled page runs under this corner, so a footer
+                // left drawn there prints itself over the text. The
+                // figures are one tap away with the rest of the chrome.
                 ReadingFooter(
                     progress = progress,
                     mode = prefs.footerMode,
@@ -574,6 +620,8 @@ fun ReaderScreen(
             onColumnModeChanged = onPrefsAction.setColumnMode,
             keepScreenOn = keepScreenOn,
             onKeepScreenOnChanged = onKeepScreenOnChanged,
+            scrollMode = scrollMode,
+            onScrollModeChanged = onScrollModeChanged,
             onDismiss = { showTypography = false },
         )
     }
@@ -837,25 +885,17 @@ fun ReaderErrorScreen(message: String, onBack: () -> Unit) {
 }
 
 /**
- * The space a page of text may actually use: everything but the system bars
- * and the display cutout, whether or not the bars happen to be on screen.
- */
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun readerInsets(): WindowInsets =
-    WindowInsets.systemBarsIgnoringVisibility.union(WindowInsets.displayCutout)
-
-/**
  * Stops the window insets at Readium's own view.
  *
  * Readium lays its web view out inside a `CoordinatorLayout`, which offsets
  * its children by whatever insets reach it. Compose does not consume insets
- * on behalf of the views it hosts, so they arrive here a second time even
- * though [readerInsets] has already made room for them: the web view ends up
- * pushed down by the height of the status bar, hanging that far past the
- * bottom of the pager that clips it. Readium paginates against the web view's
- * full height, so the text in that hidden strip — a line or two of every
- * page — is laid out and then never drawn, and the reader simply loses it.
+ * on behalf of the views it hosts, so the status bar's height is added under
+ * the page: the web view ends up pushed down by that much, hanging as far
+ * past the bottom of the pager that clips it. Readium paginates against the
+ * web view's full height, so the text in that hidden strip — a line or two
+ * of every page — is laid out and then never drawn, and the reader simply
+ * loses it. The page is meant to run the whole screen, so nothing gets to
+ * move it.
  */
 private fun consumeInsetsForReadium(view: View) {
     ViewCompat.setOnApplyWindowInsetsListener(view) { _, _ -> WindowInsetsCompat.CONSUMED }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -17,11 +17,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.navigationBarsIgnoringVisibility
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -214,6 +216,11 @@ fun ReaderScreen(
             isAnimated = { prefsFlow.value.pageTurnAnimation && !eInkNow },
             isEffectSuppressed = { chromeVisibleNow },
             isScrolling = { scrollModeNow },
+            // Readium reads this off the book rather than the reader:
+            // vertical text is always scrolled, because CSS columns
+            // cannot paginate it, so a book can be scrolling here with
+            // the setting switched off.
+            isVerticalText = { navigatorNow?.settings?.value?.verticalText == true },
         )
     }
 
@@ -305,6 +312,7 @@ fun ReaderScreen(
                 ScrollEdgeTurner(
                     navigator = it,
                     isScrolling = { scrollModeNow },
+                    isVerticalText = { it.settings.value.verticalText },
                     onStepChapter = { forward -> pageTurner.stepChapter(forward) },
                 ),
             ).onEach(it::addInputListener)
@@ -349,9 +357,11 @@ fun ReaderScreen(
         // detection this needs, and no more than the hardware costs on a
         // phone that has one.
         //
-        // A scrolled book refuses even that: it has no last line to
-        // protect, and whatever the hole covers is a moment's scrolling
-        // away.
+        // A scrolled book keeps only the sides of it. Text moving up the
+        // screen passes under a hole at the top and out again, so the
+        // reader loses a word for a moment and gets it back; a hole on
+        // the side, which is where it lands in landscape, sits over the
+        // same end of every line and never gives any of them back.
         // Keyed on the column mode: the count is part of the ReadiumCSS
         // properties the navigator is constructed with and cannot be
         // changed on a live fragment, so the fragment is rebuilt instead.
@@ -366,7 +376,9 @@ fun ReaderScreen(
                     .fillMaxSize()
                     .then(
                         if (scrollMode) {
-                            Modifier
+                            Modifier.windowInsetsPadding(
+                                WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal),
+                            )
                         } else {
                             Modifier
                                 .windowInsetsPadding(WindowInsets.displayCutout)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -18,6 +18,9 @@ import com.chmouel.liseur.data.db.BookAnnotationDao
 import com.chmouel.liseur.data.db.BookDao
 import com.chmouel.liseur.data.db.BookScreen
 import com.chmouel.liseur.data.db.BookScreenDao
+import com.chmouel.liseur.data.db.BookReadingMode
+import com.chmouel.liseur.data.db.BookReadingModeDao
+import com.chmouel.liseur.data.db.scrollsWith
 import com.chmouel.liseur.data.db.keepsScreenOnWith
 import com.chmouel.liseur.data.db.BookTypography
 import com.chmouel.liseur.data.db.BookTypographyDao
@@ -97,6 +100,7 @@ class ReaderViewModel(
     private val annotationDao: BookAnnotationDao,
     private val typographyDao: BookTypographyDao,
     private val bookScreenDao: BookScreenDao,
+    private val readingModeDao: BookReadingModeDao,
     private val library: LocalLibraryRepository,
     private val prefsRepo: ReaderPreferencesRepository,
     private val readingPace: ReadingPaceRepository,
@@ -406,6 +410,15 @@ class ReaderViewModel(
     val keepScreenOn: StateFlow<Boolean> = appSettings.settings
         .map { it.keepScreenOn }
         .combine(bookScreenDao.observe(bookId)) { global, own -> own.keepsScreenOnWith(global) }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    /**
+     * Whether this book is read by scrolling: the app-wide setting,
+     * unless the book has been answered for on its own.
+     */
+    val scrollMode: StateFlow<Boolean> = appSettings.settings
+        .map { it.scrollMode }
+        .combine(readingModeDao.observe(bookId)) { global, own -> own.scrollsWith(global) }
         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     /** Most recent position, used to persist progress and to survive recreation. */
@@ -979,6 +992,16 @@ class ReaderViewModel(
         bookScreenDao.upsert(BookScreen(bookUrl = bookId, keepScreenOn = enabled))
     }
 
+    /**
+     * Answers the scrolling question for this book alone, for the same
+     * reason [setKeepScreenOn] does: the switch is reached from inside a
+     * book, so it is about that book, and a later change to the app-wide
+     * setting has no business undoing it.
+     */
+    fun setScrollMode(enabled: Boolean) = viewModelScope.launch {
+        readingModeDao.upsert(BookReadingMode(bookUrl = bookId, scroll = enabled))
+    }
+
     fun setColumnMode(mode: ColumnMode) =
         viewModelScope.launch { prefsRepo.setColumnMode(mode) }
 
@@ -1033,6 +1056,7 @@ class ReaderViewModel(
                     annotationDao = container.database.annotationDao(),
                     typographyDao = container.database.typographyDao(),
                     bookScreenDao = container.database.bookScreenDao(),
+                    readingModeDao = container.database.bookReadingModeDao(),
                     library = container.libraryRepository,
                     prefsRepo = container.readerPreferences,
                     readingPace = container.readingPace,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnEffect.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnEffect.kt
@@ -98,6 +98,7 @@ class PageTurner(
     private val isAnimated: () -> Boolean,
     private val isEffectSuppressed: () -> Boolean,
     private val isScrolling: () -> Boolean = { false },
+    private val isVerticalText: () -> Boolean = { false },
 ) {
     var navigator: OverflowableNavigator? = null
     var window: Window? = null
@@ -170,7 +171,12 @@ class PageTurner(
             navigate(nav, forward, animated = false)
             return
         }
-        web.evaluateJavascript(scrollScreenfulScript(forward, smooth = isAnimated())) { result ->
+        val script = scrollScreenfulScript(
+            forward = forward,
+            smooth = isAnimated(),
+            vertical = isVerticalText(),
+        )
+        web.evaluateJavascript(script) { result ->
             if (result?.contains(AT_END) == true) stepChapter(forward)
         }
     }
@@ -211,22 +217,38 @@ class PageTurner(
  * taller by whatever padding Readium CSS puts around the text, and using
  * it would call the end of the chapter a screenful before the last line
  * was read.
+ *
+ * [vertical] is a book set in vertical lines, which Readium scrolls
+ * sideways: the text runs right to left, so the offset it reads is
+ * negative and grows more negative further into the chapter. Only the
+ * axis changes — how far along the chapter is, and how far it goes, are
+ * the same question asked of the other dimension.
  */
-internal fun scrollScreenfulScript(forward: Boolean, smooth: Boolean): String {
-    val edge = if (forward) "top >= max - $EDGE_SLACK" else "top <= $EDGE_SLACK"
+internal fun scrollScreenfulScript(
+    forward: Boolean,
+    smooth: Boolean,
+    vertical: Boolean = false,
+): String {
+    val edge = if (forward) "at >= max - $EDGE_SLACK" else "at <= $EDGE_SLACK"
     val step = if (forward) SCREENFUL else -SCREENFUL
     val behavior = if (smooth) "smooth" else "auto"
+    val page = if (vertical) {
+        "e.clientWidth || window.innerWidth"
+    } else {
+        "e.clientHeight || window.innerHeight"
+    }
+    val span = if (vertical) "e.scrollWidth" else "e.scrollHeight"
+    val at = if (vertical) "Math.abs(e.scrollLeft)" else "e.scrollTop"
+    val target = if (vertical) "left: -to" else "top: to"
     return """
         (function() {
           var e = document.scrollingElement || document.documentElement;
-          var page = e.clientHeight || window.innerHeight;
-          var max = Math.max(0, e.scrollHeight - page);
-          var top = e.scrollTop;
+          var page = $page;
+          var max = Math.max(0, $span - page);
+          var at = $at;
           if ($edge) { return "$AT_END"; }
-          e.scrollTo({
-            top: Math.max(0, Math.min(max, top + page * $step)),
-            behavior: "$behavior"
-          });
+          var to = Math.max(0, Math.min(max, at + page * $step));
+          e.scrollTo({ $target, behavior: "$behavior" });
           return "$SCROLLED";
         })();
     """.trimIndent()

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnEffect.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnEffect.kt
@@ -5,7 +5,10 @@ import android.graphics.Rect
 import android.os.Handler
 import android.os.Looper
 import android.view.PixelCopy
+import android.view.View
+import android.view.ViewGroup
 import android.view.Window
+import android.webkit.WebView
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.tween
@@ -27,6 +30,8 @@ import kotlinx.coroutines.launch
 import org.readium.r2.navigator.OverflowableNavigator
 import org.readium.r2.navigator.preferences.ReadingProgression
 import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.publication.indexOfFirstWithHref
 
 /**
  * Kindle-style page turn: the departing page is snapshotted, the book
@@ -83,18 +88,33 @@ fun PageTurnOverlay(state: PageTurnEffectState, modifier: Modifier = Modifier) {
  * preference is on and the effect is available, the turn uses the
  * sliding snapshot; otherwise it falls back to the navigator's plain
  * slide, or an instant jump when animations are disabled.
+ *
+ * A scrolled book is a different movement altogether, and [isScrolling]
+ * says so: see [scrollScreenful].
  */
 @OptIn(ExperimentalReadiumApi::class)
 class PageTurner(
     private val effect: PageTurnEffectState,
     private val isAnimated: () -> Boolean,
     private val isEffectSuppressed: () -> Boolean,
+    private val isScrolling: () -> Boolean = { false },
 ) {
     var navigator: OverflowableNavigator? = null
     var window: Window? = null
 
+    /**
+     * The book being read, for the one thing the navigator cannot be
+     * asked once page turns are off while scrolling: what comes after
+     * the chapter on screen.
+     */
+    var publication: Publication? = null
+
     fun turn(forward: Boolean) {
         val nav = navigator ?: return
+        if (isScrolling()) {
+            scrollScreenful(nav, forward)
+            return
+        }
         if (!isAnimated()) {
             navigate(nav, forward, animated = false)
             return
@@ -133,4 +153,98 @@ class PageTurner(
         animated: Boolean,
     ): Boolean =
         if (forward) nav.goForward(animated) else nav.goBackward(animated)
+
+    /**
+     * Moves a screenful through a scrolled book, and on to the next
+     * chapter once this one runs out.
+     *
+     * Readium turns a whole chapter at a time while scrolling, which is
+     * not what a volume key or a D-pad means, so page turns are switched
+     * off in that mode (`disablePageTurnsWhileScrolling`) and the
+     * movement is asked of the page itself. The document knows where it
+     * is in its own units and stops at its own ends; arithmetic on view
+     * heights, densities and web view scale does not.
+     */
+    private fun scrollScreenful(nav: OverflowableNavigator, forward: Boolean) {
+        val web = visibleWebView(nav.publicationView) ?: run {
+            navigate(nav, forward, animated = false)
+            return
+        }
+        web.evaluateJavascript(scrollScreenfulScript(forward, smooth = isAnimated())) { result ->
+            if (result?.contains(AT_END) == true) stepChapter(forward)
+        }
+    }
+
+    /**
+     * Opens the chapter before or after the one on screen.
+     *
+     * Going back lands at the end of the chapter before, because that is
+     * where a reader moving backwards is heading; the beginning is a
+     * whole chapter further than they asked for.
+     *
+     * The reading order is searched with Readium's own comparison, the
+     * one that answered when this locator was made.
+     */
+    fun stepChapter(forward: Boolean): Boolean {
+        val nav = navigator ?: return false
+        val pub = publication ?: return false
+        val readingOrder = pub.readingOrder
+        val index = readingOrder.indexOfFirstWithHref(nav.currentLocator.value.href)
+            ?: return false
+        val next = readingOrder.getOrNull(index + if (forward) 1 else -1) ?: return false
+        val locator = pub.locatorFromLink(next) ?: return nav.go(next, animated = false)
+        return nav.go(
+            if (forward) locator else locator.copyWithLocations(progression = 1.0),
+            animated = false,
+        )
+    }
 }
+
+/**
+ * The one screenful of scrolling a volume key or a D-pad press means in
+ * a scrolled book, or [AT_END] when the page is already against the edge
+ * it was asked to move towards and the chapter has to change instead.
+ *
+ * Every measurement is the document's own. `scrollingElement` is what
+ * Readium scrolls in this mode, and its `clientHeight` is the part of it
+ * the reader can see: `window.innerHeight` is the web view, which is
+ * taller by whatever padding Readium CSS puts around the text, and using
+ * it would call the end of the chapter a screenful before the last line
+ * was read.
+ */
+internal fun scrollScreenfulScript(forward: Boolean, smooth: Boolean): String {
+    val edge = if (forward) "top >= max - $EDGE_SLACK" else "top <= $EDGE_SLACK"
+    val step = if (forward) SCREENFUL else -SCREENFUL
+    val behavior = if (smooth) "smooth" else "auto"
+    return """
+        (function() {
+          var e = document.scrollingElement || document.documentElement;
+          var page = e.clientHeight || window.innerHeight;
+          var max = Math.max(0, e.scrollHeight - page);
+          var top = e.scrollTop;
+          if ($edge) { return "$AT_END"; }
+          e.scrollTo({
+            top: Math.max(0, Math.min(max, top + page * $step)),
+            behavior: "$behavior"
+          });
+          return "$SCROLLED";
+        })();
+    """.trimIndent()
+}
+
+/**
+ * A little less than a screen, so the line that was at the edge is still
+ * there to be picked up again.
+ */
+private const val SCREENFUL = 0.9
+
+/**
+ * Scroll offsets are fractional, and a chapter read to its last pixel
+ * can land a hair short of the end. Two pixels of a chapter are not
+ * worth a key press that does nothing.
+ */
+private const val EDGE_SLACK = 2
+
+internal const val AT_END = "at-end"
+
+private const val SCROLLED = "scrolled"

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReaderTapZones.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReaderTapZones.kt
@@ -27,6 +27,11 @@ import kotlin.math.abs
  * any tap on the page dismisses it. Page turns are delegated to
  * [onTurnPage] so they can run the page-turn effect.
  *
+ * A book read by scrolling has no page to turn, so the whole page
+ * becomes the chrome zone and the text is moved by dragging it. Side
+ * taps there would scroll by a screenful with no page-turn to make
+ * sense of it, and would take the tap the reader has anywhere else.
+ *
  * The zones are proportional, which is right for turning pages — a
  * third of the page is a third of the page whatever the page is — but
  * wrong for the chrome. Two fifths of a phone is a thumb's worth of
@@ -39,6 +44,7 @@ import kotlin.math.abs
 class ReaderTapZones(
     private val navigator: OverflowableNavigator,
     private val isChromeVisible: () -> Boolean,
+    private val isScrolling: () -> Boolean = { false },
     private val onTurnPage: (forward: Boolean) -> Unit,
     private val onShowChrome: () -> Unit,
     private val onHideChrome: () -> Unit,
@@ -58,7 +64,7 @@ class ReaderTapZones(
         val dp = view.resources.displayMetrics.density
         val rtl = navigator.overflow.value.readingProgression == ReadingProgression.RTL
 
-        when (zoneAt(event.point.x, event.point.y, width, height, dp)) {
+        when (zoneAt(event.point.x, event.point.y, width, height, dp, isScrolling())) {
             Zone.CHROME -> onShowChrome()
             Zone.BACK -> onTurnPage(rtl)
             Zone.FORWARD -> onTurnPage(!rtl)
@@ -101,6 +107,9 @@ class ReaderTapZones(
          *
          * Split out from the tap handling so the shape of the page can be
          * checked at any screen size without a navigator to tap on.
+         *
+         * [scrolling] answers the whole page at once: there is nothing to
+         * turn, so every tap is a tap on the chrome.
          */
         fun zoneAt(
             x: Float,
@@ -108,7 +117,9 @@ class ReaderTapZones(
             width: Float,
             height: Float,
             density: Float,
+            scrolling: Boolean = false,
         ): Zone {
+            if (scrolling) return Zone.CHROME
             val fx = x / width
             val fy = y / height
             val capped = width / density >= WidthClass.MEDIUM_MIN_DP

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReaderWebViews.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReaderWebViews.kt
@@ -1,0 +1,38 @@
+package com.chmouel.liseur.reader.chrome
+
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebView
+import android.graphics.Rect
+
+/**
+ * The web view showing the chapter being read.
+ *
+ * Readium keeps the neighbouring chapters attached to the pager, so
+ * being a web view is not enough: the one covering the middle of the
+ * reader is the one the reader is reading. The widest visible one is
+ * the fallback for the moment when nothing covers that point, which is
+ * better than doing nothing at all.
+ */
+internal fun visibleWebView(root: View): WebView? {
+    val origin = IntArray(2)
+    root.getLocationOnScreen(origin)
+    val x = origin[0] + root.width / 2
+    val y = origin[1] + root.height / 2
+    val visible = mutableListOf<Pair<WebView, Rect>>()
+    collectVisibleWebViews(root, visible)
+    return visible.firstOrNull { (_, rect) -> rect.contains(x, y) }?.first
+        ?: visible.maxByOrNull { (_, rect) -> rect.width() * rect.height() }?.first
+}
+
+private fun collectVisibleWebViews(view: View, into: MutableList<Pair<WebView, Rect>>) {
+    when {
+        view is WebView -> {
+            val rect = Rect()
+            if (view.getGlobalVisibleRect(rect) && !rect.isEmpty) into += view to rect
+        }
+
+        view is ViewGroup ->
+            for (i in 0 until view.childCount) collectVisibleWebViews(view.getChildAt(i), into)
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ScrollEdgeTurner.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ScrollEdgeTurner.kt
@@ -1,0 +1,123 @@
+package com.chmouel.liseur.reader.chrome
+
+import org.readium.r2.navigator.OverflowableNavigator
+import org.readium.r2.navigator.input.DragEvent
+import org.readium.r2.navigator.input.InputListener
+import org.readium.r2.shared.ExperimentalReadiumApi
+
+/**
+ * Carries a scrolled book across a chapter boundary: keep dragging when
+ * the chapter has no more to give and the next one opens.
+ *
+ * Readium lays every chapter out in its own web view, so a book read by
+ * scrolling stops dead at the end of each one, and the only way onwards
+ * it offers is a sideways swipe — a page turn in a book that has no
+ * pages. Sideways swipes are switched off here (see
+ * `epubNavigatorConfiguration`), and this listener puts the way onwards
+ * where the reader's thumb already is.
+ *
+ * The drags come from Readium's own gesture script, which reports them
+ * whether or not the page is scrolling; nothing is consumed, so the page
+ * scrolls exactly as it did.
+ */
+@OptIn(ExperimentalReadiumApi::class)
+class ScrollEdgeTurner(
+    private val navigator: OverflowableNavigator,
+    private val isScrolling: () -> Boolean,
+    private val onStepChapter: (forward: Boolean) -> Unit,
+) : InputListener {
+
+    private val pull = EdgePull()
+
+    override fun onDrag(event: DragEvent): Boolean {
+        if (!isScrolling()) return false
+        when (event.type) {
+            DragEvent.Type.Start -> pull.reset()
+
+            DragEvent.Type.Move -> {
+                val view = navigator.publicationView
+                val web = visibleWebView(view) ?: return false
+                val step = pull.onMove(
+                    offsetY = event.offset.y,
+                    canScrollDown = web.canScrollVertically(1),
+                    canScrollUp = web.canScrollVertically(-1),
+                    threshold = PULL_DP * view.resources.displayMetrics.density,
+                )
+                when (step) {
+                    EdgePull.Step.FORWARD -> onStepChapter(true)
+                    EdgePull.Step.BACKWARD -> onStepChapter(false)
+                    EdgePull.Step.NONE -> Unit
+                }
+            }
+
+            DragEvent.Type.End -> pull.reset()
+        }
+        return false
+    }
+
+    private companion object {
+        /**
+         * How far past the end the reader has to keep dragging. Short
+         * enough to be found by anyone who simply carries on reading,
+         * long enough that a drag which merely arrives at the end of a
+         * chapter leaves them there to finish the last line.
+         */
+        const val PULL_DP = 64f
+    }
+}
+
+/**
+ * Watches one drag for a pull past an edge the page cannot scroll past.
+ *
+ * The distance is measured from where the edge was met rather than from
+ * where the drag began, so a single long drag that scrolls the rest of
+ * the chapter and keeps going crosses over, while a drag that only just
+ * reaches the end does not. A drag turns at most one chapter, however
+ * far it goes: a book is not scrolled through by leaning on it.
+ *
+ * Kept free of Android types so the gesture can be checked without one.
+ */
+class EdgePull {
+
+    enum class Step { NONE, FORWARD, BACKWARD }
+
+    private var atBottomSince: Float? = null
+    private var atTopSince: Float? = null
+    private var stepped = false
+
+    fun reset() {
+        atBottomSince = null
+        atTopSince = null
+        stepped = false
+    }
+
+    /**
+     * [offsetY] is how far the finger has travelled since the drag
+     * began, in pixels, negative upwards — the direction that moves the
+     * reader forwards through the text.
+     */
+    fun onMove(
+        offsetY: Float,
+        canScrollDown: Boolean,
+        canScrollUp: Boolean,
+        threshold: Float,
+    ): Step {
+        if (stepped) return Step.NONE
+        atBottomSince = if (canScrollDown) null else atBottomSince ?: offsetY
+        atTopSince = if (canScrollUp) null else atTopSince ?: offsetY
+
+        atBottomSince?.let {
+            if (it - offsetY >= threshold) {
+                stepped = true
+                return Step.FORWARD
+            }
+        }
+        atTopSince?.let {
+            if (offsetY - it >= threshold) {
+                stepped = true
+                return Step.BACKWARD
+            }
+        }
+        return Step.NONE
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ScrollEdgeTurner.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ScrollEdgeTurner.kt
@@ -24,6 +24,7 @@ import org.readium.r2.shared.ExperimentalReadiumApi
 class ScrollEdgeTurner(
     private val navigator: OverflowableNavigator,
     private val isScrolling: () -> Boolean,
+    private val isVerticalText: () -> Boolean = { false },
     private val onStepChapter: (forward: Boolean) -> Unit,
 ) : InputListener {
 
@@ -37,10 +38,24 @@ class ScrollEdgeTurner(
             DragEvent.Type.Move -> {
                 val view = navigator.publicationView
                 val web = visibleWebView(view) ?: return false
+                // A book set in vertical lines is scrolled sideways, and
+                // the reader carries the text along with the finger just
+                // the same: later text lies to the left, so it is brought
+                // in by dragging right, as later text below is brought in
+                // by dragging up.
+                val vertical = isVerticalText()
                 val step = pull.onMove(
-                    offsetY = event.offset.y,
-                    canScrollDown = web.canScrollVertically(1),
-                    canScrollUp = web.canScrollVertically(-1),
+                    forwardTravel = if (vertical) event.offset.x else -event.offset.y,
+                    atForwardEdge = if (vertical) {
+                        !web.canScrollHorizontally(-1)
+                    } else {
+                        !web.canScrollVertically(1)
+                    },
+                    atBackwardEdge = if (vertical) {
+                        !web.canScrollHorizontally(1)
+                    } else {
+                        !web.canScrollVertically(-1)
+                    },
                     threshold = PULL_DP * view.resources.displayMetrics.density,
                 )
                 when (step) {
@@ -81,39 +96,41 @@ class EdgePull {
 
     enum class Step { NONE, FORWARD, BACKWARD }
 
-    private var atBottomSince: Float? = null
-    private var atTopSince: Float? = null
+    private var atEndSince: Float? = null
+    private var atStartSince: Float? = null
     private var stepped = false
 
     fun reset() {
-        atBottomSince = null
-        atTopSince = null
+        atEndSince = null
+        atStartSince = null
         stepped = false
     }
 
     /**
-     * [offsetY] is how far the finger has travelled since the drag
-     * began, in pixels, negative upwards — the direction that moves the
-     * reader forwards through the text.
+     * [forwardTravel] is how far the finger has travelled since the drag
+     * began, in pixels, counted positive in the direction that moves the
+     * reader forwards through the text. Which way that is on the screen
+     * is the caller's business: it is up the page in a book set in lines
+     * across, and rightwards in one set in lines down.
      */
     fun onMove(
-        offsetY: Float,
-        canScrollDown: Boolean,
-        canScrollUp: Boolean,
+        forwardTravel: Float,
+        atForwardEdge: Boolean,
+        atBackwardEdge: Boolean,
         threshold: Float,
     ): Step {
         if (stepped) return Step.NONE
-        atBottomSince = if (canScrollDown) null else atBottomSince ?: offsetY
-        atTopSince = if (canScrollUp) null else atTopSince ?: offsetY
+        atEndSince = if (atForwardEdge) atEndSince ?: forwardTravel else null
+        atStartSince = if (atBackwardEdge) atStartSince ?: forwardTravel else null
 
-        atBottomSince?.let {
-            if (it - offsetY >= threshold) {
+        atEndSince?.let {
+            if (forwardTravel - it >= threshold) {
                 stepped = true
                 return Step.FORWARD
             }
         }
-        atTopSince?.let {
-            if (offsetY - it >= threshold) {
+        atStartSince?.let {
+            if (it - forwardTravel >= threshold) {
                 stepped = true
                 return Step.BACKWARD
             }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/TypographySheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/TypographySheet.kt
@@ -52,7 +52,9 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.sp
+import com.chmouel.liseur.R
 import com.chmouel.liseur.data.settings.ColumnMode
 import com.chmouel.liseur.data.settings.FooterMode
 import com.chmouel.liseur.data.settings.ReaderFont
@@ -83,6 +85,8 @@ fun TypographySheet(
     onColumnModeChanged: (ColumnMode) -> Unit,
     keepScreenOn: Boolean,
     onKeepScreenOnChanged: (Boolean) -> Unit,
+    scrollMode: Boolean,
+    onScrollModeChanged: (Boolean) -> Unit,
     onDismiss: () -> Unit,
 ) {
     ModalBottomSheet(onDismissRequest = onDismiss) {
@@ -103,15 +107,27 @@ fun TypographySheet(
                 lineHeight = prefs.lineHeight,
                 pageMargins = prefs.pageMargins,
                 columnMode = prefs.columnMode,
+                // A scrolled chapter is one running column, so the count
+                // has nothing to divide and the control would take a tap
+                // and change nothing.
+                showColumns = !scrollMode,
                 onLineHeightChanged = onLineHeightChanged,
                 onPageMarginsChanged = onPageMarginsChanged,
                 onColumnModeChanged = onColumnModeChanged,
             )
             FooterModeDropdown(selected = prefs.footerMode, onSelected = onFooterModeChanged)
-            PageTurnAnimationToggle(
-                enabled = prefs.pageTurnAnimation,
-                onChanged = onPageTurnAnimationChanged,
+            ScrollModeToggle(
+                enabled = scrollMode,
+                onChanged = onScrollModeChanged,
             )
+            // Nothing lifts off the screen when the text is scrolled, so
+            // the animation has no page to describe.
+            if (!scrollMode) {
+                PageTurnAnimationToggle(
+                    enabled = prefs.pageTurnAnimation,
+                    onChanged = onPageTurnAnimationChanged,
+                )
+            }
             KeepScreenOnToggle(
                 enabled = keepScreenOn,
                 onChanged = onKeepScreenOnChanged,
@@ -353,6 +369,36 @@ private fun BrightnessSlider(value: Float?, onChanged: (Float?) -> Unit) {
     }
 }
 
+/**
+ * Reads this book by scrolling rather than by turning pages.
+ *
+ * Settings holds the answer for the library, and it is what a book
+ * starts from; flipping it here sets this book apart for good, the same
+ * way the screen switch below does, so a later change in Settings leaves
+ * this book where it was put.
+ */
+@Composable
+private fun ScrollModeToggle(enabled: Boolean, onChanged: (Boolean) -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .toggleable(
+                value = enabled,
+                role = Role.Switch,
+                onValueChange = onChanged,
+            ),
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.settings_scroll_mode),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+        }
+        Switch(checked = enabled, onCheckedChange = null)
+    }
+}
+
 @Composable
 private fun PageTurnAnimationToggle(enabled: Boolean, onChanged: (Boolean) -> Unit) {
     Row(
@@ -394,11 +440,6 @@ private fun KeepScreenOnToggle(enabled: Boolean, onChanged: (Boolean) -> Unit) {
             Text(
                 text = "Keep the screen on",
                 style = MaterialTheme.typography.bodyLarge,
-            )
-            Text(
-                text = "For this book. Settings decides for the others.",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
         Switch(checked = enabled, onCheckedChange = null)
@@ -445,6 +486,7 @@ private fun LayoutControls(
     lineHeight: Double?,
     pageMargins: Double?,
     columnMode: ColumnMode,
+    showColumns: Boolean,
     onLineHeightChanged: (Double?) -> Unit,
     onPageMarginsChanged: (Double?) -> Unit,
     onColumnModeChanged: (ColumnMode) -> Unit,
@@ -475,7 +517,7 @@ private fun LayoutControls(
         // Only offered where it can be honoured. Two columns need room
         // for two columns, and on a phone there is none: the control
         // would sit there taking a tap and changing nothing.
-        if (widthClass().isAtLeastMedium) {
+        if (showColumns && widthClass().isAtLeastMedium) {
             SectionLabel("Columns")
             SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
                 val options = ColumnMode.entries

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
@@ -89,6 +89,7 @@ fun SettingsScreen(
     onResumeLastBook: (Boolean) -> Unit,
     onKeepScreenOn: (Boolean) -> Unit,
     onGroupSeries: (Boolean) -> Unit,
+    onScrollMode: (Boolean) -> Unit,
     onDefinitionTarget: (DefinitionTarget) -> Unit,
     onDictionaryLookup: (Boolean) -> Unit,
     onDictionaryBaseUrl: (String) -> Unit,
@@ -249,6 +250,13 @@ fun SettingsScreen(
                         subtitle = stringResource(R.string.settings_resume_detail),
                         checked = settings.resumeLastBook,
                         onCheckedChange = onResumeLastBook,
+                    )
+                    RowDivider()
+                    SwitchRow(
+                        title = stringResource(R.string.settings_scroll_mode),
+                        subtitle = stringResource(R.string.settings_scroll_mode_detail),
+                        checked = settings.scrollMode,
+                        onCheckedChange = onScrollMode,
                     )
                     RowDivider()
                     SwitchRow(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -311,6 +311,8 @@
     <string name="settings_resume_detail">Skip the library when you left off mid-book.</string>
     <string name="settings_keep_screen_on">Keep the screen on</string>
     <string name="settings_keep_screen_on_detail">The screen stays awake while a book is open, however your device is set to sleep. Costs battery, and a single book can be set apart from the reader\'s own switch.</string>
+    <string name="settings_scroll_mode">Read by scrolling</string>
+    <string name="settings_scroll_mode_detail">The chapter runs on as one long page instead of being broken into pages you turn. A single book can be set apart from the reader\'s own switch.</string>
     <string name="settings_eink">E-ink screen</string>
     <string name="settings_eink_detail">Drops animation, which electronic paper smears rather than draws. Detected automatically; set it yourself if the guess is wrong.</string>
     <string name="eink_auto">Auto</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/BookReadingModeTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/BookReadingModeTest.kt
@@ -1,0 +1,27 @@
+package com.chmouel.liseur.data.db
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * A book that has been answered for keeps its answer, whatever Settings
+ * goes on to say. That is the whole difference between this and simply
+ * reading the app-wide setting, so it is what is checked.
+ */
+class BookReadingModeTest {
+
+    @Test
+    fun `a book with no answer follows the app-wide setting`() {
+        assertTrue(null.scrollsWith(global = true))
+        assertFalse(null.scrollsWith(global = false))
+    }
+
+    @Test
+    fun `a book that was answered for keeps its answer`() {
+        val scrolled = BookReadingMode(bookUrl = "book", scroll = true)
+        val paginated = BookReadingMode(bookUrl = "book", scroll = false)
+        assertTrue(scrolled.scrollsWith(global = false))
+        assertFalse(paginated.scrollsWith(global = true))
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
@@ -690,6 +690,6 @@ class MigrationTest {
         const val TEST_DB = "migration-test.db"
 
         /** Kept in step with the `version` on [LiseurDatabase]. */
-        const val LATEST = 33
+        const val LATEST = 34
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapperTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapperTest.kt
@@ -68,4 +68,20 @@ class ReaderPreferencesMapperTest {
         val two = ReaderPrefs(columnMode = ColumnMode.TWO).toEpubPreferences()
         assertEquals(one.copy(columnCount = null), two.copy(columnCount = null))
     }
+
+    @Test
+    fun `a book is paginated unless it is asked to scroll`() {
+        assertEquals(false, ReaderPrefs().toEpubPreferences().scroll)
+        assertEquals(
+            true,
+            ReaderPrefs().toEpubPreferences(scroll = true).scroll,
+        )
+    }
+
+    @Test
+    fun `scrolling is the only thing the scroll flag changes`() {
+        val paginated = ReaderPrefs().toEpubPreferences(scroll = false)
+        val scrolled = ReaderPrefs().toEpubPreferences(scroll = true)
+        assertEquals(paginated.copy(scroll = null), scrolled.copy(scroll = null))
+    }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/EdgePullTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/EdgePullTest.kt
@@ -7,30 +7,40 @@ class EdgePullTest {
 
     private val threshold = 100f
 
-    private fun EdgePull.move(offsetY: Float, down: Boolean = true, up: Boolean = true) =
-        onMove(offsetY, canScrollDown = down, canScrollUp = up, threshold = threshold)
+    /**
+     * [forward] is travel towards later text, so the signs read the same
+     * whichever way the book is set; [down]/[up] are the room the page
+     * still has ahead of and behind the reader.
+     */
+    private fun EdgePull.move(forward: Float, down: Boolean = true, up: Boolean = true) =
+        onMove(
+            forwardTravel = forward,
+            atForwardEdge = !down,
+            atBackwardEdge = !up,
+            threshold = threshold,
+        )
 
     @Test
     fun `scrolling within a chapter turns nothing`() {
         val pull = EdgePull()
-        assertEquals(EdgePull.Step.NONE, pull.move(-50f))
-        assertEquals(EdgePull.Step.NONE, pull.move(-400f))
+        assertEquals(EdgePull.Step.NONE, pull.move(50f))
+        assertEquals(EdgePull.Step.NONE, pull.move(400f))
     }
 
     @Test
     fun `arriving at the end is not enough on its own`() {
         val pull = EdgePull()
-        assertEquals(EdgePull.Step.NONE, pull.move(-300f))
-        assertEquals(EdgePull.Step.NONE, pull.move(-380f, down = false))
+        assertEquals(EdgePull.Step.NONE, pull.move(300f))
+        assertEquals(EdgePull.Step.NONE, pull.move(380f, down = false))
     }
 
     @Test
     fun `dragging on past the end opens the next chapter`() {
         val pull = EdgePull()
-        pull.move(-300f)
-        pull.move(-320f, down = false)
-        assertEquals(EdgePull.Step.NONE, pull.move(-400f, down = false))
-        assertEquals(EdgePull.Step.FORWARD, pull.move(-421f, down = false))
+        pull.move(300f)
+        pull.move(320f, down = false)
+        assertEquals(EdgePull.Step.NONE, pull.move(400f, down = false))
+        assertEquals(EdgePull.Step.FORWARD, pull.move(421f, down = false))
     }
 
     @Test
@@ -38,53 +48,53 @@ class EdgePullTest {
         val pull = EdgePull()
         // A drag that scrolls a long way and only just reaches the end
         // has travelled further than the threshold, and must not count.
-        assertEquals(EdgePull.Step.NONE, pull.move(-500f))
-        assertEquals(EdgePull.Step.NONE, pull.move(-560f, down = false))
+        assertEquals(EdgePull.Step.NONE, pull.move(500f))
+        assertEquals(EdgePull.Step.NONE, pull.move(560f, down = false))
     }
 
     @Test
     fun `dragging on past the top opens the chapter before`() {
         val pull = EdgePull()
-        pull.move(40f, up = false)
-        assertEquals(EdgePull.Step.NONE, pull.move(130f, up = false))
-        assertEquals(EdgePull.Step.BACKWARD, pull.move(141f, up = false))
+        pull.move(-40f, up = false)
+        assertEquals(EdgePull.Step.NONE, pull.move(-130f, up = false))
+        assertEquals(EdgePull.Step.BACKWARD, pull.move(-141f, up = false))
     }
 
     @Test
     fun `one drag turns one chapter, however far it goes`() {
         val pull = EdgePull()
         pull.move(0f, down = false)
-        assertEquals(EdgePull.Step.FORWARD, pull.move(-100f, down = false))
-        assertEquals(EdgePull.Step.NONE, pull.move(-800f, down = false))
+        assertEquals(EdgePull.Step.FORWARD, pull.move(100f, down = false))
+        assertEquals(EdgePull.Step.NONE, pull.move(800f, down = false))
     }
 
     @Test
     fun `a new drag can turn again`() {
         val pull = EdgePull()
         pull.move(0f, down = false)
-        assertEquals(EdgePull.Step.FORWARD, pull.move(-100f, down = false))
+        assertEquals(EdgePull.Step.FORWARD, pull.move(100f, down = false))
         pull.reset()
         pull.move(0f, down = false)
-        assertEquals(EdgePull.Step.FORWARD, pull.move(-100f, down = false))
+        assertEquals(EdgePull.Step.FORWARD, pull.move(100f, down = false))
     }
 
     @Test
     fun `scrolling back off the end starts the measurement over`() {
         val pull = EdgePull()
-        pull.move(-200f, down = false)
-        pull.move(-260f)
-        assertEquals(EdgePull.Step.NONE, pull.move(-320f, down = false))
-        assertEquals(EdgePull.Step.FORWARD, pull.move(-421f, down = false))
+        pull.move(200f, down = false)
+        pull.move(260f)
+        assertEquals(EdgePull.Step.NONE, pull.move(320f, down = false))
+        assertEquals(EdgePull.Step.FORWARD, pull.move(421f, down = false))
     }
 
     @Test
     fun `a chapter shorter than the screen is left in either direction`() {
         val forward = EdgePull()
         forward.move(0f, down = false, up = false)
-        assertEquals(EdgePull.Step.FORWARD, forward.move(-100f, down = false, up = false))
+        assertEquals(EdgePull.Step.FORWARD, forward.move(100f, down = false, up = false))
 
         val backward = EdgePull()
         backward.move(0f, down = false, up = false)
-        assertEquals(EdgePull.Step.BACKWARD, backward.move(100f, down = false, up = false))
+        assertEquals(EdgePull.Step.BACKWARD, backward.move(-100f, down = false, up = false))
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/EdgePullTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/EdgePullTest.kt
@@ -1,0 +1,90 @@
+package com.chmouel.liseur.reader.chrome
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EdgePullTest {
+
+    private val threshold = 100f
+
+    private fun EdgePull.move(offsetY: Float, down: Boolean = true, up: Boolean = true) =
+        onMove(offsetY, canScrollDown = down, canScrollUp = up, threshold = threshold)
+
+    @Test
+    fun `scrolling within a chapter turns nothing`() {
+        val pull = EdgePull()
+        assertEquals(EdgePull.Step.NONE, pull.move(-50f))
+        assertEquals(EdgePull.Step.NONE, pull.move(-400f))
+    }
+
+    @Test
+    fun `arriving at the end is not enough on its own`() {
+        val pull = EdgePull()
+        assertEquals(EdgePull.Step.NONE, pull.move(-300f))
+        assertEquals(EdgePull.Step.NONE, pull.move(-380f, down = false))
+    }
+
+    @Test
+    fun `dragging on past the end opens the next chapter`() {
+        val pull = EdgePull()
+        pull.move(-300f)
+        pull.move(-320f, down = false)
+        assertEquals(EdgePull.Step.NONE, pull.move(-400f, down = false))
+        assertEquals(EdgePull.Step.FORWARD, pull.move(-421f, down = false))
+    }
+
+    @Test
+    fun `the pull is measured from the end, not from where the drag began`() {
+        val pull = EdgePull()
+        // A drag that scrolls a long way and only just reaches the end
+        // has travelled further than the threshold, and must not count.
+        assertEquals(EdgePull.Step.NONE, pull.move(-500f))
+        assertEquals(EdgePull.Step.NONE, pull.move(-560f, down = false))
+    }
+
+    @Test
+    fun `dragging on past the top opens the chapter before`() {
+        val pull = EdgePull()
+        pull.move(40f, up = false)
+        assertEquals(EdgePull.Step.NONE, pull.move(130f, up = false))
+        assertEquals(EdgePull.Step.BACKWARD, pull.move(141f, up = false))
+    }
+
+    @Test
+    fun `one drag turns one chapter, however far it goes`() {
+        val pull = EdgePull()
+        pull.move(0f, down = false)
+        assertEquals(EdgePull.Step.FORWARD, pull.move(-100f, down = false))
+        assertEquals(EdgePull.Step.NONE, pull.move(-800f, down = false))
+    }
+
+    @Test
+    fun `a new drag can turn again`() {
+        val pull = EdgePull()
+        pull.move(0f, down = false)
+        assertEquals(EdgePull.Step.FORWARD, pull.move(-100f, down = false))
+        pull.reset()
+        pull.move(0f, down = false)
+        assertEquals(EdgePull.Step.FORWARD, pull.move(-100f, down = false))
+    }
+
+    @Test
+    fun `scrolling back off the end starts the measurement over`() {
+        val pull = EdgePull()
+        pull.move(-200f, down = false)
+        pull.move(-260f)
+        assertEquals(EdgePull.Step.NONE, pull.move(-320f, down = false))
+        assertEquals(EdgePull.Step.FORWARD, pull.move(-421f, down = false))
+    }
+
+    @Test
+    fun `a chapter shorter than the screen is left in either direction`() {
+        val forward = EdgePull()
+        forward.move(0f, down = false, up = false)
+        assertEquals(EdgePull.Step.FORWARD, forward.move(-100f, down = false, up = false))
+
+        val backward = EdgePull()
+        backward.move(0f, down = false, up = false)
+        assertEquals(EdgePull.Step.BACKWARD, backward.move(100f, down = false, up = false))
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/ReaderTapZonesTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/ReaderTapZonesTest.kt
@@ -29,6 +29,9 @@ class ReaderTapZonesTest {
     private fun Screen.at(fx: Float, fy: Float) =
         zoneAt(w * fx, h * fy, w, h, density)
 
+    private fun Screen.scrolledAt(fx: Float, fy: Float) =
+        zoneAt(w * fx, h * fy, w, h, density, scrolling = true)
+
     @Test
     fun `phone zones are exactly what they always were`() {
         // Just inside the old 14% strip.
@@ -79,5 +82,18 @@ class ReaderTapZonesTest {
         // forward and back. Left is always BACK here, even though an RTL
         // book turns it into a forward page.
         assertEquals(Zone.BACK, phone.at(0.05f, 0.9f))
+    }
+
+    @Test
+    fun `a scrolled book has no side to turn`() {
+        // Every corner and edge of every screen: there is no page to
+        // turn, so a tap can only mean the menu.
+        for (screen in listOf(phone, eink, tablet, wideCompact)) {
+            for (fx in listOf(0.02f, 0.25f, 0.5f, 0.75f, 0.98f)) {
+                for (fy in listOf(0.02f, 0.25f, 0.5f, 0.75f, 0.98f)) {
+                    assertEquals(Zone.CHROME, screen.scrolledAt(fx, fy))
+                }
+            }
+        }
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/ScrollScreenfulScriptTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/ScrollScreenfulScriptTest.kt
@@ -1,0 +1,50 @@
+package com.chmouel.liseur.reader.chrome
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ScrollScreenfulScriptTest {
+
+    @Test
+    fun `measures the visible part of the document, not the web view`() {
+        val script = scrollScreenfulScript(forward = true, smooth = false)
+        assertTrue(script.contains("e.clientHeight || window.innerHeight"))
+        assertTrue(script.contains("e.scrollHeight - page"))
+    }
+
+    @Test
+    fun `forward stops at the bottom and asks for the next chapter`() {
+        val script = scrollScreenfulScript(forward = true, smooth = false)
+        assertTrue(script.contains("""if (top >= max - 2) { return "at-end"; }"""))
+        assertTrue(script.contains("top + page * 0.9"))
+    }
+
+    @Test
+    fun `backward stops at the top and moves the other way`() {
+        val script = scrollScreenfulScript(forward = false, smooth = false)
+        assertTrue(script.contains("""if (top <= 2) { return "at-end"; }"""))
+        assertTrue(script.contains("top + page * -0.9"))
+    }
+
+    @Test
+    fun `the scroll never leaves the document`() {
+        val script = scrollScreenfulScript(forward = true, smooth = false)
+        assertTrue(script.contains("Math.max(0, Math.min(max, top + page * 0.9))"))
+    }
+
+    @Test
+    fun `gliding follows the page turn animation`() {
+        assertTrue(
+            scrollScreenfulScript(forward = true, smooth = true).contains("""behavior: "smooth""""),
+        )
+        assertTrue(
+            scrollScreenfulScript(forward = true, smooth = false).contains("""behavior: "auto""""),
+        )
+    }
+
+    @Test
+    fun `the end is reported with the token the caller looks for`() {
+        assertEquals("at-end", AT_END)
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/ScrollScreenfulScriptTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/ScrollScreenfulScriptTest.kt
@@ -1,6 +1,7 @@
 package com.chmouel.liseur.reader.chrome
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -16,21 +17,21 @@ class ScrollScreenfulScriptTest {
     @Test
     fun `forward stops at the bottom and asks for the next chapter`() {
         val script = scrollScreenfulScript(forward = true, smooth = false)
-        assertTrue(script.contains("""if (top >= max - 2) { return "at-end"; }"""))
-        assertTrue(script.contains("top + page * 0.9"))
+        assertTrue(script.contains("""if (at >= max - 2) { return "at-end"; }"""))
+        assertTrue(script.contains("at + page * 0.9"))
     }
 
     @Test
     fun `backward stops at the top and moves the other way`() {
         val script = scrollScreenfulScript(forward = false, smooth = false)
-        assertTrue(script.contains("""if (top <= 2) { return "at-end"; }"""))
-        assertTrue(script.contains("top + page * -0.9"))
+        assertTrue(script.contains("""if (at <= 2) { return "at-end"; }"""))
+        assertTrue(script.contains("at + page * -0.9"))
     }
 
     @Test
     fun `the scroll never leaves the document`() {
         val script = scrollScreenfulScript(forward = true, smooth = false)
-        assertTrue(script.contains("Math.max(0, Math.min(max, top + page * 0.9))"))
+        assertTrue(script.contains("Math.max(0, Math.min(max, at + page * 0.9))"))
     }
 
     @Test
@@ -40,6 +41,28 @@ class ScrollScreenfulScriptTest {
         )
         assertTrue(
             scrollScreenfulScript(forward = true, smooth = false).contains("""behavior: "auto""""),
+        )
+    }
+
+    @Test
+    fun `a book set in vertical lines is scrolled sideways`() {
+        val script = scrollScreenfulScript(forward = true, smooth = false, vertical = true)
+        assertTrue(script.contains("e.clientWidth || window.innerWidth"))
+        assertTrue(script.contains("e.scrollWidth - page"))
+        assertTrue(script.contains("Math.abs(e.scrollLeft)"))
+        // The text runs right to left, so further in is further negative.
+        assertTrue(script.contains("left: -to"))
+        assertFalse(script.contains("scrollTop"))
+        assertFalse(script.contains("scrollHeight"))
+    }
+
+    @Test
+    fun `vertical lines end where their own axis runs out`() {
+        val script = scrollScreenfulScript(forward = true, smooth = false, vertical = true)
+        assertTrue(script.contains("""if (at >= max - 2) { return "at-end"; }"""))
+        assertTrue(
+            scrollScreenfulScript(forward = false, smooth = false, vertical = true)
+                .contains("""if (at <= 2) { return "at-end"; }"""),
         )
     }
 


### PR DESCRIPTION
Added ability to read books using continuous scrolling instead of
page-turning, with an app-wide default in settings and an override
switch available from the typography settings inside individual books.

Implementation notes, a book read by scrolling stopped dead at every
chapter boundary: Readium lays each chapter out in its own web view, and
the only way onwards it offered was a sideways swipe, which is a page
turn in a book that has no pages.

Sideways swipes are now switched off while scrolling
(disablePageTurnsWhileScrolling), and ScrollEdgeTurner puts the way
onwards where the reader's thumb already is: keep dragging once the page
cannot scroll any further and the next chapter opens. The pull is
measured from where the edge was met rather than from where the drag
began, so a drag that merely arrives at the end of a chapter leaves the
reader there to finish the last line. The same at the top opens the
chapter before, at its end, which is where a reader moving backwards is
heading.

Volume keys and the D-pad scroll a screenful instead of jumping a whole
chapter, measured by the document itself, and roll into the next chapter
once there is no more to scroll.

Fixes #12
Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>
