### PR TITLE
feat: Add endpaper screen for finished books

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -289,6 +289,7 @@ class AppContainer(context: Context) {
             )
         },
         refreshFinished = finishedState::refreshFromProgress,
+        markFinished = { finishedState.setFinished(it, true) },
         latestSync = latestPositionSync,
         scheduleClose = { PositionSyncWorker.pushBook(context.applicationContext, it) },
         onError = { message, error -> Log.e("reading-position", message, error) },

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/SeriesCompletion.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/SeriesCompletion.kt
@@ -1,0 +1,62 @@
+package com.chmouel.liseur.domain
+
+/**
+ * Whether a series is finished, as opposed to whether every volume
+ * currently on the shelf has been read.
+ *
+ * The shelf fading when every known book is done is a presentation
+ * detail. This is the sentence the reader is owed: that the series is
+ * over, that they are caught up, or only that everything here has been
+ * read. Optional server metadata is allowed to be late; until it
+ * arrives the wording stays conservative and upgrades itself.
+ */
+enum class SeriesCompletion {
+    /** At least one known volume is unfinished. */
+    IN_PROGRESS,
+
+    /**
+     * The series is over and every volume of it has been read: no
+     * gaps, an authoritative ENDED, and a total that is exactly the
+     * shelf.
+     */
+    COMPLETE,
+
+    /**
+     * Everything published so far has been read, and more is expected:
+     * ONGOING or HIATUS, with no known holes.
+     */
+    CAUGHT_UP,
+
+    /**
+     * Every known volume is finished, and that is all that can be said.
+     * Local and calibre libraries with no total, abandoned series, and
+     * shelves with missing volumes land here.
+     */
+    ALL_KNOWN_READ,
+}
+
+/**
+ * Classifies a shelf once every volume on it has been looked at.
+ *
+ * Unknown extras are not a guess at COMPLETE or CAUGHT_UP: they are
+ * [SeriesCompletion.ALL_KNOWN_READ], and a later cache fill is allowed
+ * to promote the answer.
+ */
+fun seriesCompletion(
+    shelf: SeriesShelf,
+    extras: SeriesExtras? = null,
+): SeriesCompletion {
+    if (shelf.volumes.isEmpty() || shelf.volumes.any { !it.finished }) {
+        return SeriesCompletion.IN_PROGRESS
+    }
+    val status = extras?.status?.uppercase()
+    val total = extras?.totalBookCount
+    val noGaps = shelf.gaps.isEmpty()
+    return when {
+        status == "ENDED" && noGaps && total != null && total == shelf.volumes.size ->
+            SeriesCompletion.COMPLETE
+        (status == "ONGOING" || status == "HIATUS") && noGaps ->
+            SeriesCompletion.CAUGHT_UP
+        else -> SeriesCompletion.ALL_KNOWN_READ
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/SeriesShelf.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/SeriesShelf.kt
@@ -173,46 +173,96 @@ private fun gapsBetween(volumes: List<SeriesVolume>): List<Double> {
 private const val MAX_GAP_SPAN = 500L
 
 /**
- * The book to offer once one is finished: the next volume along, if it
+ * What the endpaper can say after a volume is finished: the next number
+ * that is missing, if that can be proved, and the next book in the
+ * library that can actually be opened, even when that book sits past
+ * the hole.
+ *
+ * The two answers are independent. A missing #2 does not hide a #3
+ * already on the shelf, and a #3 on the shelf does not invent a title
+ * for the #2 that is not there.
+ */
+data class SeriesContinuation(
+    val missingIndex: Double? = null,
+    val next: Book? = null,
+)
+
+/**
+ * The book to offer once one is finished: the next volume along that
  * is in the library and has not been read.
  *
- * Null for anything the least bit uncertain — a book with no series, one
- * with no number, the last volume, a next volume that is missing or
- * already read. An offer that is wrong is worse than no offer, because
- * it appears at the one moment the reader is not looking for a decision.
+ * A volume already begun is still the next volume — continuing a series
+ * means picking up where that book was left, not skipping it. Finished
+ * and archived volumes are stepped over. A hole in the numbering is
+ * reported separately as [SeriesContinuation.missingIndex] rather than
+ * blocking the offer: #3 is still the next book in the library when #2
+ * is not there.
+ *
+ * Null for anything uncertain: a book with no series, one with no
+ * number, or nothing later on the shelf that can be opened. Whether the
+ * file is on the device is not this function's business.
  */
+@Suppress("UNUSED_PARAMETER")
 fun nextInSeries(
     finished: Book,
     library: List<Book>,
     progressions: Map<String, Double> = emptyMap(),
-): Book? {
-    val key = seriesKey(finished.seriesName)
-    if (key.isEmpty()) return null
-    val index = finished.seriesIndex ?: return null
+): Book? = seriesContinuation(finished, library).next
 
-    // Walked in order rather than filtered, because the two reasons a
-    // volume is not the answer are different. One already read is
-    // stepped over — the reader has moved past it. One missing from the
-    // shelf altogether is a hole, and offering across a hole means
-    // offering #5 to someone who has just put down #1.
-    val shelf = library
+/**
+ * The missing volume immediately after [finished], and the first later
+ * volume in the library that can still be read.
+ *
+ * A later numbered book proves the hole: #1 then #3 means #2 is
+ * missing. #1 then #1.5 is a novella, not a gap; #1.5 then #3 proves
+ * #2. Only that immediate missing number is named. An authoritative
+ * series total can prove the same hole when no later book is on the
+ * shelf; without a total, the number is not guessed.
+ */
+fun seriesContinuation(
+    finished: Book,
+    library: List<Book>,
+    extras: SeriesExtras? = null,
+): SeriesContinuation {
+    val key = seriesKey(finished.seriesName)
+    if (key.isEmpty()) return SeriesContinuation()
+    val index = finished.seriesIndex ?: return SeriesContinuation()
+
+    val later = library
         .asSequence()
         .filter { it.url != finished.url }
         .filter { seriesKey(it.seriesName) == key }
         .mapNotNull { book -> book.seriesIndex?.let { it to book } }
         .filter { (candidate, _) -> candidate > index }
         .sortedBy { (candidate, _) -> candidate }
+        .toList()
 
-    var previous = index
-    for ((candidate, book) in shelf) {
-        // A novella between two volumes is a step, not a hole: #7 -> #7.5
-        // and #7.5 -> #8 both land inside the next whole number.
-        if (candidate > Math.floor(previous) + 1.0) return null
-        val begun = (progressions[book.url] ?: 0.0) > 0.0
-        if (!book.archived && !book.finished && !begun) return book
-        previous = candidate
+    val expected = Math.floor(index) + 1.0
+    val nextPresent = later.firstOrNull()?.first
+    val missing = when {
+        nextPresent != null -> expected.takeIf { nextPresent > expected }
+        else -> extras?.totalBookCount
+            ?.toDouble()
+            ?.let { total -> expected.takeIf { it <= total } }
     }
-    return null
+    val next = later.firstOrNull { (_, book) -> !book.archived && !book.finished }?.second
+    return SeriesContinuation(missingIndex = missing, next = next)
+}
+
+/**
+ * The server id to ask for series extras.
+ *
+ * A local file filed with downloaded volumes has none of its own. The
+ * shelf still might: another volume that came from the server carries
+ * it, and that is the one the series screen uses.
+ */
+fun seriesIdForExtras(book: Book, library: List<Book>): String? {
+    val key = seriesKey(book.seriesName)
+    if (key.isEmpty()) return null
+    return library.groupedIntoSeries()
+        .firstOrNull { it.key == key }
+        ?.volumes
+        ?.firstNotNullOfOrNull { it.book.shelfSeriesId }
 }
 
 /**

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/EndpaperContinuation.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/EndpaperContinuation.kt
@@ -1,0 +1,148 @@
+package com.chmouel.liseur.reader
+
+import com.chmouel.liseur.data.db.Book
+import com.chmouel.liseur.data.db.DownloadState
+import com.chmouel.liseur.domain.SeriesCompletion
+import com.chmouel.liseur.domain.SeriesExtras
+import com.chmouel.liseur.domain.groupedIntoSeries
+import com.chmouel.liseur.domain.seriesCompletion
+import com.chmouel.liseur.domain.seriesContinuation
+import com.chmouel.liseur.domain.seriesIndexLabel
+import com.chmouel.liseur.domain.seriesKey
+
+/**
+ * Whether the next volume can be opened, fetched, or only named.
+ *
+ * The file being here is one state among several, not a precondition
+ * for making the offer. A download that cannot succeed is named as
+ * unavailable rather than queued.
+ */
+sealed interface NextVolumeAvailability {
+    data class Ready(val fileUrl: String) : NextVolumeAvailability
+    data object Remote : NextVolumeAvailability
+    data object Queued : NextVolumeAvailability
+    data class Downloading(val fraction: Float?) : NextVolumeAvailability
+    data object Failed : NextVolumeAvailability
+    data object Unavailable : NextVolumeAvailability
+}
+
+/** A WorkManager snapshot, without dragging the repository into tests. */
+data class DownloadSnapshot(
+    val queued: Boolean = false,
+    val fraction: Float? = null,
+    val running: Boolean = false,
+)
+
+data class NextUp(
+    val book: Book,
+    val volume: String?,
+    val availability: NextVolumeAvailability,
+) {
+    val id: String get() = book.url
+    val title: String get() = book.title
+}
+
+/**
+ * What the endpaper can say once the last page has been turned.
+ *
+ * [seriesName] and [finishedVolume] name the book that just ended, so
+ * the colophon can say which volume of the series this was.
+ * [missingIndex] is the volume that should come next and is not in the
+ * library, when that can be proved. [next] is a later volume that is
+ * here and can be opened, even across that hole. [noNextInLibrary] is
+ * the conservative sentence when neither can be said and the series is
+ * still in progress. [seriesCompletion] is how the series itself reads
+ * when there is no next book and no named missing volume.
+ */
+data class EndpaperContinuation(
+    val next: NextUp?,
+    val seriesCompletion: SeriesCompletion,
+    val seriesName: String? = null,
+    val finishedVolume: String? = null,
+    val missingIndex: Double? = null,
+    val noNextInLibrary: Boolean = false,
+)
+
+internal fun shouldOfferEndpaperContinuation(
+    finished: Boolean,
+    endpaperReached: Boolean,
+): Boolean = finished && endpaperReached
+
+internal fun nextVolumeAvailability(
+    openableUrl: String?,
+    downloadState: DownloadState,
+    download: DownloadSnapshot?,
+    canDownload: Boolean,
+): NextVolumeAvailability {
+    openableUrl?.let { return NextVolumeAvailability.Ready(it) }
+    if (download?.queued == true || downloadState == DownloadState.QUEUED) {
+        return NextVolumeAvailability.Queued
+    }
+    if (download?.running == true || downloadState == DownloadState.DOWNLOADING) {
+        return NextVolumeAvailability.Downloading(download?.fraction)
+    }
+    if (downloadState == DownloadState.FAILED) {
+        return if (canDownload) NextVolumeAvailability.Failed else NextVolumeAvailability.Unavailable
+    }
+    if (!canDownload) return NextVolumeAvailability.Unavailable
+    return NextVolumeAvailability.Remote
+}
+
+internal fun endpaperContinuation(
+    current: Book,
+    library: List<Book>,
+    progressions: Map<String, Double>,
+    dismissed: Boolean,
+    endpaperReached: Boolean,
+    downloads: Map<String, DownloadSnapshot>,
+    canDownload: Boolean,
+    extras: SeriesExtras?,
+): EndpaperContinuation? {
+    if (!shouldOfferEndpaperContinuation(current.finished, endpaperReached)) return null
+    val seriesName = current.seriesName?.takeIf { it.isNotBlank() }
+    val finishedVolume = seriesName?.let { seriesIndexLabel(current.seriesIndex) }
+    val shelf = library.groupedIntoSeries(progressions).firstOrNull {
+        seriesKey(it.name) == seriesKey(current.seriesName)
+    }
+    val completion = shelf?.let { seriesCompletion(it, extras) } ?: SeriesCompletion.IN_PROGRESS
+    if (dismissed) {
+        return EndpaperContinuation(
+            next = null,
+            seriesCompletion = SeriesCompletion.IN_PROGRESS,
+            seriesName = seriesName,
+            finishedVolume = finishedVolume,
+        )
+    }
+    val offer = seriesContinuation(current, library, extras)
+    val nextUp = offer.next?.let { nextBook ->
+        val snapshot = downloads[nextBook.url]
+        NextUp(
+            book = nextBook,
+            volume = seriesIndexLabel(nextBook.seriesIndex),
+            availability = nextVolumeAvailability(
+                openableUrl = nextBook.openableUrl,
+                downloadState = nextBook.downloadState,
+                download = snapshot,
+                canDownload = canDownload,
+            ),
+        )
+    }
+    val hasOffer = nextUp != null || offer.missingIndex != null
+    return EndpaperContinuation(
+        next = nextUp,
+        seriesName = seriesName,
+        finishedVolume = finishedVolume,
+        missingIndex = offer.missingIndex,
+        noNextInLibrary = !hasOffer && completion == SeriesCompletion.IN_PROGRESS,
+        seriesCompletion = if (hasOffer) SeriesCompletion.IN_PROGRESS else completion,
+    )
+}
+
+internal fun readyToOpen(
+    continuation: EndpaperContinuation?,
+    continueAfterDownload: Boolean,
+): NextUp? {
+    if (!continueAfterDownload) return null
+    val next = continuation?.next ?: return null
+    return next.takeIf { it.availability is NextVolumeAvailability.Ready }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
@@ -7,6 +7,7 @@ import android.view.KeyEvent
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.collectAsState
@@ -15,7 +16,9 @@ import com.chmouel.liseur.data.settings.AppSettings
 import com.chmouel.liseur.data.settings.ThemeMode
 import androidx.core.net.toUri
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import com.chmouel.liseur.reader.chrome.BookSyncDialog
 import com.chmouel.liseur.reader.chrome.PageTurner
 import androidx.lifecycle.lifecycleScope
@@ -137,6 +140,20 @@ class ReaderActivity : FragmentActivity() {
                                     ),
                                 ).also { supportFragmentManager.fragmentFactory = it }
                             }
+                            LaunchedEffect(viewModel) {
+                                lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                                    viewModel.pendingOpen.collect { next ->
+                                        if (next == null) return@collect
+                                        val url = (next.availability as? NextVolumeAvailability.Ready)
+                                            ?.fileUrl ?: return@collect
+                                        viewModel.consumeOpenNext()
+                                        startActivity(
+                                            intent(this@ReaderActivity, url, next.id),
+                                        )
+                                        finish()
+                                    }
+                                }
+                            }
                             ReaderScreen(
                                 publication = s.publication,
                                 prefsFlow = viewModel.prefs,
@@ -144,12 +161,10 @@ class ReaderActivity : FragmentActivity() {
                                 progressFlow = viewModel.progress,
                                 jumpBackFlow = viewModel.jumpBack,
                                 catchUpFlow = viewModel.catchUp,
-                                nextUpFlow = viewModel.nextUp,
-                                onOpenNextUp = { next ->
-                                    startActivity(intent(this@ReaderActivity, next.fileUrl, next.id))
-                                    finish()
-                                },
-                                onDismissNextUp = viewModel::dismissNextUp,
+                                continuationFlow = viewModel.continuation,
+                                onContinueNext = viewModel::onContinueNext,
+                                onReachedEndpaper = viewModel::onReachedEndpaper,
+                                onLeftEndpaper = viewModel::onLeftEndpaper,
                                 onLocatorChanged = viewModel::onLocatorChanged,
                                 onNavigatorChanged = { navigator = it },
                                 keepScreenOnFlow = viewModel.keepScreenOn,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -93,7 +93,6 @@ import com.chmouel.liseur.data.settings.ReaderFont
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.ReaderTheme
 import com.chmouel.liseur.reader.chrome.CatchUpPill
-import com.chmouel.liseur.reader.chrome.NextInSeriesPill
 import com.chmouel.liseur.reader.chrome.JumpBackPill
 import com.chmouel.liseur.reader.chrome.PageTurnEffectState
 import com.chmouel.liseur.reader.chrome.PageTurnOverlay
@@ -143,9 +142,10 @@ fun ReaderScreen(
     progressFlow: StateFlow<ReaderProgress?>,
     jumpBackFlow: StateFlow<ReaderViewModel.JumpBack?>,
     catchUpFlow: StateFlow<ReaderViewModel.CatchUp?>,
-    nextUpFlow: StateFlow<ReaderViewModel.NextUp?>,
-    onOpenNextUp: (ReaderViewModel.NextUp) -> Unit,
-    onDismissNextUp: () -> Unit,
+    continuationFlow: StateFlow<EndpaperContinuation?>,
+    onContinueNext: () -> Unit,
+    onReachedEndpaper: () -> Unit,
+    onLeftEndpaper: () -> Unit,
     onLocatorChanged: (Locator) -> Unit,
     onNavigatorChanged: (EpubNavigatorFragment?) -> Unit,
     onPageTurnerChanged: (PageTurner?) -> Unit,
@@ -191,7 +191,7 @@ fun ReaderScreen(
     val progress by progressFlow.collectAsStateWithLifecycle()
     val jumpBack by jumpBackFlow.collectAsStateWithLifecycle()
     val catchUp by catchUpFlow.collectAsStateWithLifecycle()
-    val nextUp by nextUpFlow.collectAsStateWithLifecycle()
+    val continuation by continuationFlow.collectAsStateWithLifecycle()
     val annotations by annotationsFlow.collectAsStateWithLifecycle()
     val searchState by searchFlow.collectAsStateWithLifecycle()
     val bookmarked by bookmarkedFlow.collectAsStateWithLifecycle()
@@ -234,8 +234,15 @@ fun ReaderScreen(
                 chromeVisible = false
                 view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
             },
-            onLeaveEnd = { showingEnd = false },
+            onLeaveEnd = {
+                showingEnd = false
+                onLeftEndpaper()
+            },
         )
+    }
+
+    LaunchedEffect(showingEnd) {
+        if (showingEnd) onReachedEndpaper()
     }
 
     LaunchedEffect(navigator, lifecycle) {
@@ -412,12 +419,22 @@ fun ReaderScreen(
                     .joinToString(", ") { it.name }
                     .ifBlank { null },
                 theme = prefs.theme,
-                nextTitle = nextUp?.title,
-                nextVolume = nextUp?.volume,
+                seriesName = continuation?.seriesName,
+                finishedVolume = continuation?.finishedVolume,
+                next = continuation?.next,
+                missingIndex = continuation?.missingIndex,
+                noNextInLibrary = continuation?.noNextInLibrary == true,
+                seriesCompletion = continuation?.seriesCompletion,
                 rtl = endpaperRtl,
-                onTurnBack = { showingEnd = false },
-                onLibrary = onBack,
-                onOpenNext = { nextUp?.let(onOpenNextUp) },
+                onTurnBack = {
+                    showingEnd = false
+                    onLeftEndpaper()
+                },
+                onLibrary = {
+                    onLeftEndpaper()
+                    onBack()
+                },
+                onOpenNext = onContinueNext,
             )
         }
 
@@ -467,19 +484,6 @@ fun ReaderScreen(
                             onDismiss = onProgressAction.dismissCatchUp,
                         )
                     }
-                    // The book is finished, so nothing about this one is
-                    // still pending: the next one is the only offer left.
-                    if (catchUp == null) {
-                        nextUp?.let { offer ->
-                            NextInSeriesPill(
-                                title = offer.title,
-                                volume = offer.volume,
-                                theme = prefs.theme,
-                                onOpen = { onOpenNextUp(offer) },
-                                onDismiss = onDismissNextUp,
-                            )
-                        }
-                    }
                 }
                 if (chromeVisible) {
                     ReadingScrubber(
@@ -497,7 +501,7 @@ fun ReaderScreen(
                             }
                         },
                     )
-                } else if (!scrollMode && jumpBack == null && catchUp == null && nextUp == null) {
+                } else if (!scrollMode && jumpBack == null && catchUp == null) {
                     // A scrolled page runs under this corner, so a footer
                     // left drawn there prints itself over the text. The
                     // figures are one tap away with the rest of the chrome.
@@ -672,7 +676,10 @@ fun ReaderScreen(
         )
     }
 
-    BackHandler(enabled = showingEnd) { showingEnd = false }
+    BackHandler(enabled = showingEnd) {
+        showingEnd = false
+        onLeftEndpaper()
+    }
 
     searchFor?.let { initial ->
         BackHandler {
@@ -706,6 +713,7 @@ fun ReaderScreen(
     LaunchedEffect(goTo) {
         goTo.collect { locator ->
             showingEnd = false
+            onLeftEndpaper()
             showToc = false
             chromeVisible = false
             navigatorNow?.go(locator, animated = false)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -103,6 +103,7 @@ import com.chmouel.liseur.reader.chrome.ReadingFooter
 import com.chmouel.liseur.reader.chrome.ScrollEdgeTurner
 import com.chmouel.liseur.reader.chrome.ReadingScrubber
 import com.chmouel.liseur.reader.chrome.ContentsScreen
+import com.chmouel.liseur.reader.chrome.Endpaper
 import com.chmouel.liseur.reader.chrome.TypographySheet
 import com.chmouel.liseur.reader.progress.ReaderProgress
 import com.chmouel.liseur.reader.search.SearchScreen
@@ -120,6 +121,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.drop
 import org.readium.r2.navigator.Decoration
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
+import org.readium.r2.navigator.preferences.ReadingProgression
 import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
@@ -203,6 +205,9 @@ fun ReaderScreen(
     val effectScope = rememberCoroutineScope()
     val eInk = LocalEInk.current
     val eInkNow by rememberUpdatedState(eInk)
+    var showingEnd by remember { mutableStateOf(false) }
+    val showingEndNow by rememberUpdatedState(showingEnd)
+    var endpaperRtl by remember { mutableStateOf(false) }
     val pageTurnEffect = remember { PageTurnEffectState(effectScope) }
     val pageTurner = remember {
         PageTurner(
@@ -221,6 +226,15 @@ fun ReaderScreen(
             // cannot paginate it, so a book can be scrolling here with
             // the setting switched off.
             isVerticalText = { navigatorNow?.settings?.value?.verticalText == true },
+            showingEnd = { showingEndNow },
+            onReachedEnd = {
+                endpaperRtl = navigatorNow?.overflow?.value?.readingProgression ==
+                    ReadingProgression.RTL
+                showingEnd = true
+                chromeVisible = false
+                view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+            },
+            onLeaveEnd = { showingEnd = false },
         )
     }
 
@@ -391,19 +405,37 @@ fun ReaderScreen(
             }
         }
 
+        if (showingEnd) {
+            Endpaper(
+                title = publication.metadata.title.orEmpty(),
+                author = publication.metadata.authors
+                    .joinToString(", ") { it.name }
+                    .ifBlank { null },
+                theme = prefs.theme,
+                nextTitle = nextUp?.title,
+                nextVolume = nextUp?.volume,
+                rtl = endpaperRtl,
+                onTurnBack = { showingEnd = false },
+                onLibrary = onBack,
+                onOpenNext = { nextUp?.let(onOpenNextUp) },
+            )
+        }
+
         PageTurnOverlay(pageTurnEffect)
 
-        BookmarkRibbon(
-            bookmarked = bookmarked,
-            theme = prefs.theme,
-            onToggle = {
-                view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
-                onAnnotationAction.toggleBookmark()
-            },
-            modifier = Modifier
-                .align(Alignment.TopEnd)
-                .padding(end = 12.dp),
-        )
+        if (!showingEnd) {
+            BookmarkRibbon(
+                bookmarked = bookmarked,
+                theme = prefs.theme,
+                onToggle = {
+                    view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+                    onAnnotationAction.toggleBookmark()
+                },
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(end = 12.dp),
+            )
+        }
 
         Column(
             Modifier
@@ -411,69 +443,71 @@ fun ReaderScreen(
                 .fillMaxWidth()
                 .windowInsetsPadding(WindowInsets.navigationBarsIgnoringVisibility),
         ) {
-            jumpBack?.let { target ->
-                JumpBackPill(
-                    position = target.position,
-                    fromSync = target.fromSync,
-                    theme = prefs.theme,
-                    onJumpBack = {
-                        onProgressAction.dismissJumpBack()
-                        navigator?.go(target.locator, animated = false)
-                    },
-                    onDismiss = onProgressAction.dismissJumpBack,
-                )
-            }
-            // The way back outranks the way forward: a jump that just
-            // happened is the fresher offer, and two pills is a quiz.
-            if (jumpBack == null) {
-                catchUp?.let { offer ->
-                    CatchUpPill(
-                        position = offer.position,
+            if (!showingEnd) {
+                jumpBack?.let { target ->
+                    JumpBackPill(
+                        position = target.position,
+                        fromSync = target.fromSync,
                         theme = prefs.theme,
-                        onCatchUp = onProgressAction.acceptCatchUp,
-                        onDismiss = onProgressAction.dismissCatchUp,
+                        onJumpBack = {
+                            onProgressAction.dismissJumpBack()
+                            navigator?.go(target.locator, animated = false)
+                        },
+                        onDismiss = onProgressAction.dismissJumpBack,
                     )
                 }
-                // The book is finished, so nothing about this one is
-                // still pending: the next one is the only offer left.
-                if (catchUp == null) {
-                    nextUp?.let { offer ->
-                        NextInSeriesPill(
-                            title = offer.title,
-                            volume = offer.volume,
+                // The way back outranks the way forward: a jump that just
+                // happened is the fresher offer, and two pills is a quiz.
+                if (jumpBack == null) {
+                    catchUp?.let { offer ->
+                        CatchUpPill(
+                            position = offer.position,
                             theme = prefs.theme,
-                            onOpen = { onOpenNextUp(offer) },
-                            onDismiss = onDismissNextUp,
+                            onCatchUp = onProgressAction.acceptCatchUp,
+                            onDismiss = onProgressAction.dismissCatchUp,
                         )
                     }
-                }
-            }
-            if (chromeVisible) {
-                ReadingScrubber(
-                    progress = progress,
-                    theme = prefs.theme,
-                    chapterTicks = remember(progress?.totalPositions) {
-                        onProgressAction.chapterTicks()
-                    },
-                    titleAtPosition = onProgressAction.chapterTitleAtPosition,
-                    positionAtProgression = onProgressAction.positionAtProgression,
-                    onSeek = { position ->
-                        onProgressAction.locatorAtPosition(position)?.let {
-                            onProgressAction.onJump()
-                            navigator?.go(it, animated = false)
+                    // The book is finished, so nothing about this one is
+                    // still pending: the next one is the only offer left.
+                    if (catchUp == null) {
+                        nextUp?.let { offer ->
+                            NextInSeriesPill(
+                                title = offer.title,
+                                volume = offer.volume,
+                                theme = prefs.theme,
+                                onOpen = { onOpenNextUp(offer) },
+                                onDismiss = onDismissNextUp,
+                            )
                         }
-                    },
-                )
-            } else if (!scrollMode && jumpBack == null && catchUp == null && nextUp == null) {
-                // A scrolled page runs under this corner, so a footer
-                // left drawn there prints itself over the text. The
-                // figures are one tap away with the rest of the chrome.
-                ReadingFooter(
-                    progress = progress,
-                    mode = prefs.footerMode,
-                    theme = prefs.theme,
-                    onCycleMode = onProgressAction.cycleFooterMode,
-                )
+                    }
+                }
+                if (chromeVisible) {
+                    ReadingScrubber(
+                        progress = progress,
+                        theme = prefs.theme,
+                        chapterTicks = remember(progress?.totalPositions) {
+                            onProgressAction.chapterTicks()
+                        },
+                        titleAtPosition = onProgressAction.chapterTitleAtPosition,
+                        positionAtProgression = onProgressAction.positionAtProgression,
+                        onSeek = { position ->
+                            onProgressAction.locatorAtPosition(position)?.let {
+                                onProgressAction.onJump()
+                                navigator?.go(it, animated = false)
+                            }
+                        },
+                    )
+                } else if (!scrollMode && jumpBack == null && catchUp == null && nextUp == null) {
+                    // A scrolled page runs under this corner, so a footer
+                    // left drawn there prints itself over the text. The
+                    // figures are one tap away with the rest of the chrome.
+                    ReadingFooter(
+                        progress = progress,
+                        mode = prefs.footerMode,
+                        theme = prefs.theme,
+                        onCycleMode = onProgressAction.cycleFooterMode,
+                    )
+                }
             }
         }
 
@@ -483,7 +517,7 @@ fun ReaderScreen(
         // drawn once.
         val chromeAnim = if (LocalEInk.current) 0 else CHROME_ANIM_MS
         AnimatedVisibility(
-            visible = chromeVisible,
+            visible = chromeVisible && !showingEnd,
             enter = slideInVertically(tween(chromeAnim)) { -it } + fadeIn(tween(chromeAnim)),
             exit = slideOutVertically(tween(chromeAnim)) { -it } + fadeOut(tween(chromeAnim)),
             modifier = Modifier.align(Alignment.TopCenter),
@@ -638,6 +672,8 @@ fun ReaderScreen(
         )
     }
 
+    BackHandler(enabled = showingEnd) { showingEnd = false }
+
     searchFor?.let { initial ->
         BackHandler {
             searchFor = null
@@ -669,6 +705,7 @@ fun ReaderScreen(
     // is recorded before the move, so it is not done again here.
     LaunchedEffect(goTo) {
         goTo.collect { locator ->
+            showingEnd = false
             showToc = false
             chromeVisible = false
             navigatorNow?.go(locator, animated = false)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -9,10 +9,14 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.chmouel.liseur.R
 import com.chmouel.liseur.container
+import com.chmouel.liseur.data.calibre.BookDownloadRepository
 import com.chmouel.liseur.data.remote.PreviewOutcome
+import com.chmouel.liseur.data.remote.RemoteAccountRepository
 import com.chmouel.liseur.data.remote.ResolveOutcome
+import com.chmouel.liseur.data.remote.SeriesExtrasRepository
 import com.chmouel.liseur.data.remote.SyncPreview
 import com.chmouel.liseur.data.db.AnnotationKind
+import com.chmouel.liseur.data.db.Book
 import com.chmouel.liseur.data.db.BookAnnotation
 import com.chmouel.liseur.data.db.BookAnnotationDao
 import com.chmouel.liseur.data.db.BookDao
@@ -43,8 +47,8 @@ import com.chmouel.liseur.data.settings.ColumnMode
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.ReaderTheme
 import com.chmouel.liseur.domain.EPSILON
-import com.chmouel.liseur.domain.nextInSeries
-import com.chmouel.liseur.domain.seriesIndexLabel
+import com.chmouel.liseur.domain.SeriesExtras
+import com.chmouel.liseur.domain.seriesIdForExtras
 import com.chmouel.liseur.domain.DictionaryUrl
 import com.chmouel.liseur.domain.isSamePassage
 import com.chmouel.liseur.domain.exportNotebookMarkdown
@@ -57,6 +61,7 @@ import com.chmouel.liseur.reader.progress.ReaderProgress
 import com.chmouel.liseur.reader.progress.ReadingPace
 import com.chmouel.liseur.reader.progress.ReadingSpeedEstimator
 import com.chmouel.liseur.reader.progress.StableBookProgress
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -67,6 +72,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -107,6 +113,9 @@ class ReaderViewModel(
     private val positionSync: PositionSyncCoordinator,
     private val appSettings: AppSettingsRepository,
     private val positionPublisher: ReadingPositionPublisher,
+    private val downloads: BookDownloadRepository,
+    private val seriesExtras: SeriesExtrasRepository,
+    private val remoteAccount: RemoteAccountRepository,
     sessionManager: ReadingSessionManager,
 ) : ViewModel() {
 
@@ -166,63 +175,132 @@ class ReaderViewModel(
     val jumpBack: StateFlow<JumpBack?> = _jumpBack.asStateFlow()
 
     /**
-     * The book to read after this one, once this one is done.
+     * Raised when the last page has been turned: the next volume, if
+     * there is one, and how the series itself reads if there is not.
      *
-     * Offered only when the file is already here. A series is exactly
-     * where "read the next one" is a real answer rather than a guess,
-     * but an offer that turns into a download, a wait and a failure is
-     * not the same offer, and the last page of a book is the worst place
-     * to find that out.
-     */
-    data class NextUp(
-        /** The file to open. */
-        val fileUrl: String,
-        /** The book's identity in the library, so its position is its own. */
-        val id: String,
-        val title: String,
-        val volume: String?,
-    )
-
-    /**
-     * Raised when the book being read is finished and the next volume of
-     * its series is on the shelf, unread.
-     *
-     * Dismissing it is remembered for as long as the book is open, so it
-     * is offered once and does not come back every time the last page is
-     * turned to.
+     * Dismissing the next volume is remembered for as long as this book
+     * is open. Turning back off the endpaper withdraws the offer without
+     * undoing that the book is finished.
      */
     private val dismissedNextUp = MutableStateFlow(false)
+    private val endpaperReached = MutableStateFlow(false)
+    private val continueAfterDownload = MutableStateFlow(false)
+    private val _seriesExtras = MutableStateFlow<SeriesExtras?>(null)
+    private val _pendingOpen = MutableStateFlow<NextUp?>(null)
 
-    val nextUp: StateFlow<NextUp?> = combine(
-        bookDao.observeAll(),
-        progressDao.observeProgressions(),
-        dismissedNextUp,
-        _progress,
-    ) { books, progressions, dismissed, readerProgress ->
-        if (dismissed) return@combine null
-        val current = books.firstOrNull { it.url == bookId } ?: return@combine null
-        if (!shouldOfferNextInSeries(current.finished, readerProgress)) return@combine null
-        val next = nextInSeries(
-            finished = current,
-            library = books,
-            progressions = progressions
-                .mapNotNull { row -> row.totalProgression?.let { row.bookUrl to it } }
-                .toMap(),
-        ) ?: return@combine null
-        // Only a book that can be opened right now.
-        val openable = next.openableUrl ?: return@combine null
-        NextUp(
-            fileUrl = openable,
-            id = next.url,
-            title = next.title,
-            volume = seriesIndexLabel(next.seriesIndex),
+    /**
+     * The next volume to open once it is ready, kept until a resumed
+     * reader takes it. A one-shot event would vanish during rotation
+     * and fire while the activity is stopped.
+     */
+    val pendingOpen: StateFlow<NextUp?> = _pendingOpen.asStateFlow()
+
+    private val canDownload: StateFlow<Boolean> = remoteAccount.server
+        .map { it?.canDownload == true }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    val continuation: StateFlow<EndpaperContinuation?> = combine(
+        combine(
+            bookDao.observeAll(),
+            progressDao.observeProgressions(),
+            dismissedNextUp,
+            endpaperReached,
+            downloads.progress,
+        ) { books, progressions, dismissed, endpaper, running ->
+            ContinuationInputs(
+                books = books,
+                progressions = progressions
+                    .mapNotNull { row -> row.totalProgression?.let { row.bookUrl to it } }
+                    .toMap(),
+                dismissed = dismissed,
+                endpaperReached = endpaper,
+                downloads = running.mapValues { (_, progress) ->
+                    DownloadSnapshot(
+                        queued = progress.queued,
+                        fraction = progress.fraction,
+                        running = !progress.queued,
+                    )
+                },
+            )
+        },
+        canDownload,
+        _seriesExtras,
+    ) { inputs, allowed, extras ->
+        val current = inputs.books.firstOrNull { it.url == bookId } ?: return@combine null
+        endpaperContinuation(
+            current = current,
+            library = inputs.books,
+            progressions = inputs.progressions,
+            dismissed = inputs.dismissed,
+            endpaperReached = inputs.endpaperReached,
+            downloads = inputs.downloads,
+            canDownload = allowed,
+            extras = extras,
         )
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-    /** The offer was declined, or taken. Either way it is done with. */
+    /** The last page was turned past. The book is finished from here. */
+    fun onReachedEndpaper() {
+        endpaperReached.value = true
+        positionPublisher.completeBook(bookId)
+    }
+
+    /**
+     * The reader turned back, went to the library, or otherwise left
+     * the endpaper. A download already started keeps running; it just
+     * will not open itself.
+     */
+    fun onLeftEndpaper() {
+        endpaperReached.value = false
+        continueAfterDownload.value = false
+        _pendingOpen.value = null
+    }
+
+    /** The offer was declined. Either way it is done with. */
     fun dismissNextUp() {
         dismissedNextUp.value = true
+        continueAfterDownload.value = false
+        _pendingOpen.value = null
     }
+
+    /**
+     * The endpaper action was taken: open a file that is here, or fetch
+     * one that is not. A download that cannot succeed is not started.
+     */
+    fun onContinueNext() {
+        val next = continuation.value?.next ?: return
+        when (next.availability) {
+            is NextVolumeAvailability.Ready,
+            NextVolumeAvailability.Queued,
+            is NextVolumeAvailability.Downloading,
+            -> {
+                continueAfterDownload.value = true
+            }
+            NextVolumeAvailability.Remote, NextVolumeAvailability.Failed -> {
+                if (!canDownload.value) return
+                continueAfterDownload.value = true
+                viewModelScope.launch {
+                    val book = bookDao.getByUrl(next.id) ?: return@launch
+                    downloads.enqueue(book)
+                }
+            }
+            NextVolumeAvailability.Unavailable -> Unit
+        }
+    }
+
+    /** The resumed reader opened the pending volume, so it is spent. */
+    fun consumeOpenNext() {
+        continueAfterDownload.value = false
+        _pendingOpen.value = null
+    }
+
+    private data class ContinuationInputs(
+        val books: List<Book>,
+        val progressions: Map<String, Double>,
+        val dismissed: Boolean,
+        val endpaperReached: Boolean,
+        val downloads: Map<String, DownloadSnapshot>,
+    )
 
     /** An offer to continue where another device has read further. */
     data class CatchUp(val progression: Double, val position: Int?)
@@ -431,6 +509,30 @@ class ReaderViewModel(
                 if (failedBook == bookId) {
                     _bookSync.value = BookSync.Note(R.string.reader_position_not_saved)
                 }
+            }
+        }
+        viewModelScope.launch {
+            bookDao.observeAll()
+                .map { books ->
+                    val current = books.firstOrNull { it.url == bookId } ?: return@map null
+                    seriesIdForExtras(current, books)
+                }
+                .distinctUntilChanged()
+                .collect { seriesId ->
+                    _seriesExtras.value = try {
+                        seriesExtras.extras(seriesId)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (_: Exception) {
+                        null
+                    }
+                }
+        }
+        viewModelScope.launch {
+            combine(continuation, continueAfterDownload) { offer, auto ->
+                readyToOpen(offer, auto)
+            }.collect { next ->
+                _pendingOpen.value = next
             }
         }
         open()
@@ -1063,14 +1165,12 @@ class ReaderViewModel(
                     positionSync = container.positionSync,
                     appSettings = container.appSettings,
                     positionPublisher = container.readingPositions,
+                    downloads = container.bookDownloads,
+                    seriesExtras = container.seriesExtras,
+                    remoteAccount = container.remoteAccount,
                     sessionManager = container.readingSessions,
                 )
             }
         }
     }
 }
-
-/** A completed flag alone is not enough: manually finished books can be reopened anywhere. */
-internal fun shouldOfferNextInSeries(finished: Boolean, progress: ReaderProgress?): Boolean =
-    finished && progress != null && progress.totalPositions > 0 &&
-        progress.position >= progress.totalPositions

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/Endpaper.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/Endpaper.kt
@@ -1,0 +1,230 @@
+package com.chmouel.liseur.reader.chrome
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import com.chmouel.liseur.R
+import com.chmouel.liseur.data.settings.ReaderTheme
+import com.chmouel.liseur.ui.contentWidthCap
+import com.chmouel.liseur.ui.windowWidth
+
+/**
+ * The page past the last page: a quiet colophon instead of the empty
+ * columns Readium would keep turning through.
+ *
+ * It is a page, so the same tap zones apply — the back side returns to
+ * the last page of the book, the forward side stays put. The actions
+ * stay at the foot of the page so a short window or a large font cannot
+ * push them off the screen; the title above them scrolls if it must.
+ */
+@Composable
+fun Endpaper(
+    title: String,
+    author: String?,
+    theme: ReaderTheme,
+    nextTitle: String?,
+    nextVolume: String?,
+    rtl: Boolean,
+    onTurnBack: () -> Unit,
+    onLibrary: () -> Unit,
+    onOpenNext: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val density = LocalDensity.current.density
+    var size by remember { mutableStateOf(IntSize.Zero) }
+    val description = stringResource(R.string.the_end)
+    Box(
+        modifier
+            .fillMaxSize()
+            .background(theme.background)
+            .semantics { contentDescription = description }
+            .onSizeChanged { size = it }
+            .pointerInput(size, rtl, density) {
+                if (size.width <= 0 || size.height <= 0) return@pointerInput
+                detectTapGestures { offset ->
+                    val zone = ReaderTapZones.zoneAt(
+                        x = offset.x,
+                        y = offset.y,
+                        width = size.width.toFloat(),
+                        height = size.height.toFloat(),
+                        density = density,
+                    )
+                    val forward = when (zone) {
+                        ReaderTapZones.Zone.BACK -> rtl
+                        ReaderTapZones.Zone.FORWARD -> !rtl
+                        ReaderTapZones.Zone.CHROME -> return@detectTapGestures
+                    }
+                    if (!forward) onTurnBack()
+                }
+            },
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .align(Alignment.Center)
+                .fillMaxHeight()
+                .fillMaxWidth()
+                .widthIn(max = contentWidthCap(windowWidth()))
+                .windowInsetsPadding(WindowInsets.systemBars)
+                .padding(horizontal = 32.dp, vertical = 16.dp),
+        ) {
+            BoxWithConstraints(
+                Modifier
+                    .weight(1f)
+                    .fillMaxWidth(),
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = maxHeight)
+                        .verticalScroll(rememberScrollState()),
+                ) {
+                    EndRule(color = theme.foreground.copy(alpha = 0.35f))
+                    Spacer(Modifier.height(20.dp))
+                    Text(
+                        text = stringResource(R.string.the_end),
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontStyle = FontStyle.Italic,
+                        color = theme.foreground,
+                        textAlign = TextAlign.Center,
+                    )
+                    Spacer(Modifier.height(20.dp))
+                    if (title.isNotBlank()) {
+                        Text(
+                            text = title,
+                            style = MaterialTheme.typography.titleLarge,
+                            color = theme.foreground,
+                            textAlign = TextAlign.Center,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                    if (!author.isNullOrBlank()) {
+                        Spacer(Modifier.height(8.dp))
+                        Text(
+                            text = author,
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontStyle = FontStyle.Italic,
+                            color = theme.foreground.copy(alpha = 0.7f),
+                            textAlign = TextAlign.Center,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
+            if (nextTitle != null) {
+                Spacer(Modifier.height(12.dp))
+                EndpaperAction(
+                    text = if (nextVolume != null) {
+                        stringResource(R.string.endpaper_next_numbered, nextVolume, nextTitle)
+                    } else {
+                        stringResource(R.string.endpaper_next, nextTitle)
+                    },
+                    color = theme.foreground,
+                    onClick = onOpenNext,
+                )
+            }
+            EndpaperAction(
+                text = stringResource(R.string.endpaper_library),
+                color = theme.foreground.copy(alpha = if (nextTitle != null) 0.7f else 1f),
+                onClick = onLibrary,
+            )
+        }
+    }
+}
+
+@Composable
+private fun EndpaperAction(
+    text: String,
+    color: Color,
+    onClick: () -> Unit,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyLarge,
+        color = color,
+        textAlign = TextAlign.Center,
+        modifier = Modifier
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onClick,
+            )
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+    )
+}
+
+/** A colophon rule: two thin lines with a point between them. */
+@Composable
+private fun EndRule(color: Color, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier.fillMaxWidth(0.42f),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Box(
+            Modifier
+                .weight(1f)
+                .height(1.dp)
+                .background(color),
+        )
+        Box(
+            Modifier
+                .size(5.dp)
+                .clip(CircleShape)
+                .background(color),
+        )
+        Box(
+            Modifier
+                .weight(1f)
+                .height(1.dp)
+                .background(color),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/Endpaper.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/Endpaper.kt
@@ -1,6 +1,7 @@
 package com.chmouel.liseur.reader.chrome
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -19,11 +21,14 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -35,6 +40,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
@@ -42,13 +48,22 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.chmouel.liseur.R
 import com.chmouel.liseur.data.settings.ReaderTheme
+import com.chmouel.liseur.domain.SeriesCompletion
+import com.chmouel.liseur.domain.displayTitle
+import com.chmouel.liseur.domain.seriesIndexLabel
+import com.chmouel.liseur.reader.NextUp
+import com.chmouel.liseur.reader.NextVolumeAvailability
+import com.chmouel.liseur.ui.LocalEInk
 import com.chmouel.liseur.ui.contentWidthCap
+import com.chmouel.liseur.ui.library.BookCover
 import com.chmouel.liseur.ui.windowWidth
 
 /**
@@ -59,14 +74,20 @@ import com.chmouel.liseur.ui.windowWidth
  * the last page of the book, the forward side stays put. The actions
  * stay at the foot of the page so a short window or a large font cannot
  * push them off the screen; the title above them scrolls if it must.
+ * The next volume is a small card of its own: cover, name, and one
+ * action, in the reading colours rather than a second chrome.
  */
 @Composable
 fun Endpaper(
     title: String,
     author: String?,
     theme: ReaderTheme,
-    nextTitle: String?,
-    nextVolume: String?,
+    seriesName: String? = null,
+    finishedVolume: String? = null,
+    next: NextUp?,
+    missingIndex: Double? = null,
+    noNextInLibrary: Boolean = false,
+    seriesCompletion: SeriesCompletion?,
     rtl: Boolean,
     onTurnBack: () -> Unit,
     onLibrary: () -> Unit,
@@ -109,7 +130,7 @@ fun Endpaper(
                 .fillMaxWidth()
                 .widthIn(max = contentWidthCap(windowWidth()))
                 .windowInsetsPadding(WindowInsets.systemBars)
-                .padding(horizontal = 32.dp, vertical = 16.dp),
+                .padding(horizontal = 28.dp, vertical = 16.dp),
         ) {
             BoxWithConstraints(
                 Modifier
@@ -133,7 +154,7 @@ fun Endpaper(
                         color = theme.foreground,
                         textAlign = TextAlign.Center,
                     )
-                    Spacer(Modifier.height(20.dp))
+                    Spacer(Modifier.height(16.dp))
                     if (title.isNotBlank()) {
                         Text(
                             text = title,
@@ -144,8 +165,20 @@ fun Endpaper(
                             overflow = TextOverflow.Ellipsis,
                         )
                     }
+                    val seriesLine = finishedSeriesLine(seriesName, finishedVolume)
+                    if (seriesLine != null) {
+                        Spacer(Modifier.height(6.dp))
+                        Text(
+                            text = seriesLine,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = theme.foreground.copy(alpha = 0.7f),
+                            textAlign = TextAlign.Center,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
                     if (!author.isNullOrBlank()) {
-                        Spacer(Modifier.height(8.dp))
+                        Spacer(Modifier.height(6.dp))
                         Text(
                             text = author,
                             style = MaterialTheme.typography.bodyLarge,
@@ -158,21 +191,46 @@ fun Endpaper(
                     }
                 }
             }
-            if (nextTitle != null) {
-                Spacer(Modifier.height(12.dp))
-                EndpaperAction(
-                    text = if (nextVolume != null) {
-                        stringResource(R.string.endpaper_next_numbered, nextVolume, nextTitle)
-                    } else {
-                        stringResource(R.string.endpaper_next, nextTitle)
-                    },
-                    color = theme.foreground,
-                    onClick = onOpenNext,
+            val missingLabel = seriesIndexLabel(missingIndex)
+            if (missingLabel != null) {
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    text = stringResource(R.string.series_missing_volume, missingLabel),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = theme.foreground.copy(alpha = 0.7f),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
                 )
+            }
+            if (next != null) {
+                Spacer(Modifier.height(if (missingLabel != null) 10.dp else 16.dp))
+                EndpaperNextOffer(
+                    next = next,
+                    color = theme.foreground,
+                    onOpenNext = onOpenNext,
+                )
+            } else if (missingLabel == null) {
+                val copy = if (noNextInLibrary) {
+                    stringResource(R.string.endpaper_no_next_in_library)
+                } else {
+                    seriesCompletionCopy(seriesCompletion)
+                }
+                copy?.let {
+                    Spacer(Modifier.height(16.dp))
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = theme.foreground.copy(alpha = 0.7f),
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
+                    )
+                }
             }
             EndpaperAction(
                 text = stringResource(R.string.endpaper_library),
-                color = theme.foreground.copy(alpha = if (nextTitle != null) 0.7f else 1f),
+                color = theme.foreground.copy(
+                    alpha = if (next != null || missingLabel != null) 0.55f else 1f,
+                ),
                 onClick = onLibrary,
             )
         }
@@ -180,23 +238,157 @@ fun Endpaper(
 }
 
 @Composable
+private fun EndpaperNextOffer(
+    next: NextUp,
+    color: Color,
+    onOpenNext: () -> Unit,
+) {
+    val clickable = when (next.availability) {
+        is NextVolumeAvailability.Ready,
+        NextVolumeAvailability.Remote,
+        NextVolumeAvailability.Failed,
+        NextVolumeAvailability.Queued,
+        is NextVolumeAvailability.Downloading,
+        -> true
+        NextVolumeAvailability.Unavailable -> false
+    }
+    val eInk = LocalEInk.current
+    val shape = RoundedCornerShape(14.dp)
+    val kicker = next.volume?.let { stringResource(R.string.endpaper_next_kicker_numbered, it) }
+        ?: stringResource(R.string.endpaper_next_kicker)
+    val action = nextActionLabel(next)
+    val title = next.book.displayTitle
+    val fraction = (next.availability as? NextVolumeAvailability.Downloading)?.fraction
+    val description = "$kicker. $title. $action"
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(shape)
+            .then(
+                if (eInk) {
+                    Modifier.border(1.dp, color.copy(alpha = 0.4f), shape)
+                } else {
+                    Modifier
+                        .background(color.copy(alpha = 0.07f), shape)
+                        .border(1.dp, color.copy(alpha = 0.12f), shape)
+                },
+            )
+            .then(
+                if (clickable) {
+                    Modifier.clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = onOpenNext,
+                    )
+                } else {
+                    Modifier
+                },
+            )
+            .semantics(mergeDescendants = true) { contentDescription = description }
+            .padding(12.dp),
+    ) {
+        BookCover(
+            book = next.book,
+            modifier = Modifier
+                .width(76.dp)
+                .aspectRatio(2f / 3f),
+        )
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(
+                text = kicker.uppercase(),
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = 1.4.sp,
+                color = color.copy(alpha = 0.55f),
+                maxLines = 1,
+            )
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = color.copy(alpha = if (clickable) 1f else 0.7f),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = action,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = color.copy(alpha = if (clickable) 0.9f else 0.55f),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (fraction != null) {
+                Spacer(Modifier.height(8.dp))
+                LinearProgressIndicator(
+                    progress = { fraction },
+                    color = color,
+                    trackColor = color.copy(alpha = 0.2f),
+                    strokeCap = StrokeCap.Round,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(4.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun nextActionLabel(next: NextUp): String = when (next.availability) {
+    is NextVolumeAvailability.Ready -> stringResource(R.string.endpaper_continue)
+    NextVolumeAvailability.Remote -> stringResource(R.string.endpaper_download)
+    NextVolumeAvailability.Queued -> stringResource(R.string.endpaper_waiting)
+    is NextVolumeAvailability.Downloading -> stringResource(R.string.endpaper_downloading)
+    NextVolumeAvailability.Failed -> stringResource(R.string.endpaper_retry)
+    NextVolumeAvailability.Unavailable -> stringResource(R.string.endpaper_unavailable)
+}
+
+@Composable
+private fun finishedSeriesLine(seriesName: String?, finishedVolume: String?): String? {
+    val series = seriesName?.takeIf { it.isNotBlank() } ?: return null
+    val volume = finishedVolume?.takeIf { it.isNotBlank() } ?: return series
+    return stringResource(R.string.series_position, series, volume)
+}
+
+@Composable
+private fun seriesCompletionCopy(completion: SeriesCompletion?): String? = when (completion) {
+    SeriesCompletion.COMPLETE -> stringResource(R.string.series_all_read)
+    SeriesCompletion.CAUGHT_UP -> stringResource(R.string.series_caught_up)
+    SeriesCompletion.ALL_KNOWN_READ -> stringResource(R.string.series_all_known_read)
+    SeriesCompletion.IN_PROGRESS, null -> null
+}
+
+@Composable
 private fun EndpaperAction(
     text: String,
     color: Color,
-    onClick: () -> Unit,
+    onClick: (() -> Unit)?,
 ) {
     Text(
         text = text,
-        style = MaterialTheme.typography.bodyLarge,
+        style = MaterialTheme.typography.bodyMedium,
         color = color,
         textAlign = TextAlign.Center,
         modifier = Modifier
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
-                onClick = onClick,
+            .then(
+                if (onClick != null) {
+                    Modifier.clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = onClick,
+                    )
+                } else {
+                    Modifier
+                },
             )
-            .padding(horizontal = 16.dp, vertical = 10.dp),
+            .padding(horizontal = 16.dp, vertical = 12.dp),
     )
 }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnEffect.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnEffect.kt
@@ -6,9 +6,7 @@ import android.os.Handler
 import android.os.Looper
 import android.view.PixelCopy
 import android.view.View
-import android.view.ViewGroup
 import android.view.Window
-import android.webkit.WebView
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.tween
@@ -30,6 +28,7 @@ import kotlinx.coroutines.launch
 import org.readium.r2.navigator.OverflowableNavigator
 import org.readium.r2.navigator.preferences.ReadingProgression
 import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.indexOfFirstWithHref
 
@@ -91,6 +90,10 @@ fun PageTurnOverlay(state: PageTurnEffectState, modifier: Modifier = Modifier) {
  *
  * A scrolled book is a different movement altogether, and [isScrolling]
  * says so: see [scrollScreenful].
+ *
+ * The page past the last page of the book is not another leaf: Readium
+ * paginates leftover CSS columns, so [goForward] keeps succeeding on
+ * empty air. [onReachedEnd] is that extra turn, onto the endpaper.
  */
 @OptIn(ExperimentalReadiumApi::class)
 class PageTurner(
@@ -99,6 +102,9 @@ class PageTurner(
     private val isEffectSuppressed: () -> Boolean,
     private val isScrolling: () -> Boolean = { false },
     private val isVerticalText: () -> Boolean = { false },
+    private val showingEnd: () -> Boolean = { false },
+    private val onReachedEnd: () -> Unit = {},
+    private val onLeaveEnd: () -> Unit = {},
 ) {
     var navigator: OverflowableNavigator? = null
     var window: Window? = null
@@ -110,12 +116,38 @@ class PageTurner(
      */
     var publication: Publication? = null
 
+    /** True while a snapshot of the last page is being taken for the endpaper. */
+    private var pendingEnd = false
+
+    /**
+     * Bumped on every turn so an in-flight last-page probe cannot act
+     * after the reader has already moved.
+     */
+    private var probeGeneration = 0L
+
     fun turn(forward: Boolean) {
-        val nav = navigator ?: return
-        if (isScrolling()) {
-            scrollScreenful(nav, forward)
+        if (showingEnd() || pendingEnd) {
+            if (!forward && showingEnd()) onLeaveEnd()
             return
         }
+        val generation = ++probeGeneration
+        val nav = navigator ?: return
+        if (isScrolling()) {
+            scrollScreenful(nav, forward, generation)
+            return
+        }
+        if (forward && isOnLastResource(nav)) {
+            val probed = nav.currentLocator.value
+            askIfLastContentVisible(nav) { atEnd ->
+                if (!probeStillHolds(generation, nav, probed)) return@askIfLastContentVisible
+                if (atEnd) revealEnd() else turnPaginated(nav, forward = true)
+            }
+            return
+        }
+        turnPaginated(nav, forward)
+    }
+
+    private fun turnPaginated(nav: OverflowableNavigator, forward: Boolean) {
         if (!isAnimated()) {
             navigate(nav, forward, animated = false)
             return
@@ -130,6 +162,49 @@ class PageTurner(
             navigate(nav, forward, animated = !effect.isRunning)
             return
         }
+        copyPage(win, view) { bitmap ->
+            val moved = navigate(nav, forward, animated = false)
+            val rtl = nav.overflow.value.readingProgression == ReadingProgression.RTL
+            if (moved && bitmap != null) {
+                effect.start(bitmap, slideLeft = forward != rtl)
+            }
+        }
+    }
+
+    /**
+     * The extra turn after the last line: lift the last page off and
+     * leave the endpaper underneath, the same motion every other turn
+     * already makes.
+     */
+    private fun revealEnd() {
+        if (showingEnd() || pendingEnd) return
+        pendingEnd = true
+        val nav = navigator
+        val win = window
+        val view = nav?.publicationView
+        val show = {
+            pendingEnd = false
+            onReachedEnd()
+        }
+        if (nav == null || win == null || view == null || !isAnimated() ||
+            isEffectSuppressed() || effect.isRunning ||
+            view.width <= 0 || view.height <= 0
+        ) {
+            show()
+            return
+        }
+        val rtl = nav.overflow.value.readingProgression == ReadingProgression.RTL
+        copyPage(win, view) { bitmap ->
+            show()
+            if (bitmap != null) effect.start(bitmap, slideLeft = !rtl)
+        }
+    }
+
+    private fun copyPage(
+        win: Window,
+        view: View,
+        onCopied: (ImageBitmap?) -> Unit,
+    ) {
         val location = IntArray(2)
         view.getLocationInWindow(location)
         val bounds = Rect(
@@ -139,12 +214,8 @@ class PageTurner(
             location[1] + view.height,
         )
         val bitmap = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
-        val rtl = nav.overflow.value.readingProgression == ReadingProgression.RTL
         PixelCopy.request(win, bounds, bitmap, { result ->
-            val moved = navigate(nav, forward, animated = false)
-            if (moved && result == PixelCopy.SUCCESS) {
-                effect.start(bitmap.asImageBitmap(), slideLeft = forward != rtl)
-            }
+            onCopied(bitmap.takeIf { result == PixelCopy.SUCCESS }?.asImageBitmap())
         }, Handler(Looper.getMainLooper()))
     }
 
@@ -152,8 +223,55 @@ class PageTurner(
         nav: OverflowableNavigator,
         forward: Boolean,
         animated: Boolean,
-    ): Boolean =
-        if (forward) nav.goForward(animated) else nav.goBackward(animated)
+    ): Boolean {
+        val moved = if (forward) nav.goForward(animated) else nav.goBackward(animated)
+        // The last resource can still refuse to move even when the page
+        // itself was not sure it was finished; that refusal is the end.
+        if (forward && !moved && isOnLastResource(nav)) revealEnd()
+        return moved
+    }
+
+    private fun isOnLastResource(nav: OverflowableNavigator): Boolean {
+        val pub = publication ?: return false
+        val index = pub.readingOrder.indexOfFirstWithHref(nav.currentLocator.value.href)
+        return isLastReadingResource(index, pub.readingOrder.lastIndex)
+    }
+
+    /**
+     * Asks the page whether its last line (or last picture) is already
+     * on screen. Scroll width cannot be trusted for this: leftover CSS
+     * columns inflate it past the text, which is how the last page
+     * keeps flipping.
+     */
+    private fun askIfLastContentVisible(
+        nav: OverflowableNavigator,
+        onResult: (Boolean) -> Unit,
+    ) {
+        val web = visibleWebView(nav.publicationView) ?: run {
+            onResult(false)
+            return
+        }
+        web.evaluateJavascript(lastContentVisibleScript()) { result ->
+            onResult(atEndOfBook(lastResource = true, pageReport = result))
+        }
+    }
+
+    /**
+     * True when the page that was asked is still the page on screen.
+     *
+     * `evaluateJavascript` answers later, and a backward turn or a
+     * chapter step in between would otherwise paint the endpaper over
+     * wherever the reader has gone.
+     */
+    private fun probeStillHolds(
+        generation: Long,
+        nav: OverflowableNavigator,
+        probed: Locator,
+    ): Boolean {
+        if (generation != probeGeneration) return false
+        if (navigator !== nav) return false
+        return sameProbeLocator(nav.currentLocator.value, probed)
+    }
 
     /**
      * Moves a screenful through a scrolled book, and on to the next
@@ -166,7 +284,11 @@ class PageTurner(
      * is in its own units and stops at its own ends; arithmetic on view
      * heights, densities and web view scale does not.
      */
-    private fun scrollScreenful(nav: OverflowableNavigator, forward: Boolean) {
+    private fun scrollScreenful(
+        nav: OverflowableNavigator,
+        forward: Boolean,
+        generation: Long,
+    ) {
         val web = visibleWebView(nav.publicationView) ?: run {
             navigate(nav, forward, animated = false)
             return
@@ -177,6 +299,7 @@ class PageTurner(
             vertical = isVerticalText(),
         )
         web.evaluateJavascript(script) { result ->
+            if (generation != probeGeneration || navigator !== nav) return@evaluateJavascript
             if (result?.contains(AT_END) == true) stepChapter(forward)
         }
     }
@@ -192,12 +315,20 @@ class PageTurner(
      * one that answered when this locator was made.
      */
     fun stepChapter(forward: Boolean): Boolean {
+        if (showingEnd() || pendingEnd) {
+            if (!forward && showingEnd()) onLeaveEnd()
+            return false
+        }
+        probeGeneration++
         val nav = navigator ?: return false
         val pub = publication ?: return false
         val readingOrder = pub.readingOrder
         val index = readingOrder.indexOfFirstWithHref(nav.currentLocator.value.href)
             ?: return false
-        val next = readingOrder.getOrNull(index + if (forward) 1 else -1) ?: return false
+        val next = readingOrder.getOrNull(index + if (forward) 1 else -1) ?: run {
+            if (forward) revealEnd()
+            return false
+        }
         val locator = pub.locatorFromLink(next) ?: return nav.go(next, animated = false)
         return nav.go(
             if (forward) locator else locator.copyWithLocations(progression = 1.0),
@@ -270,3 +401,131 @@ private const val EDGE_SLACK = 2
 internal const val AT_END = "at-end"
 
 private const val SCROLLED = "scrolled"
+
+/**
+ * Whether the resource on screen is the last one in the book.
+ *
+ * [indexInReadingOrder] is null when the href is not in the spine at
+ * all; [lastIndex] is -1 when the spine is empty. Neither is the end
+ * of a book — there is no book there.
+ */
+internal fun isLastReadingResource(indexInReadingOrder: Int?, lastIndex: Int): Boolean =
+    lastIndex >= 0 && indexInReadingOrder == lastIndex
+
+/**
+ * The last page of the last resource is the end of the book; the last
+ * page of a middle chapter is only the end of that chapter, and more
+ * content still waiting in the last resource is still a page.
+ */
+internal fun atEndOfBook(lastResource: Boolean, pageReport: String?): Boolean =
+    lastResource && pageReport?.contains(AT_END) == true
+
+/**
+ * Whether a last-page probe still describes the page on screen.
+ *
+ * Href and progression are both required: the last resource is one
+ * file, and a backward turn inside it would otherwise look like the
+ * same place.
+ */
+internal fun sameProbeLocator(current: Locator, probed: Locator): Boolean =
+    sameProbePlace(
+        currentHref = current.href.toString(),
+        currentProgression = current.locations.progression,
+        probedHref = probed.href.toString(),
+        probedProgression = probed.locations.progression,
+    )
+
+internal fun sameProbePlace(
+    currentHref: String,
+    currentProgression: Double?,
+    probedHref: String,
+    probedProgression: Double?,
+): Boolean {
+    if (currentHref != probedHref) return false
+    if (currentProgression == null && probedProgression == null) return true
+    if (currentProgression == null || probedProgression == null) return false
+    return kotlin.math.abs(currentProgression - probedProgression) < PROBE_PROGRESSION_SLACK
+}
+
+/**
+ * Whether the last line (or last picture) of this document is already
+ * on the page the reader can see.
+ *
+ * Scroll width is the wrong question in paginated mode: leftover CSS
+ * columns make the document wider than its text, so a page that has
+ * already shown every word still looks as if it can turn. The last
+ * *rendered* content node's box is the book's own answer.
+ *
+ * Trailing nodes that never paint — `<script>`, `<style>`, hidden
+ * footnotes — are skipped. An empty rectangle is not the end of the
+ * book; it is a node that does not count, and the walker keeps going.
+ */
+internal fun lastContentVisibleScript(): String = """
+    (function() {
+      var w = window.innerWidth, h = window.innerHeight;
+      var slack = $EDGE_SLACK;
+      // No body yet is a page still loading, not a finished book.
+      if (!document.body) { return "$SCROLLED"; }
+      function isHidden(node) {
+        var el = node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement;
+        while (el && el !== document.documentElement) {
+          var tag = el.tagName;
+          if (tag === "SCRIPT" || tag === "STYLE" || tag === "NOSCRIPT" || tag === "TEMPLATE") {
+            return true;
+          }
+          if (el.hidden) return true;
+          var s = window.getComputedStyle(el);
+          if (s && (s.display === "none" || s.visibility === "hidden")) return true;
+          el = el.parentElement;
+        }
+        return false;
+      }
+      function rectOf(node) {
+        if (node.nodeType === Node.TEXT_NODE) {
+          var range = document.createRange();
+          range.selectNodeContents(node);
+          var rects = range.getClientRects();
+          return rects.length ? rects[rects.length - 1] : range.getBoundingClientRect();
+        }
+        return node.getBoundingClientRect();
+      }
+      var walker = document.createTreeWalker(
+        document.body,
+        NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
+        {
+          acceptNode: function(n) {
+            if (n.nodeType === Node.ELEMENT_NODE) {
+              var tag = n.tagName;
+              if (tag === "SCRIPT" || tag === "STYLE" || tag === "NOSCRIPT" || tag === "TEMPLATE") {
+                return NodeFilter.FILTER_REJECT;
+              }
+              if (isHidden(n)) return NodeFilter.FILTER_REJECT;
+              if (tag === "IMG" || tag === "SVG" || tag === "CANVAS" || tag === "VIDEO") {
+                return NodeFilter.FILTER_ACCEPT;
+              }
+              return NodeFilter.FILTER_SKIP;
+            }
+            if (!(n.nodeValue && n.nodeValue.trim()) || isHidden(n)) {
+              return NodeFilter.FILTER_REJECT;
+            }
+            return NodeFilter.FILTER_ACCEPT;
+          }
+        }
+      );
+      var lastRect = null, n;
+      while (n = walker.nextNode()) {
+        var r = rectOf(n);
+        if (r.width < 1 && r.height < 1) continue;
+        lastRect = r;
+      }
+      if (!lastRect) { return "$AT_END"; }
+      if (lastRect.left < w - slack && lastRect.right > slack &&
+          lastRect.top < h - slack && lastRect.bottom > slack) {
+        return "$AT_END";
+      }
+      return "$SCROLLED";
+    })();
+""".trimIndent()
+
+/** Progression slack for deciding two locators are still the same page. */
+private const val PROBE_PROGRESSION_SLACK = 0.0005

--- a/app/src/main/kotlin/com/chmouel/liseur/sync/ReadingPositionPublisher.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/sync/ReadingPositionPublisher.kt
@@ -35,12 +35,14 @@ class ReadingPositionPublisher(
     private val overrideFor: suspend (String) -> FinishedOverride,
     private val persist: suspend (PositionUpdate, String?) -> Unit,
     private val refreshFinished: suspend (String) -> Unit,
+    private val markFinished: suspend (String) -> Unit,
     private val latestSync: LatestPositionSync,
     private val scheduleClose: (String) -> Unit,
     private val onError: (String, Throwable) -> Unit,
 ) {
     private sealed interface Event {
         data class Position(val update: PositionUpdate) : Event
+        data class Complete(val bookUrl: String) : Event
         data class Close(val bookUrl: String) : Event
     }
 
@@ -53,6 +55,7 @@ class ReadingPositionPublisher(
             for (event in events) {
                 when (event) {
                     is Event.Position -> store(event.update)
+                    is Event.Complete -> complete(event.bookUrl)
                     is Event.Close -> scheduleClose(event.bookUrl)
                 }
             }
@@ -61,6 +64,15 @@ class ReadingPositionPublisher(
 
     fun publish(update: PositionUpdate): Boolean =
         events.trySend(Event.Position(update)).isSuccess
+
+    /**
+     * The reader turned past the last page. Queued behind any position
+     * writes already accepted, so the locator that prompted this is on
+     * disk before the finished flag is. A second visit is the same
+     * event and does not need a second write.
+     */
+    fun completeBook(bookUrl: String): Boolean =
+        events.trySend(Event.Complete(bookUrl)).isSuccess
 
     fun closeBook(bookUrl: String): Boolean =
         events.trySend(Event.Close(bookUrl)).isSuccess
@@ -80,6 +92,22 @@ class ReadingPositionPublisher(
         retry {
             refreshFinished(update.bookUrl)
         }
+    }
+
+    private suspend fun complete(bookUrl: String) {
+        var wrote = false
+        val stored = retry {
+            // Already finished is the same visit again: no new revision,
+            // and nothing for the other devices to hear.
+            if (overrideFor(bookUrl) == FinishedOverride.FINISHED) return@retry
+            markFinished(bookUrl)
+            wrote = true
+        }
+        if (!stored) {
+            _failures.tryEmit(bookUrl)
+            return
+        }
+        if (wrote) latestSync.signal(bookUrl)
     }
 
     private suspend fun retry(block: suspend () -> Unit): Boolean {

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
@@ -1304,7 +1304,7 @@ internal fun PlaceholderCover(book: Book, modifier: Modifier = Modifier) {
 }
 
 @Composable
-internal fun BookCover(book: Book, modifier: Modifier = Modifier) {
+fun BookCover(book: Book, modifier: Modifier = Modifier) {
     val shape = RoundedCornerShape(10.dp)
     val artwork = book.coverPath ?: book.coverUrl
     val borderModifier = modifier

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/SeriesScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/SeriesScreen.kt
@@ -72,10 +72,12 @@ import androidx.compose.ui.unit.dp
 import com.chmouel.liseur.R
 import com.chmouel.liseur.data.calibre.DownloadProgress
 import com.chmouel.liseur.data.db.Book
+import com.chmouel.liseur.domain.SeriesCompletion
 import com.chmouel.liseur.domain.SeriesExtras
 import com.chmouel.liseur.domain.SeriesShelf
 import com.chmouel.liseur.domain.SeriesVolume
 import com.chmouel.liseur.domain.displayTitle
+import com.chmouel.liseur.domain.seriesCompletion
 import com.chmouel.liseur.domain.seriesIndexLabel
 import com.chmouel.liseur.ui.LocalEInk
 import kotlinx.coroutines.flow.Flow
@@ -632,12 +634,14 @@ private fun SeriesHero(
                     )
                 }
             } else {
-                Text(
-                    text = stringResource(R.string.series_all_read),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.padding(top = 16.dp),
-                )
+                seriesCompletionCopy(seriesCompletion(shelf, extras))?.let { copy ->
+                    Text(
+                        text = copy,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(top = 16.dp),
+                    )
+                }
             }
 
             extras?.summary?.takeIf { it.isNotBlank() }?.let { summary ->
@@ -970,4 +974,12 @@ private fun SeriesRenameDialog(
             TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
         },
     )
+}
+
+@Composable
+private fun seriesCompletionCopy(completion: SeriesCompletion): String? = when (completion) {
+    SeriesCompletion.COMPLETE -> stringResource(R.string.series_all_read)
+    SeriesCompletion.CAUGHT_UP -> stringResource(R.string.series_caught_up)
+    SeriesCompletion.ALL_KNOWN_READ -> stringResource(R.string.series_all_known_read)
+    SeriesCompletion.IN_PROGRESS -> null
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,6 +97,10 @@
     <string name="empty_library_subtitle">Add EPUB books from your device, or connect a calibre-web or Komga server to browse and download your collection.</string>
 
     <string name="reader_back">Back</string>
+    <string name="the_end">The End</string>
+    <string name="endpaper_library">Back to the library</string>
+    <string name="endpaper_next">Continue with %1$s</string>
+    <string name="endpaper_next_numbered">Continue with #%1$s %2$s</string>
     <string name="reader_contents">Contents</string>
     <string name="reader_open_failed">Couldn\'t open this book</string>
     <string name="dismiss">Dismiss</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,8 @@
     <string name="series_continue">Continue with %s</string>
     <string name="series_start">Start %s</string>
     <string name="series_all_read">You\'ve read the whole series</string>
+    <string name="series_caught_up">You\'re caught up with this series</string>
+    <string name="series_all_known_read">You\'ve read every book here</string>
     <string name="series_missing_volume">Book %s — not in your library</string>
     <string name="series_not_published_yet">Book %s — not published yet</string>
     <string name="series_download_missing">Download the rest</string>
@@ -99,8 +101,15 @@
     <string name="reader_back">Back</string>
     <string name="the_end">The End</string>
     <string name="endpaper_library">Back to the library</string>
-    <string name="endpaper_next">Continue with %1$s</string>
-    <string name="endpaper_next_numbered">Continue with #%1$s %2$s</string>
+    <string name="endpaper_next_kicker">Next in your library</string>
+    <string name="endpaper_next_kicker_numbered">Next in your library · #%1$s</string>
+    <string name="endpaper_no_next_in_library">No next volume from this series is currently in your library</string>
+    <string name="endpaper_continue">Continue</string>
+    <string name="endpaper_download">Download and continue</string>
+    <string name="endpaper_waiting">Waiting to download</string>
+    <string name="endpaper_downloading">Downloading…</string>
+    <string name="endpaper_retry">Couldn\'t download. Try again</string>
+    <string name="endpaper_unavailable">Isn\'t available to download</string>
     <string name="reader_contents">Contents</string>
     <string name="reader_open_failed">Couldn\'t open this book</string>
     <string name="dismiss">Dismiss</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/SeriesCompletionTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/SeriesCompletionTest.kt
@@ -1,0 +1,112 @@
+package com.chmouel.liseur.domain
+
+import com.chmouel.liseur.data.db.Book
+import com.chmouel.liseur.data.db.DownloadState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SeriesCompletionTest {
+
+    private fun book(
+        title: String,
+        index: Double,
+        finished: Boolean = true,
+        series: String = "The Expanse",
+    ) = Book(
+        url = "https://example.test/$title",
+        title = title,
+        author = null,
+        coverPath = null,
+        source = null,
+        addedAt = 0,
+        lastOpenedAt = null,
+        downloadState = DownloadState.DOWNLOADED,
+        finishedAt = if (finished) 1 else null,
+        seriesName = series,
+        seriesIndex = index,
+    )
+
+    private fun shelf(vararg books: Book) = listOf(*books).groupedIntoSeries().single()
+
+    @Test
+    fun `an unfinished volume means the series is in progress`() {
+        val s = shelf(book("One", 1.0), book("Two", 2.0, finished = false))
+        assertEquals(SeriesCompletion.IN_PROGRESS, seriesCompletion(s, extras(status = "ENDED", total = 2)))
+    }
+
+    @Test
+    fun `ended with an exact total and no gaps is complete`() {
+        val s = shelf(book("One", 1.0), book("Two", 2.0))
+        assertEquals(
+            SeriesCompletion.COMPLETE,
+            seriesCompletion(s, extras(status = "ENDED", total = 2)),
+        )
+    }
+
+    @Test
+    fun `ongoing with every known volume read is caught up`() {
+        val s = shelf(book("One", 1.0), book("Two", 2.0))
+        assertEquals(
+            SeriesCompletion.CAUGHT_UP,
+            seriesCompletion(s, extras(status = "ONGOING", total = 9)),
+        )
+    }
+
+    @Test
+    fun `hiatus with every known volume read is caught up`() {
+        val s = shelf(book("One", 1.0), book("Two", 2.0))
+        assertEquals(
+            SeriesCompletion.CAUGHT_UP,
+            seriesCompletion(s, extras(status = "HIATUS")),
+        )
+    }
+
+    @Test
+    fun `no server extras is only every book here`() {
+        val s = shelf(book("One", 1.0), book("Two", 2.0))
+        assertEquals(SeriesCompletion.ALL_KNOWN_READ, seriesCompletion(s, extras = null))
+    }
+
+    @Test
+    fun `an abandoned series is only every book here`() {
+        val s = shelf(book("One", 1.0), book("Two", 2.0))
+        assertEquals(
+            SeriesCompletion.ALL_KNOWN_READ,
+            seriesCompletion(s, extras(status = "ABANDONED", total = 2)),
+        )
+    }
+
+    @Test
+    fun `ended with a mismatched total is not complete`() {
+        val s = shelf(book("One", 1.0), book("Two", 2.0))
+        assertEquals(
+            SeriesCompletion.ALL_KNOWN_READ,
+            seriesCompletion(s, extras(status = "ENDED", total = 14)),
+        )
+    }
+
+    @Test
+    fun `a gap in the shelf is not complete or caught up`() {
+        val s = shelf(book("One", 1.0), book("Three", 3.0))
+        assertEquals(
+            SeriesCompletion.ALL_KNOWN_READ,
+            seriesCompletion(s, extras(status = "ENDED", total = 2)),
+        )
+        assertEquals(
+            SeriesCompletion.ALL_KNOWN_READ,
+            seriesCompletion(s, extras(status = "ONGOING")),
+        )
+    }
+
+    @Test
+    fun `ended without a total stays conservative`() {
+        val s = shelf(book("One", 1.0), book("Two", 2.0))
+        assertEquals(
+            SeriesCompletion.ALL_KNOWN_READ,
+            seriesCompletion(s, extras(status = "ENDED")),
+        )
+    }
+
+    private fun extras(status: String? = null, total: Int? = null) =
+        SeriesExtras(status = status, totalBookCount = total)
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/SeriesShelfTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/SeriesShelfTest.kt
@@ -277,11 +277,13 @@ class NextInSeriesTest {
     }
 
     @Test
-    fun `a missing next volume does not guess past the gap`() {
+    fun `a missing next volume is named and the later book is still offered`() {
         val one = book("One", index = 1.0, finishedAt = 1)
-        val library = listOf(one, book("Four", index = 4.0))
+        val four = book("Four", index = 4.0)
+        val offer = seriesContinuation(one, listOf(one, four))
 
-        assertNull(nextInSeries(one, library))
+        assertEquals(2.0, offer.missingIndex)
+        assertEquals("Four", offer.next?.title)
     }
 
     @Test
@@ -311,13 +313,47 @@ class NextInSeriesTest {
     }
 
     @Test
-    fun `a volume already begun is not offered as new`() {
+    fun `a remote volume is still the next volume`() {
+        val one = book("One", index = 1.0, finishedAt = 1)
+        val two = Book(
+            url = "https://example.test/Two",
+            title = "Two",
+            author = null,
+            coverPath = null,
+            source = null,
+            addedAt = 0,
+            lastOpenedAt = null,
+            downloadState = DownloadState.REMOTE,
+            seriesName = "Wheel of Time",
+            seriesIndex = 2.0,
+        )
+        assertEquals("Two", nextInSeries(one, listOf(one, two))?.title)
+    }
+
+    @Test
+    fun `a local volume uses a sibling's series id for extras`() {
+        val local = book("Leviathan Wakes", index = 1.0)
+        val fromServer = book("Caliban's War", index = 2.0).copy(seriesId = "komga-expanse")
+        assertEquals(
+            "komga-expanse",
+            seriesIdForExtras(local, listOf(local, fromServer)),
+        )
+    }
+
+    @Test
+    fun `a book with no series has no extras id`() {
+        val alone = book("Dune", series = null)
+        assertNull(seriesIdForExtras(alone, listOf(alone)))
+    }
+
+    @Test
+    fun `an in-progress volume is the next one to continue`() {
         val one = book("One", index = 1.0, finishedAt = 1)
         val two = book("Two", index = 2.0)
         val library = listOf(one, two, book("Three", index = 3.0))
 
         assertEquals(
-            "Three",
+            "Two",
             nextInSeries(one, library, progressions = mapOf(two.url to 0.3))?.title,
         )
     }
@@ -340,15 +376,18 @@ class NextInSeriesTest {
 
     /**
      * A hole in the shelf and a volume already read are different
-     * things. Stepping over the second is the whole point; stepping
-     * over the first offers #5 to someone who has just put down #1.
+     * things. The hole is named; the later book is still the next one
+     * in the library. Offering nothing because #2 is missing would hide
+     * a #5 the reader already has.
      */
     @Test
-    fun `a volume missing from the shelf is not read across`() {
+    fun `a volume missing from the shelf is named without hiding a later book`() {
         val one = book("One", index = 1.0, finishedAt = 1)
-        val library = listOf(one, book("Five", index = 5.0))
+        val five = book("Five", index = 5.0)
+        val offer = seriesContinuation(one, listOf(one, five))
 
-        assertNull(nextInSeries(one, library))
+        assertEquals(2.0, offer.missingIndex)
+        assertEquals("Five", offer.next?.title)
     }
 
     @Test
@@ -365,6 +404,95 @@ class NextInSeriesTest {
         val library = listOf(book("Seven", index = 7.0), novella, book("Eight", index = 8.0))
 
         assertEquals("Eight", nextInSeries(novella, library)?.title)
+        assertNull(seriesContinuation(novella, library).missingIndex)
+    }
+
+    @Test
+    fun `a novella after a whole volume is not a missing book`() {
+        val one = book("One", index = 1.0, finishedAt = 1)
+        val novella = book("Novella", index = 1.5)
+        val offer = seriesContinuation(one, listOf(one, novella))
+
+        assertNull(offer.missingIndex)
+        assertEquals("Novella", offer.next?.title)
+    }
+
+    @Test
+    fun `a jump after a novella proves the skipped whole number is missing`() {
+        val novella = book("Novella", index = 1.5, finishedAt = 1)
+        val three = book("Three", index = 3.0)
+        val offer = seriesContinuation(novella, listOf(novella, three))
+
+        assertEquals(2.0, offer.missingIndex)
+        assertEquals("Three", offer.next?.title)
+    }
+
+    @Test
+    fun `several missing volumes name only the immediate hole`() {
+        val one = book("One", index = 1.0, finishedAt = 1)
+        val five = book("Five", index = 5.0)
+        val six = book("Six", index = 6.0)
+        val offer = seriesContinuation(one, listOf(one, five, six))
+
+        assertEquals(2.0, offer.missingIndex)
+        assertEquals("Five", offer.next?.title)
+    }
+
+    @Test
+    fun `a finished intermediate volume is skipped rather than called missing`() {
+        val one = book("One", index = 1.0, finishedAt = 1)
+        val two = book("Two", index = 2.0, finishedAt = 2)
+        val three = book("Three", index = 3.0)
+        val offer = seriesContinuation(one, listOf(one, two, three))
+
+        assertNull(offer.missingIndex)
+        assertEquals("Three", offer.next?.title)
+    }
+
+    @Test
+    fun `an archived intermediate volume is skipped rather than called missing`() {
+        val one = book("One", index = 1.0, finishedAt = 1)
+        val two = book("Two", index = 2.0, archivedAt = 9)
+        val three = book("Three", index = 3.0)
+        val offer = seriesContinuation(one, listOf(one, two, three))
+
+        assertNull(offer.missingIndex)
+        assertEquals("Three", offer.next?.title)
+    }
+
+    @Test
+    fun `an authoritative total proves the next volume is missing`() {
+        val one = book("One", index = 1.0, finishedAt = 1)
+        val offer = seriesContinuation(
+            one,
+            listOf(one),
+            extras = SeriesExtras(status = "ENDED", totalBookCount = 5),
+        )
+
+        assertEquals(2.0, offer.missingIndex)
+        assertNull(offer.next)
+    }
+
+    @Test
+    fun `a total that is already represented invents no missing volume`() {
+        val one = book("One", index = 1.0, finishedAt = 1)
+        val offer = seriesContinuation(
+            one,
+            listOf(one),
+            extras = SeriesExtras(status = "ENDED", totalBookCount = 1),
+        )
+
+        assertNull(offer.missingIndex)
+        assertNull(offer.next)
+    }
+
+    @Test
+    fun `without a total the next missing number is not guessed`() {
+        val one = book("One", index = 1.0, finishedAt = 1)
+        val offer = seriesContinuation(one, listOf(one))
+
+        assertNull(offer.missingIndex)
+        assertNull(offer.next)
     }
 }
 

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/EndpaperContinuationTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/EndpaperContinuationTest.kt
@@ -1,0 +1,321 @@
+package com.chmouel.liseur.reader
+
+import com.chmouel.liseur.data.db.Book
+import com.chmouel.liseur.data.db.DownloadState
+import com.chmouel.liseur.domain.SeriesCompletion
+import com.chmouel.liseur.domain.SeriesExtras
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EndpaperContinuationTest {
+
+    private fun book(
+        title: String,
+        index: Double,
+        finished: Boolean = false,
+        state: DownloadState = DownloadState.DOWNLOADED,
+        localUri: String? = if (state == DownloadState.DOWNLOADED) "file://$title.epub" else null,
+        series: String = "The Expanse",
+    ) = Book(
+        url = "calibre:$title",
+        title = title,
+        author = null,
+        coverPath = null,
+        source = null,
+        addedAt = 0,
+        lastOpenedAt = null,
+        downloadState = state,
+        localUri = localUri,
+        finishedAt = if (finished) 1 else null,
+        seriesName = series,
+        seriesIndex = index,
+    )
+
+    @Test
+    fun `continuation waits for the endpaper even when the book is finished`() {
+        assertFalse(shouldOfferEndpaperContinuation(finished = true, endpaperReached = false))
+        assertTrue(shouldOfferEndpaperContinuation(finished = true, endpaperReached = true))
+        assertFalse(shouldOfferEndpaperContinuation(finished = false, endpaperReached = true))
+    }
+
+    @Test
+    fun `a file on the device is ready to open`() {
+        val one = book("One", 1.0, finished = true)
+        val two = book("Two", 2.0).copy(coverPath = "/covers/two.jpg")
+        val offer = continuation(one, listOf(one, two))
+        assertEquals(NextVolumeAvailability.Ready("file://Two.epub"), offer?.next?.availability)
+        assertEquals("Two", offer?.next?.title)
+        assertEquals("/covers/two.jpg", offer?.next?.book?.coverPath)
+    }
+
+    @Test
+    fun `an in-progress volume is offered`() {
+        val one = book("One", 1.0, finished = true)
+        val two = book("Two", 2.0)
+        val offer = continuation(
+            one,
+            listOf(one, two),
+            progressions = mapOf(two.url to 0.4),
+        )
+        assertEquals("Two", offer?.next?.title)
+    }
+
+    @Test
+    fun `a remote volume is offered as a download`() {
+        val one = book("One", 1.0, finished = true)
+        val two = book("Two", 2.0, state = DownloadState.REMOTE)
+        val offer = continuation(one, listOf(one, two), canDownload = true)
+        assertEquals(NextVolumeAvailability.Remote, offer?.next?.availability)
+    }
+
+    @Test
+    fun `a queued download is waiting`() {
+        val one = book("One", 1.0, finished = true)
+        val two = book("Two", 2.0, state = DownloadState.QUEUED)
+        val offer = continuation(
+            one,
+            listOf(one, two),
+            downloads = mapOf(two.url to DownloadSnapshot(queued = true)),
+        )
+        assertEquals(NextVolumeAvailability.Queued, offer?.next?.availability)
+    }
+
+    @Test
+    fun `a running download carries its fraction`() {
+        val one = book("One", 1.0, finished = true)
+        val two = book("Two", 2.0, state = DownloadState.DOWNLOADING)
+        val offer = continuation(
+            one,
+            listOf(one, two),
+            downloads = mapOf(two.url to DownloadSnapshot(running = true, fraction = 0.4f)),
+        )
+        assertEquals(NextVolumeAvailability.Downloading(0.4f), offer?.next?.availability)
+    }
+
+    @Test
+    fun `a failed download can be retried`() {
+        val one = book("One", 1.0, finished = true)
+        val two = book("Two", 2.0, state = DownloadState.FAILED)
+        val offer = continuation(one, listOf(one, two), canDownload = true)
+        assertEquals(NextVolumeAvailability.Failed, offer?.next?.availability)
+    }
+
+    @Test
+    fun `a forbidden download is named rather than queued`() {
+        val one = book("One", 1.0, finished = true)
+        val two = book("Two", 2.0, state = DownloadState.REMOTE)
+        val offer = continuation(one, listOf(one, two), canDownload = false)
+        assertEquals(NextVolumeAvailability.Unavailable, offer?.next?.availability)
+    }
+
+    @Test
+    fun `a failed download without permission is unavailable rather than retried`() {
+        val one = book("One", 1.0, finished = true)
+        val two = book("Two", 2.0, state = DownloadState.FAILED)
+        val offer = continuation(one, listOf(one, two), canDownload = false)
+        assertEquals(NextVolumeAvailability.Unavailable, offer?.next?.availability)
+    }
+
+    @Test
+    fun `leaving the endpaper withdraws the offer`() {
+        val one = book("One", 1.0, finished = true)
+        val two = book("Two", 2.0)
+        assertNull(continuation(one, listOf(one, two), endpaperReached = false))
+    }
+
+    @Test
+    fun `dismissing hides the next volume without claiming the series is done`() {
+        val one = book("One", 1.0, finished = true)
+        val two = book("Two", 2.0)
+        val offer = continuation(one, listOf(one, two), dismissed = true)
+        assertNull(offer?.next)
+        assertEquals(SeriesCompletion.IN_PROGRESS, offer?.seriesCompletion)
+        assertEquals("The Expanse", offer?.seriesName)
+        assertEquals("1", offer?.finishedVolume)
+    }
+
+    @Test
+    fun `a series book names the volume that was just finished`() {
+        val one = book("One", 1.0, finished = true)
+        val three = book("Three", 3.0)
+        val offer = continuation(one, listOf(one, three))
+        assertEquals("The Expanse", offer?.seriesName)
+        assertEquals("1", offer?.finishedVolume)
+    }
+
+    @Test
+    fun `a fractional volume keeps its place in the series`() {
+        val novella = book("Novella", 1.5, finished = true)
+        val two = book("Two", 2.0)
+        val offer = continuation(novella, listOf(novella, two))
+        assertEquals("1.5", offer?.finishedVolume)
+    }
+
+    @Test
+    fun `a book with no series does not invent a volume number`() {
+        val standalone = book("Standalone", 1.0, finished = true, series = "")
+            .copy(seriesName = null, seriesIndex = null)
+        val offer = continuation(standalone, listOf(standalone))
+        assertNull(offer?.seriesName)
+        assertNull(offer?.finishedVolume)
+    }
+
+    @Test
+    fun `the last volume of an ended series is complete`() {
+        val one = book("One", 1.0, finished = true)
+        val two = book("Two", 2.0, finished = true)
+        val offer = continuation(
+            two,
+            listOf(one, two),
+            extras = SeriesExtras(status = "ENDED", totalBookCount = 2),
+        )
+        assertNull(offer?.next)
+        assertNull(offer?.missingIndex)
+        assertFalse(offer?.noNextInLibrary == true)
+        assertEquals(SeriesCompletion.COMPLETE, offer?.seriesCompletion)
+    }
+
+    @Test
+    fun `an ongoing series with every known volume read is caught up`() {
+        val one = book("One", 1.0, finished = true)
+        val two = book("Two", 2.0, finished = true)
+        val offer = continuation(
+            two,
+            listOf(one, two),
+            extras = SeriesExtras(status = "ONGOING", totalBookCount = 2),
+        )
+        assertNull(offer?.next)
+        assertNull(offer?.missingIndex)
+        assertEquals(SeriesCompletion.CAUGHT_UP, offer?.seriesCompletion)
+    }
+
+    @Test
+    fun `a missing volume is named and a later book is still offered`() {
+        val one = book("One", 1.0, finished = true)
+        val three = book("Three", 3.0)
+        val offer = continuation(one, listOf(one, three))
+        assertEquals(2.0, offer?.missingIndex)
+        assertEquals("Three", offer?.next?.title)
+        assertEquals(SeriesCompletion.IN_PROGRESS, offer?.seriesCompletion)
+    }
+
+    @Test
+    fun `the immediate next volume is offered without a missing notice`() {
+        val one = book("One", 1.0, finished = true)
+        val two = book("Two", 2.0)
+        val offer = continuation(one, listOf(one, two))
+        assertNull(offer?.missingIndex)
+        assertEquals("Two", offer?.next?.title)
+    }
+
+    @Test
+    fun `a novella does not look like a missing volume`() {
+        val one = book("One", 1.0, finished = true)
+        val novella = book("Novella", 1.5)
+        val offer = continuation(one, listOf(one, novella))
+        assertNull(offer?.missingIndex)
+        assertEquals("Novella", offer?.next?.title)
+    }
+
+    @Test
+    fun `several missing volumes name the immediate hole and offer the first later book`() {
+        val one = book("One", 1.0, finished = true)
+        val four = book("Four", 4.0)
+        val five = book("Five", 5.0)
+        val offer = continuation(one, listOf(one, four, five))
+        assertEquals(2.0, offer?.missingIndex)
+        assertEquals("Four", offer?.next?.title)
+    }
+
+    @Test
+    fun `an authoritative total names a missing volume without a later book`() {
+        val one = book("One", 1.0, finished = true)
+        val offer = continuation(
+            one,
+            listOf(one),
+            extras = SeriesExtras(status = "ENDED", totalBookCount = 5),
+        )
+        assertEquals(2.0, offer?.missingIndex)
+        assertNull(offer?.next)
+        assertEquals(SeriesCompletion.IN_PROGRESS, offer?.seriesCompletion)
+    }
+
+    @Test
+    fun `without a total the missing number is not invented`() {
+        val one = book("One", 1.0, finished = true)
+        val offer = continuation(one, listOf(one))
+        assertNull(offer?.missingIndex)
+        assertNull(offer?.next)
+        assertFalse(offer?.noNextInLibrary == true)
+        assertEquals(SeriesCompletion.ALL_KNOWN_READ, offer?.seriesCompletion)
+    }
+
+    @Test
+    fun `an unfinished unnumbered companion is a series still in the library`() {
+        val one = book("One", 1.0, finished = true)
+        val companion = Book(
+            url = "calibre:Companion",
+            title = "Companion",
+            author = null,
+            coverPath = null,
+            source = null,
+            addedAt = 0,
+            lastOpenedAt = null,
+            downloadState = DownloadState.DOWNLOADED,
+            localUri = "file://Companion.epub",
+            seriesName = "The Expanse",
+            seriesIndex = null,
+        )
+        val offer = continuation(one, listOf(one, companion))
+        assertNull(offer?.next)
+        assertNull(offer?.missingIndex)
+        assertTrue(offer?.noNextInLibrary == true)
+        assertEquals(SeriesCompletion.IN_PROGRESS, offer?.seriesCompletion)
+    }
+
+    @Test
+    fun `leaving the endpaper cancels auto-open even after the file arrives`() {
+        val two = NextUp(
+            book = book("Two", 2.0),
+            volume = "2",
+            availability = NextVolumeAvailability.Ready("file://Two.epub"),
+        )
+        assertNull(readyToOpen(EndpaperContinuation(two, SeriesCompletion.IN_PROGRESS), false))
+        assertEquals(two, readyToOpen(EndpaperContinuation(two, SeriesCompletion.IN_PROGRESS), true))
+    }
+
+    @Test
+    fun `a download does not auto-open until the file is ready`() {
+        val two = NextUp(
+            book = book("Two", 2.0),
+            volume = "2",
+            availability = NextVolumeAvailability.Remote,
+        )
+        assertNull(readyToOpen(EndpaperContinuation(two, SeriesCompletion.IN_PROGRESS), true))
+        val ready = two.copy(availability = NextVolumeAvailability.Ready("file://Two.epub"))
+        assertEquals(ready, readyToOpen(EndpaperContinuation(ready, SeriesCompletion.IN_PROGRESS), true))
+    }
+
+    private fun continuation(
+        current: Book,
+        library: List<Book>,
+        progressions: Map<String, Double> = emptyMap(),
+        dismissed: Boolean = false,
+        endpaperReached: Boolean = true,
+        downloads: Map<String, DownloadSnapshot> = emptyMap(),
+        canDownload: Boolean = true,
+        extras: SeriesExtras? = null,
+    ) = endpaperContinuation(
+        current = current,
+        library = library,
+        progressions = progressions,
+        dismissed = dismissed,
+        endpaperReached = endpaperReached,
+        downloads = downloads,
+        canDownload = canDownload,
+        extras = extras,
+    )
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/NextInSeriesOfferTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/NextInSeriesOfferTest.kt
@@ -1,6 +1,5 @@
 package com.chmouel.liseur.reader
 
-import com.chmouel.liseur.reader.progress.ReaderProgress
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -8,27 +7,17 @@ import org.junit.Test
 class NextInSeriesOfferTest {
 
     @Test
-    fun `a manually finished book does not offer the next volume before its last page`() {
-        assertFalse(shouldOfferNextInSeries(finished = true, progress = progress(position = 20)))
+    fun `a finished book does not offer the next volume before the endpaper`() {
+        assertFalse(shouldOfferEndpaperContinuation(finished = true, endpaperReached = false))
     }
 
     @Test
-    fun `a finished book offers the next volume on its last page`() {
-        assertTrue(shouldOfferNextInSeries(finished = true, progress = progress(position = 100)))
+    fun `a finished book offers the next volume on the endpaper`() {
+        assertTrue(shouldOfferEndpaperContinuation(finished = true, endpaperReached = true))
     }
 
     @Test
-    fun `the next volume is not offered before reader position is known`() {
-        assertFalse(shouldOfferNextInSeries(finished = true, progress = null))
+    fun `an unfinished book does not offer the next volume from the endpaper`() {
+        assertFalse(shouldOfferEndpaperContinuation(finished = false, endpaperReached = true))
     }
-
-    private fun progress(position: Int) = ReaderProgress(
-        position = position,
-        totalPositions = 100,
-        totalProgression = position / 100f,
-        chapterTitle = null,
-        minutesLeftInChapter = 0,
-        minutesLeftInBook = 0,
-        isSpeedMeasured = false,
-    )
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/LastPageTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/LastPageTest.kt
@@ -1,0 +1,120 @@
+package com.chmouel.liseur.reader.chrome
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LastPageTest {
+
+    @Test
+    fun `the last resource in a book is the last one`() {
+        assertTrue(isLastReadingResource(indexInReadingOrder = 3, lastIndex = 3))
+        assertTrue(isLastReadingResource(indexInReadingOrder = 0, lastIndex = 0))
+    }
+
+    @Test
+    fun `a middle resource is not the end of the book`() {
+        assertFalse(isLastReadingResource(indexInReadingOrder = 2, lastIndex = 3))
+        assertFalse(isLastReadingResource(indexInReadingOrder = 0, lastIndex = 1))
+    }
+
+    @Test
+    fun `a href that is not in the spine is not the last page`() {
+        assertFalse(isLastReadingResource(indexInReadingOrder = null, lastIndex = 3))
+    }
+
+    @Test
+    fun `an empty spine has no last page`() {
+        assertFalse(isLastReadingResource(indexInReadingOrder = 0, lastIndex = -1))
+        assertFalse(isLastReadingResource(indexInReadingOrder = null, lastIndex = -1))
+    }
+
+    @Test
+    fun `the last page of the last resource is the end of the book`() {
+        assertTrue(atEndOfBook(lastResource = true, pageReport = "\"at-end\""))
+        assertTrue(atEndOfBook(lastResource = true, pageReport = "at-end"))
+    }
+
+    @Test
+    fun `the last page of a middle chapter is not the end of the book`() {
+        assertFalse(atEndOfBook(lastResource = false, pageReport = "\"at-end\""))
+    }
+
+    @Test
+    fun `more content still waiting in the last resource is not the end`() {
+        assertFalse(atEndOfBook(lastResource = true, pageReport = "\"scrolled\""))
+        assertFalse(atEndOfBook(lastResource = true, pageReport = null))
+    }
+
+    @Test
+    fun `the last-content script looks at the page, not at leftover columns`() {
+        val script = lastContentVisibleScript()
+        assertTrue(script.contains("getBoundingClientRect"))
+        assertTrue(script.contains("NodeFilter.SHOW_TEXT"))
+        assertFalse(script.contains("scrollWidth"))
+        assertTrue(script.contains("\"$AT_END\""))
+        // A missing body is a page that has not loaded yet, not the end
+        // of the book: "scrolled" lets the turn fall through until the
+        // document can actually be inspected.
+        assertTrue(script.contains("""if (!document.body) { return "scrolled"; }"""))
+        assertFalse(script.contains("""if (!document.body) { return "$AT_END"; }"""))
+    }
+
+    @Test
+    fun `the last-content script skips nodes that never paint`() {
+        val script = lastContentVisibleScript()
+        assertTrue(script.contains("SCRIPT"))
+        assertTrue(script.contains("STYLE"))
+        assertTrue(script.contains("isHidden"))
+        assertTrue(script.contains("FILTER_REJECT"))
+        assertTrue(script.contains("if (r.width < 1 && r.height < 1) continue"))
+        assertFalse(script.contains("if (r.width < 1 && r.height < 1) { return"))
+        // aria-hidden only hides from the accessibility tree; a visible
+        // illustration marked that way still has to count as the last page.
+        assertFalse(script.contains("aria-hidden"))
+    }
+
+    @Test
+    fun `a probe is still the same page at the same place`() {
+        assertTrue(
+            sameProbePlace(
+                currentHref = "chapter-end.xhtml",
+                currentProgression = 0.95,
+                probedHref = "chapter-end.xhtml",
+                probedProgression = 0.95,
+            ),
+        )
+        assertTrue(
+            sameProbePlace(
+                currentHref = "chapter-end.xhtml",
+                currentProgression = null,
+                probedHref = "chapter-end.xhtml",
+                probedProgression = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `a probe is stale after a turn inside the last resource`() {
+        assertFalse(
+            sameProbePlace(
+                currentHref = "chapter-end.xhtml",
+                currentProgression = 0.80,
+                probedHref = "chapter-end.xhtml",
+                probedProgression = 0.95,
+            ),
+        )
+    }
+
+    @Test
+    fun `a probe is stale after leaving the resource it inspected`() {
+        assertFalse(
+            sameProbePlace(
+                currentHref = "chapter-1.xhtml",
+                currentProgression = 0.95,
+                probedHref = "chapter-end.xhtml",
+                probedProgression = 0.95,
+            ),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/sync/ReadingPositionPublisherTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/sync/ReadingPositionPublisherTest.kt
@@ -5,6 +5,7 @@ import com.chmouel.liseur.data.remote.SyncOutcome
 import com.chmouel.liseur.domain.FinishedOverride
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -135,6 +136,7 @@ class ReadingPositionPublisherTest {
             overrideFor = { FinishedOverride.NONE },
             persist = { update, _ -> events += "write:${update.progression}" },
             refreshFinished = { events += "refresh:$it" },
+            markFinished = { events += "complete:$it" },
             latestSync = sync,
             scheduleClose = { events += "close:$it" },
             onError = { _, error -> throw error },
@@ -183,6 +185,7 @@ class ReadingPositionPublisherTest {
                 refreshes++
                 error("book flag failed")
             },
+            markFinished = {},
             latestSync = sync,
             scheduleClose = {},
             onError = { _, _ -> },
@@ -196,6 +199,151 @@ class ReadingPositionPublisherTest {
         assertEquals(1, writes)
         assertEquals(2, refreshes)
         assertEquals(1, syncs)
+    }
+
+    @Test
+    fun `completion waits for earlier position writes then syncs`() = runTest {
+        val events = mutableListOf<String>()
+        val sync = LatestPositionSync(
+            scope = backgroundScope,
+            request = {
+                events += "sync:$it"
+                SyncOutcome.Success
+            },
+            scheduleRetry = {},
+            onError = { _, error -> throw error },
+        )
+        val publisher = ReadingPositionPublisher(
+            scope = backgroundScope,
+            overrideFor = { FinishedOverride.NONE },
+            persist = { update, _ -> events += "write:${update.progression}" },
+            refreshFinished = { events += "refresh:$it" },
+            markFinished = { events += "complete:$it" },
+            latestSync = sync,
+            scheduleClose = { events += "close:$it" },
+            onError = { _, error -> throw error },
+        )
+
+        assertTrue(publisher.publish(update(0.99)))
+        assertTrue(publisher.completeBook("book"))
+        assertTrue(publisher.closeBook("book"))
+        runCurrent()
+
+        assertEquals(
+            listOf(
+                "write:0.99",
+                "refresh:book",
+                "complete:book",
+                "close:book",
+                "sync:book",
+            ),
+            events,
+        )
+    }
+
+    @Test
+    fun `a second completion does not write again`() = runTest {
+        var override = FinishedOverride.NONE
+        var completions = 0
+        var syncs = 0
+        val sync = LatestPositionSync(
+            scope = backgroundScope,
+            request = {
+                syncs++
+                SyncOutcome.Success
+            },
+            scheduleRetry = {},
+            onError = { _, error -> throw error },
+        )
+        val publisher = ReadingPositionPublisher(
+            scope = backgroundScope,
+            overrideFor = { override },
+            persist = { _, _ -> },
+            refreshFinished = {},
+            markFinished = {
+                completions++
+                override = FinishedOverride.FINISHED
+            },
+            latestSync = sync,
+            scheduleClose = {},
+            onError = { _, error -> throw error },
+        )
+
+        assertTrue(publisher.completeBook("book"))
+        assertTrue(publisher.completeBook("book"))
+        runCurrent()
+
+        assertEquals(1, completions)
+        assertEquals(1, syncs)
+    }
+
+    @Test
+    fun `an already finished book is not completed again`() = runTest {
+        var completions = 0
+        var syncs = 0
+        val sync = LatestPositionSync(
+            scope = backgroundScope,
+            request = {
+                syncs++
+                SyncOutcome.Success
+            },
+            scheduleRetry = {},
+            onError = { _, error -> throw error },
+        )
+        val publisher = ReadingPositionPublisher(
+            scope = backgroundScope,
+            overrideFor = { FinishedOverride.FINISHED },
+            persist = { _, _ -> },
+            refreshFinished = {},
+            markFinished = { completions++ },
+            latestSync = sync,
+            scheduleClose = {},
+            onError = { _, error -> throw error },
+        )
+
+        assertTrue(publisher.completeBook("book"))
+        assertTrue(publisher.completeBook("book"))
+        runCurrent()
+
+        assertEquals(0, completions)
+        assertEquals(0, syncs)
+    }
+
+    @Test
+    fun `a failing completion is retried and then reported`() = runTest {
+        var attempts = 0
+        val failures = mutableListOf<String>()
+        val sync = LatestPositionSync(
+            scope = backgroundScope,
+            request = { SyncOutcome.Success },
+            scheduleRetry = {},
+            onError = { _, _ -> },
+        )
+        val publisher = ReadingPositionPublisher(
+            scope = backgroundScope,
+            overrideFor = { FinishedOverride.NONE },
+            persist = { _, _ -> },
+            refreshFinished = {},
+            markFinished = {
+                attempts++
+                error("flag failed")
+            },
+            latestSync = sync,
+            scheduleClose = {},
+            onError = { _, _ -> },
+        )
+        val job = backgroundScope.launch {
+            publisher.failures.collect { failures += it }
+        }
+
+        assertTrue(publisher.completeBook("book"))
+        runCurrent()
+        advanceTimeBy(100)
+        runCurrent()
+
+        assertEquals(2, attempts)
+        assertEquals(listOf("book"), failures)
+        job.cancel()
     }
 
     private fun update(progression: Double) = PositionUpdate(


### PR DESCRIPTION
Readers reaching the end of a book could continue turning through empty Readium columns without a clear completion state. This adds a dedicated endpaper after the final rendered content, giving readers a quiet, themed colophon with the book title and author, plus clear actions to return to the library or continue with the next volume when one is available.

The endpaper is integrated with the existing reading flow so completion works consistently across paginated and scrolled books, preserves right-to-left navigation, and does not mistake leftover layout space for unread content. It makes the finished-book state explicit while keeping the existing next-in-series flow available.

Fixes #22

### End page example:

<img width="958" height="2116" alt="image" src="https://github.com/user-attachments/assets/7b1e310d-8b53-42d8-9b2b-d3e8a536c8ad" />

### End in a series show next book

<img width="951" height="2118" alt="image" src="https://github.com/user-attachments/assets/f859539a-a084-408a-88c1-2da0fef410a7" />

