### PR TITLE
feat(upload): send a local book to liseur-sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ Single `:app` module, layered packages under `com.chmouel.liseur`:
   custom reading chrome (tap zones, typography sheet, progress, annotations,
   search).
 - `ui/` — Compose screens: theme (`ui/theme`), library, settings.
-- `sync/` — WorkManager workers for downloads and position sync.
+- `sync/` — WorkManager workers for downloads, uploads and position sync.
 
 State management: plain `ViewModel` + `StateFlow`, unidirectional data flow.
 DI is a manual composition root (no Hilt/Koin). Extract non-trivial logic
@@ -137,6 +137,15 @@ emulator.
 - Statistics from a server are decoration. Every failure there is
   null and silent; the stats screen is built from local sessions and
   must stand on its own.
+- A book only on this device can be sent to liseur-sync, where the
+  server allows it: `BookUploader`, `ServerCapabilities.canUpload` (read
+  from the `library-upload` scope) and `BookUploadWorker`, whose unique
+  work name `upload:$bookUrl` is itself the no-double-upload guarantee.
+  What follows a successful upload is **adoption, not replacement**: the
+  local row keeps its own `url`, because that is the key every reading
+  position, annotation and session hangs off, and only `remote_uuid` and
+  `download_href` are written (`BookDao.linkToRemote`). Never rewrite
+  `books.url` to the server's spelling — the reader's place goes with it.
 - Blocking network calls move to `Dispatchers.IO` inside the client that
   blocks, not in the caller. A `suspend` signature reads as a promise
   that the thread is safe, and a repository reached from a

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -67,6 +67,37 @@ There is no instrumented/emulator test suite. Reader interactions
 (gestures, immersive mode, process-death restore, rotation) are verified
 manually on a booted AVD.
 
+### The upload end-to-end check
+
+Sending a local book to liseur-sync is the one path where a unit test
+proves almost nothing: what can go wrong is the shape of the whole
+round trip, not a function. `hack/e2e-upload` drives it through the
+app's own screens against a real server and then reads both sides.
+
+```bash
+hack/e2e-upload -u http://10.0.2.2:8686 -t <token> -d /srv/books
+```
+
+`-u` is the server as the *device* sees it, so an emulator wants
+`10.0.2.2` and never `127.0.0.1`. `-t` is a device token holding at
+least `sync`, `library-read` and `library-upload`. `-d` is the watched
+folder's root on this machine, which is how the script sees what landed.
+The folder has to accept uploads already:
+
+```bash
+liseur-sync admin folder-uploads <folder-id> on
+```
+
+It asserts four things, and each one is a bug that actually happened:
+the `library-upload` scope reaches the app as `can_upload`, the files
+appear in the folder, no uploaded book had its `url` rewritten (that
+key is what every reading position hangs off), and no book came back
+from the following catalog pass as a second row.
+
+Nothing about it is mocked. Start with a clean shelf — `hack/reset-books`
+then `adb shell pm clear com.chmouel.liseur` — or the counts it compares
+are counting an earlier run.
+
 ### Checking a folder's storage permission
 
 Deleting a book's file needs write access to the folder it lives in, and
@@ -475,6 +506,23 @@ what lets it sync a book that came off an SD card.
 - Statistics (`/v1/insights/*`) are decoration. Every failure is null
   and silent, and a null `eta_seconds` is carried through untouched: no
   estimate beats an invented one.
+- **Uploading is opt-in twice over.** The server advertises the
+  `library-upload` scope on `GET /v1/token` and marks the folders that
+  take uploads in `GET /v1/folders`; without both, the action is not
+  offered at all, which is how an older server needs no version check.
+  `POST /v1/folders/{folder}/books` is `multipart/form-data`, keyed by
+  the file's SHA-256, so a repeated upload answers `200 duplicate` and
+  stores nothing twice. `202` means the bytes are safe but the server
+  had not catalogued them yet; the worker simply asks again, and the
+  digest makes the second ask free.
+- **What follows an upload is adoption, not replacement.** The local row
+  keeps its own `url` and gains `remote_uuid` and `download_href`
+  (`BookDao.linkToRemote`). Rewriting the URL to the server's spelling
+  would take every reading position, annotation and session with it.
+  Because the catalog reads what the library holds once, before its
+  walk begins, both sides guard against the book being introduced twice:
+  the catalog re-asks about the ids on a page it has not accounted for,
+  and adoption drops a catalog row that got there first.
 
 ## F-Droid readiness
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -92,7 +92,25 @@ It asserts four things, and each one is a bug that actually happened:
 the `library-upload` scope reaches the app as `can_upload`, the files
 appear in the folder, no uploaded book had its `url` rewritten (that
 key is what every reading position hangs off), and no book came back
-from the following catalog pass as a second row.
+from the following catalog pass as a second row. That third one is
+worth the whole script: a book uploaded from the device was being
+deleted by the next refresh, and its reading position with it.
+
+The other half of the capability is refusing, and `-r` checks it:
+
+```bash
+hack/e2e-upload -r -u http://10.0.2.2:8686 -t <token> -d /srv/books
+```
+
+A server says no in two places. A token without the scope is refused on
+sight, and the action is never offered. A token that holds the scope but
+finds every folder closed can only be refused by trying, and the app has
+to remember the answer — otherwise it offers, once per book, an action
+that silently fails every time. Either way `-r` asserts the app ends up
+not offering, no book was linked, none left the shelf and nothing was
+written into the folder. Run it with the folder still closed, then
+`folder-uploads <folder-id> on` and run the check above, and you have
+covered both answers with one server.
 
 Nothing about it is mocked. Start with a clean shelf — `hack/reset-books`
 then `adb shell pm clear com.chmouel.liseur` — or the counts it compares

