### PR TITLE
feat: Add reading appearance settings and follow app theme mode

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -50,16 +50,17 @@ import com.chmouel.liseur.ui.settings.ServerAccountScreen
 import com.chmouel.liseur.ui.settings.ServerAccountViewModel
 import com.chmouel.liseur.ui.settings.LicencesScreen
 import com.chmouel.liseur.ui.settings.SettingsScreen
+import com.chmouel.liseur.ui.settings.ReadingAppearanceScreen
 import com.chmouel.liseur.ui.settings.AnnotationBackupUi
 import com.chmouel.liseur.ui.LocalEInk
 import com.chmouel.liseur.ui.ProvideEInk
 import com.chmouel.liseur.data.settings.AppSettings
-import com.chmouel.liseur.data.settings.ThemeMode
+import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.ui.theme.LiseurTheme
 import com.chmouel.liseur.ui.theme.dynamicColorAvailable
+import com.chmouel.liseur.ui.theme.isDark
 import android.net.Uri
 import androidx.core.net.toUri
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.collectAsState
 import com.chmouel.liseur.domain.SeriesShelf
 
@@ -87,11 +88,7 @@ class MainActivity : ComponentActivity() {
                 .collectAsState(initial = AppSettings())
             ProvideEInk(settings.eInkMode) {
                 LiseurTheme(
-                    darkTheme = when (settings.themeMode) {
-                        ThemeMode.SYSTEM -> isSystemInDarkTheme()
-                        ThemeMode.LIGHT -> false
-                        ThemeMode.DARK -> true
-                    },
+                    darkTheme = settings.themeMode.isDark(),
                     // A palette lifted from a wallpaper is chosen for how
                     // its colours sit together, which is exactly what a
                     // greyscale screen throws away — hence the monochrome
@@ -147,6 +144,7 @@ class MainActivity : ComponentActivity() {
 private enum class Screen {
     LIBRARY,
     SETTINGS,
+    READING_APPEARANCE,
     SERVER_ACCOUNT,
     LICENCES,
     STATS,
@@ -177,6 +175,9 @@ private fun LiseurApp(settings: AppSettings) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val repository = remember(context) { context.container.appSettings }
+    val readerPreferences = remember(context) { context.container.readerPreferences }
+    val readerPrefs by readerPreferences.prefs.collectAsStateWithLifecycle(ReaderPrefs())
+    val appIsDark = settings.themeMode.isDark()
     val annotationBackup = rememberAnnotationBackup()
 
     when (screen) {
@@ -244,6 +245,7 @@ private fun LiseurApp(settings: AppSettings) {
             BackHandler { screen = Screen.LIBRARY }
             SettingsScreen(
                 settings = settings,
+                readingThemeChoice = readerPrefs.themeChoice,
                 dynamicColorAvailable = dynamicColorAvailable,
                 onThemeMode = { scope.launch { repository.setThemeMode(it) } },
                 onDynamicColor = { scope.launch { repository.setDynamicColor(it) } },
@@ -270,6 +272,7 @@ private fun LiseurApp(settings: AppSettings) {
                     accountReturnsTo = Screen.SETTINGS
                     screen = Screen.SERVER_ACCOUNT
                 },
+                onOpenReadingAppearance = { screen = Screen.READING_APPEARANCE },
                 backup = annotationBackup,
                 connections = context.container.connections,
                 onOpenSource = { context.openLink(SOURCE_URL.toUri()) },
@@ -278,11 +281,31 @@ private fun LiseurApp(settings: AppSettings) {
             )
         }
 
+        Screen.READING_APPEARANCE -> {
+            val back = { screen = Screen.SETTINGS }
+            BackHandler { back() }
+            ReadingAppearanceScreen(
+                prefs = readerPrefs,
+                appIsDark = appIsDark,
+                onTheme = { scope.launch { readerPreferences.setTheme(it) } },
+                onFont = { scope.launch { readerPreferences.setFont(it) } },
+                onFontSize = { scope.launch { readerPreferences.setFontSize(it) } },
+                onLineHeight = { scope.launch { readerPreferences.setLineHeight(it) } },
+                onPageMargins = { scope.launch { readerPreferences.setPageMargins(it) } },
+                onBrightness = { scope.launch { readerPreferences.setBrightness(it) } },
+                onColumnMode = { scope.launch { readerPreferences.setColumnMode(it) } },
+                onFooterMode = { scope.launch { readerPreferences.setFooterMode(it) } },
+                onPageTurnAnimation = {
+                    scope.launch { readerPreferences.setPageTurnAnimation(it) }
+                },
+                onBack = back,
+            )
+        }
+
         Screen.SERVER_ACCOUNT -> {
             BackHandler { screen = accountReturnsTo }
             ServerAccountRoute(onBack = { screen = accountReturnsTo })
         }
-
 
         Screen.LICENCES -> {
             BackHandler { screen = Screen.SETTINGS }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
@@ -21,6 +21,20 @@ enum class ThemeMode(val id: String) {
     DARK("dark"),
     ;
 
+    /**
+     * Whether this mode is asking for a dark app, given what the system
+     * is currently set to.
+     *
+     * [systemDark] is only consulted under [SYSTEM]; the other two have
+     * already answered. Kept here, off Compose, so the reading theme can
+     * be resolved against the same answer the app draws itself with.
+     */
+    fun isDark(systemDark: Boolean): Boolean = when (this) {
+        SYSTEM -> systemDark
+        LIGHT -> false
+        DARK -> true
+    }
+
     companion object {
         val Default = SYSTEM
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPreferencesRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPreferencesRepository.kt
@@ -35,7 +35,7 @@ class ReaderPreferencesRepository(private val context: Context) {
         ReaderPrefs(
             font = ReaderFont.fromId(p[Keys.FONT]),
             fontSize = p[Keys.FONT_SIZE] ?: 1.0,
-            theme = ReaderTheme.fromId(p[Keys.THEME]),
+            themeChoice = ReaderThemeChoice.fromId(p[Keys.THEME]),
             lineHeight = p[Keys.LINE_HEIGHT],
             pageMargins = p[Keys.PAGE_MARGINS],
             brightness = p[Keys.BRIGHTNESS],
@@ -55,7 +55,7 @@ class ReaderPreferencesRepository(private val context: Context) {
         }
     }
 
-    suspend fun setTheme(theme: ReaderTheme) {
+    suspend fun setTheme(theme: ReaderThemeChoice) {
         context.readerPrefsStore.edit { it[Keys.THEME] = theme.id }
     }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPrefs.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPrefs.kt
@@ -43,6 +43,51 @@ enum class ReaderTheme(
 }
 
 /**
+ * The reading theme as it was chosen, which is not always a palette.
+ *
+ * [ReaderTheme] answers "what colour is the page"; every piece of
+ * reading chrome asks it that. This answers "what was asked for", and
+ * the two differ in exactly one case: [FOLLOW_APP], which has no
+ * colours of its own and takes them from how the app is drawn.
+ *
+ * That case is the point of the type. Reading themes used to be
+ * unreachable from Settings and to default to [ReaderTheme.LIGHT]
+ * whatever the app was set to, so turning the app dark left every book
+ * white with nothing to say why.
+ *
+ * The ids are the ones already written to DataStore, so a reader who
+ * chose a theme before this existed keeps it, and only a reader who
+ * never chose one — who has no stored id at all — lands on
+ * [FOLLOW_APP].
+ */
+enum class ReaderThemeChoice(val id: String, val palette: ReaderTheme?) {
+    FOLLOW_APP("follow_app", null),
+    LIGHT("light", ReaderTheme.LIGHT),
+    SEPIA("sepia", ReaderTheme.SEPIA),
+    DARK("dark", ReaderTheme.DARK),
+    BLACK("black", ReaderTheme.BLACK),
+    ;
+
+    /**
+     * The page this choice comes to, given how the app is drawn.
+     *
+     * [FOLLOW_APP] resolves to [ReaderTheme.DARK] or
+     * [ReaderTheme.LIGHT] and never to [ReaderTheme.SEPIA]: sepia is a
+     * taste, dark is a lighting condition, and only the second is
+     * something asking the app for a dark theme can be read as wanting.
+     */
+    fun resolve(appIsDark: Boolean): ReaderTheme =
+        palette ?: if (appIsDark) ReaderTheme.DARK else ReaderTheme.LIGHT
+
+    companion object {
+        val Default = FOLLOW_APP
+
+        fun fromId(id: String?): ReaderThemeChoice =
+            entries.firstOrNull { it.id == id } ?: Default
+    }
+}
+
+/**
  * What the middle of the reading footer shows.
  *
  * The percentage read and the page number live at the footer's edges
@@ -130,7 +175,7 @@ enum class ColumnMode(val id: String, val displayName: String) {
 data class ReaderPrefs(
     val font: ReaderFont = ReaderFont.Default,
     val fontSize: Double = 1.0,
-    val theme: ReaderTheme = ReaderTheme.Default,
+    val themeChoice: ReaderThemeChoice = ReaderThemeChoice.Default,
     val lineHeight: Double? = null,
     val pageMargins: Double? = null,
     val brightness: Float? = null,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
@@ -9,11 +9,9 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import com.chmouel.liseur.data.settings.AppSettings
-import com.chmouel.liseur.data.settings.ThemeMode
 import androidx.core.net.toUri
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
@@ -24,6 +22,7 @@ import com.chmouel.liseur.reader.chrome.PageTurner
 import androidx.lifecycle.lifecycleScope
 import com.chmouel.liseur.container
 import com.chmouel.liseur.ui.theme.LiseurTheme
+import com.chmouel.liseur.ui.theme.isDark
 import org.readium.r2.navigator.preferences.ReadingProgression
 import org.readium.r2.shared.ExperimentalReadiumApi
 import com.chmouel.liseur.ui.LocalEInk
@@ -80,13 +79,10 @@ class ReaderActivity : FragmentActivity() {
         }
         setContent {
             val settings by container.appSettings.settings.collectAsState(initial = AppSettings())
+            val appIsDark = settings.themeMode.isDark()
             ProvideEInk(settings.eInkMode) {
                 LiseurTheme(
-                    darkTheme = when (settings.themeMode) {
-                        ThemeMode.SYSTEM -> isSystemInDarkTheme()
-                        ThemeMode.LIGHT -> false
-                        ThemeMode.DARK -> true
-                    },
+                    darkTheme = appIsDark,
                     dynamicColor = settings.dynamicColor,
                     monochrome = LocalEInk.current,
                 ) {
@@ -124,12 +120,14 @@ class ReaderActivity : FragmentActivity() {
                             // navigator is configured, and turning scrolling on
                             // has to take the sideways chapter jumps with it.
                             val prefs by viewModel.prefs.collectAsStateWithLifecycle()
+                            val readingTheme = prefs.themeChoice.resolve(appIsDark)
                             val scrollMode by viewModel.scrollMode.collectAsStateWithLifecycle()
                             val columnMode = prefs.columnMode.effectiveFor(widthClass())
                             remember(s.navigatorFactory, columnMode, scrollMode) {
                                 s.navigatorFactory.createFragmentFactory(
                                     initialLocator = viewModel.lastLocator ?: s.initialLocator,
                                     initialPreferences = prefs.toEpubPreferences(
+                                        theme = readingTheme,
                                         columnMode = columnMode,
                                         scroll = scrollMode,
                                     ),
@@ -157,6 +155,7 @@ class ReaderActivity : FragmentActivity() {
                             ReaderScreen(
                                 publication = s.publication,
                                 prefsFlow = viewModel.prefs,
+                                readingTheme = readingTheme,
                                 typographyIsOwnFlow = viewModel.typographyIsOwn,
                                 progressFlow = viewModel.progress,
                                 jumpBackFlow = viewModel.jumpBack,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapper.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapper.kt
@@ -24,12 +24,19 @@ import org.readium.r2.shared.ExperimentalReadiumApi
 /**
  * Maps the app's reading preferences onto Readium's EPUB preferences.
  *
- * [scroll] is not part of [ReaderPrefs]: it is answered per book against
- * an app-wide default, so it arrives from the reader's own flow rather
- * than from the shared reading settings.
+ * [theme] is passed in rather than read off [ReaderPrefs], which holds
+ * the theme as it was *chosen* — and a choice of "follow the app" has no
+ * colours until someone knows how the app is drawn. That is a question
+ * only Compose can answer, so it is answered once at the top of the
+ * reader and the palette arrives here settled.
+ *
+ * [scroll] is not part of [ReaderPrefs] either: it is answered per book
+ * against an app-wide default, so it arrives from the reader's own flow
+ * rather than from the shared reading settings.
  */
 @OptIn(ExperimentalReadiumApi::class)
 fun ReaderPrefs.toEpubPreferences(
+    theme: ReaderTheme,
     columnMode: ColumnMode = this.columnMode,
     scroll: Boolean = false,
 ): EpubPreferences =

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -57,6 +58,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -92,6 +95,7 @@ import com.chmouel.liseur.data.settings.ColumnMode
 import com.chmouel.liseur.data.settings.ReaderFont
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.ReaderTheme
+import com.chmouel.liseur.data.settings.ReaderThemeChoice
 import com.chmouel.liseur.reader.chrome.CatchUpPill
 import com.chmouel.liseur.reader.chrome.JumpBackPill
 import com.chmouel.liseur.reader.chrome.PageTurnEffectState
@@ -117,6 +121,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.drop
 import org.readium.r2.navigator.Decoration
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
@@ -138,6 +143,7 @@ private const val CHROME_ANIM_MS = 300
 fun ReaderScreen(
     publication: Publication,
     prefsFlow: StateFlow<ReaderPrefs>,
+    readingTheme: ReaderTheme,
     typographyIsOwnFlow: StateFlow<Boolean>,
     progressFlow: StateFlow<ReaderProgress?>,
     jumpBackFlow: StateFlow<ReaderViewModel.JumpBack?>,
@@ -171,6 +177,7 @@ fun ReaderScreen(
 ) {
     var navigator by remember { mutableStateOf<EpubNavigatorFragment?>(null) }
     val navigatorNow by rememberUpdatedState(navigator)
+    val readingThemeNow by rememberUpdatedState(readingTheme)
     var chromeVisible by remember { mutableStateOf(false) }
     var showToc by remember { mutableStateOf(false) }
     var searchFor by remember { mutableStateOf<String?>(null) }
@@ -268,9 +275,16 @@ fun ReaderScreen(
         // preferences. Submitting that same value once more reflows the
         // freshly opened book and emits a second restoration locator,
         // which must not be recorded as a page the reader turned.
-        prefsFlow.drop(1).collect {
-            nav.submitPreferences(it.toEpubPreferences(columnMode, scrollMode))
+        //
+        // The theme is combined in rather than read once because it can
+        // change without the preferences changing at all: a reader on
+        // the app's theme who leaves their phone to turn itself dark at
+        // dusk has chosen nothing, and the open book should still follow.
+        combine(prefsFlow, snapshotFlow { readingThemeNow }) { p, theme ->
+            p.toEpubPreferences(theme, columnMode, scrollMode)
         }
+            .drop(1)
+            .collect { nav.submitPreferences(it) }
     }
 
     // Picking the selection up from the navigator when it tells us the
@@ -355,7 +369,7 @@ fun ReaderScreen(
     Box(
         Modifier
             .fillMaxSize()
-            .background(prefs.theme.background),
+            .background(readingTheme.background),
     ) {
         // The page runs the whole screen in both modes. Readium's own
         // padding is switched off (see dimens.xml) because it is applied
@@ -418,7 +432,7 @@ fun ReaderScreen(
                 author = publication.metadata.authors
                     .joinToString(", ") { it.name }
                     .ifBlank { null },
-                theme = prefs.theme,
+                theme = readingTheme,
                 finished = continuation?.finished,
                 timeSpentMs = continuation?.timeSpentMs,
                 seriesName = continuation?.seriesName,
@@ -445,7 +459,7 @@ fun ReaderScreen(
         if (!showingEnd) {
             BookmarkRibbon(
                 bookmarked = bookmarked,
-                theme = prefs.theme,
+                theme = readingTheme,
                 onToggle = {
                     view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
                     onAnnotationAction.toggleBookmark()
@@ -467,7 +481,7 @@ fun ReaderScreen(
                     JumpBackPill(
                         position = target.position,
                         fromSync = target.fromSync,
-                        theme = prefs.theme,
+                        theme = readingTheme,
                         onJumpBack = {
                             onProgressAction.dismissJumpBack()
                             navigator?.go(target.locator, animated = false)
@@ -481,7 +495,7 @@ fun ReaderScreen(
                     catchUp?.let { offer ->
                         CatchUpPill(
                             position = offer.position,
-                            theme = prefs.theme,
+                            theme = readingTheme,
                             onCatchUp = onProgressAction.acceptCatchUp,
                             onDismiss = onProgressAction.dismissCatchUp,
                         )
@@ -490,7 +504,7 @@ fun ReaderScreen(
                 if (chromeVisible) {
                     ReadingScrubber(
                         progress = progress,
-                        theme = prefs.theme,
+                        theme = readingTheme,
                         chapterTicks = remember(progress?.totalPositions) {
                             onProgressAction.chapterTicks()
                         },
@@ -510,7 +524,7 @@ fun ReaderScreen(
                     ReadingFooter(
                         progress = progress,
                         mode = prefs.footerMode,
-                        theme = prefs.theme,
+                        theme = readingTheme,
                         onCycleMode = onProgressAction.cycleFooterMode,
                     )
                 }
@@ -552,7 +566,18 @@ fun ReaderScreen(
                             contentDescription = stringResource(R.string.reader_search),
                         )
                     }
-                    IconButton(onClick = { showTypography = true }) {
+                    // "Aa" is what a reader looks for and what every other
+                    // reading app draws here, so it stays — but it is a
+                    // picture of two letters, not a word, and TalkBack
+                    // announcing "Aa" describes nothing. The button says
+                    // what it opens instead.
+                    val typographyLabel = stringResource(R.string.reader_typography)
+                    IconButton(
+                        onClick = { showTypography = true },
+                        modifier = Modifier.semantics {
+                            contentDescription = typographyLabel
+                        },
+                    ) {
                         Text(
                             text = "Aa",
                             style = MaterialTheme.typography.titleMedium,
@@ -566,10 +591,10 @@ fun ReaderScreen(
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = prefs.theme.background,
-                    titleContentColor = prefs.theme.foreground,
-                    navigationIconContentColor = prefs.theme.foreground,
-                    actionIconContentColor = prefs.theme.foreground,
+                    containerColor = readingTheme.background,
+                    titleContentColor = readingTheme.foreground,
+                    navigationIconContentColor = readingTheme.foreground,
+                    actionIconContentColor = readingTheme.foreground,
                 ),
             )
         }
@@ -659,6 +684,7 @@ fun ReaderScreen(
     if (showTypography) {
         TypographySheet(
             prefs = prefs,
+            readingTheme = readingTheme,
             typographyIsOwn = typographyIsOwn,
             onTypographyIsOwnChanged = onPrefsAction.setTypographyIsOwn,
             onFontSelected = onPrefsAction.setFont,
@@ -691,7 +717,7 @@ fun ReaderScreen(
         }
         SearchScreen(
             state = searchState,
-            theme = prefs.theme,
+            theme = readingTheme,
             initialQuery = initial,
             onSearch = onSearchAction.search,
             onHitSelected = { hit ->
@@ -728,7 +754,7 @@ fun ReaderScreen(
         val here = navigator?.currentLocator?.collectAsStateWithLifecycle()
         ContentsScreen(
             publication = publication,
-            theme = prefs.theme,
+            theme = readingTheme,
             currentHref = here?.value?.href?.toString(),
             annotations = annotations,
             onAnnotationSelected = { annotation ->
@@ -807,7 +833,7 @@ class ReaderAnnotationActions(
 class ReaderPrefsActions(
     val setFont: (ReaderFont) -> Unit,
     val setFontSize: (Double) -> Unit,
-    val setTheme: (ReaderTheme) -> Unit,
+    val setTheme: (ReaderThemeChoice) -> Unit,
     val setLineHeight: (Double?) -> Unit,
     val setPageMargins: (Double?) -> Unit,
     val setBrightness: (Float?) -> Unit,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -45,7 +45,7 @@ import com.chmouel.liseur.sync.PositionUpdate
 import com.chmouel.liseur.sync.ReadingPositionPublisher
 import com.chmouel.liseur.data.settings.ColumnMode
 import com.chmouel.liseur.data.settings.ReaderPrefs
-import com.chmouel.liseur.data.settings.ReaderTheme
+import com.chmouel.liseur.data.settings.ReaderThemeChoice
 import com.chmouel.liseur.domain.EPSILON
 import com.chmouel.liseur.domain.SeriesExtras
 import com.chmouel.liseur.domain.seriesIdForExtras
@@ -1068,7 +1068,7 @@ class ReaderViewModel(
         },
     )
 
-    fun setTheme(theme: ReaderTheme) = viewModelScope.launch { prefsRepo.setTheme(theme) }
+    fun setTheme(theme: ReaderThemeChoice) = viewModelScope.launch { prefsRepo.setTheme(theme) }
 
     fun setLineHeight(value: Double?) = typography(
         shared = { prefsRepo.setLineHeight(value) },

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/TypographySheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/TypographySheet.kt
@@ -1,82 +1,62 @@
 package com.chmouel.liseur.reader.chrome
 
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.outlined.BrightnessAuto
-import androidx.compose.material.icons.outlined.BrightnessHigh
-import androidx.compose.material.icons.outlined.BrightnessLow
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
-import androidx.compose.material3.Slider
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.sp
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
 import com.chmouel.liseur.R
 import com.chmouel.liseur.data.settings.ColumnMode
 import com.chmouel.liseur.data.settings.FooterMode
 import com.chmouel.liseur.data.settings.ReaderFont
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.ReaderTheme
+import com.chmouel.liseur.data.settings.ReaderThemeChoice
 import com.chmouel.liseur.ui.contentWidthCap
-import com.chmouel.liseur.ui.widthClass
+import com.chmouel.liseur.ui.reading.ReadingBrightnessSlider
+import com.chmouel.liseur.ui.reading.ReadingFontDropdown
+import com.chmouel.liseur.ui.reading.ReadingFontSizeSlider
+import com.chmouel.liseur.ui.reading.ReadingFooterModeDropdown
+import com.chmouel.liseur.ui.reading.ReadingLayoutControls
+import com.chmouel.liseur.ui.reading.ReadingPageTurnAnimationToggle
+import com.chmouel.liseur.ui.reading.ReadingThemeRow
 import com.chmouel.liseur.ui.windowWidth
 
 /**
  * Kindle-style "Aa" sheet: reading theme, font, size, brightness
  * and layout, applied live as they change.
+ *
+ * The controls themselves live in `ui/reading`, because Settings shows
+ * the same ones on a screen of its own. This sheet is the quick path to
+ * them with a book open, and adds the three answers that only make
+ * sense with one: scrolling, the screen, and setting this book apart.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TypographySheet(
     prefs: ReaderPrefs,
+    readingTheme: ReaderTheme,
     typographyIsOwn: Boolean,
     onTypographyIsOwnChanged: (Boolean) -> Unit,
     onFontSelected: (ReaderFont) -> Unit,
     onFontSizeChanged: (Double) -> Unit,
-    onThemeSelected: (ReaderTheme) -> Unit,
+    onThemeSelected: (ReaderThemeChoice) -> Unit,
     onLineHeightChanged: (Double?) -> Unit,
     onPageMarginsChanged: (Double?) -> Unit,
     onBrightnessChanged: (Float?) -> Unit,
@@ -99,11 +79,15 @@ fun TypographySheet(
                 .padding(bottom = 24.dp),
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
-            ThemeRow(selected = prefs.theme, onSelected = onThemeSelected)
-            FontSizeSlider(value = prefs.fontSize, onChanged = onFontSizeChanged)
-            BrightnessSlider(value = prefs.brightness, onChanged = onBrightnessChanged)
-            FontDropdown(selected = prefs.font, onSelected = onFontSelected)
-            LayoutControls(
+            ReadingThemeRow(
+                selected = prefs.themeChoice,
+                resolved = readingTheme,
+                onSelected = onThemeSelected,
+            )
+            ReadingFontSizeSlider(value = prefs.fontSize, onChanged = onFontSizeChanged)
+            ReadingBrightnessSlider(value = prefs.brightness, onChanged = onBrightnessChanged)
+            ReadingFontDropdown(selected = prefs.font, onSelected = onFontSelected)
+            ReadingLayoutControls(
                 lineHeight = prefs.lineHeight,
                 pageMargins = prefs.pageMargins,
                 columnMode = prefs.columnMode,
@@ -115,7 +99,10 @@ fun TypographySheet(
                 onPageMarginsChanged = onPageMarginsChanged,
                 onColumnModeChanged = onColumnModeChanged,
             )
-            FooterModeDropdown(selected = prefs.footerMode, onSelected = onFooterModeChanged)
+            ReadingFooterModeDropdown(
+                selected = prefs.footerMode,
+                onSelected = onFooterModeChanged,
+            )
             ScrollModeToggle(
                 enabled = scrollMode,
                 onChanged = onScrollModeChanged,
@@ -123,7 +110,7 @@ fun TypographySheet(
             // Nothing lifts off the screen when the text is scrolled, so
             // the animation has no page to describe.
             if (!scrollMode) {
-                PageTurnAnimationToggle(
+                ReadingPageTurnAnimationToggle(
                     enabled = prefs.pageTurnAnimation,
                     onChanged = onPageTurnAnimationChanged,
                 )
@@ -140,234 +127,6 @@ fun TypographySheet(
     }
 }
 
-@Composable
-private fun SectionLabel(text: String) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.labelLarge,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-    )
-}
-
-@Composable
-private fun ThemeRow(selected: ReaderTheme, onSelected: (ReaderTheme) -> Unit) {
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        SectionLabel("Theme")
-        Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-            ReaderTheme.entries.forEach { theme ->
-                val isSelected = theme == selected
-                Surface(
-                    shape = CircleShape,
-                    color = theme.background,
-                    border = androidx.compose.foundation.BorderStroke(
-                        width = if (isSelected) 3.dp else 1.dp,
-                        color = if (isSelected) {
-                            MaterialTheme.colorScheme.primary
-                        } else {
-                            MaterialTheme.colorScheme.outlineVariant
-                        },
-                    ),
-                    modifier = Modifier
-                        .size(56.dp)
-                        .clickable { onSelected(theme) }
-                        .semantics { contentDescription = theme.displayName },
-                ) {
-                    Box(contentAlignment = Alignment.Center) {
-                        Text(
-                            text = "Aa",
-                            color = theme.foreground,
-                            style = MaterialTheme.typography.titleMedium,
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun FontDropdown(selected: ReaderFont, onSelected: (ReaderFont) -> Unit) {
-    val context = LocalContext.current
-    var expanded by remember { mutableStateOf(false) }
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        SectionLabel("Font")
-        ExposedDropdownMenuBox(
-            expanded = expanded,
-            onExpandedChange = { expanded = it },
-        ) {
-            OutlinedTextField(
-                value = selected.displayName,
-                onValueChange = {},
-                readOnly = true,
-                singleLine = true,
-                textStyle = LocalTextStyle.current.copy(
-                    fontFamily = remember(selected) { selected.composeFamily(context.assets) },
-                    fontSize = 18.sp,
-                ),
-                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .menuAnchor(MenuAnchorType.PrimaryNotEditable),
-            )
-            ExposedDropdownMenu(
-                expanded = expanded,
-                onDismissRequest = { expanded = false },
-            ) {
-                ReaderFont.entries.forEach { font ->
-                    val family = remember(font) { font.composeFamily(context.assets) }
-                    DropdownMenuItem(
-                        text = {
-                            Text(font.displayName, fontFamily = family, fontSize = 18.sp)
-                        },
-                        trailingIcon = {
-                            if (font == selected) {
-                                Icon(
-                                    Icons.Default.Check,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.primary,
-                                )
-                            }
-                        },
-                        onClick = {
-                            onSelected(font)
-                            expanded = false
-                        },
-                    )
-                }
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun FooterModeDropdown(selected: FooterMode, onSelected: (FooterMode) -> Unit) {
-    var expanded by remember { mutableStateOf(false) }
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        SectionLabel("Progress")
-        ExposedDropdownMenuBox(
-            expanded = expanded,
-            onExpandedChange = { expanded = it },
-        ) {
-            OutlinedTextField(
-                value = selected.label,
-                onValueChange = {},
-                readOnly = true,
-                singleLine = true,
-                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .menuAnchor(MenuAnchorType.PrimaryNotEditable),
-            )
-            ExposedDropdownMenu(
-                expanded = expanded,
-                onDismissRequest = { expanded = false },
-            ) {
-                FooterMode.entries.forEach { mode ->
-                    DropdownMenuItem(
-                        text = { Text(mode.label) },
-                        trailingIcon = {
-                            if (mode == selected) {
-                                Icon(
-                                    Icons.Default.Check,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.primary,
-                                )
-                            }
-                        },
-                        onClick = {
-                            onSelected(mode)
-                            expanded = false
-                        },
-                    )
-                }
-            }
-        }
-    }
-}
-
-private val FooterMode.label: String
-    get() = when (this) {
-        FooterMode.SMART -> "Time left, or the chapter"
-        FooterMode.TIME_LEFT_BOOK -> "Time left in book"
-        FooterMode.CHAPTER_TITLE -> "Chapter title"
-        FooterMode.EMPTY -> "Nothing in the middle"
-        FooterMode.NONE -> "Hide the footer"
-    }
-
-private fun ReaderFont.composeFamily(assets: android.content.res.AssetManager): FontFamily? =
-    when (this) {
-        ReaderFont.LITERATA -> FontFamily(Font("fonts/Literata.ttf", assets))
-        ReaderFont.VOLLKORN -> FontFamily(Font("fonts/Vollkorn.ttf", assets))
-        ReaderFont.ATKINSON -> FontFamily(Font("fonts/AtkinsonHyperlegible-Regular.ttf", assets))
-        ReaderFont.INTER -> FontFamily(Font("fonts/Inter.ttf", assets))
-        ReaderFont.PUBLISHER -> null
-    }
-
-@Composable
-private fun FontSizeSlider(value: Double, onChanged: (Double) -> Unit) {
-    var sliderValue by remember(Unit) { mutableFloatStateOf(value.toFloat()) }
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        SectionLabel("Size")
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Text("A", fontSize = 14.sp)
-            Slider(
-                value = sliderValue,
-                onValueChange = { sliderValue = it },
-                onValueChangeFinished = { onChanged(sliderValue.toDouble()) },
-                valueRange = ReaderPrefs.MIN_FONT_SIZE.toFloat()..ReaderPrefs.MAX_FONT_SIZE.toFloat(),
-                steps = 17,
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(horizontal = 12.dp),
-            )
-            Text("A", fontSize = 26.sp)
-        }
-    }
-}
-
-@Composable
-private fun BrightnessSlider(value: Float?, onChanged: (Float?) -> Unit) {
-    var sliderValue by remember(Unit) { mutableFloatStateOf(value ?: 0.5f) }
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        SectionLabel("Brightness")
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(
-                Icons.Outlined.BrightnessLow,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Slider(
-                value = sliderValue,
-                onValueChange = {
-                    sliderValue = it
-                    onChanged(it)
-                },
-                valueRange = 0f..1f,
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(horizontal = 12.dp),
-            )
-            Icon(
-                Icons.Outlined.BrightnessHigh,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            IconButton(onClick = { onChanged(null) }) {
-                Icon(
-                    Icons.Outlined.BrightnessAuto,
-                    contentDescription = "Follow system brightness",
-                    tint = if (value == null) {
-                        MaterialTheme.colorScheme.primary
-                    } else {
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                    },
-                )
-            }
-        }
-    }
-}
 
 /**
  * Reads this book by scrolling rather than by turning pages.
@@ -399,22 +158,6 @@ private fun ScrollModeToggle(enabled: Boolean, onChanged: (Boolean) -> Unit) {
     }
 }
 
-@Composable
-private fun PageTurnAnimationToggle(enabled: Boolean, onChanged: (Boolean) -> Unit) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable { onChanged(!enabled) },
-    ) {
-        Text(
-            text = "Page turn animation",
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.weight(1f),
-        )
-        Switch(checked = enabled, onCheckedChange = onChanged)
-    }
-}
 
 /**
  * Holds the screen awake for this book alone.
@@ -438,7 +181,7 @@ private fun KeepScreenOnToggle(enabled: Boolean, onChanged: (Boolean) -> Unit) {
     ) {
         Column(Modifier.weight(1f)) {
             Text(
-                text = "Keep the screen on",
+                text = stringResource(R.string.settings_keep_screen_on),
                 style = MaterialTheme.typography.bodyLarge,
             )
         }
@@ -464,71 +207,19 @@ private fun JustThisBookToggle(enabled: Boolean, onChanged: (Boolean) -> Unit) {
     ) {
         Column(Modifier.weight(1f)) {
             Text(
-                text = "Use separate settings for this book",
+                text = stringResource(R.string.reader_typography_own),
                 style = MaterialTheme.typography.bodyLarge,
             )
             Text(
                 text = if (enabled) {
-                    "Font, size and layout stay with this book."
+                    stringResource(R.string.reader_typography_own_on)
                 } else {
-                    "Font, size and layout are shared with every book."
+                    stringResource(R.string.reader_typography_own_off)
                 },
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
         Switch(checked = enabled, onCheckedChange = onChanged)
-    }
-}
-
-@Composable
-private fun LayoutControls(
-    lineHeight: Double?,
-    pageMargins: Double?,
-    columnMode: ColumnMode,
-    showColumns: Boolean,
-    onLineHeightChanged: (Double?) -> Unit,
-    onPageMarginsChanged: (Double?) -> Unit,
-    onColumnModeChanged: (ColumnMode) -> Unit,
-) {
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        SectionLabel("Line spacing")
-        SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
-            val options = listOf("Compact" to 1.2, "Default" to null, "Relaxed" to 1.8)
-            options.forEachIndexed { index, (label, v) ->
-                SegmentedButton(
-                    selected = lineHeight == v,
-                    onClick = { onLineHeightChanged(v) },
-                    shape = SegmentedButtonDefaults.itemShape(index, options.size),
-                ) { Text(label) }
-            }
-        }
-        SectionLabel("Margins")
-        SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
-            val options = listOf("Narrow" to 0.5, "Default" to null, "Wide" to 2.0)
-            options.forEachIndexed { index, (label, v) ->
-                SegmentedButton(
-                    selected = pageMargins == v,
-                    onClick = { onPageMarginsChanged(v) },
-                    shape = SegmentedButtonDefaults.itemShape(index, options.size),
-                ) { Text(label) }
-            }
-        }
-        // Only offered where it can be honoured. Two columns need room
-        // for two columns, and on a phone there is none: the control
-        // would sit there taking a tap and changing nothing.
-        if (showColumns && widthClass().isAtLeastMedium) {
-            SectionLabel("Columns")
-            SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
-                val options = ColumnMode.entries
-                options.forEachIndexed { index, mode ->
-                    SegmentedButton(
-                        selected = columnMode == mode,
-                        onClick = { onColumnModeChanged(mode) },
-                        shape = SegmentedButtonDefaults.itemShape(index, options.size),
-                    ) { Text(mode.displayName) }
-                }
-            }
-        }
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/reading/ReadingAppearanceControls.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/reading/ReadingAppearanceControls.kt
@@ -1,0 +1,450 @@
+package com.chmouel.liseur.ui.reading
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.outlined.BrightnessAuto
+import androidx.compose.material.icons.outlined.BrightnessHigh
+import androidx.compose.material.icons.outlined.BrightnessLow
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.chmouel.liseur.R
+import com.chmouel.liseur.data.settings.ColumnMode
+import com.chmouel.liseur.data.settings.FooterMode
+import com.chmouel.liseur.data.settings.ReaderFont
+import com.chmouel.liseur.data.settings.ReaderPrefs
+import com.chmouel.liseur.data.settings.ReaderTheme
+import com.chmouel.liseur.data.settings.ReaderThemeChoice
+import com.chmouel.liseur.ui.widthClass
+
+/*
+ * The controls that say how a page looks, in one place.
+ *
+ * Two screens draw them: the "Aa" sheet over an open book, and the
+ * reading appearance screen in Settings. They were only in the sheet
+ * once, which meant the only way to find the dark reading theme was to
+ * open a book and press a button labelled "Aa". Having them in both
+ * places is deliberate; having them written twice would not be, so they
+ * live here and both callers ask for the same composable.
+ */
+
+@Composable
+fun ReadingSectionLabel(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+/**
+ * The reading themes, as swatches of themselves.
+ *
+ * [resolved] is what the page is actually set in, which for
+ * [ReaderThemeChoice.FOLLOW_APP] is not something the choice can say on
+ * its own — so the Auto swatch borrows those colours and marks itself
+ * with an icon rather than the "Aa" the fixed themes show. Selection is
+ * compared on the choice, so sitting on Auto in the dark and having
+ * asked for Dark outright stay visibly different states.
+ */
+@Composable
+fun ReadingThemeRow(
+    selected: ReaderThemeChoice,
+    resolved: ReaderTheme,
+    onSelected: (ReaderThemeChoice) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        ReadingSectionLabel(stringResource(R.string.settings_theme))
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()),
+        ) {
+            ReaderThemeChoice.entries.forEach { choice ->
+                val palette = choice.palette ?: resolved
+                val isSelected = choice == selected
+                val label = stringResource(choice.label)
+                Surface(
+                    shape = CircleShape,
+                    color = palette.background,
+                    border = BorderStroke(
+                        width = if (isSelected) 3.dp else 1.dp,
+                        color = if (isSelected) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.outlineVariant
+                        },
+                    ),
+                    modifier = Modifier
+                        .size(56.dp)
+                        .clickable { onSelected(choice) }
+                        .semantics { contentDescription = label },
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        if (choice.palette == null) {
+                            Icon(
+                                Icons.Outlined.BrightnessAuto,
+                                contentDescription = null,
+                                tint = palette.foreground,
+                            )
+                        } else {
+                            Text(
+                                text = "Aa",
+                                color = palette.foreground,
+                                style = MaterialTheme.typography.titleMedium,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        if (selected == ReaderThemeChoice.FOLLOW_APP) {
+            // The one theme whose swatch cannot show what it is: it
+            // borrows another's colours, so it has to say so in words.
+            Text(
+                text = stringResource(R.string.reader_theme_auto_detail),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReadingFontDropdown(selected: ReaderFont, onSelected: (ReaderFont) -> Unit) {
+    val context = LocalContext.current
+    var expanded by remember { mutableStateOf(false) }
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        ReadingSectionLabel(stringResource(R.string.reader_font))
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = it },
+        ) {
+            OutlinedTextField(
+                value = stringResource(selected.label),
+                onValueChange = {},
+                readOnly = true,
+                singleLine = true,
+                textStyle = LocalTextStyle.current.copy(
+                    fontFamily = remember(selected) { selected.composeFamily(context.assets) },
+                    fontSize = 18.sp,
+                ),
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+            )
+            ExposedDropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+            ) {
+                ReaderFont.entries.forEach { font ->
+                    val family = remember(font) { font.composeFamily(context.assets) }
+                    DropdownMenuItem(
+                        text = {
+                            Text(
+                                text = stringResource(font.label),
+                                fontFamily = family,
+                                fontSize = 18.sp,
+                            )
+                        },
+                        trailingIcon = {
+                            if (font == selected) {
+                                Icon(
+                                    Icons.Default.Check,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.primary,
+                                )
+                            }
+                        },
+                        onClick = {
+                            onSelected(font)
+                            expanded = false
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReadingFooterModeDropdown(selected: FooterMode, onSelected: (FooterMode) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        ReadingSectionLabel(stringResource(R.string.reader_progress))
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = it },
+        ) {
+            OutlinedTextField(
+                value = stringResource(selected.label),
+                onValueChange = {},
+                readOnly = true,
+                singleLine = true,
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+            )
+            ExposedDropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+            ) {
+                FooterMode.entries.forEach { mode ->
+                    DropdownMenuItem(
+                        text = { Text(stringResource(mode.label)) },
+                        trailingIcon = {
+                            if (mode == selected) {
+                                Icon(
+                                    Icons.Default.Check,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.primary,
+                                )
+                            }
+                        },
+                        onClick = {
+                            onSelected(mode)
+                            expanded = false
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ReadingFontSizeSlider(value: Double, onChanged: (Double) -> Unit) {
+    var sliderValue by remember(value) { mutableFloatStateOf(value.toFloat()) }
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        ReadingSectionLabel(stringResource(R.string.reader_size))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text("A", fontSize = 14.sp)
+            Slider(
+                value = sliderValue,
+                onValueChange = { sliderValue = it },
+                onValueChangeFinished = { onChanged(sliderValue.toDouble()) },
+                valueRange = ReaderPrefs.MIN_FONT_SIZE.toFloat()..ReaderPrefs.MAX_FONT_SIZE.toFloat(),
+                steps = 17,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(horizontal = 12.dp),
+            )
+            Text("A", fontSize = 26.sp)
+        }
+    }
+}
+
+@Composable
+fun ReadingBrightnessSlider(value: Float?, onChanged: (Float?) -> Unit) {
+    var sliderValue by remember(value) { mutableFloatStateOf(value ?: 0.5f) }
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        ReadingSectionLabel(stringResource(R.string.reader_brightness))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                Icons.Outlined.BrightnessLow,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Slider(
+                value = sliderValue,
+                onValueChange = {
+                    sliderValue = it
+                    onChanged(it)
+                },
+                valueRange = 0f..1f,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(horizontal = 12.dp),
+            )
+            Icon(
+                Icons.Outlined.BrightnessHigh,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            IconButton(onClick = { onChanged(null) }) {
+                Icon(
+                    Icons.Outlined.BrightnessAuto,
+                    contentDescription = stringResource(R.string.reader_brightness_system),
+                    tint = if (value == null) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ReadingLayoutControls(
+    lineHeight: Double?,
+    pageMargins: Double?,
+    columnMode: ColumnMode,
+    showColumns: Boolean,
+    onLineHeightChanged: (Double?) -> Unit,
+    onPageMarginsChanged: (Double?) -> Unit,
+    onColumnModeChanged: (ColumnMode) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        ReadingSectionLabel(stringResource(R.string.reader_line_spacing))
+        SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
+            val options = listOf(
+                R.string.reader_spacing_compact to 1.2,
+                R.string.reader_spacing_default to null,
+                R.string.reader_spacing_relaxed to 1.8,
+            )
+            options.forEachIndexed { index, (label, v) ->
+                SegmentedButton(
+                    selected = lineHeight == v,
+                    onClick = { onLineHeightChanged(v) },
+                    shape = SegmentedButtonDefaults.itemShape(index, options.size),
+                ) { Text(stringResource(label)) }
+            }
+        }
+        ReadingSectionLabel(stringResource(R.string.reader_margins))
+        SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
+            val options = listOf(
+                R.string.reader_margins_narrow to 0.5,
+                R.string.reader_margins_default to null,
+                R.string.reader_margins_wide to 2.0,
+            )
+            options.forEachIndexed { index, (label, v) ->
+                SegmentedButton(
+                    selected = pageMargins == v,
+                    onClick = { onPageMarginsChanged(v) },
+                    shape = SegmentedButtonDefaults.itemShape(index, options.size),
+                ) { Text(stringResource(label)) }
+            }
+        }
+        // Only offered where it can be honoured. Two columns need room
+        // for two columns, and on a phone there is none: the control
+        // would sit there taking a tap and changing nothing.
+        if (showColumns && widthClass().isAtLeastMedium) {
+            ReadingSectionLabel(stringResource(R.string.reader_columns))
+            SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
+                val options = ColumnMode.entries
+                options.forEachIndexed { index, mode ->
+                    SegmentedButton(
+                        selected = columnMode == mode,
+                        onClick = { onColumnModeChanged(mode) },
+                        shape = SegmentedButtonDefaults.itemShape(index, options.size),
+                    ) { Text(stringResource(mode.label)) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ReadingPageTurnAnimationToggle(enabled: Boolean, onChanged: (Boolean) -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onChanged(!enabled) },
+    ) {
+        Text(
+            text = stringResource(R.string.reader_page_turn_animation),
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.weight(1f),
+        )
+        Switch(checked = enabled, onCheckedChange = onChanged)
+    }
+}
+
+internal fun ReaderFont.composeFamily(assets: android.content.res.AssetManager): FontFamily? =
+    when (this) {
+        ReaderFont.LITERATA -> FontFamily(Font("fonts/Literata.ttf", assets))
+        ReaderFont.VOLLKORN -> FontFamily(Font("fonts/Vollkorn.ttf", assets))
+        ReaderFont.ATKINSON -> FontFamily(Font("fonts/AtkinsonHyperlegible-Regular.ttf", assets))
+        ReaderFont.INTER -> FontFamily(Font("fonts/Inter.ttf", assets))
+        ReaderFont.PUBLISHER -> null
+    }
+
+/*
+ * The names these settings go by, mapped where the strings live rather
+ * than carried on the enums, which stay pure Kotlin and testable off a
+ * device. Same shape as ThemeMode.label and EInkMode.label in Settings.
+ */
+
+val ReaderThemeChoice.label: Int
+    get() = when (this) {
+        ReaderThemeChoice.FOLLOW_APP -> R.string.reader_theme_auto
+        ReaderThemeChoice.LIGHT -> R.string.reader_theme_light
+        ReaderThemeChoice.SEPIA -> R.string.reader_theme_sepia
+        ReaderThemeChoice.DARK -> R.string.reader_theme_dark
+        ReaderThemeChoice.BLACK -> R.string.reader_theme_black
+    }
+
+val ReaderFont.label: Int
+    get() = when (this) {
+        ReaderFont.LITERATA -> R.string.reader_font_literata
+        ReaderFont.VOLLKORN -> R.string.reader_font_vollkorn
+        ReaderFont.ATKINSON -> R.string.reader_font_atkinson
+        ReaderFont.INTER -> R.string.reader_font_inter
+        ReaderFont.PUBLISHER -> R.string.reader_font_publisher
+    }
+
+val ColumnMode.label: Int
+    get() = when (this) {
+        ColumnMode.AUTO -> R.string.reader_columns_auto
+        ColumnMode.ONE -> R.string.reader_columns_one
+        ColumnMode.TWO -> R.string.reader_columns_two
+    }
+
+val FooterMode.label: Int
+    get() = when (this) {
+        FooterMode.SMART -> R.string.footer_mode_smart
+        FooterMode.TIME_LEFT_BOOK -> R.string.footer_mode_time_book
+        FooterMode.CHAPTER_TITLE -> R.string.footer_mode_chapter
+        FooterMode.EMPTY -> R.string.footer_mode_empty
+        FooterMode.NONE -> R.string.footer_mode_none
+    }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
@@ -1,0 +1,187 @@
+package com.chmouel.liseur.ui.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.chmouel.liseur.R
+import com.chmouel.liseur.data.settings.ColumnMode
+import com.chmouel.liseur.data.settings.FooterMode
+import com.chmouel.liseur.data.settings.ReaderFont
+import com.chmouel.liseur.data.settings.ReaderPrefs
+import com.chmouel.liseur.data.settings.ReaderTheme
+import com.chmouel.liseur.data.settings.ReaderThemeChoice
+import com.chmouel.liseur.ui.contentWidthCap
+import com.chmouel.liseur.ui.reading.ReadingBrightnessSlider
+import com.chmouel.liseur.ui.reading.ReadingFontDropdown
+import com.chmouel.liseur.ui.reading.ReadingFontSizeSlider
+import com.chmouel.liseur.ui.reading.ReadingFooterModeDropdown
+import com.chmouel.liseur.ui.reading.ReadingLayoutControls
+import com.chmouel.liseur.ui.reading.ReadingPageTurnAnimationToggle
+import com.chmouel.liseur.ui.reading.ReadingSectionLabel
+import com.chmouel.liseur.ui.reading.ReadingThemeRow
+import com.chmouel.liseur.ui.reading.composeFamily
+import com.chmouel.liseur.ui.windowWidth
+
+/**
+ * How the page looks, away from any particular page.
+ *
+ * The same controls the "Aa" sheet shows, on a screen you can reach
+ * without opening a book — which is what a reader who had turned the app
+ * dark and found their books still white was looking for, and could not
+ * find (issue #13).
+ *
+ * The preview at the top is the point of having this here rather than a
+ * row of sentences: with no page behind them, these settings need
+ * something to be true of.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReadingAppearanceScreen(
+    prefs: ReaderPrefs,
+    appIsDark: Boolean,
+    onTheme: (ReaderThemeChoice) -> Unit,
+    onFont: (ReaderFont) -> Unit,
+    onFontSize: (Double) -> Unit,
+    onLineHeight: (Double?) -> Unit,
+    onPageMargins: (Double?) -> Unit,
+    onBrightness: (Float?) -> Unit,
+    onColumnMode: (ColumnMode) -> Unit,
+    onFooterMode: (FooterMode) -> Unit,
+    onPageTurnAnimation: (Boolean) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    val resolved = prefs.themeChoice.resolve(appIsDark)
+
+    Scaffold(
+        modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        topBar = {
+            LargeTopAppBar(
+                title = { Text(stringResource(R.string.settings_reading_appearance)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.Outlined.ArrowBack,
+                            contentDescription = stringResource(R.string.back),
+                        )
+                    }
+                },
+                scrollBehavior = scrollBehavior,
+            )
+        },
+    ) { padding ->
+        Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.TopCenter) {
+            Column(
+                Modifier
+                    .widthIn(max = contentWidthCap(windowWidth()))
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 20.dp)
+                    .padding(bottom = 32.dp),
+                verticalArrangement = Arrangement.spacedBy(20.dp),
+            ) {
+                ReadingPreview(prefs = prefs, theme = resolved)
+                ReadingThemeRow(
+                    selected = prefs.themeChoice,
+                    resolved = resolved,
+                    onSelected = onTheme,
+                )
+                ReadingFontSizeSlider(value = prefs.fontSize, onChanged = onFontSize)
+                ReadingBrightnessSlider(value = prefs.brightness, onChanged = onBrightness)
+                ReadingFontDropdown(selected = prefs.font, onSelected = onFont)
+                ReadingLayoutControls(
+                    lineHeight = prefs.lineHeight,
+                    pageMargins = prefs.pageMargins,
+                    columnMode = prefs.columnMode,
+                    // Unlike the sheet, there is no book here to be
+                    // scrolled, so the count always has something to
+                    // divide and the control is always worth offering.
+                    showColumns = true,
+                    onLineHeightChanged = onLineHeight,
+                    onPageMarginsChanged = onPageMargins,
+                    onColumnModeChanged = onColumnMode,
+                )
+                ReadingFooterModeDropdown(
+                    selected = prefs.footerMode,
+                    onSelected = onFooterMode,
+                )
+                ReadingPageTurnAnimationToggle(
+                    enabled = prefs.pageTurnAnimation,
+                    onChanged = onPageTurnAnimation,
+                )
+                Text(
+                    text = stringResource(R.string.settings_reading_appearance_detail),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * A few lines of a book that is not there.
+ *
+ * Drawn in the reading theme's own colours rather than the app's, so
+ * the difference between the two — the thing the reporter of #13 could
+ * not see — is on the screen where the setting is. The size, spacing
+ * and margins are the real ones; the brightness is not, since it is the
+ * screen's and not the page's.
+ */
+@Composable
+private fun ReadingPreview(prefs: ReaderPrefs, theme: ReaderTheme) {
+    val context = LocalContext.current
+    val family = remember(prefs.font) { prefs.font.composeFamily(context.assets) }
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        ReadingSectionLabel(stringResource(R.string.reader_preview_title))
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(theme.background)
+                .padding(
+                    horizontal = (24 * (prefs.pageMargins ?: 1.0)).dp,
+                    vertical = 20.dp,
+                ),
+        ) {
+            Text(
+                text = stringResource(R.string.reader_preview_body),
+                color = theme.foreground,
+                fontFamily = family,
+                fontSize = (17 * prefs.fontSize).sp,
+                lineHeight = (17 * prefs.fontSize * (prefs.lineHeight ?: 1.4)).sp,
+                textAlign = TextAlign.Start,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.outlined.FileOpen
 import androidx.compose.material.icons.outlined.FileUpload
 import androidx.compose.material.icons.outlined.CloudDownload
 import androidx.compose.material.icons.outlined.HelpOutline
+import androidx.compose.material.icons.outlined.TextFormat
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.FilterChip
@@ -69,9 +70,11 @@ import com.chmouel.liseur.data.library.Inspection
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.chmouel.liseur.data.settings.DefinitionTarget
 import com.chmouel.liseur.data.settings.EInkMode
+import com.chmouel.liseur.data.settings.ReaderThemeChoice
 import com.chmouel.liseur.data.settings.ThemeMode
 import com.chmouel.liseur.domain.DictionaryUrl
 import com.chmouel.liseur.ui.contentWidthCap
+import com.chmouel.liseur.ui.reading.label
 import com.chmouel.liseur.ui.windowWidth
 
 private const val LISEUR_SYNC_REPO_URL = "https://github.com/chmouel/liseur-sync"
@@ -81,6 +84,7 @@ private const val LISEUR_SYNC_REPO_URL = "https://github.com/chmouel/liseur-sync
 @Composable
 fun SettingsScreen(
     settings: AppSettings,
+    readingThemeChoice: ReaderThemeChoice,
     dynamicColorAvailable: Boolean,
     onThemeMode: (ThemeMode) -> Unit,
     onDynamicColor: (Boolean) -> Unit,
@@ -94,6 +98,7 @@ fun SettingsScreen(
     onDictionaryLookup: (Boolean) -> Unit,
     onDictionaryBaseUrl: (String) -> Unit,
     onOpenAccount: () -> Unit,
+    onOpenReadingAppearance: () -> Unit,
     backup: AnnotationBackupUi,
     connections: ConnectionsState,
     onOpenSource: () -> Unit,
@@ -152,6 +157,21 @@ fun SettingsScreen(
                             onCheckedChange = onDynamicColor,
                         )
                     }
+                    RowDivider()
+                    // The theme above is the app's, and the page has one of
+                    // its own; a reader who turns this screen dark and finds
+                    // their books still white has nowhere to look unless
+                    // this row says where. Naming the "Aa" button here is
+                    // half of what it is for.
+                    ConnectionRow(
+                        icon = { Icon(Icons.Outlined.TextFormat, contentDescription = null) },
+                        title = stringResource(R.string.settings_reading_appearance),
+                        subtitle = stringResource(
+                            R.string.settings_reading_appearance_current,
+                            stringResource(readingThemeChoice.label),
+                        ),
+                        onClick = onOpenReadingAppearance,
+                    )
                 }
 
                 val showLibraryHelp = remember { mutableStateOf(false) }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/theme/Theme.kt
@@ -8,9 +8,11 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import com.chmouel.liseur.data.settings.ThemeMode
 
 /*
  * Every role M3 draws from is set here, deliberately.
@@ -172,6 +174,17 @@ private val MonoDarkColors = darkColorScheme(
 
 /** Whether this device can take its colours from the wallpaper. */
 val dynamicColorAvailable: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+
+/**
+ * Whether the app is dark right now.
+ *
+ * Only Compose can answer this, because [ThemeMode.SYSTEM] defers to a
+ * setting that can change under a running activity. Both activities and
+ * the reading theme ask through here, so there is one answer.
+ */
+@Composable
+@ReadOnlyComposable
+fun ThemeMode.isDark(): Boolean = isDark(isSystemInDarkTheme())
 
 @Composable
 fun LiseurTheme(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -318,6 +318,52 @@
     <string name="theme_dark">Dark</string>
     <string name="settings_dynamic_color">Colours from your wallpaper</string>
     <string name="settings_dynamic_color_detail">Use the system palette instead of Liseur\'s own paper-and-ink one.</string>
+    <string name="settings_reading_appearance">Reading appearance</string>
+    <string name="settings_reading_appearance_detail">Theme, typeface, size and spacing for the page itself. Also on the “Aa” button while you read.</string>
+    <string name="settings_reading_appearance_current">%1$s theme. Also on the “Aa” button while you read.</string>
+
+    <!-- The page itself: shared by the Aa sheet and the reading appearance screen. -->
+    <string name="reader_typography">Reading appearance</string>
+    <string name="reader_font">Font</string>
+    <string name="reader_size">Size</string>
+    <string name="reader_brightness">Brightness</string>
+    <string name="reader_brightness_system">Follow system brightness</string>
+    <string name="reader_progress">Progress</string>
+    <string name="reader_line_spacing">Line spacing</string>
+    <string name="reader_spacing_compact">Compact</string>
+    <string name="reader_spacing_default">Default</string>
+    <string name="reader_spacing_relaxed">Relaxed</string>
+    <string name="reader_margins">Margins</string>
+    <string name="reader_margins_narrow">Narrow</string>
+    <string name="reader_margins_default">Default</string>
+    <string name="reader_margins_wide">Wide</string>
+    <string name="reader_columns">Columns</string>
+    <string name="reader_columns_auto">Auto</string>
+    <string name="reader_columns_one">1</string>
+    <string name="reader_columns_two">2</string>
+    <string name="reader_page_turn_animation">Page turn animation</string>
+    <string name="reader_preview_title">Preview</string>
+    <string name="reader_preview_body">She had read the same page three times, and each time the room had grown a shade darker around it.</string>
+    <string name="reader_theme_auto">Automatic</string>
+    <string name="reader_theme_auto_detail">Automatic follows the app theme: dark pages when the app is dark, light when it is not.</string>
+    <string name="reader_theme_light">Light</string>
+    <string name="reader_theme_sepia">Sepia</string>
+    <string name="reader_theme_dark">Dark</string>
+    <string name="reader_theme_black">Black</string>
+    <string name="reader_font_literata" translatable="false">Literata</string>
+    <string name="reader_font_vollkorn" translatable="false">Vollkorn</string>
+    <string name="reader_font_atkinson" translatable="false">Atkinson Hyperlegible</string>
+    <string name="reader_font_inter" translatable="false">Inter</string>
+    <string name="reader_font_publisher">Publisher font</string>
+    <string name="reader_typography_own">Use separate settings for this book</string>
+    <string name="reader_typography_own_on">Font, size and layout stay with this book.</string>
+    <string name="reader_typography_own_off">Font, size and layout are shared with every book.</string>
+    <string name="footer_mode_smart">Time left, or the chapter</string>
+    <string name="footer_mode_time_book">Time left in book</string>
+    <string name="footer_mode_chapter">Chapter title</string>
+    <string name="footer_mode_empty">Nothing in the middle</string>
+    <string name="footer_mode_none">Hide the footer</string>
+
     <string name="settings_reading">Reading</string>
     <string name="settings_volume_keys">Volume keys turn pages</string>
     <string name="settings_volume_keys_detail">Volume down goes forward, volume up goes back.</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/BookTypographyTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/BookTypographyTest.kt
@@ -3,7 +3,7 @@ package com.chmouel.liseur.data.db
 import com.chmouel.liseur.data.settings.FooterMode
 import com.chmouel.liseur.data.settings.ReaderFont
 import com.chmouel.liseur.data.settings.ReaderPrefs
-import com.chmouel.liseur.data.settings.ReaderTheme
+import com.chmouel.liseur.data.settings.ReaderThemeChoice
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -19,7 +19,7 @@ class BookTypographyTest {
     private val shared = ReaderPrefs(
         font = ReaderFont.LITERATA,
         fontSize = 1.0,
-        theme = ReaderTheme.DARK,
+        themeChoice = ReaderThemeChoice.DARK,
         lineHeight = 1.4,
         pageMargins = 1.0,
         brightness = 0.3f,
@@ -52,7 +52,7 @@ class BookTypographyTest {
     @Test
     fun `the theme, the brightness and the rest stay shared`() {
         val effective = shared.withTypographyOf(own)
-        assertEquals(ReaderTheme.DARK, effective.theme)
+        assertEquals(ReaderThemeChoice.DARK, effective.themeChoice)
         assertEquals(0.3f, effective.brightness!!, 0f)
         assertEquals(false, effective.pageTurnAnimation)
         assertEquals(FooterMode.SMART, effective.footerMode)

--- a/app/src/test/kotlin/com/chmouel/liseur/data/settings/ReaderThemeChoiceTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/settings/ReaderThemeChoiceTest.kt
@@ -1,0 +1,63 @@
+package com.chmouel.liseur.data.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * What the reader stored, and what the page ends up being painted in.
+ *
+ * The two are no longer the same thing: "follow the app" has no colours
+ * of its own, and the ids in DataStore predate it. Both facts are load
+ * bearing, so both are asserted here.
+ */
+class ReaderThemeChoiceTest {
+
+    @Test
+    fun `a stated theme is that theme, whatever the app is doing`() {
+        for (dark in listOf(false, true)) {
+            assertEquals(ReaderTheme.LIGHT, ReaderThemeChoice.LIGHT.resolve(dark))
+            assertEquals(ReaderTheme.SEPIA, ReaderThemeChoice.SEPIA.resolve(dark))
+            assertEquals(ReaderTheme.DARK, ReaderThemeChoice.DARK.resolve(dark))
+            assertEquals(ReaderTheme.BLACK, ReaderThemeChoice.BLACK.resolve(dark))
+        }
+    }
+
+    @Test
+    fun `following the app means following it both ways`() {
+        assertEquals(ReaderTheme.LIGHT, ReaderThemeChoice.FOLLOW_APP.resolve(false))
+        assertEquals(ReaderTheme.DARK, ReaderThemeChoice.FOLLOW_APP.resolve(true))
+    }
+
+    @Test
+    fun `following the app never lands on Sepia`() {
+        // Dark is a lighting condition and the app theme can be read as
+        // asking for it. Sepia is a taste, and it cannot.
+        for (dark in listOf(false, true)) {
+            assertNotEquals(ReaderTheme.SEPIA, ReaderThemeChoice.FOLLOW_APP.resolve(dark))
+        }
+    }
+
+    @Test
+    fun `everything already stored still reads back as itself`() {
+        // These four ids are what earlier versions wrote. Losing any of
+        // them would silently reset a reader to Auto on upgrade.
+        assertEquals(ReaderThemeChoice.LIGHT, ReaderThemeChoice.fromId("light"))
+        assertEquals(ReaderThemeChoice.SEPIA, ReaderThemeChoice.fromId("sepia"))
+        assertEquals(ReaderThemeChoice.DARK, ReaderThemeChoice.fromId("dark"))
+        assertEquals(ReaderThemeChoice.BLACK, ReaderThemeChoice.fromId("black"))
+    }
+
+    @Test
+    fun `a reader who never chose gets the app's answer`() {
+        assertEquals(ReaderThemeChoice.FOLLOW_APP, ReaderThemeChoice.fromId(null))
+        assertEquals(ReaderThemeChoice.FOLLOW_APP, ReaderThemeChoice.fromId("a-theme-we-removed"))
+        assertEquals(ReaderThemeChoice.FOLLOW_APP, ReaderThemeChoice.Default)
+    }
+
+    @Test
+    fun `every choice has an id of its own`() {
+        val ids = ReaderThemeChoice.entries.map { it.id }
+        assertEquals(ids.size, ids.toSet().size)
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/settings/ThemeModeTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/settings/ThemeModeTest.kt
@@ -1,0 +1,27 @@
+package com.chmouel.liseur.data.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * "Is the app dark right now" now has two callers beyond the theme
+ * itself — the reader's chrome and the reading theme that follows it —
+ * so it is worth being sure the answer does not depend on which one
+ * asks.
+ */
+class ThemeModeTest {
+
+    @Test
+    fun `a stated mode ignores the system`() {
+        for (systemDark in listOf(false, true)) {
+            assertEquals(false, ThemeMode.LIGHT.isDark(systemDark))
+            assertEquals(true, ThemeMode.DARK.isDark(systemDark))
+        }
+    }
+
+    @Test
+    fun `following the system means following it`() {
+        assertEquals(false, ThemeMode.SYSTEM.isDark(systemDark = false))
+        assertEquals(true, ThemeMode.SYSTEM.isDark(systemDark = true))
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapperTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapperTest.kt
@@ -2,17 +2,24 @@ package com.chmouel.liseur.reader
 
 import com.chmouel.liseur.data.settings.ColumnMode
 import com.chmouel.liseur.data.settings.ReaderPrefs
+import com.chmouel.liseur.data.settings.ReaderTheme
+import com.chmouel.liseur.data.settings.ReaderThemeChoice
 import com.chmouel.liseur.ui.WidthClass
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.readium.r2.navigator.preferences.ColumnCount
+import org.readium.r2.navigator.preferences.Theme
 
 /**
  * Columns are the one reading preference the window gets a veto on, so
  * the veto is checked here rather than by opening a book on a tablet.
  */
 class ReaderPreferencesMapperTest {
+
+    /** The palette the reader arrived at; irrelevant to these cases. */
+    private val theme = ReaderTheme.LIGHT
 
     @Test
     fun `a compact window refuses a column count it cannot carry`() {
@@ -40,48 +47,82 @@ class ReaderPreferencesMapperTest {
     fun `Auto leaves the column count unset rather than sending AUTO`() {
         // An untouched preference has to produce the page Readium would
         // have laid out on its own, byte for byte.
-        assertNull(ReaderPrefs().toEpubPreferences().columnCount)
-        assertNull(ReaderPrefs(columnMode = ColumnMode.AUTO).toEpubPreferences().columnCount)
+        assertNull(ReaderPrefs().toEpubPreferences(theme).columnCount)
+        assertNull(ReaderPrefs(columnMode = ColumnMode.AUTO).toEpubPreferences(theme).columnCount)
     }
 
     @Test
     fun `an explicit choice reaches Readium`() {
         assertEquals(
             ColumnCount.ONE,
-            ReaderPrefs(columnMode = ColumnMode.ONE).toEpubPreferences().columnCount,
+            ReaderPrefs(columnMode = ColumnMode.ONE).toEpubPreferences(theme).columnCount,
         )
         assertEquals(
             ColumnCount.TWO,
-            ReaderPrefs(columnMode = ColumnMode.TWO).toEpubPreferences().columnCount,
+            ReaderPrefs(columnMode = ColumnMode.TWO).toEpubPreferences(theme).columnCount,
         )
     }
 
     @Test
     fun `the override argument wins over the stored preference`() {
         val prefs = ReaderPrefs(columnMode = ColumnMode.TWO)
-        assertNull(prefs.toEpubPreferences(ColumnMode.AUTO).columnCount)
+        assertNull(prefs.toEpubPreferences(theme, ColumnMode.AUTO).columnCount)
     }
 
     @Test
     fun `columns are the only thing this changes`() {
-        val one = ReaderPrefs(columnMode = ColumnMode.ONE).toEpubPreferences()
-        val two = ReaderPrefs(columnMode = ColumnMode.TWO).toEpubPreferences()
+        val one = ReaderPrefs(columnMode = ColumnMode.ONE).toEpubPreferences(theme)
+        val two = ReaderPrefs(columnMode = ColumnMode.TWO).toEpubPreferences(theme)
         assertEquals(one.copy(columnCount = null), two.copy(columnCount = null))
     }
 
     @Test
     fun `a book is paginated unless it is asked to scroll`() {
-        assertEquals(false, ReaderPrefs().toEpubPreferences().scroll)
+        assertEquals(false, ReaderPrefs().toEpubPreferences(theme).scroll)
         assertEquals(
             true,
-            ReaderPrefs().toEpubPreferences(scroll = true).scroll,
+            ReaderPrefs().toEpubPreferences(theme, scroll = true).scroll,
         )
     }
 
     @Test
     fun `scrolling is the only thing the scroll flag changes`() {
-        val paginated = ReaderPrefs().toEpubPreferences(scroll = false)
-        val scrolled = ReaderPrefs().toEpubPreferences(scroll = true)
+        val paginated = ReaderPrefs().toEpubPreferences(theme, scroll = false)
+        val scrolled = ReaderPrefs().toEpubPreferences(theme, scroll = true)
         assertEquals(paginated.copy(scroll = null), scrolled.copy(scroll = null))
+    }
+
+    @Test
+    fun `the theme passed in is the one that reaches Readium`() {
+        // The prefs carry a choice, not a palette, and "follow the app"
+        // has no colours of its own — so the resolved theme has to win
+        // outright rather than be a hint the mapper can second-guess.
+        val prefs = ReaderPrefs(themeChoice = ReaderThemeChoice.LIGHT)
+        assertEquals(Theme.DARK, prefs.toEpubPreferences(ReaderTheme.DARK).theme)
+        assertEquals(Theme.SEPIA, prefs.toEpubPreferences(ReaderTheme.SEPIA).theme)
+    }
+
+    @Test
+    fun `Black is a dark page of its own colour`() {
+        // Readium has no true-black theme, so both of ours arrive as
+        // DARK; what keeps them apart is the background we send with it.
+        val dark = ReaderPrefs().toEpubPreferences(ReaderTheme.DARK)
+        val black = ReaderPrefs().toEpubPreferences(ReaderTheme.BLACK)
+        assertEquals(Theme.DARK, dark.theme)
+        assertEquals(Theme.DARK, black.theme)
+        assertNotEquals(dark.backgroundColor, black.backgroundColor)
+    }
+
+    @Test
+    fun `images are left exactly as the book drew them`() {
+        // Readium can dim or invert them on a dark page. We deliberately
+        // ask for neither: brightness(80%) leaves a white diagram nearly
+        // as bright while muddying every photograph beside it, and the
+        // per-image version that would be worth having needs JavaScript
+        // in the WebView. A reader who wants this has no setting for it
+        // on purpose, so this stays null rather than drifting.
+        for (palette in ReaderTheme.entries) {
+            assertNull(ReaderPrefs().toEpubPreferences(palette).imageFilter)
+        }
     }
 }

--- a/hack/lib/demo-books.sh
+++ b/hack/lib/demo-books.sh
@@ -13,38 +13,50 @@
 readonly REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 readonly CACHE_DIR="$REPO_ROOT/tmp/books"
 
+# In a non-main worktree, symlink the book cache from the main worktree
+# so downloads are shared and not duplicated.
+_main_git=$(git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+_wt_git=$(git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-dir 2>/dev/null)
+if [[ -n "$_main_git" && "$_main_git" != "$_wt_git" && ! -L "$CACHE_DIR" ]]; then
+  _main_books="${_main_git%/.git}/tmp/books"
+  mkdir -p "$_main_books" "$(dirname "$CACHE_DIR")"
+  rm -rf "$CACHE_DIR"
+  ln -s "$_main_books" "$CACHE_DIR"
+fi
+unset _main_git _wt_git _main_books
+
 # The shelf, in the order it is downloaded. Standard Ebooks serves the
 # file itself only with ?source=download; without it you get the "your
 # download has started" page, saved as a .epub that is not one.
 readonly -a DEMO_BOOKS=(
-    "herman-melville/moby-dick"
-    "robert-louis-stevenson/treasure-island"
-    "oscar-wilde/the-picture-of-dorian-gray"
-    "mary-shelley/frankenstein"
-    "mark-twain/the-adventures-of-huckleberry-finn"
-    "jane-austen/pride-and-prejudice"
-    "bram-stoker/dracula"
-    "charlotte-bronte/jane-eyre"
-    "h-g-wells/the-time-machine"
-    # Two real series, for the series screens. Standard Ebooks records
-    # them the way an EPUB is supposed to, so nothing here is faked: the
-    # numbers on the shelf are the ones in the files.
-    #
-    # The gaps are deliberate. Sherlock Holmes is here as 1, 2, 3 and 5,
-    # and the Martian books as 1 and 3, so the series screen has
-    # something real to say about the volumes that are missing between
-    # the ones you own -- which is the whole point of showing it.
-    "arthur-conan-doyle/a-study-in-scarlet"
-    "arthur-conan-doyle/the-sign-of-the-four"
-    "arthur-conan-doyle/the-adventures-of-sherlock-holmes"
-    "arthur-conan-doyle/the-hound-of-the-baskervilles"
-    "edgar-rice-burroughs/a-princess-of-mars"
-    "edgar-rice-burroughs/the-warlord-of-mars"
+  "herman-melville/moby-dick"
+  "robert-louis-stevenson/treasure-island"
+  "oscar-wilde/the-picture-of-dorian-gray"
+  "mary-shelley/frankenstein"
+  "mark-twain/the-adventures-of-huckleberry-finn"
+  "jane-austen/pride-and-prejudice"
+  "bram-stoker/dracula"
+  "charlotte-bronte/jane-eyre"
+  "h-g-wells/the-time-machine"
+  # Two real series, for the series screens. Standard Ebooks records
+  # them the way an EPUB is supposed to, so nothing here is faked: the
+  # numbers on the shelf are the ones in the files.
+  #
+  # The gaps are deliberate. Sherlock Holmes is here as 1, 2, 3 and 5,
+  # and the Martian books as 1 and 3, so the series screen has
+  # something real to say about the volumes that are missing between
+  # the ones you own -- which is the whole point of showing it.
+  "arthur-conan-doyle/a-study-in-scarlet"
+  "arthur-conan-doyle/the-sign-of-the-four"
+  "arthur-conan-doyle/the-adventures-of-sherlock-holmes"
+  "arthur-conan-doyle/the-hound-of-the-baskervilles"
+  "edgar-rice-burroughs/a-princess-of-mars"
+  "edgar-rice-burroughs/the-warlord-of-mars"
 )
 
 die() {
-    printf 'error: %s\n' "$*" >&2
-    exit 1
+  printf 'error: %s\n' "$*" >&2
+  exit 1
 }
 
 step() { printf '\n== %s\n' "$*"; }
@@ -55,16 +67,16 @@ note() { printf '   %s\n' "$*"; }
 # The current window, as XML. uiautomator occasionally comes back empty
 # while a screen is still settling, so an empty dump is worth retrying.
 dump_ui() {
-    local i
-    for i in 1 2 3; do
-        if adb shell uiautomator dump /sdcard/liseur-ui.xml >/dev/null 2>&1 &&
-            adb shell cat /sdcard/liseur-ui.xml > "$work/ui.xml" 2>/dev/null &&
-            [[ -s "$work/ui.xml" ]]; then
-            return 0
-        fi
-        sleep 1
-    done
-    return 1
+  local i
+  for i in 1 2 3; do
+    if adb shell uiautomator dump /sdcard/liseur-ui.xml >/dev/null 2>&1 &&
+      adb shell cat /sdcard/liseur-ui.xml >"$work/ui.xml" 2>/dev/null &&
+      [[ -s "$work/ui.xml" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
 }
 
 # Centre of the first node whose text or content-desc matches, printed as
@@ -73,7 +85,7 @@ dump_ui() {
 #
 #   find_node <needle> [exact]
 find_node() {
-    python3 - "$work/ui.xml" "$1" "${2:-prefix}" <<'PY'
+  python3 - "$work/ui.xml" "$1" "${2:-prefix}" <<'PY'
 import re, sys, xml.etree.ElementTree as ET
 
 path, needle, mode = sys.argv[1], sys.argv[2].lower(), sys.argv[3]
@@ -108,40 +120,40 @@ PY
 #
 #   wait_for <needle> [seconds] [exact]
 wait_for() {
-    local needle=$1 limit=${2:-25} mode=${3:-prefix} waited=0 found
-    while ((waited < limit)); do
-        if dump_ui && found=$(find_node "$needle" "$mode"); then
-            printf '%s\n' "$found"
-            return 0
-        fi
-        sleep 1
-        waited=$((waited + 1))
-    done
-    return 1
+  local needle=$1 limit=${2:-25} mode=${3:-prefix} waited=0 found
+  while ((waited < limit)); do
+    if dump_ui && found=$(find_node "$needle" "$mode"); then
+      printf '%s\n' "$found"
+      return 0
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  return 1
 }
 
 # Tap what a thing says. The tap lands on the node's centre, which for a
 # Compose icon button is the icon itself.
 tap_on() {
-    local needle=$1 mode=${2:-prefix} at
-    at=$(wait_for "$needle" 25 "$mode") ||
-        die "never found \"$needle\" on screen (the layout may have changed)"
-    # shellcheck disable=SC2086
-    adb shell input tap $at
-    sleep 2
+  local needle=$1 mode=${2:-prefix} at
+  at=$(wait_for "$needle" 25 "$mode") ||
+    die "never found \"$needle\" on screen (the layout may have changed)"
+  # shellcheck disable=SC2086
+  adb shell input tap $at
+  sleep 2
 }
 
 # Same, but a missing target is not fatal: for things that are only there
 # sometimes, like a permission dialog.
 tap_if_there() {
-    local needle=$1 mode=${2:-prefix} at
-    if dump_ui && at=$(find_node "$needle" "$mode"); then
-        # shellcheck disable=SC2086
-        adb shell input tap $at
-        sleep 2
-        return 0
-    fi
-    return 1
+  local needle=$1 mode=${2:-prefix} at
+  if dump_ui && at=$(find_node "$needle" "$mode"); then
+    # shellcheck disable=SC2086
+    adb shell input tap $at
+    sleep 2
+    return 0
+  fi
+  return 1
 }
 
 on_screen() { dump_ui && find_node "$1" >/dev/null; }
@@ -151,98 +163,98 @@ back() { adb shell input keyevent KEYCODE_BACK; }
 # ------------------------------------------------------------- the app
 
 open_library() {
-    adb shell am force-stop "$APP_ID"
-    # A picker left open from an earlier run steals the launch.
-    adb shell am force-stop com.google.android.documentsui >/dev/null 2>&1 || true
-    adb shell am start -n "$MAIN_ACTIVITY" >/dev/null
-    sleep 6
-    # The app can open on the book you were reading; step back to the shelf.
-    if ! wait_for "Liseur" 20 exact >/dev/null; then
-        back
-        sleep 3
-        wait_for "Liseur" 20 exact >/dev/null || die "never reached the library"
-    fi
+  adb shell am force-stop "$APP_ID"
+  # A picker left open from an earlier run steals the launch.
+  adb shell am force-stop com.google.android.documentsui >/dev/null 2>&1 || true
+  adb shell am start -n "$MAIN_ACTIVITY" >/dev/null
+  sleep 6
+  # The app can open on the book you were reading; step back to the shelf.
+  if ! wait_for "Liseur" 20 exact >/dev/null; then
+    back
+    sleep 3
+    wait_for "Liseur" 20 exact >/dev/null || die "never reached the library"
+  fi
 }
 
 # --------------------------------------------------------------- setup
 
 fetch_books() {
-    mkdir -p "$CACHE_DIR"
-    local slug file url
-    for slug in "${DEMO_BOOKS[@]}"; do
-        file="$CACHE_DIR/${slug//\//_}.epub"
-        if [[ -s "$file" ]]; then
-            note "have ${slug#*/}"
-            continue
-        fi
-        url="https://standardebooks.org/ebooks/$slug/downloads/${slug%%/*}_${slug#*/}.epub?source=download"
-        note "fetching ${slug#*/}"
-        curl -fsSL --retry 2 -o "$file.part" "$url" ||
-            die "could not download $slug from standardebooks.org"
-        # A download that turned into the interstitial page is not a book.
-        if ! head -c 2 "$file.part" | grep -q 'PK'; then
-            rm -f "$file.part"
-            die "standardebooks.org served a page rather than $slug"
-        fi
-        mv "$file.part" "$file"
-    done
+  mkdir -p "$CACHE_DIR"
+  local slug file url
+  for slug in "${DEMO_BOOKS[@]}"; do
+    file="$CACHE_DIR/${slug//\//_}.epub"
+    if [[ -s "$file" ]]; then
+      note "have ${slug#*/}"
+      continue
+    fi
+    url="https://standardebooks.org/ebooks/$slug/downloads/${slug%%/*}_${slug#*/}.epub?source=download"
+    note "fetching ${slug#*/}"
+    curl -fsSL --retry 2 -o "$file.part" "$url" ||
+      die "could not download $slug from standardebooks.org"
+    # A download that turned into the interstitial page is not a book.
+    if ! head -c 2 "$file.part" | grep -q 'PK'; then
+      rm -f "$file.part"
+      die "standardebooks.org served a page rather than $slug"
+    fi
+    mv "$file.part" "$file"
+  done
 }
 
 push_books() {
-    adb shell mkdir -p "$DEVICE_BOOKS"
-    local file
-    for file in "$CACHE_DIR"/*.epub; do
-        adb push "$file" "$DEVICE_BOOKS/" >/dev/null
-    done
-    note "${#DEMO_BOOKS[@]} books in $DEVICE_BOOKS"
+  adb shell mkdir -p "$DEVICE_BOOKS"
+  local file
+  for file in "$CACHE_DIR"/*.epub; do
+    adb push "$file" "$DEVICE_BOOKS/" >/dev/null
+  done
+  note "${#DEMO_BOOKS[@]} books in $DEVICE_BOOKS"
 }
 
 # Grant the folder through the real picker, because there is no other way
 # to hand a SAF tree to an app.
 grant_folder() {
-    if adb shell "run-as $APP_ID sqlite3 /data/data/$APP_ID/databases/liseur.db \
+  if adb shell "run-as $APP_ID sqlite3 /data/data/$APP_ID/databases/liseur.db \
         'select count(*) from library_folders;'" 2>/dev/null | grep -qE '^[1-9]'; then
-        note "a library folder is already granted"
-        return 0
+    note "a library folder is already granted"
+    return 0
+  fi
+  open_library
+  tap_on "Add books"
+  tap_on "Add a folder"
+  sleep 3
+  # The picker reopens wherever it was left, so it may already be
+  # inside the shelf. Tapping the folder again from in there hits the
+  # breadcrumb and walks back out, and the grant then lands on the
+  # wrong directory -- or on nothing at all.
+  if ! on_screen "Files in Books"; then
+    # The picker usually opens on the device's own storage already.
+    # When it does not, go out to the roots and come back in by the
+    # model name.
+    if ! on_screen "Books"; then
+      tap_if_there "Show roots" || true
+      local model
+      model=$(adb shell getprop ro.product.model | tr -d '\r')
+      tap_on "$model"
     fi
-    open_library
-    tap_on "Add books"
-    tap_on "Add a folder"
-    sleep 3
-    # The picker reopens wherever it was left, so it may already be
-    # inside the shelf. Tapping the folder again from in there hits the
-    # breadcrumb and walks back out, and the grant then lands on the
-    # wrong directory -- or on nothing at all.
-    if ! on_screen "Files in Books"; then
-        # The picker usually opens on the device's own storage already.
-        # When it does not, go out to the roots and come back in by the
-        # model name.
-        if ! on_screen "Books"; then
-            tap_if_there "Show roots" || true
-            local model
-            model=$(adb shell getprop ro.product.model | tr -d '\r')
-            tap_on "$model"
-        fi
-        tap_on "Books"
-    fi
-    tap_on "USE THIS FOLDER"
-    # The permission dialog can take a moment to arrive, and tapping
-    # where it is about to be does nothing at all.
-    #
-    # Match the button exactly: the dialog above it opens with "Allow
-    # Liseur to access...", so a prefix match taps the sentence instead,
-    # which does nothing and loses the folder.
-    tap_on "ALLOW" exact
-    note "waiting for the shelf to fill"
-    local waited=0 count=0
-    while ((waited < 90)); do
-        count=$(adb shell "run-as $APP_ID sqlite3 /data/data/$APP_ID/databases/liseur.db \
+    tap_on "Books"
+  fi
+  tap_on "USE THIS FOLDER"
+  # The permission dialog can take a moment to arrive, and tapping
+  # where it is about to be does nothing at all.
+  #
+  # Match the button exactly: the dialog above it opens with "Allow
+  # Liseur to access...", so a prefix match taps the sentence instead,
+  # which does nothing and loses the folder.
+  tap_on "ALLOW" exact
+  note "waiting for the shelf to fill"
+  local waited=0 count=0
+  while ((waited < 90)); do
+    count=$(adb shell "run-as $APP_ID sqlite3 /data/data/$APP_ID/databases/liseur.db \
             'select count(*) from books;'" 2>/dev/null | tr -d '\r')
-        ((count >= ${#DEMO_BOOKS[@]})) && break
-        sleep 5
-        waited=$((waited + 5))
-    done
-    note "$count books on the shelf"
-    ((count > 0)) ||
-        die "the folder was not granted; the picker layout may have changed"
+    ((count >= ${#DEMO_BOOKS[@]})) && break
+    sleep 5
+    waited=$((waited + 5))
+  done
+  note "$count books on the shelf"
+  ((count > 0)) ||
+    die "the folder was not granted; the picker layout may have changed"
 }


### PR DESCRIPTION
Added a dedicated reading appearance screen in the settings and
extracted appearance controls so readers can customize theme, fonts, and
layout outside of active books. Introduced a "follow app" theme option
that automatically matches the app's dark or light mode.

Fixes #13 

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/1119eea8-31e3-48dd-aad5-071fd85d8d81" />

