### PR TITLE
feat(about): invite users to star the repository

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,14 @@ make SERIAL=emulator-5556 run         # use a specific emulator with SERIAL=...
 CI (`.github/workflows/build.yml`) runs `testDebugUnitTest`, `lintDebug`, and
 `assembleDebug` on every push/PR to `main`.
 
+## Pull requests
+
+When creating a pull request for a UI change, if an emulator is available and
+the user has authorized deployment, build and install the debug APK, navigate
+to the affected screen, capture a relevant screenshot, and attach it to the
+pull request description through GitHub's user-attachments API. If a screenshot
+is not possible, state why in the pull request.
+
 Releases go out with `hack/release`. **Never cut a release, create a
 tag, or install/replace an app on a device without asking the user
 first.** The script also updates the F-Droid

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/AboutScreen.kt
@@ -207,6 +207,14 @@ fun AboutScreen(
                     }
                 }
 
+                Text(
+                    text = stringResource(R.string.about_star_prompt),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(start = 16.dp, top = 8.dp, end = 16.dp),
+                )
+
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = Modifier.padding(top = 16.dp, bottom = 48.dp),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -421,6 +421,7 @@
     <string name="about_version">Version %1$s (%2$d)</string>
     <string name="about_source">Source code</string>
     <string name="about_licences">Open-source licences</string>
+    <string name="about_star_prompt">Enjoying Liseur? Consider giving it a star on GitHub \u2b50\ufe0f</string>
     <string name="about_licence_line">Liseur is free software under the MIT licence.</string>
     <string name="licences_intro">Liseur is built entirely from free and open-source components.</string>
     <string name="licences_read">%1$s \u2014 read it</string>


### PR DESCRIPTION
## Summary

Invite users to support Liseur with a GitHub star from the About screen.

## Changes

- Add a localized GitHub star prompt below the repository/licences links.
- Keep the existing Source code, sponsor, and licences actions unchanged.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on an Android emulator

## Screenshots or recordings


## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

![about-star-prompt.png](https://github.com/user-attachments/assets/2f4b873a-56fd-41b0-a574-c8f5aff98d1a)