--- a/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/35.json
+++ b/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/35.json
@@ -1,0 +1,1067 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 35,
+    "identityHash": "3e4a95b17b54122fd5492f441fa9b7bd",
+    "entities": [
+      {
+        "tableName": "reading_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `total_progression` REAL, `reading_speed` REAL, `reading_seconds_per_position` REAL, `reading_pace_samples` INTEGER NOT NULL DEFAULT 0, `reading_pace_elapsed_ms` INTEGER NOT NULL DEFAULT 0, `reading_pace_evidence` REAL NOT NULL DEFAULT 0, `updated_at` INTEGER NOT NULL, `status` TEXT, `synced_at` INTEGER, `local_revision` INTEGER NOT NULL DEFAULT 0, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `agreed_account` TEXT, `pending_progression` REAL, `pending_status` TEXT, `pending_updated_at` INTEGER, `pending_account` TEXT, `owner_account` TEXT, `remote_updated_at` INTEGER, `finished_override` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSpeed",
+            "columnName": "reading_speed",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSecondsPerPosition",
+            "columnName": "reading_seconds_per_position",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingPaceSamples",
+            "columnName": "reading_pace_samples",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceElapsedMs",
+            "columnName": "reading_pace_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceEvidence",
+            "columnName": "reading_pace_evidence",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localRevision",
+            "columnName": "local_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "agreedAccount",
+            "columnName": "agreed_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingAccount",
+            "columnName": "pending_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ownerAccount",
+            "columnName": "owner_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "finishedOverride",
+            "columnName": "finished_override",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `cover_path` TEXT, `source` TEXT, `added_at` INTEGER NOT NULL, `last_opened_at` INTEGER, `local_uri` TEXT, `remote_uuid` TEXT, `remote_book_id` INTEGER, `cover_url` TEXT, `download_href` TEXT, `download_state` TEXT NOT NULL, `remote_updated_at` INTEGER, `downloaded_at` INTEGER, `file_modified_at` INTEGER, `work_id` TEXT, `finished_at` INTEGER, `archived_at` INTEGER, `remote_page_count` INTEGER, `series_name` TEXT, `series_index` REAL, `file_series_name` TEXT, `file_series_index` REAL, `series_id` TEXT, `series_checked` INTEGER NOT NULL, `catalog_series_name` TEXT, `catalog_series_index` REAL, `catalog_folder_id` TEXT, `catalog_series_source` TEXT, `user_series_name` TEXT, `user_series_index` REAL, `series_override` INTEGER NOT NULL, `user_series_updated_at` INTEGER, `series_claim_pending` INTEGER NOT NULL, `series_claim_reset` INTEGER NOT NULL, `personal_series_updated_at` INTEGER, `series_index_override` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "last_opened_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localUri",
+            "columnName": "local_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUuid",
+            "columnName": "remote_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteBookId",
+            "columnName": "remote_book_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadHref",
+            "columnName": "download_href",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadState",
+            "columnName": "download_state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloaded_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finished_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archived_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remotePageCount",
+            "columnName": "remote_page_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fileSeriesName",
+            "columnName": "file_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileSeriesIndex",
+            "columnName": "file_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesChecked",
+            "columnName": "series_checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSeriesName",
+            "columnName": "catalog_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesIndex",
+            "columnName": "catalog_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "catalogFolderId",
+            "columnName": "catalog_folder_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesSource",
+            "columnName": "catalog_series_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesName",
+            "columnName": "user_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesIndex",
+            "columnName": "user_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesOverridden",
+            "columnName": "series_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userSeriesUpdatedAt",
+            "columnName": "user_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesClaimPending",
+            "columnName": "series_claim_pending",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesClaimReset",
+            "columnName": "series_claim_reset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personalSeriesUpdatedAt",
+            "columnName": "personal_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "indexOverridden",
+            "columnName": "series_index_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_books_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_books_url` ON `${TABLE_NAME}` (`url`)"
+          },
+          {
+            "name": "index_books_series_name",
+            "unique": false,
+            "columnNames": [
+              "series_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_series_name` ON `${TABLE_NAME}` (`series_name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "library_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `added_at` INTEGER NOT NULL, PRIMARY KEY(`url`))",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "url"
+          ]
+        }
+      },
+      {
+        "tableName": "remote_server",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `kind` TEXT NOT NULL, `base_url` TEXT NOT NULL, `username` TEXT, `password_cipher` TEXT, `api_key_cipher` TEXT, `account_id` TEXT, `user_id` INTEGER, `kobo_token` TEXT, `can_download` INTEGER NOT NULL, `can_manage_library` INTEGER NOT NULL, `can_upload` INTEGER NOT NULL, `can_admin` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `catalog_synced_at` INTEGER, `position_synced_at` INTEGER, `sync_token` TEXT, `liseur_token_cipher` TEXT, `liseur_account_id` TEXT, `sync_cursor_seq` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "passwordCipher",
+            "columnName": "password_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiKeyCipher",
+            "columnName": "api_key_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "koboTokenCipher",
+            "columnName": "kobo_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "canDownload",
+            "columnName": "can_download",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canManageLibrary",
+            "columnName": "can_manage_library",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canUpload",
+            "columnName": "can_upload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canAdmin",
+            "columnName": "can_admin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSyncedAt",
+            "columnName": "catalog_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "positionSyncedAt",
+            "columnName": "position_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncToken",
+            "columnName": "sync_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurTokenCipher",
+            "columnName": "liseur_token_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurAccountId",
+            "columnName": "liseur_account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncCursorSeq",
+            "columnName": "sync_cursor_seq",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `book_id` TEXT NOT NULL, `kind` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `text` TEXT, `note` TEXT, `tint` TEXT, `chapter` TEXT, `position` INTEGER, `total_progression` REAL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tint",
+            "columnName": "tint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapter",
+            "columnName": "chapter",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_typography",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `font` TEXT NOT NULL, `font_size` REAL NOT NULL, `line_height` REAL, `page_margins` REAL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "font",
+            "columnName": "font",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "font_size",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineHeight",
+            "columnName": "line_height",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pageMargins",
+            "columnName": "page_margins",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_screen",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `keep_screen_on` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keepScreenOn",
+            "columnName": "keep_screen_on",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_reading_mode",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `scroll` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scroll",
+            "columnName": "scroll",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `book_url` TEXT NOT NULL, `started_at` INTEGER NOT NULL, `ended_at` INTEGER, `last_checkpoint_at` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `start_progression` REAL, `end_progression` REAL, `uploaded_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "ended_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastCheckpointAt",
+            "columnName": "last_checkpoint_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startProgression",
+            "columnName": "start_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "endProgression",
+            "columnName": "end_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "uploadedAt",
+            "columnName": "uploaded_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_sessions_book_url",
+            "unique": false,
+            "columnNames": [
+              "book_url"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_book_url` ON `${TABLE_NAME}` (`book_url`)"
+          },
+          {
+            "name": "index_reading_sessions_started_at",
+            "unique": false,
+            "columnNames": [
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_started_at` ON `${TABLE_NAME}` (`started_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_peer_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `pending_progression` REAL, `pending_status` TEXT, `pending_updated_at` INTEGER, `has_pending` INTEGER NOT NULL DEFAULT 0, `remote_updated_at` INTEGER, `synced_at` INTEGER, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasPending",
+            "columnName": "has_pending",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_peer_state_peer_id",
+            "unique": false,
+            "columnNames": [
+              "peer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_peer_state_peer_id` ON `${TABLE_NAME}` (`peer_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_fingerprint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `sha256` TEXT NOT NULL, `partial_md5` TEXT NOT NULL, `file_size` INTEGER NOT NULL, `file_modified_at` INTEGER, `computed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256",
+            "columnName": "sha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partialMd5",
+            "columnName": "partial_md5",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "computedAt",
+            "columnName": "computed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "work_alias",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_id` TEXT NOT NULL, `confidence` TEXT NOT NULL, `confirmed` INTEGER NOT NULL, `seeded` INTEGER NOT NULL DEFAULT 0, `source_sent` INTEGER NOT NULL DEFAULT 0, `edition_sha` TEXT, `resolved_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confirmed",
+            "columnName": "confirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seeded",
+            "columnName": "seeded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceSent",
+            "columnName": "source_sent",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "editionSha",
+            "columnName": "edition_sha",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resolvedAt",
+            "columnName": "resolved_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "work_ambiguity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_ids` TEXT NOT NULL, `noticed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workIds",
+            "columnName": "work_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noticedAt",
+            "columnName": "noticed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_extra",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`series_id` TEXT NOT NULL, `summary` TEXT, `status` TEXT, `total_book_count` INTEGER, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`series_id`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalBookCount",
+            "columnName": "total_book_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "series_id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3e4a95b17b54122fd5492f441fa9b7bd')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -22,6 +22,7 @@ import com.chmouel.liseur.data.settings.AppSettingsRepository
 import com.chmouel.liseur.data.settings.ReaderPreferencesRepository
 import com.chmouel.liseur.data.settings.ReadingPaceRepository
 import com.chmouel.liseur.data.remote.DeviceIdentityRepository
+import com.chmouel.liseur.data.remote.BookUploadRepository
 import com.chmouel.liseur.data.remote.CompositePositionSync
 import com.chmouel.liseur.data.liseursync.LiseurSyncCatalogClient
 import com.chmouel.liseur.data.liseursync.LiseurSyncFileSource
@@ -149,6 +150,8 @@ class AppContainer(context: Context) {
         bookDao = database.bookDao(),
         bookRemoval = bookRemoval,
     )
+
+    val bookUploads = BookUploadRepository(context.applicationContext)
 
     /** This device, as the servers that record who saved a position see it. */
     val deviceIdentity = DeviceIdentityRepository(context.applicationContext)

--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -29,6 +29,7 @@ import com.chmouel.liseur.data.liseursync.LiseurSyncInsights
 import com.chmouel.liseur.data.liseursync.LiseurSyncPositionSync
 import com.chmouel.liseur.data.liseursync.LiseurSyncServerSetup
 import com.chmouel.liseur.data.liseursync.LiseurSyncSeriesClient
+import com.chmouel.liseur.data.liseursync.LiseurSyncUploadClient
 import com.chmouel.liseur.data.liseursync.WorkResolver
 import com.chmouel.liseur.data.remote.RemoteAccountRepository
 import com.chmouel.liseur.data.remote.RemoteCatalogRepository
@@ -248,6 +249,14 @@ class AppContainer(context: Context) {
         // route at all, and inventing one here would be lying about it.
         deleters = mapOf(
             ServerKind.CALIBRE to com.chmouel.liseur.data.calibre.CalibreBookDeleter(),
+        ),
+        // liseur-sync is the only one that takes a book, and only into a
+        // folder an administrator marked (ADR-0023). Komga and
+        // calibre-web have upload routes of their own; they are not
+        // wired here because the app has nothing to say to them yet, and
+        // an entry in this map is a promise that the action works.
+        uploaders = mapOf(
+            ServerKind.LISEUR_SYNC to LiseurSyncUploadClient(),
         ),
     )
 

--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -449,6 +449,7 @@ private fun ServerAccountRoute(
         onConnect = viewModel::connect,
         onRetryCapabilities = viewModel::retryCapabilities,
         onKoboToken = viewModel::setKoboToken,
+        onSetUploadPolicy = viewModel::setUploadPolicy,
         onDisconnect = viewModel::disconnect,
         onSyncNow = viewModel::syncPositions,
         onAnswerConfirmation = viewModel::answerConfirmation,
@@ -605,6 +606,8 @@ private fun LibraryRoute(
                 downloading = book.url in state.downloads,
                 canDownload = state.canDownload,
                 canDeleteFromServer = state.canDeleteFromServer,
+                canUploadToServer = state.canUploadToServer,
+                uploading = book.url in state.uploading,
                 onDismiss = { seriesSheetBook = null },
                 onDownload = { viewModel.download(book); seriesSheetBook = null },
                 onCancelDownload = { viewModel.cancelDownload(book); seriesSheetBook = null },
@@ -622,6 +625,10 @@ private fun LibraryRoute(
                 // button that quietly does nothing.
                 onDeleteFromServer = {
                     seriesServerDelete = book
+                    seriesSheetBook = null
+                },
+                onUploadToServer = {
+                    viewModel.uploadToServer(book)
                     seriesSheetBook = null
                 },
             )
@@ -679,6 +686,9 @@ private fun LibraryRoute(
         onSetArchived = viewModel::setArchived,
         onDeleteLocal = viewModel::deleteLocalBook,
         onDeleteFromServer = viewModel::deleteFromServer,
+        onUploadToServer = viewModel::uploadToServer,
+        onUploadPending = viewModel::uploadPending,
+        onDismissUploadPrompt = viewModel::dismissUploadPrompt,
         onSetSeries = viewModel::setBookSeries,
         onResetSeries = viewModel::resetBookSeries,
         onResetSharedSeries = viewModel::resetBookSharedSeries,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/Book.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/Book.kt
@@ -705,6 +705,9 @@ interface BookDao {
     @Query("DELETE FROM books WHERE url IN (:urls)")
     suspend fun deleteByUrls(urls: List<String>)
 
+    @Query("SELECT * FROM books WHERE remote_uuid IN (:remoteUuids)")
+    suspend fun byRemoteUuids(remoteUuids: List<String>): List<Book>
+
     /**
      * Gives a local book a server identity, after an upload landed.
      *

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
@@ -24,7 +24,7 @@ import androidx.sqlite.execSQL
         WorkAmbiguity::class,
         SeriesExtra::class,
     ],
-    version = 34,
+    version = 35,
     exportSchema = true,
 )
 abstract class LiseurDatabase : RoomDatabase() {
@@ -962,6 +962,22 @@ abstract class LiseurDatabase : RoomDatabase() {
         }
 
         /**
+         * Records whether the connected account may add a book to the
+         * server's library (ADR-0023). Off for every existing row: an
+         * account that has the permission learns so the next time it
+         * talks to the server, and offering the action on a guess would
+         * mean offering one that fails.
+         */
+        val MIGRATION_34_35 = object : Migration(34, 35) {
+            override fun migrate(connection: SQLiteConnection) {
+                connection.execSQL(
+                    "ALTER TABLE `remote_server` ADD COLUMN `can_upload` " +
+                        "INTEGER NOT NULL DEFAULT 0",
+                )
+            }
+        }
+
+        /**
          * Every migration, in order, as one list so that what the app
          * runs and what the tests replay cannot drift apart.
          */
@@ -999,6 +1015,7 @@ abstract class LiseurDatabase : RoomDatabase() {
             MIGRATION_31_32,
             MIGRATION_32_33,
             MIGRATION_33_34,
+            MIGRATION_34_35,
         )
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/RemoteServer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/RemoteServer.kt
@@ -44,6 +44,7 @@ data class RemoteServer(
     @ColumnInfo(name = "kobo_token") val koboTokenCipher: String?,
     @ColumnInfo(name = "can_download") val canDownload: Boolean,
     @ColumnInfo(name = "can_manage_library") val canManageLibrary: Boolean = false,
+    @ColumnInfo(name = "can_upload") val canUpload: Boolean = false,
     @ColumnInfo(name = "can_admin") val canAdmin: Boolean = false,
     @ColumnInfo(name = "added_at") val addedAt: Long,
     @ColumnInfo(name = "catalog_synced_at") val catalogSyncedAt: Long?,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/RemoteServer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/RemoteServer.kt
@@ -179,6 +179,9 @@ interface RemoteServerDao {
     @Query("UPDATE remote_server SET can_download = :allowed WHERE id = :id")
     suspend fun setCanDownload(allowed: Boolean, id: Long = RemoteServer.SINGLE_ID)
 
+    @Query("UPDATE remote_server SET can_upload = :allowed WHERE id = :id")
+    suspend fun setCanUpload(allowed: Boolean, id: Long = RemoteServer.SINGLE_ID)
+
     /**
      * Moves the liseur-sync cursor, touching nothing else.
      *

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncApi.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncApi.kt
@@ -27,18 +27,24 @@ object LiseurSyncApi {
     const val SCOPE_LIBRARY_READ = "library-read"
     const val SCOPE_LIBRARY_MANAGE = "library-manage"
 
+    /** Adding a book to a folder that accepts one (ADR-0023). */
+    const val SCOPE_LIBRARY_UPLOAD = "library-upload"
+
     /**
      * Every scope a full account wants, in one mint.
      *
-     * Books still reach a liseur-sync server only by being put in a
-     * watched folder. The one catalog thing the app can now write is a
-     * reader's claim about which series a book belongs to.
+     * Books reach a liseur-sync server by being put in a watched folder,
+     * and `library-upload` is the app asking to be one of the things
+     * that can put one there — for a folder an administrator marked, and
+     * no other (ADR-0023). An older server that does not know the scope
+     * refuses to mint it, which is handled where the mint is read.
      */
     val SCOPES_FULL = listOf(
         SCOPE_SYNC,
         SCOPE_INSIGHTS,
         SCOPE_LIBRARY_READ,
         SCOPE_LIBRARY_MANAGE,
+        SCOPE_LIBRARY_UPLOAD,
     )
 
     fun url(baseUrl: String, path: String): String = RemoteUrl.api(baseUrl, path)
@@ -49,6 +55,10 @@ object LiseurSyncApi {
     /** The newest positions recorded for one book, newest first. */
     fun positions(baseUrl: String, workId: String, limit: Int): String =
         url(baseUrl, "/v1/works/$workId/positions?limit=$limit")
+
+    /** Where a book is added to a folder that accepts one (ADR-0023). */
+    fun uploadBook(baseUrl: String, folderId: String): String =
+        url(baseUrl, "$FOLDERS/$folderId/books")
 
     /** One page of the folders this server watches. */
     fun folders(baseUrl: String, after: String?, limit: Int): String =

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncServerSetup.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncServerSetup.kt
@@ -104,6 +104,7 @@ class LiseurSyncServerSetup(
             canDownload = LiseurSyncApi.SCOPE_LIBRARY_READ in scopes ||
                 LiseurSyncApi.SCOPE_LIBRARY_MANAGE in scopes || isAdmin,
             canManageLibrary = LiseurSyncApi.SCOPE_LIBRARY_MANAGE in scopes || isAdmin,
+            canUpload = LiseurSyncApi.SCOPE_LIBRARY_UPLOAD in scopes || isAdmin,
             canAdmin = isAdmin,
             accountId = answer.optString("device_id").takeIf { it.isNotEmpty() },
             displayName = answer.optString("name").ifEmpty { "liseur-sync" },

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncUploadClient.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncUploadClient.kt
@@ -43,6 +43,12 @@ class LiseurSyncUploadClient(
      * so a token with the scope can still find nowhere to put a book.
      * That is a real answer and the caller shows it as one rather than
      * offering an action that cannot work.
+     *
+     * Which is why a failure to ask is not an answer of "none". The
+     * caller treats an empty list as the server refusing and turns the
+     * feature off until the reader signs in again; a dropped connection
+     * must not be able to say that. It throws instead, and the worker
+     * retries.
      */
     override suspend fun targets(
         baseUrl: String,
@@ -52,12 +58,7 @@ class LiseurSyncUploadClient(
         var after: String? = null
         var guard = MAX_PAGES
         while (guard-- > 0) {
-            val answer = try {
-                json.get(LiseurSyncApi.folders(baseUrl, after, FOLDER_PAGE), credentials)
-            } catch (e: IOException) {
-                Log.i(TAG, "Could not list folders to upload into", e)
-                return targets
-            }
+            val answer = json.get(LiseurSyncApi.folders(baseUrl, after, FOLDER_PAGE), credentials)
             val array = answer.optJSONArray("folders") ?: break
             for (index in 0 until array.length()) {
                 val folder = array.optJSONObject(index) ?: continue

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncUploadClient.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncUploadClient.kt
@@ -4,8 +4,10 @@ import android.util.Log
 import com.chmouel.liseur.data.remote.BookUploader
 import com.chmouel.liseur.data.remote.RemoteCredentials
 import com.chmouel.liseur.data.remote.RemoteHttp
+import com.chmouel.liseur.data.remote.RemoteHttpFailure
 import com.chmouel.liseur.data.remote.RemoteUploadTarget
 import com.chmouel.liseur.data.remote.ServerUploadResult
+import com.chmouel.liseur.data.remote.SyncFailure
 import java.io.File
 import java.io.IOException
 import kotlinx.coroutines.Dispatchers
@@ -48,7 +50,8 @@ class LiseurSyncUploadClient(
      * caller treats an empty list as the server refusing and turns the
      * feature off until the reader signs in again; a dropped connection
      * must not be able to say that. It throws instead, and the worker
-     * retries.
+     * retries. A body that does not carry a folder list is the same
+     * mistake wearing a 200, and is treated the same way.
      */
     override suspend fun targets(
         baseUrl: String,
@@ -59,7 +62,13 @@ class LiseurSyncUploadClient(
         var guard = MAX_PAGES
         while (guard-- > 0) {
             val answer = json.get(LiseurSyncApi.folders(baseUrl, after, FOLDER_PAGE), credentials)
-            val array = answer.optJSONArray("folders") ?: break
+            // A server with no folders sends an empty array, never an
+            // absent one, so a missing key is a body this code does not
+            // understand rather than an answer of none — a proxy's 200,
+            // most likely. Reading it as "no folders" would spend the
+            // reader's feature on somebody else's error page.
+            val array = answer.optJSONArray("folders")
+                ?: throw RemoteHttpFailure(SyncFailure.Malformed)
             for (index in 0 until array.length()) {
                 val folder = array.optJSONObject(index) ?: continue
                 if (!folder.optBoolean("accepts_uploads")) continue
@@ -69,9 +78,13 @@ class LiseurSyncUploadClient(
                     name = folder.optString("name").ifEmpty { id },
                 )
             }
-            after = answer.optString("next_after").takeIf { it.isNotEmpty() } ?: break
+            after = answer.optString("next_after").takeIf { it.isNotEmpty() } ?: return targets
         }
-        return targets
+        // Ten thousand folders in, still being handed a cursor. Something
+        // is wrong at the other end, and the truncated list this would
+        // otherwise return could be missing every folder that accepts
+        // uploads — which reads as a refusal.
+        throw RemoteHttpFailure(SyncFailure.Malformed)
     }
 
     override suspend fun upload(

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncUploadClient.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncUploadClient.kt
@@ -1,0 +1,145 @@
+package com.chmouel.liseur.data.liseursync
+
+import android.util.Log
+import com.chmouel.liseur.data.remote.BookUploader
+import com.chmouel.liseur.data.remote.RemoteCredentials
+import com.chmouel.liseur.data.remote.RemoteHttp
+import com.chmouel.liseur.data.remote.RemoteUploadTarget
+import com.chmouel.liseur.data.remote.ServerUploadResult
+import java.io.File
+import java.io.IOException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.asRequestBody
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * Adds a book to a liseur-sync folder that accepts one.
+ *
+ * The server's rule (ADR-0023) is that an upload is a file written into
+ * a folder and nothing more: the catalog is still written by the folder
+ * pass. Two things follow for this client. It has to pick a folder,
+ * because there is no "the library" to post to — and only folders whose
+ * `accepts_uploads` is set will take one. And the answer may legitimately
+ * be "the bytes are safe but there is no book yet", which is
+ * [ServerUploadResult.Pending] rather than a failure to retry.
+ *
+ * The file is streamed from disk rather than read into memory. A book is
+ * routinely tens of megabytes and this runs on a phone.
+ */
+class LiseurSyncUploadClient(
+    private val http: RemoteHttp = RemoteHttp(),
+    private val json: LiseurSyncHttp = LiseurSyncHttp(http),
+) : BookUploader {
+
+    /**
+     * The folders that said they would take a book.
+     *
+     * The permission is the server's to give and it gives it per folder,
+     * so a token with the scope can still find nowhere to put a book.
+     * That is a real answer and the caller shows it as one rather than
+     * offering an action that cannot work.
+     */
+    override suspend fun targets(
+        baseUrl: String,
+        credentials: RemoteCredentials,
+    ): List<RemoteUploadTarget> {
+        val targets = mutableListOf<RemoteUploadTarget>()
+        var after: String? = null
+        var guard = MAX_PAGES
+        while (guard-- > 0) {
+            val answer = try {
+                json.get(LiseurSyncApi.folders(baseUrl, after, FOLDER_PAGE), credentials)
+            } catch (e: IOException) {
+                Log.i(TAG, "Could not list folders to upload into", e)
+                return targets
+            }
+            val array = answer.optJSONArray("folders") ?: break
+            for (index in 0 until array.length()) {
+                val folder = array.optJSONObject(index) ?: continue
+                if (!folder.optBoolean("accepts_uploads")) continue
+                val id = folder.optString("folder_id").takeIf { it.isNotEmpty() } ?: continue
+                targets += RemoteUploadTarget(
+                    folderId = id,
+                    name = folder.optString("name").ifEmpty { id },
+                )
+            }
+            after = answer.optString("next_after").takeIf { it.isNotEmpty() } ?: break
+        }
+        return targets
+    }
+
+    override suspend fun upload(
+        baseUrl: String,
+        credentials: RemoteCredentials,
+        folderId: String,
+        file: File,
+        filename: String,
+    ): ServerUploadResult = withContext(Dispatchers.IO) {
+        val body = MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("file", filename, file.asRequestBody(EPUB))
+            .build()
+        val request = Request.Builder()
+            .url(LiseurSyncApi.uploadBook(baseUrl, folderId))
+            .post(body)
+            .also { credentials.signInto(it) }
+            .build()
+        try {
+            http.client.newCall(request).execute().use { response ->
+                answerFor(response.code, response.body?.string().orEmpty())
+            }
+        } catch (e: IOException) {
+            Log.i(TAG, "The book could not be sent to the server", e)
+            ServerUploadResult.Failed(e.message)
+        }
+    }
+
+    /**
+     * What the server's answer means to a reader.
+     *
+     * The codes are the server's own contract and each maps to a
+     * different thing to do next, which is why this is a `when` on the
+     * code rather than a success check: a 200 and a 201 are both "the
+     * server has it", a 202 is "it will have it", and a 403 is the only
+     * one where offering the action again would be a lie.
+     */
+    private fun answerFor(code: Int, text: String): ServerUploadResult {
+        val body = parseOrNull(text)
+        return when (code) {
+            200, 201 -> {
+                val id = body?.optString("book_id")?.takeIf { it.isNotEmpty() }
+                if (id == null) {
+                    ServerUploadResult.Pending
+                } else {
+                    ServerUploadResult.Uploaded(id, alreadyThere = body.optBoolean("duplicate"))
+                }
+            }
+            202 -> ServerUploadResult.Pending
+            401, 403 -> ServerUploadResult.NotAllowed
+            413 -> ServerUploadResult.TooLarge
+            422 -> ServerUploadResult.Rejected
+            else -> ServerUploadResult.Failed(
+                body?.optString("error")?.takeIf { it.isNotEmpty() } ?: "HTTP $code",
+            )
+        }
+    }
+
+    private fun parseOrNull(text: String): JSONObject? = try {
+        if (text.isBlank()) null else JSONObject(text)
+    } catch (e: JSONException) {
+        Log.i(TAG, "The server did not answer with JSON", e)
+        null
+    }
+
+    private companion object {
+        const val TAG = "LiseurSyncUpload"
+        const val FOLDER_PAGE = 200
+        const val MAX_PAGES = 50
+        val EPUB = "application/epub+zip".toMediaType()
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/WorkResolver.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/WorkResolver.kt
@@ -107,24 +107,46 @@ class WorkResolver(
         alias.usable && !alias.sourceSent && sourceOf(book) != null
 
     /**
-     * The catalog server's id for [book], or null for a local file.
+     * The catalog server's id for [book], or null for a book this
+     * server does not hold.
      *
-     * The book's own URL already is that id — `komga:<id>`,
+     * Usually the book's own URL already is that id — `komga:<id>`,
      * `calibre:<uuid>` — and it is the same string on every device
      * connected to the same catalog. A local book's URL names a path on
      * this device and means nothing anywhere else, so it is never sent.
+     *
+     * A book uploaded from here is the exception. It keeps the URL its
+     * reading history hangs off and gains the server's id as a link
+     * instead (ADR-0023), so the URL still says "local" about a book the
+     * server now catalogs. Reading only the URL would leave it resolving
+     * on its title forever: the server would never learn that the work
+     * the device has been syncing all along *is* the book it was just
+     * sent, and the library would show the two side by side — one with
+     * the file, one with the reading.
      */
     fun sourceOf(book: Book): String? =
         book.url.takeIf { url -> ServerKind.entries.any { it.remoteId(url) != null } }
+            ?: book.remoteUuid?.let { ServerKind.LISEUR_SYNC.remoteUrl(it) }
+
+    /**
+     * This server's own id for [book], however the book came by it.
+     *
+     * Both halves of [sourceOf]'s story, narrowed to the server being
+     * talked to: a catalog book names it in its URL, an uploaded one
+     * carries it as a link.
+     */
+    fun catalogIdOf(book: Book): String? =
+        ServerKind.LISEUR_SYNC.remoteId(book.url) ?: book.remoteUuid
 
     /**
      * Asks the server what to call [book], caching whatever it says.
      *
-     * A book that came from this server's own catalog is resolved
-     * through the catalog route instead: the server reads the
-     * identifiers off its own record, so the answer carries the file's
-     * hashes even when the file itself was never downloaded here, and
-     * two devices browsing the same library name it identically.
+     * A book this server catalogs is resolved through the catalog route
+     * instead: the server reads the identifiers off its own record, so
+     * the answer carries the file's hashes even when the file itself was
+     * never downloaded here, and two devices browsing the same library
+     * name it identically. A book uploaded from here counts — that route
+     * is also what tells the server which work its new book belongs to.
      *
      * Any other book with no file on the device still resolves, on its
      * title and author: that is weaker, and the server will say so, but
@@ -159,7 +181,7 @@ class WorkResolver(
             }
         }
 
-        val catalogBookId = ServerKind.LISEUR_SYNC.remoteId(book.url)
+        val catalogBookId = catalogIdOf(book)
         if (catalogBookId != null) {
             return resolveCatalog(book, catalogBookId, existing, peerId, baseUrl, credentials)
         }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/BookUploadRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/BookUploadRepository.kt
@@ -1,0 +1,78 @@
+package com.chmouel.liseur.data.remote
+
+import android.content.Context
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import com.chmouel.liseur.data.db.Book
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/** Starts and watches uploads of local books to the connected server. */
+class BookUploadRepository(private val context: Context) {
+
+    private val workManager get() = WorkManager.getInstance(context)
+
+    /**
+     * The books currently on their way up, by URL.
+     *
+     * Only whether a book is in flight, not how far along it is: an
+     * upload is one request whose progress OkHttp does not report back
+     * without wrapping the body, and a spinner that cannot say more is
+     * honest as it stands.
+     */
+    val inFlight: Flow<Set<String>> =
+        workManager.getWorkInfosByTagFlow(TAG).map { infos ->
+            infos.asSequence()
+                .filter { it.state == WorkInfo.State.RUNNING || it.state == WorkInfo.State.ENQUEUED }
+                .mapNotNull { info ->
+                    info.tags.firstOrNull { it.startsWith(BOOK_TAG_PREFIX) }
+                        ?.removePrefix(BOOK_TAG_PREFIX)
+                }
+                .toSet()
+        }
+
+    /**
+     * Queues one book for upload.
+     *
+     * The unique work name is the no-double-upload guarantee: asking
+     * twice while the first attempt is still queued keeps the first,
+     * rather than sending the same book up alongside itself.
+     */
+    fun enqueue(book: Book, folderId: String? = null) {
+        val input = Data.Builder().putString(KEY_BOOK_URL, book.url)
+        folderId?.let { input.putString(KEY_FOLDER_ID, it) }
+        workManager.enqueueUniqueWork(
+            workName(book.url),
+            ExistingWorkPolicy.KEEP,
+            OneTimeWorkRequestBuilder<BookUploadWorker>()
+                .setInputData(input.build())
+                .addTag(TAG)
+                .addTag(BOOK_TAG_PREFIX + book.url)
+                .setConstraints(
+                    Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build(),
+                )
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+                .build(),
+        )
+    }
+
+    fun cancel(bookUrl: String) {
+        workManager.cancelUniqueWork(workName(bookUrl))
+    }
+
+    companion object {
+        const val TAG = "book-upload"
+        const val KEY_BOOK_URL = "book_url"
+        const val KEY_FOLDER_ID = "folder_id"
+        private const val BOOK_TAG_PREFIX = "book:"
+
+        fun workName(bookUrl: String) = "upload:$bookUrl"
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/BookUploadWorker.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/BookUploadWorker.kt
@@ -1,0 +1,162 @@
+package com.chmouel.liseur.data.remote
+
+import android.content.Context
+import android.util.Log
+import androidx.core.net.toUri
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.chmouel.liseur.container
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Sends one book up to the server in the background.
+ *
+ * A failure here never touches the book: it stays on the device, in the
+ * library, readable, and the worker can be asked again.
+ */
+class BookUploadWorker(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        val container = applicationContext.container
+        val bookUrl = inputData.getString(BookUploadRepository.KEY_BOOK_URL)
+            ?: return giveUp("no book url")
+
+        val bookDao = container.database.bookDao()
+        val book = bookDao.getByUrl(bookUrl) ?: return giveUp("unknown book $bookUrl")
+        if (book.remoteUuid != null) return Result.success()
+
+        val server = container.remoteAccount.current() ?: return giveUp("no server")
+        val credentials = server.credentials ?: return giveUp("no credentials")
+        val uploader = container.remoteRouter.uploaderFor(server.kind)
+            ?: return giveUp("${server.kind} does not take uploads")
+
+        val folderId = inputData.getString(BookUploadRepository.KEY_FOLDER_ID)
+            ?: runCatching { uploader.targets(server.baseUrl, credentials) }
+                .getOrElse { return retryAfter("could not list upload folders: ${it.message}") }
+                .firstOrNull()?.folderId
+            ?: return giveUp("no folder accepts uploads")
+
+        val (file, temporary) = localFile(book.localUri ?: book.url)
+            ?: return giveUp("no readable file for $bookUrl")
+
+        return try {
+            when (val result = uploader.upload(
+                baseUrl = server.baseUrl,
+                credentials = credentials,
+                folderId = folderId,
+                file = file,
+                filename = filenameFor(book.title, book.author),
+            )) {
+                is ServerUploadResult.Uploaded -> {
+                    adopt(container, bookUrl, result.remoteBookId)
+                    Result.success()
+                }
+                // The bytes are safe but the server had not catalogued
+                // them when it answered. Coming back is how the id is
+                // learnt: the server keys on the book's digest, so the
+                // second ask is recognised rather than stored twice.
+                ServerUploadResult.Pending -> retryAfter("$bookUrl uploaded, not catalogued yet")
+                ServerUploadResult.NotAllowed -> {
+                    container.database.remoteServerDao().setCanUpload(false)
+                    giveUp("server refused the upload")
+                }
+                ServerUploadResult.TooLarge -> giveUp("$bookUrl is larger than the server takes")
+                ServerUploadResult.Rejected -> giveUp("the server would not read $bookUrl")
+                is ServerUploadResult.Failed -> retryAfter("upload failed: ${result.message}")
+            }
+        } finally {
+            if (temporary) file.delete()
+        }
+    }
+
+    /**
+     * Ties the local book to the server's copy.
+     *
+     * The row keeps its own URL, so reading positions, annotations and
+     * sessions stay attached to it untouched; only the link is written.
+     * The next catalog pass matches on the remote id and fills in the
+     * rest, rather than introducing the book a second time.
+     */
+    private suspend fun adopt(
+        container: com.chmouel.liseur.AppContainer,
+        bookUrl: String,
+        remoteBookId: String,
+    ) {
+        container.database.bookDao().linkToRemote(
+            url = bookUrl,
+            remoteUuid = remoteBookId,
+            downloadHref = "/v1/books/$remoteBookId/download",
+            coverUrl = null,
+            remoteUpdatedAt = System.currentTimeMillis(),
+        )
+        container.remoteCatalog.refreshDetached()
+    }
+
+    /**
+     * The book as a file OkHttp can stream, and whether it is a copy to
+     * clean up afterwards.
+     *
+     * A book picked with **Open book** lives behind a content URI that
+     * only a stream can be had from, so it is spooled into the cache;
+     * one found in a library folder is usually a real file already and
+     * is sent where it lies.
+     */
+    private suspend fun localFile(uri: String): Pair<File, Boolean>? = withContext(Dispatchers.IO) {
+        val parsed = uri.toUri()
+        if (parsed.scheme == "file") {
+            val file = parsed.path?.let(::File)
+            return@withContext file?.takeIf { it.isFile }?.let { it to false }
+        }
+        val spool = File.createTempFile("upload", ".epub", applicationContext.cacheDir)
+        runCatching {
+            applicationContext.contentResolver.openInputStream(parsed).use { input ->
+                input ?: error("no stream for $uri")
+                spool.outputStream().use(input::copyTo)
+            }
+        }.fold(
+            onSuccess = { spool to true },
+            onFailure = {
+                Log.w(TAG, "could not read $uri", it)
+                spool.delete()
+                null
+            },
+        )
+    }
+
+    private fun giveUp(why: String): Result {
+        Log.w(TAG, why)
+        return Result.failure()
+    }
+
+    private fun retryAfter(why: String): Result {
+        Log.w(TAG, why)
+        return Result.retry()
+    }
+
+    companion object {
+        private const val TAG = "book-upload"
+
+        /**
+         * A name for the file on the server, from what the library knows.
+         *
+         * The server derives its own placement from the EPUB, so this is
+         * only what shows up in a log or an error; it still avoids path
+         * separators, because a filename is not a place to put one.
+         */
+        fun filenameFor(title: String, author: String?): String {
+            val stem = listOfNotNull(title.ifBlank { null }, author?.ifBlank { null })
+                .joinToString(" - ")
+                .ifBlank { "book" }
+            return stem.map { if (it == '/' || it == '\\' || it.code < 0x20) '_' else it }
+                .joinToString("")
+                .take(120)
+                .trim()
+                .plus(".epub")
+        }
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/BookUploadWorker.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/BookUploadWorker.kt
@@ -3,6 +3,7 @@ package com.chmouel.liseur.data.remote
 import android.content.Context
 import android.util.Log
 import androidx.core.net.toUri
+import androidx.room.withTransaction
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.chmouel.liseur.container
@@ -92,18 +93,24 @@ class BookUploadWorker(
         // already introduced the server's copy under its own URL. That
         // row is minutes old and holds no reading, while this one holds
         // all of it, so the catalog's is the one that goes.
-        dao.byRemoteUuids(listOf(remoteBookId))
-            .map { it.url }
-            .filter { it != bookUrl }
-            .takeIf { it.isNotEmpty() }
-            ?.let { dao.deleteByUrls(it) }
-        dao.linkToRemote(
-            url = bookUrl,
-            remoteUuid = remoteBookId,
-            downloadHref = "/v1/books/$remoteBookId/download",
-            coverUrl = null,
-            remoteUpdatedAt = System.currentTimeMillis(),
-        )
+        //
+        // Looking and linking are one transaction: a pass landing
+        // between the two would otherwise insert the row just after it
+        // was looked for and leave the duplicate this is here to stop.
+        container.database.withTransaction {
+            dao.byRemoteUuids(listOf(remoteBookId))
+                .map { it.url }
+                .filter { it != bookUrl }
+                .takeIf { it.isNotEmpty() }
+                ?.let { dao.deleteByUrls(it) }
+            dao.linkToRemote(
+                url = bookUrl,
+                remoteUuid = remoteBookId,
+                downloadHref = "/v1/books/$remoteBookId/download",
+                coverUrl = null,
+                remoteUpdatedAt = System.currentTimeMillis(),
+            )
+        }
         container.remoteCatalog.refreshDetached()
     }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/BookUploadWorker.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/BookUploadWorker.kt
@@ -40,7 +40,7 @@ class BookUploadWorker(
             ?: runCatching { uploader.targets(server.baseUrl, credentials) }
                 .getOrElse { return retryAfter("could not list upload folders: ${it.message}") }
                 .firstOrNull()?.folderId
-            ?: return giveUp("no folder accepts uploads")
+            ?: return refuse(container, "no folder accepts uploads")
 
         val (file, temporary) = localFile(book.localUri ?: book.url)
             ?: return giveUp("no readable file for $bookUrl")
@@ -62,10 +62,7 @@ class BookUploadWorker(
                 // learnt: the server keys on the book's digest, so the
                 // second ask is recognised rather than stored twice.
                 ServerUploadResult.Pending -> retryAfter("$bookUrl uploaded, not catalogued yet")
-                ServerUploadResult.NotAllowed -> {
-                    container.database.remoteServerDao().setCanUpload(false)
-                    giveUp("server refused the upload")
-                }
+                ServerUploadResult.NotAllowed -> refuse(container, "server refused the upload")
                 ServerUploadResult.TooLarge -> giveUp("$bookUrl is larger than the server takes")
                 ServerUploadResult.Rejected -> giveUp("the server would not read $bookUrl")
                 is ServerUploadResult.Failed -> retryAfter("upload failed: ${result.message}")
@@ -148,6 +145,21 @@ class BookUploadWorker(
     private fun giveUp(why: String): Result {
         Log.w(TAG, why)
         return Result.failure()
+    }
+
+    /**
+     * Gives up, and stops the app offering to send this server a book.
+     *
+     * A token that may upload and a server where no folder will have
+     * one are the same answer to a reader. The capability is what every
+     * entry point is drawn from, so leaving it standing offers an
+     * action that can only fail — silently, once per book, for as long
+     * as they keep asking. Signing in again is what reads the server's
+     * mind afresh, exactly as it is for a refusal on the wire.
+     */
+    private suspend fun refuse(container: com.chmouel.liseur.AppContainer, why: String): Result {
+        container.database.remoteServerDao().setCanUpload(false)
+        return giveUp(why)
     }
 
     private fun retryAfter(why: String): Result {

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/BookUploadWorker.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/BookUploadWorker.kt
@@ -87,7 +87,17 @@ class BookUploadWorker(
         bookUrl: String,
         remoteBookId: String,
     ) {
-        container.database.bookDao().linkToRemote(
+        val dao = container.database.bookDao()
+        // A catalog pass that ran between the upload and this line has
+        // already introduced the server's copy under its own URL. That
+        // row is minutes old and holds no reading, while this one holds
+        // all of it, so the catalog's is the one that goes.
+        dao.byRemoteUuids(listOf(remoteBookId))
+            .map { it.url }
+            .filter { it != bookUrl }
+            .takeIf { it.isNotEmpty() }
+            ?.let { dao.deleteByUrls(it) }
+        dao.linkToRemote(
             url = bookUrl,
             remoteUuid = remoteBookId,
             downloadHref = "/v1/books/$remoteBookId/download",

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepository.kt
@@ -316,6 +316,7 @@ class RemoteAccountRepository(
                     ?: existing?.koboTokenCipher,
                 canDownload = capabilities.canDownload,
                 canManageLibrary = capabilities.canManageLibrary,
+                canUpload = capabilities.canUpload,
                 canAdmin = capabilities.canAdmin,
                 addedAt = existing?.addedAt ?: System.currentTimeMillis(),
                 catalogSyncedAt = existing?.catalogSyncedAt,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepository.kt
@@ -282,6 +282,17 @@ class RemoteCatalogRepository(
         books: List<RemoteBook>,
     ) {
         val now = System.currentTimeMillis()
+        // What is known was read once before the walk began, so a book
+        // this device uploaded and linked while the walk was in flight
+        // is missing from it — and the catalog would introduce it all
+        // over again as a second row holding none of the reading. One
+        // query a page, on the ids this page actually names, is what
+        // keeps an upload that raced the catalog from doubling. Books
+        // the snapshot already covers are left alone: their snapshot is
+        // what the series write below checks itself against.
+        val unknown = books.map { it.remoteId }
+            .filter { known.find(it, kind.remoteUrl(it)) == null }
+        if (unknown.isNotEmpty()) bookDao.byRemoteUuids(unknown).forEach(known::remember)
         // Keyed by URL so a feed that names the same book twice on one
         // page folds into one insert, rather than two rows racing for
         // the same unique URL and being refused.

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepository.kt
@@ -369,7 +369,15 @@ class RemoteCatalogRepository(
      * it is removed from the server.
      */
     private suspend fun dropVanished(seenUuids: Set<String>) {
-        val gone = bookDao.allRemote().filter { it.remoteUuid !in seenUuids }
+        // Only rows the catalog itself introduced are the catalog's to
+        // forget. A book of the reader's own that was uploaded and
+        // linked is not one: its file is its URL rather than a
+        // download, so the test below would read it as having nothing
+        // to open, and a walk that began before the upload cannot have
+        // seen its id. Between them they would delete the book and
+        // every page ever read of it.
+        val gone = bookDao.allRemote()
+            .filter { it.remoteUuid !in seenUuids && ServerKind.isRemoteUrl(it.url) }
         // Only a book with a file of its own is worth keeping. One that
         // was queued or failed has nothing to read, so it goes with the
         // rest rather than staying as a row that can never be opened.

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteRouter.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteRouter.kt
@@ -22,6 +22,11 @@ class RemoteRouter(
      * the map means the action is never offered for that kind.
      */
     private val deleters: Map<ServerKind, BookDeleter> = emptyMap(),
+    /**
+     * Which kinds can be sent a book at all. Absent means the action is
+     * never offered for that kind, the same rule [deleters] follows.
+     */
+    private val uploaders: Map<ServerKind, BookUploader> = emptyMap(),
 ) {
     private suspend fun kind(): ServerKind? = serverDao.get()?.kind
 
@@ -45,6 +50,9 @@ class RemoteRouter(
 
     /** The deleter for a server already in hand, when the kind has one. */
     fun deleterFor(kind: ServerKind): BookDeleter? = deleters[kind]
+
+    /** The uploader for a server already in hand, when the kind has one. */
+    fun uploaderFor(kind: ServerKind): BookUploader? = uploaders[kind]
 
     /** The series-claim writer for a server already in hand, when it has one. */
     fun seriesClaimsFor(kind: ServerKind): SeriesClaimSync? = seriesClaims[kind]

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteSources.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteSources.kt
@@ -245,6 +245,12 @@ interface BookUploader {
     /**
      * The folders this server will accept a book into, which may be
      * none even for an account that holds the permission.
+     *
+     * An empty list means the server was asked and said none, and the
+     * caller acts on that by turning the offer off. So an implementation
+     * that could not ask must throw rather than return empty: silence
+     * and refusal are different answers, and only one of them should
+     * cost the reader the feature.
      */
     suspend fun targets(
         baseUrl: String,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteSources.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteSources.kt
@@ -92,6 +92,16 @@ data class ServerCapabilities(
     val canDownload: Boolean,
     /** Whether the account can write liseur-sync personal series claims. */
     val canManageLibrary: Boolean = false,
+    /**
+     * Whether the account may add a book to the server's library.
+     *
+     * A separate permission from [canManageLibrary] on purpose: putting
+     * a file in somebody's library is a bigger thing than claiming a
+     * series for it, and the server gives it its own scope. It is also
+     * only half the answer — the server decides per folder as well — so
+     * this says "worth offering", not "will succeed".
+     */
+    val canUpload: Boolean = false,
     /** Whether the account can also write the shared catalog layer. */
     val canAdmin: Boolean = false,
     /** Who the server says we are, for telling two logins apart. */
@@ -184,6 +194,70 @@ interface BookDeleter {
         credentials: RemoteCredentials,
         book: Book,
     ): ServerDeleteResult
+}
+
+/** A folder on the server that a book could be uploaded into. */
+data class RemoteUploadTarget(
+    val folderId: String,
+    val name: String,
+)
+
+/** How uploading a book to the server went. */
+sealed interface ServerUploadResult {
+    /**
+     * The server has the book, and this is its id there.
+     *
+     * [alreadyThere] means the server recognised the bytes and no
+     * transfer was needed. Both are successes and the caller treats
+     * them the same; they differ only in what it is honest to say.
+     */
+    data class Uploaded(val remoteBookId: String, val alreadyThere: Boolean) : ServerUploadResult
+
+    /**
+     * The bytes arrived and are safe, but the server has not catalogued
+     * them yet, so there is no id to adopt. Not a failure and not worth
+     * retrying the transfer for: the server will get there.
+     */
+    data object Pending : ServerUploadResult
+
+    /** No folder accepts uploads, or the account may not. */
+    data object NotAllowed : ServerUploadResult
+
+    /** The book is bigger than the server will take. */
+    data object TooLarge : ServerUploadResult
+
+    /** The server would not read it as an EPUB. */
+    data object Rejected : ServerUploadResult
+
+    /** Worth trying again: a network failure, or a server that was busy. */
+    data class Failed(val message: String?) : ServerUploadResult
+}
+
+/**
+ * Sending a book the reader added on the device up to the server.
+ *
+ * Only the kinds that can accept one have an entry. Absent from the
+ * router's map means the action is never offered, which is the same rule
+ * [BookDeleter] follows and for the same reason: an action that is
+ * offered and then always fails is worse than one that is not there.
+ */
+interface BookUploader {
+    /**
+     * The folders this server will accept a book into, which may be
+     * none even for an account that holds the permission.
+     */
+    suspend fun targets(
+        baseUrl: String,
+        credentials: RemoteCredentials,
+    ): List<RemoteUploadTarget>
+
+    suspend fun upload(
+        baseUrl: String,
+        credentials: RemoteCredentials,
+        folderId: String,
+        file: java.io.File,
+        filename: String,
+    ): ServerUploadResult
 }
 
 data class SeriesLayers(

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/ServerKind.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/ServerKind.kt
@@ -46,6 +46,13 @@ enum class ServerKind(
 
     companion object {
         /**
+         * Whether a book URL names a book that came from a server, as
+         * opposed to a file the reader added on the device.
+         */
+        fun isRemoteUrl(bookUrl: String): Boolean =
+            entries.any { bookUrl.startsWith("${it.urlPrefix}:") }
+
+        /**
          * The kind stored under [name], defaulting to [CALIBRE].
          *
          * Every row that existed before Komga was added is a calibre-web

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
@@ -130,7 +130,29 @@ data class AppSettings(
     val definitionTarget: DefinitionTarget = DefinitionTarget.Default,
     val dictionaryLookupEnabled: Boolean = false,
     val dictionaryBaseUrl: String = DictionaryUrl.DEFAULT_BASE_URL,
+    val uploadPolicy: UploadPolicy = UploadPolicy.Default,
 )
+
+/**
+ * What to do with a book that arrives on the device when the connected
+ * server accepts uploads.
+ *
+ * The default is [ASK] because sending a book nobody asked to send, over
+ * whatever connection happens to be up, is the one way this feature can
+ * cost a reader something.
+ */
+enum class UploadPolicy(val id: String) {
+    ASK("ask"),
+    ALWAYS("always"),
+    NEVER("never"),
+    ;
+
+    companion object {
+        val Default = ASK
+
+        fun fromId(id: String?): UploadPolicy = entries.firstOrNull { it.id == id } ?: Default
+    }
+}
 
 private val Context.appSettingsStore: DataStore<Preferences> by preferencesDataStore(
     name = "app_settings",
@@ -155,6 +177,7 @@ class AppSettingsRepository(private val context: Context) {
         val DICTIONARY_ENABLED = booleanPreferencesKey("dictionary_lookup_enabled")
         val DICTIONARY_BASE_URL = stringPreferencesKey("dictionary_base_url")
         val ACCOUNT_LOST = booleanPreferencesKey("calibre_account_lost_to_restore")
+        val UPLOAD_POLICY = stringPreferencesKey("upload_policy")
     }
 
     /**
@@ -191,6 +214,7 @@ class AppSettingsRepository(private val context: Context) {
             dictionaryLookupEnabled = p[Keys.DICTIONARY_ENABLED] ?: false,
             dictionaryBaseUrl = p[Keys.DICTIONARY_BASE_URL]?.let(DictionaryUrl::normalise)
                 ?: DictionaryUrl.DEFAULT_BASE_URL,
+            uploadPolicy = UploadPolicy.fromId(p[Keys.UPLOAD_POLICY]),
         )
     }
 
@@ -198,6 +222,10 @@ class AppSettingsRepository(private val context: Context) {
 
     suspend fun setThemeMode(mode: ThemeMode) {
         context.appSettingsStore.edit { it[Keys.THEME_MODE] = mode.id }
+    }
+
+    suspend fun setUploadPolicy(policy: UploadPolicy) {
+        context.appSettingsStore.edit { it[Keys.UPLOAD_POLICY] = policy.id }
     }
 
     suspend fun setDynamicColor(enabled: Boolean) {

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
@@ -167,6 +167,9 @@ fun LibraryScreen(
     onSetArchived: (Book, Boolean) -> Unit,
     onDeleteLocal: (Book) -> Unit,
     onDeleteFromServer: (Book) -> Unit,
+    onUploadToServer: (Book) -> Unit,
+    onUploadPending: () -> Unit,
+    onDismissUploadPrompt: () -> Unit,
     onSetSeries: (Book, String?, Double?) -> Unit,
     onResetSeries: (Book) -> Unit,
     onResetSharedSeries: (Book) -> Unit,
@@ -662,6 +665,14 @@ fun LibraryScreen(
         )
     }
 
+    if (state.pendingUploads.isNotEmpty()) {
+        UploadOfferDialog(
+            count = state.pendingUploads.size,
+            onConfirm = onUploadPending,
+            onDismiss = onDismissUploadPrompt,
+        )
+    }
+
     sheetBook?.let { book ->
         BookActionsSheet(
             book = book,
@@ -669,6 +680,8 @@ fun LibraryScreen(
             onDismiss = { sheetBook = null },
             canDownload = state.canDownload,
             canDeleteFromServer = state.canDeleteFromServer,
+            canUploadToServer = state.canUploadToServer,
+            uploading = book.url in state.uploading,
             onDownload = { onDownload(book); sheetBook = null },
             onCancelDownload = { onCancelDownload(book); sheetBook = null },
             onRemoveDownload = { onRemoveDownload(book); sheetBook = null },
@@ -678,6 +691,7 @@ fun LibraryScreen(
             onEditSeries = { editSeriesOf = book; sheetBook = null },
             onDeleteLocal = { onDeleteLocal(book); sheetBook = null },
             onDeleteFromServer = { confirmServerDelete = book; sheetBook = null },
+            onUploadToServer = { onUploadToServer(book); sheetBook = null },
         )
     }
 
@@ -711,8 +725,7 @@ fun LibraryScreen(
  * on a mis-tap.
  */
 @Composable
-internal fun ConfirmServerDeleteDialog(
-    book: Book,
+internal fun ConfirmServerDeleteDialog(    book: Book,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -736,6 +749,38 @@ internal fun ConfirmServerDeleteDialog(
     )
 }
 
+/**
+ * Offers to send books that are only on this device up to the server.
+ *
+ * One dialog for however many there are, not one each: a folder scan
+ * that finds forty books is still one decision, and asking forty times
+ * is how a reader learns to dismiss without reading.
+ */
+@Composable
+internal fun UploadOfferDialog(
+    count: Int,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.upload_offer_title)) },
+        text = {
+            Text(pluralStringResource(R.plurals.upload_offer_message, count, count))
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.upload_offer_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.upload_offer_dismiss))
+            }
+        },
+    )
+}
+
 /** Long-press actions for a book: chiefly, freeing the space it takes. */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -744,6 +789,8 @@ internal fun BookActionsSheet(
     downloading: Boolean,
     canDownload: Boolean,
     canDeleteFromServer: Boolean,
+    canUploadToServer: Boolean,
+    uploading: Boolean,
     onDismiss: () -> Unit,
     onDownload: () -> Unit,
     onCancelDownload: () -> Unit,
@@ -754,6 +801,7 @@ internal fun BookActionsSheet(
     onEditSeries: () -> Unit,
     onDeleteLocal: () -> Unit,
     onDeleteFromServer: () -> Unit,
+    onUploadToServer: () -> Unit,
 ) {
     ModalBottomSheet(onDismissRequest = onDismiss) {
         Column(
@@ -838,6 +886,11 @@ internal fun BookActionsSheet(
                         else R.string.series_change,
                     ),
                 )
+            }
+            if (book.remoteUuid == null && canUploadToServer && !uploading) {
+                TextButton(onClick = onUploadToServer, modifier = Modifier.fillMaxWidth()) {
+                    Text(stringResource(R.string.upload_to_server))
+                }
             }
             if (book.remoteUuid != null && canDeleteFromServer) {
                 // Kept apart from the others on purpose: everything above

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
@@ -887,7 +887,7 @@ internal fun BookActionsSheet(
                     ),
                 )
             }
-            if (book.remoteUuid == null && canUploadToServer && !uploading) {
+            if (book.livesOnlyOnThisDevice() && canUploadToServer && !uploading) {
                 TextButton(onClick = onUploadToServer, modifier = Modifier.fillMaxWidth()) {
                     Text(stringResource(R.string.upload_to_server))
                 }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryViewModel.kt
@@ -1089,18 +1089,28 @@ internal fun canUploadTo(server: RemoteServer?, router: RemoteRouter): Boolean =
     server != null && server.canUpload && router.uploaderFor(server.kind) != null
 
 /**
+ * A book that exists only on this device.
+ *
+ * Its identity is a file here rather than a server's name for it, and
+ * nothing has linked it to a copy on the server yet. Both halves matter:
+ * a book downloaded from a server keeps that server's URL and loses its
+ * `remoteUuid` when the account changes, so neither test alone tells a
+ * book of ours from one that came from somewhere else.
+ *
+ * This is the single answer to "could this book be uploaded?" — the
+ * offer and the per-book action must not each decide for themselves.
+ */
+internal fun Book.livesOnlyOnThisDevice(): Boolean =
+    remoteUuid == null && !ServerKind.isRemoteUrl(url)
+
+/**
  * The books that are on this device and nowhere else.
  *
- * A book qualifies when its identity is a file on the device rather than
- * a server's name for it, and nothing has linked it to a copy on the
- * server yet. Archived books are left out: taking a book off the shelf
- * is not the moment to send it somewhere.
+ * Archived books are left out: taking a book off the shelf is not the
+ * moment to volunteer sending it somewhere. Asking for one by hand is a
+ * different question, so the per-book action does not apply this.
  */
 internal fun List<Book>.awaitingUpload(canUpload: Boolean): List<Book> {
     if (!canUpload) return emptyList()
-    return filter {
-        it.remoteUuid == null &&
-            it.archivedAt == null &&
-            !ServerKind.isRemoteUrl(it.url)
-    }
+    return filter { it.livesOnlyOnThisDevice() && it.archivedAt == null }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.chmouel.liseur.container
 import com.chmouel.liseur.data.calibre.BookDownloadRepository
+import com.chmouel.liseur.data.remote.BookUploadRepository
 import com.chmouel.liseur.data.remote.RemoteCatalogRepository
 import com.chmouel.liseur.data.calibre.DownloadProgress
 import com.chmouel.liseur.data.remote.ServerDeleteResult
@@ -27,6 +28,7 @@ import com.chmouel.liseur.data.db.ReadingProgressDao
 import com.chmouel.liseur.data.library.FinishedState
 import com.chmouel.liseur.data.library.LocalLibraryRepository
 import com.chmouel.liseur.data.settings.AppSettings
+import com.chmouel.liseur.data.settings.UploadPolicy
 import com.chmouel.liseur.data.settings.AppSettingsRepository
 import com.chmouel.liseur.domain.LibrarySort
 import com.chmouel.liseur.data.remote.SeriesExtrasRepository
@@ -176,6 +178,19 @@ data class LibraryUiState(
      * liseur-sync book is a file in a folder the server only reads.
      */
     val canDeleteFromServer: Boolean = false,
+    /**
+     * Whether a book the reader added here can be sent up to the server.
+     * True only where the account holds the permission and the server is
+     * one that takes uploads at all.
+     */
+    val canUploadToServer: Boolean = false,
+    /** Books on their way up to the server right now, by URL. */
+    val uploading: Set<String> = emptySet(),
+    /**
+     * Books that are on this device and not on the server, waiting to be
+     * offered. Empty unless the reader asked to be asked.
+     */
+    val pendingUploads: List<Book> = emptyList(),
     /** Whether a shared liseur-sync series claim can be cleared. */
     val canResetSharedSeries: Boolean = false,
     /**
@@ -254,6 +269,7 @@ class LibraryViewModel(
     private val catalog: RemoteCatalogRepository,
     private val positionSync: PositionSyncCoordinator,
     private val downloads: BookDownloadRepository,
+    private val uploads: BookUploadRepository,
     private val account: RemoteAccountRepository,
     private val router: RemoteRouter,
     private val appSettings: AppSettingsRepository,
@@ -279,6 +295,14 @@ class LibraryViewModel(
      * itself; downloads started any other way never do this.
      */
     private val awaitingOpen = MutableStateFlow<String?>(null)
+
+    /**
+     * Whether the offer to upload has been turned down since the app
+     * started. Not written down: "not now" is about now, and a book
+     * still sitting only on this device is worth mentioning again on the
+     * next run. "Never" is the setting, and it is a different answer.
+     */
+    private val uploadPromptDismissed = MutableStateFlow(false)
 
     /** Books that have finished downloading and were asked for by name. */
     val openRequests: Flow<Book> = awaitingOpen.flatMapLatest { url ->
@@ -342,10 +366,12 @@ class LibraryViewModel(
                 appSettings.settings,
                 progressDao.observeReadAt(),
                 progressDao.observeProgressions(),
+                uploads.inFlight,
             ) { values -> values },
             _searchQuery,
             _isSearchActive,
-        ) { baseValues, query, searchActive ->
+            uploadPromptDismissed,
+        ) { baseValues, query, searchActive, promptDismissed ->
             @Suppress("UNCHECKED_CAST")
             val books = baseValues[0] as List<Book>
             val recent = baseValues[1] as ContinueReading?
@@ -363,6 +389,8 @@ class LibraryViewModel(
             val progressions = progressionList
                 .mapNotNull { row -> row.totalProgression?.let { row.bookUrl to it } }
                 .toMap()
+            @Suppress("UNCHECKED_CAST")
+            val uploading = baseValues[9] as Set<String>
 
             val onTheShelf = books.filter { !it.archived }
             val allShelves = onTheShelf.groupedIntoSeries(progressions)
@@ -478,6 +506,18 @@ class LibraryViewModel(
                 canDownload = server?.canDownload != false,
                 canDeleteFromServer = server != null &&
                     router.deleterFor(server.kind) != null,
+                canUploadToServer = canUploadTo(server, router),
+                uploading = uploading,
+                // Only under Ask: Always has already sent them and Never
+                // is an answer that does not want asking again.
+                pendingUploads = if (
+                    promptDismissed || settings.uploadPolicy != UploadPolicy.ASK
+                ) {
+                    emptyList()
+                } else {
+                    books.awaitingUpload(canUploadTo(server, router))
+                        .filterNot { it.url in uploading }
+                },
                 canResetSharedSeries = server?.kind == ServerKind.LISEUR_SYNC && server.canAdmin,
                 canRenameSeries = server?.kind == ServerKind.LISEUR_SYNC &&
                     server.canManageLibrary,
@@ -568,6 +608,19 @@ class LibraryViewModel(
         // never be looked at again on their own. This fills them in
         // behind the shelf, which is already drawn and does not wait.
         viewModelScope.launch { library.backfillSeries() }
+        // Under Always, a book that arrives on the device goes up
+        // without being asked about. The work is unique per book URL, so
+        // this seeing the same book again while it is still queued keeps
+        // the first attempt rather than starting a second.
+        viewModelScope.launch {
+            combine(library.books, appSettings.settings, account.server) { books, settings, server ->
+                if (settings.uploadPolicy != UploadPolicy.ALWAYS) {
+                    emptyList()
+                } else {
+                    books.awaitingUpload(canUploadTo(server, router))
+                }
+            }.collect { pending -> pending.forEach { uploads.enqueue(it) } }
+        }
     }
 
     /**
@@ -982,6 +1035,23 @@ class LibraryViewModel(
         viewModelScope.launch { library.importBook(uri) }
     }
 
+    /** Sends one book the reader added here up to the server. */
+    fun uploadToServer(book: Book) {
+        uploads.enqueue(book)
+        uploadPromptDismissed.value = true
+    }
+
+    /** Accepts the offer covering everything on the device but not the server. */
+    fun uploadPending() {
+        state.value.pendingUploads.forEach { uploads.enqueue(it) }
+        uploadPromptDismissed.value = true
+    }
+
+    /** Turns the offer down for now; it comes back next time the app does. */
+    fun dismissUploadPrompt() {
+        uploadPromptDismissed.value = true
+    }
+
     companion object {
         private const val TAG = "LibraryViewModel"
 
@@ -994,6 +1064,7 @@ class LibraryViewModel(
                     catalog = container.remoteCatalog,
                     positionSync = container.positionSync,
                     downloads = container.bookDownloads,
+                    uploads = container.bookUploads,
                     account = container.remoteAccount,
                     router = container.remoteRouter,
                     appSettings = container.appSettings,
@@ -1004,5 +1075,32 @@ class LibraryViewModel(
                 )
             }
         }
+    }
+}
+
+/**
+ * Whether a book added here could be sent up at all: there is a server,
+ * the account holds the right, and the kind takes uploads.
+ *
+ * The offer and the per-book action both ask this, so they can never
+ * disagree about whether uploading is a thing that can happen.
+ */
+internal fun canUploadTo(server: RemoteServer?, router: RemoteRouter): Boolean =
+    server != null && server.canUpload && router.uploaderFor(server.kind) != null
+
+/**
+ * The books that are on this device and nowhere else.
+ *
+ * A book qualifies when its identity is a file on the device rather than
+ * a server's name for it, and nothing has linked it to a copy on the
+ * server yet. Archived books are left out: taking a book off the shelf
+ * is not the moment to send it somewhere.
+ */
+internal fun List<Book>.awaitingUpload(canUpload: Boolean): List<Book> {
+    if (!canUpload) return emptyList()
+    return filter {
+        it.remoteUuid == null &&
+            it.archivedAt == null &&
+            !ServerKind.isRemoteUrl(it.url)
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountScreen.kt
@@ -75,6 +75,7 @@ import com.chmouel.liseur.data.remote.SyncReport
 import com.chmouel.liseur.ui.messageRes
 import com.chmouel.liseur.data.db.RemoteServer
 import com.chmouel.liseur.data.remote.ServerKind
+import com.chmouel.liseur.data.settings.UploadPolicy
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.windowWidth
 
@@ -96,6 +97,7 @@ fun ServerAccountScreen(
     onConnect: (Boolean) -> Unit,
     onRetryCapabilities: () -> Unit,
     onKoboToken: (String) -> Unit,
+    onSetUploadPolicy: (UploadPolicy) -> Unit,
     onDisconnect: () -> Unit,
     onSyncNow: () -> Unit,
     onAnswerConfirmation: (String, Boolean) -> Unit,
@@ -166,6 +168,8 @@ fun ServerAccountScreen(
                         onRetryCapabilities = onRetryCapabilities,
                         onKoboToken = onKoboToken,
                         onDisconnect = onDisconnect,
+                        uploadPolicy = state.uploadPolicy,
+                        onSetUploadPolicy = onSetUploadPolicy,
                     )
                     if (server.kind == ServerKind.LISEUR_SYNC) {
                         if (state.confirmations.isNotEmpty()) {
@@ -416,6 +420,8 @@ private fun ConnectedCard(
     onKoboToken: (String) -> Unit,
     onDisconnect: () -> Unit,
     onSyncNow: () -> Unit,
+    uploadPolicy: UploadPolicy,
+    onSetUploadPolicy: (UploadPolicy) -> Unit,
 ) {
     Card(
         colors = CardDefaults.cardColors(
@@ -527,9 +533,33 @@ private fun ConnectedCard(
         }
     }
 
+    // Only where the account may actually send one: an option that
+    // explains a thing the server will refuse is worse than no option.
+    if (server.canUpload) {
+        Text(
+            text = stringResource(R.string.upload_policy),
+            style = MaterialTheme.typography.titleSmall,
+        )
+        Text(
+            text = stringResource(R.string.upload_policy_summary),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
+            UploadPolicy.entries.forEachIndexed { index, policy ->
+                SegmentedButton(
+                    selected = uploadPolicy == policy,
+                    onClick = { onSetUploadPolicy(policy) },
+                    shape = SegmentedButtonDefaults.itemShape(index, UploadPolicy.entries.size),
+                ) {
+                    Text(stringResource(policy.labelRes()))
+                }
+            }
+        }
+    }
+
     // The Kobo token is a calibre-web notion; the others have nothing like it.
-    if (server.kind == ServerKind.CALIBRE) {
-        AdvancedSection(server = server, onKoboToken = onKoboToken)
+    if (server.kind == ServerKind.CALIBRE) {        AdvancedSection(server = server, onKoboToken = onKoboToken)
     }
 
     OutlinedButton(onClick = onDisconnect, modifier = Modifier.fillMaxWidth()) {
@@ -820,3 +850,9 @@ private fun PositionSyncStatus.describe(lastSyncedAt: Long?): String = when (thi
 @Composable
 private fun relative(at: Long): CharSequence =
     DateUtils.getRelativeTimeSpanString(at, System.currentTimeMillis(), DateUtils.MINUTE_IN_MILLIS)
+
+private fun UploadPolicy.labelRes(): Int = when (this) {
+    UploadPolicy.ASK -> R.string.upload_policy_ask
+    UploadPolicy.ALWAYS -> R.string.upload_policy_always
+    UploadPolicy.NEVER -> R.string.upload_policy_never
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountViewModel.kt
@@ -22,6 +22,7 @@ import com.chmouel.liseur.data.remote.SyncReporting
 import com.chmouel.liseur.data.db.RemoteServer
 import com.chmouel.liseur.data.remote.ServerKind
 import com.chmouel.liseur.data.settings.AppSettingsRepository
+import com.chmouel.liseur.data.settings.UploadPolicy
 import com.chmouel.liseur.domain.displayAuthor
 import com.chmouel.liseur.domain.displayTitle
 import com.chmouel.liseur.sync.PositionSyncCoordinator
@@ -92,6 +93,8 @@ data class ServerAccountUiState(
     val confirmations: List<WorkConfirmation> = emptyList(),
     /** Books whose identifiers named two different works on the server. */
     val ambiguities: Int = 0,
+    /** What to do with a book that arrives on this device. */
+    val uploadPolicy: UploadPolicy = UploadPolicy.Default,
 )
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -131,6 +134,11 @@ class ServerAccountViewModel(
         viewModelScope.launch {
             appSettings.accountLostToRestore.collect { lost ->
                 _state.update { it.copy(lostToRestore = lost) }
+            }
+        }
+        viewModelScope.launch {
+            appSettings.settings.collect { settings ->
+                _state.update { it.copy(uploadPolicy = settings.uploadPolicy) }
             }
         }
         viewModelScope.launch {
@@ -296,6 +304,10 @@ class ServerAccountViewModel(
                 refreshed.forSync(),
             )
         }
+    }
+
+    fun setUploadPolicy(policy: UploadPolicy) {
+        viewModelScope.launch { appSettings.setUploadPolicy(policy) }
     }
 
     fun setKoboToken(value: String) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -310,6 +310,20 @@
     <string name="delete_local_failed">Could not delete the file for “%1$s”. Liseur may only be allowed to read that folder — add it again to grant deletion.</string>
     <string name="delete">Delete</string>
 
+    <string name="upload_to_server">Upload to server</string>
+    <string name="upload_offer_title">Send to the server?</string>
+    <plurals name="upload_offer_message">
+        <item quantity="one">%d book is only on this device. Sending it to the server puts it in the library on your other devices too. Where you are in it stays where it is.</item>
+        <item quantity="other">%d books are only on this device. Sending them to the server puts them in the library on your other devices too. Where you are in them stays where it is.</item>
+    </plurals>
+    <string name="upload_offer_confirm">Send</string>
+    <string name="upload_offer_dismiss">Not now</string>
+    <string name="upload_policy">Books added on this device</string>
+    <string name="upload_policy_ask">Ask before sending</string>
+    <string name="upload_policy_always">Send automatically</string>
+    <string name="upload_policy_never">Keep them here</string>
+    <string name="upload_policy_summary">A book you open or drop into a watched folder can be sent up to the server, so your other devices see it too.</string>
+
     <string name="settings">Settings</string>
     <string name="settings_appearance">Appearance</string>
     <string name="settings_theme">Theme</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
@@ -690,6 +690,6 @@ class MigrationTest {
         const val TEST_DB = "migration-test.db"
 
         /** Kept in step with the `version` on [LiseurDatabase]. */
-        const val LATEST = 34
+        const val LATEST = 35
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncServerSetupTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncServerSetupTest.kt
@@ -10,6 +10,7 @@ import mockwebserver3.MockWebServer
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -56,7 +57,8 @@ class LiseurSyncServerSetupTest {
         server.enqueue(
             json(
                 """{"id":"t-1","device_id":"d-1","name":"Test phone",
-                    "scopes":["sync","read-insights","library-read","library-manage"],
+                    "scopes":["sync","read-insights","library-read","library-manage",
+                    "library-upload"],
                     "account_id":"acc-9"}
                 """.trimIndent(),
             ),
@@ -70,6 +72,7 @@ class LiseurSyncServerSetupTest {
         assertEquals("acc-9", capabilities.liseurAccountId)
         assertTrue(capabilities.canDownload)
         assertTrue(capabilities.canManageLibrary)
+        assertTrue(capabilities.canUpload)
         assertEquals("ada", capabilities.displayName)
 
         // The password went to the login route and nowhere else, and
@@ -80,9 +83,12 @@ class LiseurSyncServerSetupTest {
         assertTrue(minted.target!!.endsWith("/v1/tokens"))
         val body = JSONObject(minted.body!!.utf8())
         val asked = body.getJSONArray("scopes")
-        assertEquals(4, asked.length())
+        assertEquals(5, asked.length())
         assertEquals(
-            setOf("sync", "read-insights", "library-read", "library-manage"),
+            setOf(
+                "sync", "read-insights", "library-read", "library-manage",
+                "library-upload",
+            ),
             (0 until asked.length()).map { asked.getString(it) }.toSet(),
         )
         assertTrue(server.takeRequest().target!!.endsWith("/v1/token"))
@@ -105,6 +111,10 @@ class LiseurSyncServerSetupTest {
         assertEquals("pasted-secret", capabilities.liseurToken)
         assertEquals("d-9", capabilities.accountId)
         assertTrue(capabilities.canDownload)
+        // A token minted before this app asked for library-upload does
+        // not get the permission by being old. The action stays hidden
+        // rather than being offered and refused.
+        assertFalse(capabilities.canUpload)
         val asked = server.takeRequest()
         assertTrue(asked.target!!.endsWith("/v1/token"))
         assertEquals("Bearer pasted-secret", asked.headers["Authorization"])

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncUploadClientTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncUploadClientTest.kt
@@ -8,6 +8,7 @@ import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -132,6 +133,48 @@ class LiseurSyncUploadClientTest {
 
         assertTrue(result is ServerUploadResult.Failed)
         assertEquals("the folder went away", (result as ServerUploadResult.Failed).message)
+    }
+
+    /**
+     * The caller reads an empty list as the server refusing, and acts on
+     * it by putting the feature away until the reader signs in again. So
+     * a connection that dropped must not be able to say that: it throws,
+     * and the worker retries.
+     */
+    @Test
+    fun `a server that could not be reached is not a server with no folders`() = runTest {
+        server.close()
+
+        var thrown: Throwable? = null
+        try {
+            LiseurSyncUploadClient().targets(base(), token())
+        } catch (e: Throwable) {
+            thrown = e
+        }
+
+        assertNotNull("listing folders swallowed the failure", thrown)
+    }
+
+    /** Half an answer is not an answer either. */
+    @Test
+    fun `a page that fails does not shorten the list of folders`() = runTest {
+        server.enqueue(
+            json(
+                """{"folders":[{"folder_id":"f-1","name":"Drop box","accepts_uploads":true}],
+                    "next_after":"f-1"}
+                """.trimIndent(),
+            ),
+        )
+        server.enqueue(json("""{"error":"gone"}""", code = 500))
+
+        var thrown: Throwable? = null
+        try {
+            LiseurSyncUploadClient().targets(base(), token())
+        } catch (e: Throwable) {
+            thrown = e
+        }
+
+        assertNotNull("a partial page was passed off as the whole answer", thrown)
     }
 
     private var books = 0

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncUploadClientTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncUploadClientTest.kt
@@ -1,0 +1,158 @@
+package com.chmouel.liseur.data.liseursync
+
+import com.chmouel.liseur.data.remote.RemoteCredentials
+import com.chmouel.liseur.data.remote.ServerUploadResult
+import java.net.InetAddress
+import kotlinx.coroutines.test.runTest
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Sending a book to liseur-sync.
+ *
+ * The server's answer is the whole contract here (ADR-0023), and the
+ * codes do not collapse into "worked" and "did not": a 200 means the
+ * server already had these bytes and no transfer was needed, a 202 means
+ * they are safe but not yet a book, and a 403 is the one answer where
+ * offering the action again would be a lie. Getting any of those wrong
+ * either loses a book or nags the reader about one that arrived.
+ */
+@Config(sdk = [35], application = android.app.Application::class)
+@RunWith(RobolectricTestRunner::class)
+class LiseurSyncUploadClientTest {
+
+    @get:Rule
+    val temp = TemporaryFolder()
+
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun open() {
+        server = MockWebServer()
+        server.start(InetAddress.getByName("127.0.0.1"), 0)
+    }
+
+    @After
+    fun close() {
+        server.close()
+    }
+
+    @Test
+    fun `only folders that asked for uploads are offered`() = runTest {
+        server.enqueue(
+            json(
+                """{"folders":[
+                    {"folder_id":"f-1","name":"Read-only shelf","accepts_uploads":false},
+                    {"folder_id":"f-2","name":"Drop box","accepts_uploads":true},
+                    {"folder_id":"f-3","name":"Old server","kind":"plain"}
+                ]}
+                """.trimIndent(),
+            ),
+        )
+
+        val targets = LiseurSyncUploadClient().targets(base(), token())
+
+        // f-3 has no flag at all, which is what an older server sends:
+        // absent is not permission.
+        assertEquals(1, targets.size)
+        assertEquals("f-2", targets[0].folderId)
+        assertEquals("Drop box", targets[0].name)
+    }
+
+    @Test
+    fun `a created book comes back with the id to adopt`() = runTest {
+        server.enqueue(
+            json(
+                """{"book_id":"b-9","folder_id":"f-2",
+                    "relative_path":"Ada - Notes.epub","duplicate":false}
+                """.trimIndent(),
+                code = 201,
+            ),
+        )
+
+        val result = upload()
+
+        assertEquals(ServerUploadResult.Uploaded("b-9", alreadyThere = false), result)
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertTrue(request.target!!.endsWith("/v1/folders/f-2/books"))
+        assertTrue(request.headers["Content-Type"]!!.startsWith("multipart/form-data"))
+    }
+
+    @Test
+    fun `a book the server already had is a success, not a transfer`() = runTest {
+        server.enqueue(
+            json("""{"book_id":"b-9","folder_id":"f-2","duplicate":true}""", code = 200),
+        )
+
+        assertEquals(
+            ServerUploadResult.Uploaded("b-9", alreadyThere = true),
+            upload(),
+        )
+    }
+
+    @Test
+    fun `bytes that arrived before the catalogue did are pending`() = runTest {
+        // Rules 1 and 2 of ADR-0017 let a folder pass conclude nothing
+        // yet. The book is not lost and the transfer must not be redone.
+        server.enqueue(
+            json("""{"folder_id":"f-2","relative_path":"Ada - Notes.epub"}""", code = 202),
+        )
+
+        assertEquals(ServerUploadResult.Pending, upload())
+    }
+
+    @Test
+    fun `each refusal keeps its own meaning`() = runTest {
+        for ((code, expected) in listOf(
+            403 to ServerUploadResult.NotAllowed,
+            413 to ServerUploadResult.TooLarge,
+            422 to ServerUploadResult.Rejected,
+        )) {
+            server.enqueue(json("""{"error":"no"}""", code = code))
+            assertEquals("HTTP $code", expected, upload())
+        }
+    }
+
+    @Test
+    fun `a server error is worth trying again`() = runTest {
+        server.enqueue(json("""{"error":"the folder went away"}""", code = 500))
+
+        val result = upload()
+
+        assertTrue(result is ServerUploadResult.Failed)
+        assertEquals("the folder went away", (result as ServerUploadResult.Failed).message)
+    }
+
+    private var books = 0
+
+    private suspend fun upload(): ServerUploadResult {
+        val book = temp.newFile("book-${books++}.epub")
+        book.writeBytes(ByteArray(64) { it.toByte() })
+        return LiseurSyncUploadClient().upload(
+            base(), token(), "f-2", book, "Ada - Notes.epub",
+        )
+    }
+
+    private fun base(): String = server.url("/").toString().trimEnd('/')
+
+    private fun token(): RemoteCredentials = RemoteCredentials.ApiKey("device-secret")
+
+    private fun json(body: String, code: Int = 200): MockResponse =
+        MockResponse.Builder()
+            .code(code)
+            .setHeader("Content-Type", "application/json")
+            .body(body)
+            .build()
+
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncUploadClientTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncUploadClientTest.kt
@@ -177,6 +177,34 @@ class LiseurSyncUploadClientTest {
         assertNotNull("a partial page was passed off as the whole answer", thrown)
     }
 
+    /**
+     * A 200 is not by itself an answer. Anything on the way in can serve
+     * one — a proxy, a portal — and if its JSON happens to parse, the
+     * absent folder list would read as "no folder takes books" and cost
+     * the reader the feature.
+     */
+    @Test
+    fun `a body with no folder list is not a server with no folders`() = runTest {
+        server.enqueue(json("""{"error":"not the server you wanted"}"""))
+
+        var thrown: Throwable? = null
+        try {
+            LiseurSyncUploadClient().targets(base(), token())
+        } catch (e: Throwable) {
+            thrown = e
+        }
+
+        assertNotNull("a body carrying no folders was read as a refusal", thrown)
+    }
+
+    /** An empty list, on the other hand, is the server's to send. */
+    @Test
+    fun `a server with nothing to offer says so, and is believed`() = runTest {
+        server.enqueue(json("""{"folders":[]}"""))
+
+        assertTrue(LiseurSyncUploadClient().targets(base(), token()).isEmpty())
+    }
+
     private var books = 0
 
     private suspend fun upload(): ServerUploadResult {

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/WorkResolverTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/WorkResolverTest.kt
@@ -361,6 +361,47 @@ class WorkResolverTest {
         assertTrue(JSONObject(server.takeRequest().body!!.utf8()).getBoolean("confirmed"))
     }
 
+    @Test
+    fun `a book uploaded from here resolves as the catalog book it became`() = runTest {
+        // The ghost this stops. A book added on the device syncs its
+        // position for weeks, so the server holds a work for it and no
+        // file. Uploading it gives the server the file too — but
+        // adoption leaves the URL alone, because all that reading hangs
+        // off it, and writes the server's id as a link instead. Read
+        // only the URL and the book stays "local" for ever: the work and
+        // the new catalog entry never meet, and the library shows the
+        // same book twice, one half with the file and the other with the
+        // reading.
+        db.workIdentityDao().upsert(
+            WorkAlias(
+                bookUrl = LOCAL,
+                peerId = PEER,
+                workId = "w-1",
+                confidence = WorkAlias.HIGH,
+                seeded = true,
+                sourceSent = false,
+                editionSha = "aa",
+                resolvedAt = NOW,
+            ),
+        )
+        answer(200, """{"work_id":"w-1","confidence":"high"}""")
+
+        val adopted = downloaded().copy(url = LOCAL, remoteUuid = "b-7")
+        val result = resolver.resolve(adopted, PEER, baseUrl(), TOKEN)
+
+        // The catalog route, which is the one that tells the server
+        // which work its new book belongs to.
+        assertTrue(server.takeRequest().target!!.endsWith("/v1/books/b-7/resolve"))
+        val alias = (result as WorkResolution.Named).alias
+        assertEquals("w-1", alias.workId)
+        assertEquals(LOCAL, alias.bookUrl)
+        assertTrue(alias.seeded)
+        // Said once, and not asked again.
+        assertTrue(alias.sourceSent)
+        assertEquals("w-1", (resolver.resolve(adopted, PEER, baseUrl(), TOKEN) as WorkResolution.Named).alias.workId)
+        assertEquals(1, server.requestCount)
+    }
+
     private fun baseUrl() = "http://127.0.0.1:${server.port}"
 
     private fun downloaded(modifiedAt: Long = NOW) = Book(
@@ -384,6 +425,7 @@ class WorkResolverTest {
     private companion object {
         const val NOW = 1_700_000_000_000L
         const val BOOK = "calibre:2f9b"
+        const val LOCAL = "file:///sd/books/rois.epub"
         const val PEER = "liseursync|https://sync.example|ada"
         val TOKEN = RemoteCredentials.Bearer("device-secret")
     }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepositoryTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepositoryTest.kt
@@ -205,6 +205,51 @@ class RemoteCatalogRepositoryTest {
         assertEquals(20L, stored.personalSeriesUpdatedAt)
     }
 
+    /**
+     * The catalog may forget a book the reader uploaded from their own
+     * shelf, and must not take the book with it.
+     *
+     * Such a row is not the catalog's: its file is its URL rather than a
+     * download, so the "nothing to open" test reads it as disposable,
+     * and a walk that started before the upload cannot name an id that
+     * did not exist when it began. Deleting it would take the book, the
+     * reading position and every session with it.
+     */
+    @Test
+    fun `a book uploaded from the device survives a walk that never names it`() = runTest {
+        connect(ServerKind.LISEUR_SYNC)
+        val mine = "content://tree/primary%3ABooks/document/mine.epub"
+        db.bookDao().upsertAll(
+            listOf(
+                Book(
+                    url = mine,
+                    title = "Mine",
+                    author = "Me",
+                    coverPath = null,
+                    source = null,
+                    addedAt = 0,
+                    lastOpenedAt = null,
+                    localUri = null,
+                ),
+            ),
+        )
+        db.bookDao().linkToRemote(
+            url = mine,
+            remoteUuid = "uploaded",
+            downloadHref = "/v1/books/uploaded/download",
+            coverUrl = null,
+            remoteUpdatedAt = 1L,
+        )
+
+        // A page that names some other book: the walk simply never saw
+        // the one that was uploaded while it was in flight.
+        repository(FakeCatalog { onPage -> onPage(listOf(book("b1"))) }).refresh()
+
+        val kept = db.bookDao().getByUrl(mine)
+        assertEquals("the uploaded book was deleted", mine, kept?.url)
+        assertEquals("uploaded", kept?.remoteUuid)
+    }
+
     @Test
     fun `non liseur-sync catalog refresh keeps a local series override local`() = runTest {
         connect(ServerKind.KOMGA)

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/library/AwaitingUploadTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/library/AwaitingUploadTest.kt
@@ -1,0 +1,63 @@
+package com.chmouel.liseur.ui.library
+
+import com.chmouel.liseur.data.db.Book
+import com.chmouel.liseur.data.remote.BookUploadWorker
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Which books the library offers to send up, and which it leaves alone. */
+class AwaitingUploadTest {
+
+    @Test
+    fun `a book added on this device is offered`() {
+        val books = listOf(local("file:///sd/a.epub"))
+        assertEquals(listOf("file:///sd/a.epub"), books.awaitingUpload(true).map { it.url })
+    }
+
+    @Test
+    fun `a book that came from a server is not sent back to it`() {
+        val books = listOf(local("liseur-sync:42"), local("calibre:7"), local("komga:9"))
+        assertTrue(books.awaitingUpload(true).isEmpty())
+    }
+
+    @Test
+    fun `a book already linked to the server is left alone`() {
+        val books = listOf(local("file:///sd/a.epub").copy(remoteUuid = "42"))
+        assertTrue(books.awaitingUpload(true).isEmpty())
+    }
+
+    @Test
+    fun `an archived book is not offered`() {
+        val books = listOf(local("file:///sd/a.epub").copy(archivedAt = 1))
+        assertTrue(books.awaitingUpload(true).isEmpty())
+    }
+
+    @Test
+    fun `nothing is offered where uploading is not on the table`() {
+        assertTrue(listOf(local("file:///sd/a.epub")).awaitingUpload(false).isEmpty())
+    }
+
+    @Test
+    fun `a filename never carries a path separator into the request`() {
+        assertEquals(
+            "A_B - C_D.epub",
+            BookUploadWorker.filenameFor("A/B", "C\\D"),
+        )
+    }
+
+    @Test
+    fun `a book with no title still gets a name`() {
+        assertEquals("book.epub", BookUploadWorker.filenameFor("", null))
+    }
+
+    private fun local(url: String) = Book(
+        url = url,
+        title = "A book",
+        author = "An author",
+        coverPath = null,
+        source = null,
+        addedAt = 0,
+        lastOpenedAt = null,
+    )
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/library/AwaitingUploadTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/library/AwaitingUploadTest.kt
@@ -3,6 +3,7 @@ package com.chmouel.liseur.ui.library
 import com.chmouel.liseur.data.db.Book
 import com.chmouel.liseur.data.remote.BookUploadWorker
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -36,6 +37,23 @@ class AwaitingUploadTest {
     @Test
     fun `nothing is offered where uploading is not on the table`() {
         assertTrue(listOf(local("file:///sd/a.epub")).awaitingUpload(false).isEmpty())
+    }
+
+    /**
+     * Switching accounts clears `remote_uuid` from downloaded books but
+     * leaves them their old server's URL. Asking only whether the book is
+     * linked would offer to upload another server's copy, so the per-book
+     * action asks the same question the offer does.
+     */
+    @Test
+    fun `a downloaded book that lost its link is still not ours to send`() {
+        val orphan = local("komga:9").copy(remoteUuid = null, localUri = "file:///data/9.epub")
+        assertFalse(orphan.livesOnlyOnThisDevice())
+    }
+
+    @Test
+    fun `an archived book can still be sent when it is asked for by hand`() {
+        assertTrue(local("file:///sd/a.epub").copy(archivedAt = 1).livesOnlyOnThisDevice())
     }
 
     @Test

--- a/hack/e2e-upload
+++ b/hack/e2e-upload
@@ -14,8 +14,12 @@
 #   -d  the watched folder's root on this machine, so the script can see
 #       what landed in it
 #   -s  pick a device when several are attached
+#   -r  expect the server to refuse: assert the app never offers to
+#       upload, rather than that it succeeds. Use with a token without
+#       the library-upload scope, or a server whose folders are all
+#       closed.
 #
-# The folder must already accept uploads:
+# Without -r the folder must already accept uploads:
 #
 #   liseur-sync admin folder-uploads <folder-id> on
 #
@@ -31,9 +35,10 @@ readonly MAIN_ACTIVITY="$APP_ID/.MainActivity"
 # shellcheck source=hack/lib/demo-books.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib/demo-books.sh"
 
-serial="" url="" token="" root=""
+serial="" url="" token="" root="" refused=""
 while [[ $# -gt 0 ]]; do
     case $1 in
+        -r | --refused) refused=yes ;;
         -s | --serial) serial=${2:-}; shift ;;
         -u | --url) url=${2:-}; shift ;;
         -t | --token) token=${2:-}; shift ;;
@@ -49,7 +54,9 @@ done
 
 [[ -n "$url" ]] || die "need -u, the server address as the device sees it"
 [[ -n "$token" ]] || die "need -t, a device token with the library-upload scope"
-[[ -d "$root" ]] || die "need -d, the watched folder's root on this machine"
+[[ -n "$root" || -n "$refused" ]] ||
+    die "need -d, the watched folder's root on this machine"
+[[ -z "$root" || -d "$root" ]] || die "$root is not a directory"
 
 command -v adb >/dev/null || die "adb is not installed"
 command -v python3 >/dev/null || die "python3 is not installed"
@@ -113,7 +120,8 @@ tap_button() {
     tap_on "$@"
 }
 
-before=$(find "$root" -name '*.epub' | wc -l | tr -d ' ')
+before=0
+[[ -n "$root" ]] && before=$(find "$root" -name '*.epub' | wc -l | tr -d ' ')
 
 step "Connecting to $url"
 open_library
@@ -151,6 +159,61 @@ done
 note "connected"
 
 can_upload=$(query "select can_upload from remote_server;")
+
+# A server that will not take a book has to be believed, and it can say
+# so in two places: the token may lack the scope, which the app learns
+# on sight, or every folder may be closed, which it can only learn by
+# trying. Both have to end with the app no longer offering, because the
+# capability is what every entry point is drawn from and an offer that
+# can only fail is one the reader is left to repeat.
+if [[ -n "$refused" ]]; then
+    step "Checking the app takes no for an answer"
+    shelved=$(query "select count(*) from books;")
+
+    hide_keyboard
+    back
+    sleep 2
+    back
+    sleep 3
+
+    if [[ "$can_upload" == 1 ]]; then
+        note "the token holds the scope, so only an attempt can settle it"
+        tap_if_there "Send" exact || true
+        waited=0
+        while ((waited < 120)); do
+            [[ $(query "select can_upload from remote_server;") == 0 ]] && break
+            sleep 5
+            waited=$((waited + 5))
+        done
+    else
+        note "the app read the token as not allowed to upload"
+        ! on_screen "Send" ||
+            die "the app offered to send books to a server that refuses them"
+    fi
+
+    can_upload=$(query "select can_upload from remote_server;")
+    [[ "$can_upload" == 0 ]] ||
+        die "the app still thinks it may upload (can_upload=$can_upload)"
+    note "the app stopped offering"
+
+    linked=$(query "select count(*) from books where remote_uuid is not null;")
+    [[ "$linked" == 0 ]] ||
+        die "$linked books were linked to a server that takes no uploads"
+    now=$(query "select count(*) from books;")
+    [[ "$now" == "$shelved" ]] ||
+        die "the shelf went from $shelved books to $now; a refusal must cost nothing"
+    note "all $now books are still on the shelf"
+
+    if [[ -n "$root" ]]; then
+        after=$(find "$root" -name '*.epub' | wc -l | tr -d ' ')
+        [[ "$after" == "$before" ]] ||
+            die "$((after - before)) books were written into a folder that refuses them"
+        note "nothing was written into $root"
+    fi
+    printf '\nDone. The server refused, and the app stopped offering.\n'
+    exit 0
+fi
+
 [[ "$can_upload" == 1 ]] ||
     die "the app read the token as not allowed to upload (can_upload=$can_upload)"
 note "the library-upload scope reached the app"

--- a/hack/e2e-upload
+++ b/hack/e2e-upload
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+#
+# End-to-end check of the upload path: a book that is only on this
+# device gets sent to a real liseur-sync server, and the row that holds
+# the reader's place is linked to the server's copy rather than replaced
+# by it.
+#
+#   hack/e2e-upload -u URL -t TOKEN -d /path/to/folder/root
+#
+#   -u  the server as the *device* sees it (an emulator reaches the host
+#       at 10.0.2.2, never at 127.0.0.1)
+#   -t  a device-token secret holding at least sync, library-read and
+#       library-upload
+#   -d  the watched folder's root on this machine, so the script can see
+#       what landed in it
+#   -s  pick a device when several are attached
+#
+# The folder must already accept uploads:
+#
+#   liseur-sync admin folder-uploads <folder-id> on
+#
+# Nothing here is faked. The app is driven through its own screens, the
+# transfer is a real multipart POST over the network, and the assertions
+# read the server's disk and the app's database.
+
+set -euo pipefail
+
+readonly APP_ID="com.chmouel.liseur"
+readonly MAIN_ACTIVITY="$APP_ID/.MainActivity"
+
+# shellcheck source=hack/lib/demo-books.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/demo-books.sh"
+
+serial="" url="" token="" root=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -s | --serial) serial=${2:-}; shift ;;
+        -u | --url) url=${2:-}; shift ;;
+        -t | --token) token=${2:-}; shift ;;
+        -d | --dir) root=${2:-}; shift ;;
+        -h | --help)
+            sed -n '3,24p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) die "unknown argument $1" ;;
+    esac
+    shift
+done
+
+[[ -n "$url" ]] || die "need -u, the server address as the device sees it"
+[[ -n "$token" ]] || die "need -t, a device token with the library-upload scope"
+[[ -d "$root" ]] || die "need -d, the watched folder's root on this machine"
+
+command -v adb >/dev/null || die "adb is not installed"
+command -v python3 >/dev/null || die "python3 is not installed"
+
+if [[ -z "$serial" ]]; then
+    mapfile -t devices < <(adb devices | awk 'NR > 1 && $2 == "device" { print $1 }')
+    [[ ${#devices[@]} -eq 1 ]] ||
+        die "expected exactly one attached device, got ${#devices[@]}; pass --serial"
+    serial=${devices[0]}
+fi
+
+adb() { command adb -s "$serial" "$@"; }
+
+adb shell pm path "$APP_ID" >/dev/null 2>&1 ||
+    die "$APP_ID is not installed on $serial; run make install"
+
+work=$(mktemp -d)
+cleanup() {
+    adb shell rm -f /sdcard/liseur-ui.xml >/dev/null 2>&1 || true
+    rm -rf "$work"
+}
+trap cleanup EXIT
+
+# What the app's own database says, which is the only place the outcome
+# of an adoption can be read.
+query() {
+    adb shell "run-as $APP_ID sqlite3 /data/data/$APP_ID/databases/liseur.db \"$1\"" |
+        tr -d '\r'
+}
+
+type_into() {
+    local needle=$1 text=$2 at
+    hide_keyboard
+    at=$(wait_for "$needle" 25) || die "no field called \"$needle\""
+    # shellcheck disable=SC2086
+    adb shell input tap $at
+    sleep 1
+    adb shell input text "${text//&/\\&}"
+    sleep 1
+}
+
+# The soft keyboard is drawn in its own window, so it is invisible to a
+# uiautomator dump while still swallowing every tap that lands under it.
+# A tap meant for a button then arrives as a keystroke in the field that
+# has focus, which is how a token grows a stray letter. Nothing is typed
+# or tapped here until the keyboard is actually gone.
+hide_keyboard() {
+    local tries=0
+    while ((tries < 5)); do
+        adb shell dumpsys input_method | grep -q "mInputShown=true" || return 0
+        adb shell input keyevent KEYCODE_BACK
+        sleep 1
+        tries=$((tries + 1))
+    done
+    die "the soft keyboard would not go away"
+}
+
+# Like tap_on, but never with the keyboard in the way.
+tap_button() {
+    hide_keyboard
+    tap_on "$@"
+}
+
+before=$(find "$root" -name '*.epub' | wc -l | tr -d ' ')
+
+step "Connecting to $url"
+open_library
+tap_on "More" exact
+tap_on "Settings"
+tap_on "Book server" exact
+# The first visit explains what a book server is, in a dialog, and
+# dismissing it returns to settings rather than revealing the form. Its
+# title is "Book servers", so nothing may be tapped by prefix until the
+# dialog is really gone or the settings row is matched against it.
+if at=$(wait_for "Dismiss" 6 exact); then
+    # shellcheck disable=SC2086
+    adb shell input tap $at
+    waited=0
+    while ((waited < 10)) && on_screen "Dismiss"; do
+        sleep 1
+        waited=$((waited + 1))
+    done
+    tap_on "Book server" exact
+fi
+tap_on "liseur-sync" exact
+tap_on "Paste a token"
+type_into "Server address" "$url"
+type_into "Device token" "$token"
+tap_button "Connect" exact
+
+waited=0
+while ((waited < 40)); do
+    [[ $(query "select count(*) from remote_server;") == 1 ]] && break
+    sleep 2
+    waited=$((waited + 2))
+done
+[[ $(query "select count(*) from remote_server;") == 1 ]] ||
+    die "the app never connected; check the address and the token"
+note "connected"
+
+can_upload=$(query "select can_upload from remote_server;")
+[[ "$can_upload" == 1 ]] ||
+    die "the app read the token as not allowed to upload (can_upload=$can_upload)"
+note "the library-upload scope reached the app"
+
+# The offer is drawn over the library, not over the settings screen.
+step "Accepting the offer"
+hide_keyboard
+back
+sleep 2
+back
+tap_on "Send" exact
+
+step "Waiting for the transfer"
+waited=0
+while ((waited < 180)); do
+    linked=$(query "select count(*) from books where remote_uuid is not null;")
+    ((linked > 0)) && break
+    sleep 5
+    waited=$((waited + 5))
+done
+
+linked=$(query "select count(*) from books where remote_uuid is not null;")
+((linked > 0)) || die "nothing was linked to the server after $waited seconds"
+note "$linked books linked to the server"
+
+after=$(find "$root" -name '*.epub' | wc -l | tr -d ' ')
+((after > before)) ||
+    die "the server's folder still holds $after books; nothing was written"
+note "$((after - before)) books landed in $root"
+
+# The point of the whole exercise: adoption links, it does not replace.
+# A rewritten URL would take the reader's place in the book with it.
+local_urls=$(query "select count(*) from books where remote_uuid is not null \
+    and url not like 'file:%' and url not like 'content:%';")
+[[ "$local_urls" == 0 ]] ||
+    die "$local_urls uploaded books had their URL rewritten; positions would be lost"
+note "every uploaded book kept its own URL"
+
+# The other half of adoption: the catalog pass that follows an upload has
+# to recognise the book, not introduce it again beside itself.
+doubled=$(query "select count(*) from (select remote_uuid from books \
+    where remote_uuid is not null group by remote_uuid having count(*) > 1);")
+[[ "$doubled" == 0 ]] ||
+    die "$doubled uploaded books came back from the catalog as a second row"
+note "no book was catalogued twice"
+
+printf '\nDone. %s books uploaded, %s linked, none moved.\n' \
+    "$((after - before))" "$linked"


### PR DESCRIPTION
## Summary

Adds the Android half of "upload a locally added book to the connected
server", for liseur-sync. A book that only exists on this device can now
be sent up to a folder the server's administrator opened, and once it
lands the local row is *linked* to the server copy rather than replaced —
so reading position and history survive the trip.

The server side is already on `main` in
[liseur-sync](https://github.com/chmouel/liseur-sync) and deployed.

Fixes #28

## Changes

- Learn at connect whether a server will take a book: `canUpload` is
  `library-upload` in the token's scopes, or admin.
- `BookUploadWorker` sends the file, then adopts the resulting catalog
  row in a single transaction.
- An Ask / Always / Never policy, an offer for books not yet on the
  server, and a per-book "Upload to server" action behind a long press —
  shown only when the book has no `remoteUuid`.
- A server that will not take a book clears the capability, whether it
  refuses by scope (403) or because no folder accepts uploads.
- Docs: `DEVELOPER.md` gains the end-to-end check, and `hack/e2e-upload`
  drives it on an emulator.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

Six emulator cycles against a real liseur-sync from a wiped server and a
wiped app: two plain-folder happy paths (15 uploaded, 15 linked, no URL
moved, nothing doubled, stable across a later catalog pass), two refusal
paths (scope leg and folder leg), one recovery, and one Calibre folder —
that last verified by asking Calibre itself to read the result with
`calibredb list`.

Then once more against the live server, which returned 201 with the
correct Calibre layout and `duplicate:true` on a retry.

Three bugs came out of those runs rather than the tests, each with a
regression test that fails without its fix:

- a freshly adopted book was deleted by the next catalog walk, taking
  its reading position with it (local books have a null `local_uri`);
- adoption was two writes with a gap;
- a server with no open folder failed silently and left the app offering
  forever.

## Screenshots or recordings

Not included — the UI is an offer dialog and one row in the existing
book actions sheet.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
