### PR TITLE
feat(reader): show footnotes on the page instead of at the back of the book

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ and keep scrolling past the end of a chapter to fall into the next one.
 A discreet footer shows the time remaining in the chapter (just enough to
 convince yourself that one more chapter won't hurt), while highlights, margin
 notes, bookmarks, and instant dictionary lookups remain right under your
-fingers when you stumble upon a word you pretend to know.
+fingers when you stumble upon a word you pretend to know. Footnotes open as a
+small card over the page rather than throwing you to the back of the book, so
+an author's aside costs you nothing more than a tap — and when a note is long
+enough to deserve the full page, "Go to note" takes you there and leaves a way
+back.
 
 Your library gathers onto a single shelf, whether your books live in messy folders on your phone or on a self-hosted [calibre-web](https://github.com/janeczku/calibre-web), [Komga](https://komga.org) or [liseur-sync](https://github.com/chmouel/liseur-sync) server. Books that belong to a series politely group into compact stacks that track your reading order, your progress, and the missing volumes you still need to hunt down. When you reach the final page of a novel, the next volume is already sitting there, gently enabling your binge-reading habits.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -144,6 +144,12 @@ dependencies {
     implementation(libs.readium.streamer)
     implementation(libs.readium.navigator)
 
+    // Already inside readium-navigator, which uses it to lift footnotes out
+    // of a chapter. Declared here because the reader parses notes of its own
+    // that Readium does not recognise, and a transitive dependency is not a
+    // promise.
+    implementation(libs.jsoup)
+
     implementation(libs.room.runtime)
     implementation(libs.room.ktx)
     ksp(libs.room.compiler)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.KeyEvent
+import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
@@ -20,8 +21,10 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import com.chmouel.liseur.reader.chrome.BookSyncDialog
+import com.chmouel.liseur.reader.chrome.ExternalLinkDialog
 import com.chmouel.liseur.reader.chrome.PageTurner
 import androidx.lifecycle.lifecycleScope
+import com.chmouel.liseur.R
 import com.chmouel.liseur.container
 import com.chmouel.liseur.data.db.Book
 import androidx.compose.foundation.layout.Box
@@ -83,6 +86,9 @@ class ReaderActivity : FragmentActivity() {
 
     /** The title of a book on its way up, while the note about it shows. */
     private var sendingNote by mutableStateOf<String?>(null)
+
+    /** A link out of the book, waiting for the reader to allow it. */
+    private var pendingExternalLink by mutableStateOf<AbsoluteUrl?>(null)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // The Publication doesn't survive process death, so saved navigator
@@ -206,12 +212,33 @@ class ReaderActivity : FragmentActivity() {
                                             columnMode = columnMode,
                                             scroll = scrollMode,
                                         ),
+                                        // Without a listener the navigator answers
+                                        // every link the same way — go there — and
+                                        // a footnote costs the reader their page.
+                                        listener = ReaderNavigatorListener(
+                                            scope = lifecycleScope,
+                                            noteAt = viewModel::noteAt,
+                                            onFootnote = viewModel::showFootnote,
+                                            onFollow = { link ->
+                                                viewModel.onJump()
+                                                navigator?.go(link, animated = false)
+                                            },
+                                            onExternal = { pendingExternalLink = it },
+                                        ),
                                         configuration = epubNavigatorConfiguration(
                                             columnMode = columnMode,
                                             scroll = scrollMode,
                                             onTextSelected = viewModel::onTextSelected,
                                         ),
                                     ).also { supportFragmentManager.fragmentFactory = it }
+                                }
+                                pendingExternalLink?.let { link ->
+                                    ExternalLinkDialog(
+                                        url = link.toString(),
+                                        host = link.host ?: link.toString(),
+                                        onOpen = { openExternally(it); pendingExternalLink = null },
+                                        onDismiss = { pendingExternalLink = null },
+                                    )
                                 }
                                 LaunchedEffect(viewModel) {
                                     lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
@@ -297,6 +324,8 @@ class ReaderActivity : FragmentActivity() {
                                     syncableFlow = viewModel.syncable,
                                     dictionaryFlow = viewModel.dictionary,
                                     onEnableDictionary = viewModel::enableDictionary,
+                                    footnoteFlow = viewModel.footnote,
+                                    onDismissFootnote = viewModel::dismissFootnote,
                                     goTo = viewModel.goTo,
                                     onBookSyncAction = remember {
                                         ReaderBookSyncActions(
@@ -373,6 +402,21 @@ class ReaderActivity : FragmentActivity() {
 
     private fun declineUpload(book: Book) {
         container.uploadPrompts.answer(book.url)
+    }
+
+    /**
+     * Hands a link in a book to whatever the phone uses for links.
+     *
+     * Only ever reached through the dialog that named the host, so this is
+     * the reader's decision being carried out and not the app's. A phone with
+     * nothing to open it with says so rather than doing nothing.
+     */
+    private fun openExternally(url: String) {
+        val intent = Intent(Intent.ACTION_VIEW, url.toUri())
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        runCatching { startActivity(intent) }.onFailure {
+            Toast.makeText(this, R.string.reader_external_link_failed, Toast.LENGTH_SHORT).show()
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderNavigatorListener.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderNavigatorListener.kt
@@ -1,0 +1,85 @@
+package com.chmouel.liseur.reader
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.readium.r2.navigator.HyperlinkNavigator
+import org.readium.r2.navigator.epub.EpubNavigatorFragment
+import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.util.AbsoluteUrl
+
+/**
+ * What a tap on a link in the book means.
+ *
+ * Without one of these the navigator is left to answer for itself, and its
+ * answer to every link is the same: go there. For a footnote that is the
+ * wrong answer twice over — the reader loses the page they were on, and the
+ * note Readium had already lifted out of the back matter is thrown away
+ * unread.
+ *
+ * Three kinds of link arrive here.
+ *
+ * A **note Readium recognised** comes with its content attached, in a
+ * [HyperlinkNavigator.FootnoteContext]. Nothing to fetch: pop it up.
+ *
+ * A **link into this book** comes with nothing but itself. It might be a note
+ * spelled a way Readium does not know — `role="doc-noteref"`, an `<aside>`,
+ * an EPUB2 anchor with no type at all — or it might be a cross-reference the
+ * reader means to follow. Only the target can say which, and reading the
+ * target takes a coroutine, so the answer here is always "no, I'll handle
+ * it": either the note pops up, or [onFollow] makes the jump that was going
+ * to happen anyway. One frame later, and with a way back.
+ *
+ * A **link out of the book** is not ours to follow. It goes to [onExternal],
+ * which asks first — a reader who taps a footnote should never find that
+ * their phone has quietly opened a browser on somebody else's server.
+ */
+@OptIn(ExperimentalReadiumApi::class)
+class ReaderNavigatorListener(
+    private val scope: CoroutineScope,
+    private val noteAt: suspend (Link) -> String?,
+    private val onFootnote: (html: String, link: Link) -> Unit,
+    private val onFollow: (Link) -> Unit,
+    private val onExternal: (AbsoluteUrl) -> Unit,
+) : EpubNavigatorFragment.Listener {
+
+    override fun shouldFollowInternalLink(
+        link: Link,
+        context: HyperlinkNavigator.LinkContext?,
+    ): Boolean {
+        val known = (context as? HyperlinkNavigator.FootnoteContext)?.noteContent
+        if (!known.isNullOrBlank()) {
+            onFootnote(known, link)
+            return false
+        }
+
+        if (link.url().fragment.isNullOrBlank()) {
+            // A whole resource is never a note; it is a chapter, and going
+            // there is what was asked for.
+            onFollow(link)
+            return false
+        }
+
+        scope.launch {
+            // A cancellation is not a failed lookup, and must not be turned
+            // into one: swallowing it here would let the reader be navigated
+            // by a coroutine belonging to a screen that is already going away.
+            val note = try {
+                noteAt(link)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                // An unreadable resource is not worth a message. The link
+                // still goes where it said it would.
+                null
+            }
+            if (note != null) onFootnote(note, link) else onFollow(link)
+        }
+        return false
+    }
+
+    override fun onExternalLinkActivated(url: AbsoluteUrl) {
+        onExternal(url)
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -109,6 +111,7 @@ import com.chmouel.liseur.reader.chrome.ScrollEdgeTurner
 import com.chmouel.liseur.reader.chrome.ReadingScrubber
 import com.chmouel.liseur.reader.chrome.ContentsScreen
 import com.chmouel.liseur.reader.chrome.Endpaper
+import com.chmouel.liseur.reader.chrome.FootnoteCard
 import com.chmouel.liseur.reader.chrome.TypographySheet
 import com.chmouel.liseur.reader.progress.ReaderProgress
 import com.chmouel.liseur.reader.search.SearchScreen
@@ -170,6 +173,8 @@ fun ReaderScreen(
     syncableFlow: StateFlow<Boolean>,
     dictionaryFlow: StateFlow<ReaderViewModel.DictionarySettings>,
     onEnableDictionary: () -> Unit,
+    footnoteFlow: StateFlow<ReaderViewModel.Footnote?>,
+    onDismissFootnote: () -> Unit,
     keepScreenOnFlow: StateFlow<Boolean>,
     onKeepScreenOnChanged: (Boolean) -> Unit,
     scrollModeFlow: StateFlow<Boolean>,
@@ -206,6 +211,23 @@ fun ReaderScreen(
     val searchState by searchFlow.collectAsStateWithLifecycle()
     val bookmarked by bookmarkedFlow.collectAsStateWithLifecycle()
     val dictionary by dictionaryFlow.collectAsStateWithLifecycle()
+    val footnote by footnoteFlow.collectAsStateWithLifecycle()
+
+    /*
+     * Where the last touch landed, so a note can be shown beside the marker
+     * that raised it.
+     *
+     * Readium reports no point for a tap on a footnote: the moment it
+     * recognises a link it stops forwarding the gesture and starts resolving
+     * the note. The touch is therefore caught here on the way down, on the
+     * initial pass and without consuming anything, which leaves the web view
+     * and the tap zones seeing exactly what they saw before.
+     */
+    var lastTouchY by remember { mutableStateOf<Float?>(null) }
+    // The tracker below outlives every recomposition, so it cannot read
+    // `footnote` directly — it would keep seeing whatever was true when it
+    // started. This gives it a window onto the current value.
+    val noteShowing by rememberUpdatedState(footnote != null)
     var selection by remember { mutableStateOf<ActiveSelection?>(null) }
     var noteFor by remember { mutableStateOf<ActiveSelection?>(null) }
     var defineWord by remember { mutableStateOf<String?>(null) }
@@ -372,7 +394,21 @@ fun ReaderScreen(
     Box(
         Modifier
             .fillMaxSize()
-            .background(readingTheme.background),
+            .background(readingTheme.background)
+            .pointerInput(Unit) {
+                awaitPointerEventScope {
+                    while (true) {
+                        val event = awaitPointerEvent(PointerEventPass.Initial)
+                        // The card is drawn inside this box, so without this
+                        // guard reading a note would move it: every touch on
+                        // the card would become the new anchor and the card
+                        // would jump out from under the finger scrolling it.
+                        if (noteShowing) continue
+                        event.changes.firstOrNull { it.pressed }
+                            ?.let { lastTouchY = it.position.y }
+                    }
+                }
+            },
     ) {
         // The page runs the whole screen in both modes. Readium's own
         // padding is switched off (see dimens.xml) because it is applied
@@ -599,6 +635,23 @@ fun ReaderScreen(
                     navigationIconContentColor = readingTheme.foreground,
                     actionIconContentColor = readingTheme.foreground,
                 ),
+            )
+        }
+
+        // Last inside the box, and so on top of everything in it: a note is
+        // the thing the reader just asked for, and the page, the pills and
+        // the chrome are all what they asked to be shown it over.
+        footnote?.let { note ->
+            FootnoteCard(
+                html = note.html,
+                theme = readingTheme,
+                anchorY = lastTouchY,
+                onGoToNote = {
+                    onDismissFootnote()
+                    onProgressAction.onJump()
+                    navigator?.go(note.link, animated = false)
+                },
+                onDismiss = onDismissFootnote,
             )
         }
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -57,11 +57,13 @@ import com.chmouel.liseur.reader.annotations.locator
 import com.chmouel.liseur.reader.annotations.markedPassage
 import com.chmouel.liseur.ui.messageRes
 import com.chmouel.liseur.reader.progress.BookPositions
+import com.chmouel.liseur.reader.footnotes.FootnoteResolver
 import com.chmouel.liseur.reader.progress.ReaderProgress
 import com.chmouel.liseur.reader.progress.ReadingPace
 import com.chmouel.liseur.reader.progress.ReadingSpeedEstimator
 import com.chmouel.liseur.reader.progress.StableBookProgress
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -78,9 +80,11 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONObject
 import org.readium.r2.navigator.epub.EpubNavigatorFactory
+import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.indexOfFirstWithHref
@@ -88,6 +92,7 @@ import org.readium.r2.shared.publication.services.search.search
 import org.readium.r2.shared.util.AbsoluteUrl
 import org.readium.r2.shared.util.asset.AssetRetriever
 import org.readium.r2.shared.util.getOrElse
+import org.readium.r2.shared.util.use
 import org.readium.r2.streamer.PublicationOpener
 import java.util.UUID
 
@@ -344,6 +349,49 @@ class ReaderViewModel(
     /** Raised when a choice moves the reader somewhere else in the book. */
     private val _goTo = MutableSharedFlow<Locator>(extraBufferCapacity = 1)
     val goTo: SharedFlow<Locator> = _goTo.asSharedFlow()
+
+    /**
+     * A note to show over the page, and where it was referenced from.
+     *
+     * [link] is kept so the card can offer the way it used to be the only
+     * way: opening the note where it actually lives, for the long ones and
+     * the ones carrying a picture the card cannot draw.
+     */
+    data class Footnote(val html: String, val link: Link)
+
+    private val _footnote = MutableStateFlow<Footnote?>(null)
+
+    /** The note popped up over the page, if the reader tapped one. */
+    val footnote: StateFlow<Footnote?> = _footnote.asStateFlow()
+
+    fun showFootnote(html: String, link: Link) {
+        _footnote.value = Footnote(html = html, link = link)
+    }
+
+    fun dismissFootnote() {
+        _footnote.value = null
+    }
+
+    /**
+     * The note [link] points at, if what it points at is a note.
+     *
+     * This is the half Readium does not do. It only recognises
+     * `epub:type="noteref"` on the marker; every other spelling arrives here
+     * with nothing but a link, so the target is fetched and judged on its own
+     * content. Reading the resource blocks, so it is done off the main thread
+     * inside the thing that blocks rather than at the call site.
+     */
+    suspend fun noteAt(link: Link): String? = withContext(Dispatchers.IO) {
+        val publication = publication ?: return@withContext null
+        val url = link.url()
+        val fragment = url.fragment?.takeIf { it.isNotBlank() } ?: return@withContext null
+        val resource = publication.get(url.removeFragment())
+            ?: return@withContext null
+        val html = resource.use { res ->
+            res.read().getOrNull()?.decodeToString()
+        } ?: return@withContext null
+        FootnoteResolver.noteAt(html, fragment)
+    }
 
     /** Whether this book can sync at all, so the action can stay hidden. */
     val syncable: StateFlow<Boolean> = flow { emit(positionSync.canSync(bookId)) }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ExternalLinkDialog.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ExternalLinkDialog.kt
@@ -1,0 +1,38 @@
+package com.chmouel.liseur.reader.chrome
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.chmouel.liseur.R
+
+/**
+ * Asks before a link in a book takes the reader out of it.
+ *
+ * Liseur promises to talk to the reader's own book server and to nothing
+ * else. A link in a book is somebody else's server, and following one on a
+ * tap would break that promise quietly — which is the only way promises like
+ * this ever get broken. So the host is named and the reader decides.
+ */
+@Composable
+fun ExternalLinkDialog(
+    url: String,
+    host: String,
+    onOpen: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.reader_external_link_title)) },
+        text = { Text(stringResource(R.string.reader_external_link_body, host)) },
+        confirmButton = {
+            TextButton(onClick = { onOpen(url) }) {
+                Text(stringResource(R.string.reader_external_link_open))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
+        },
+    )
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/FootnoteCard.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/FootnoteCard.kt
@@ -1,0 +1,210 @@
+package com.chmouel.liseur.reader.chrome
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.fromHtml
+import androidx.compose.ui.unit.dp
+import com.chmouel.liseur.R
+import com.chmouel.liseur.data.settings.ReaderTheme
+import com.chmouel.liseur.reader.footnotes.FootnoteText
+import com.chmouel.liseur.ui.LocalEInk
+import com.chmouel.liseur.ui.contentWidthCap
+import com.chmouel.liseur.ui.windowWidth
+
+/**
+ * The note, shown where it was referenced.
+ *
+ * A footnote used to send the reader to the back of the book and leave them
+ * to find their own way home. The card is the answer: the note appears over
+ * the page it belongs to, the page does not move, and dismissing it costs a
+ * tap anywhere.
+ *
+ * It is painted in the reading theme rather than in Material colours, because
+ * it sits on the page, and a white card over a black page at night is a lamp
+ * in the face. For the same reason it is opaque: a note read through the
+ * paragraph behind it is not read.
+ *
+ * The card follows the marker. [anchorY] is where the reader's finger landed,
+ * and the card takes whichever side of that has room, so the marker itself is
+ * never the thing covered up. With no anchor — a note reached from a keyboard,
+ * say — it settles in the middle.
+ *
+ * Meant to be laid over the page inside the reader's own box, not in a
+ * [androidx.compose.ui.window.Popup]: the scrim has to cover the same area
+ * the tap zones do, or the tap meant to dismiss the note turns a page.
+ */
+@Composable
+fun FootnoteCard(
+    html: String,
+    theme: ReaderTheme,
+    anchorY: Float?,
+    onGoToNote: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val text = remember(html) {
+        FootnoteText.forCard(html)
+            ?.let { AnnotatedString.fromHtml(it) }
+            ?: AnnotatedString(FootnoteText.plainText(html))
+    }
+    val eInk = LocalEInk.current
+    var cardHeight by remember { mutableIntStateOf(0) }
+    var boxHeight by remember { mutableIntStateOf(0) }
+
+    BackHandler(onBack = onDismiss)
+
+    Box(
+        Modifier
+            .fillMaxSize()
+            .onSizeChanged { boxHeight = it.height }
+            // Always darkens, never tints: a scrim built from the reading
+            // theme's own ink would lighten a night page instead of pushing it
+            // back. Electronic paper redraws a translucent wash as a grey
+            // smear, so there the border is what separates note from page.
+            .background(Color.Black.copy(alpha = if (eInk) 0f else 0.35f))
+            // Named, so a screen reader announces what dismisses the note
+            // rather than a full-screen tap target with nothing to say.
+            .noRipple(
+                onClickLabel = stringResource(R.string.reader_footnote_dismiss),
+                onClick = onDismiss,
+            ),
+    ) {
+        val density = LocalDensity.current
+        val top = if (anchorY != null && cardHeight > 0 && boxHeight > 0) {
+            placeCard(anchorY, cardHeight.toFloat(), boxHeight.toFloat())
+        } else {
+            null
+        }
+
+        Surface(
+            shape = RoundedCornerShape(16.dp),
+            color = theme.background,
+            contentColor = theme.foreground,
+            border = BorderStroke(1.dp, theme.foreground.copy(alpha = 0.25f)),
+            shadowElevation = if (eInk) 0.dp else 12.dp,
+            modifier = Modifier
+                .align(if (top == null) Alignment.Center else Alignment.TopCenter)
+                .then(
+                    if (top == null) {
+                        Modifier
+                    } else {
+                        Modifier.offset(y = with(density) { top.toDp() })
+                    },
+                )
+                .padding(horizontal = 16.dp)
+                .widthIn(max = contentWidthCap(windowWidth()))
+                .fillMaxWidth()
+                .onSizeChanged { cardHeight = it.height }
+                // Swallow taps on the card, so reading a note is not also
+                // dismissing it.
+                .noRipple {},
+        ) {
+            Column(Modifier.padding(start = 20.dp, end = 20.dp, top = 16.dp, bottom = 8.dp)) {
+                Text(
+                    text = stringResource(R.string.reader_footnote),
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = theme.foreground.copy(alpha = 0.6f),
+                )
+                Text(
+                    text = text,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = theme.foreground,
+                    modifier = Modifier
+                        .padding(top = 8.dp)
+                        .heightIn(max = 300.dp)
+                        .verticalScroll(rememberScrollState()),
+                )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.End),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    TextButton(onClick = onGoToNote) {
+                        Text(
+                            text = stringResource(R.string.reader_footnote_go_to),
+                            color = theme.foreground.copy(alpha = 0.75f),
+                        )
+                    }
+                    TextButton(onClick = onDismiss) {
+                        Text(
+                            text = stringResource(R.string.reader_footnote_dismiss),
+                            color = theme.foreground,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Modifier.noRipple(
+    onClickLabel: String? = null,
+    onClick: () -> Unit,
+): Modifier =
+    clickable(
+        interactionSource = remember { MutableInteractionSource() },
+        indication = null,
+        onClickLabel = onClickLabel,
+        onClick = onClick,
+    )
+
+/**
+ * Where the top of a card of [cardHeight] goes, given a marker at [anchorY].
+ *
+ * Below the marker by preference, because that is where the eye already is
+ * and the note reads on from the sentence that raised it. Above it when there
+ * is no room below, which is the common case for a marker near the foot of
+ * the page. Either way the card never covers the marker, so the reader can
+ * still see what they tapped.
+ *
+ * Split out from the drawing so the arithmetic can be checked without a
+ * screen.
+ */
+internal fun placeCard(
+    anchorY: Float,
+    cardHeight: Float,
+    viewportHeight: Float,
+    gap: Float = 48f,
+): Float {
+    val below = anchorY + gap
+    if (below + cardHeight <= viewportHeight) return below
+    val above = anchorY - gap - cardHeight
+    if (above >= 0f) return above
+    // Neither side fits: centre it and let it scroll. A note this long was
+    // never going to sit beside its marker.
+    return ((viewportHeight - cardHeight) / 2f).coerceAtLeast(0f)
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteResolver.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteResolver.kt
@@ -1,0 +1,74 @@
+package com.chmouel.liseur.reader.footnotes
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.jsoup.safety.Safelist
+
+/**
+ * Lifting a note out of the page it was banished to.
+ *
+ * Readium recognises one spelling of a footnote, `epub:type="noteref"`, and
+ * hands its content back before the tap is even forwarded. That covers books
+ * made carefully — Standard Ebooks, most EPUB3 — and misses everything else:
+ * a converted EPUB2 whose markers are plain anchors, a book that uses the
+ * ARIA vocabulary and not the EPUB one, an `<aside>` sitting quietly at the
+ * foot of the chapter.
+ *
+ * So the target is judged by what it *is* rather than by how it was linked
+ * to. Three ways of saying "this is a note" are accepted, because between
+ * them they cover every book worth opening:
+ *
+ *  - `epub:type` naming a note of any kind;
+ *  - the ARIA `doc-footnote` / `doc-endnote` role;
+ *  - an `<aside>`, which is what the EPUB spec itself suggests notes be.
+ *
+ * Everything else is a cross-reference, not a note, and the reader asked to
+ * go there. That distinction is the whole point of this file: guessing wrong
+ * in one direction pops up a chapter, and in the other throws the reader out
+ * of the page for a single line of Latin.
+ */
+object FootnoteResolver {
+
+    /** `epub:type` words that name a note. */
+    private val NOTE_TYPES = setOf("footnote", "endnote", "rearnote", "note")
+
+    /** ARIA roles that name a note. */
+    private val NOTE_ROLES = setOf("doc-footnote", "doc-endnote")
+
+    /**
+     * The note identified by [fragment] in [html], or null if there is none.
+     *
+     * The returned HTML is sanitised the same way Readium sanitises its own,
+     * so both paths hand the same shape of thing to the card and neither can
+     * carry a script into it.
+     */
+    fun noteAt(html: String, fragment: String): String? {
+        val document = runCatching { Jsoup.parse(html) }.getOrNull() ?: return null
+        val element = document.getElementById(fragment) ?: return null
+        if (!isNote(element)) return null
+
+        // A list item is the usual home of an endnote, and the number in
+        // front of it is drawn by the list, not stored in the note, so its
+        // inner HTML loses nothing.
+        val content = element.html()
+        if (content.isBlank()) return null
+        return Jsoup.clean(content, Safelist.relaxed()).takeIf { it.isNotBlank() }
+    }
+
+    /**
+     * Whether [element] is a note rather than somewhere the reader asked to go.
+     *
+     * The element's children are not consulted: a chapter that happens to
+     * contain a note is not a note, and a note nested in a section is found
+     * by its id, never by looking down.
+     */
+    private fun isNote(element: Element): Boolean {
+        // Jsoup lowercases attribute names but keeps the namespace prefix, so
+        // the EPUB attribute survives as `epub:type`. `type` alone is the
+        // shape it takes once a sanitiser has flattened the namespace.
+        val epubType = element.attr("epub:type").ifEmpty { element.attr("type") }
+        if (epubType.split(' ').any { it.substringAfterLast(':') in NOTE_TYPES }) return true
+        if (element.attr("role").split(' ').any { it in NOTE_ROLES }) return true
+        return element.normalName() == "aside"
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteText.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteText.kt
@@ -1,0 +1,85 @@
+package com.chmouel.liseur.reader.footnotes
+
+import org.jsoup.Jsoup
+import org.jsoup.safety.Safelist
+
+/**
+ * Getting a note ready to be read where it was referenced.
+ *
+ * A note written for the back of the book carries furniture that only makes
+ * sense back there. The worst of it is the backlink — the little `↩` that
+ * exists solely to undo a journey the reader is no longer making. Popped up
+ * in place it is at best noise and at worst a trap, because it is the one
+ * thing on the card that would throw the reader out of the page again.
+ *
+ * Images go too. The card is text, and a note whose point is a picture is
+ * exactly the note that wants opening in full.
+ *
+ * What is left is narrowed to the handful of tags that survive the trip into
+ * an `AnnotatedString`: emphasis, sub- and superscripts, paragraphs, breaks.
+ * Anything else would be dropped later anyway, and dropping it here keeps the
+ * decision in a function that can be tested without an emulator.
+ */
+object FootnoteText {
+
+    /**
+     * Characters a backlink is made of.
+     *
+     * A backlink is recognised by what it says rather than by how it is
+     * marked, because by the time Readium has sanitised a note the `role` and
+     * `epub:type` that named it are gone and only the arrow is left.
+     */
+    private const val BACKLINK_CHARS = "↩↰⏎←↑⤴«‹^"
+
+    /** Tags an [androidx.compose.ui.text.AnnotatedString] can still show. */
+    private val KEEP: Safelist = Safelist.none()
+        .addTags(
+            "b", "strong", "i", "em", "u", "s", "sup", "sub",
+            "p", "br", "span", "small", "cite", "q", "blockquote",
+        )
+
+    /**
+     * [html] with its back-matter furniture removed, or null if nothing is
+     * left worth showing.
+     */
+    fun forCard(html: String): String? {
+        val document = runCatching { Jsoup.parse(html) }.getOrNull() ?: return null
+
+        document.select("img, svg, figure").remove()
+        document.select("a").forEach { anchor ->
+            if (isBacklink(anchor.attr("role"), anchor.attr("epub:type"), anchor.text())) {
+                anchor.remove()
+            } else {
+                // A note may legitimately quote a cross-reference. The words
+                // stay; the target does not, because a card is not a place
+                // to start a second journey from.
+                anchor.unwrap()
+            }
+        }
+
+        val cleaned = Jsoup.clean(document.body().html(), KEEP)
+        val trimmed = collapse(cleaned)
+        return trimmed.takeIf { plainText(it).isNotBlank() }
+    }
+
+    /** [html] as the words alone, for talkback and for tests. */
+    fun plainText(html: String): String =
+        collapse(Jsoup.parse(html).wholeText())
+
+    private fun isBacklink(role: String, epubType: String, text: String): Boolean {
+        if (role.split(' ').any { it == "doc-backlink" }) return true
+        if (epubType.split(' ').any { it.substringAfterLast(':') == "backlink" }) return true
+        // Variation selectors and word joiners ride along with these arrows
+        // often enough that stripping them is what makes the test pass on a
+        // real book rather than on a hand-written one.
+        val bare = text.filterNot { it.isWhitespace() || it in "\uFE0E\uFE0F\u200B\u2060\uFEFF" }
+        return bare.isNotEmpty() && bare.all { it in BACKLINK_CHARS }
+    }
+
+    private fun collapse(text: String): String =
+        text.replace('\u00A0', ' ')
+            .replace(Regex("[ \t]+"), " ")
+            .replace(Regex(" ?\n ?"), "\n")
+            .replace(Regex("\n{3,}"), "\n\n")
+            .trim()
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -508,4 +508,11 @@
     <string name="duration_hours_minutes">%1$d h %2$d min</string>
     <string name="duration_none">None</string>
     <string name="more_options">More</string>
+    <string name="reader_footnote">Note</string>
+    <string name="reader_footnote_dismiss">Close note</string>
+    <string name="reader_footnote_go_to">Go to note</string>
+    <string name="reader_external_link_title">Leave Liseur?</string>
+    <string name="reader_external_link_body">This link opens %1$s in your browser. Liseur will not follow it for you.</string>
+    <string name="reader_external_link_open">Open</string>
+    <string name="reader_external_link_failed">No app on this device can open that link.</string>
 </resources>

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/FootnoteCardPlacementTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/FootnoteCardPlacementTest.kt
@@ -1,0 +1,38 @@
+package com.chmouel.liseur.reader.chrome
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FootnoteCardPlacementTest {
+
+    @Test
+    fun `a marker high on the page puts the note under it`() {
+        assertEquals(248f, placeCard(anchorY = 200f, cardHeight = 400f, viewportHeight = 2400f))
+    }
+
+    @Test
+    fun `a marker near the foot puts the note above it`() {
+        val top = placeCard(anchorY = 2200f, cardHeight = 400f, viewportHeight = 2400f)
+        assertEquals(1752f, top)
+        assertTrue("must clear the marker", top + 400f <= 2200f)
+    }
+
+    @Test
+    fun `a note too tall for either side is centred`() {
+        val top = placeCard(anchorY = 1200f, cardHeight = 2000f, viewportHeight = 2400f)
+        assertEquals(200f, top)
+    }
+
+    @Test
+    fun `a note taller than the page still starts on it`() {
+        val top = placeCard(anchorY = 1200f, cardHeight = 3000f, viewportHeight = 2400f)
+        assertEquals(0f, top)
+    }
+
+    @Test
+    fun `a marker at the very top is still cleared`() {
+        val top = placeCard(anchorY = 0f, cardHeight = 300f, viewportHeight = 2400f)
+        assertTrue("must not sit over the marker", top > 0f)
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteResolverTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteResolverTest.kt
@@ -1,0 +1,95 @@
+package com.chmouel.liseur.reader.footnotes
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FootnoteResolverTest {
+
+    /** How Standard Ebooks writes an endnote, which is most of the corpus. */
+    private val standardEbooks = """
+        <html xmlns:epub="http://www.idpf.org/2007/ops">
+          <body>
+            <section id="endnotes" epub:type="endnotes footnotes">
+              <ol>
+                <li id="note-1" epub:type="endnote footnote">
+                  <p>Is that my governess?
+                    <a href="chapter-11.xhtml#noteref-1" epub:type="backlink">↩︎</a>
+                  </p>
+                </li>
+              </ol>
+            </section>
+          </body>
+        </html>
+    """.trimIndent()
+
+    @Test
+    fun `finds an endnote marked with epub type`() {
+        val note = FootnoteResolver.noteAt(standardEbooks, "note-1")!!
+        assertTrue(note, note.contains("Is that my governess?"))
+    }
+
+    @Test
+    fun `finds a note marked only with an ARIA role`() {
+        val html = """
+            <body><div id="fn3" role="doc-endnote"><p>A note by role alone.</p></div></body>
+        """.trimIndent()
+        val note = FootnoteResolver.noteAt(html, "fn3")!!
+        assertTrue(note, note.contains("A note by role alone."))
+    }
+
+    @Test
+    fun `finds a note in an aside, which is what the spec suggests`() {
+        val html = """<body><aside id="fn7"><p>Set in an aside.</p></aside></body>"""
+        val note = FootnoteResolver.noteAt(html, "fn7")!!
+        assertTrue(note, note.contains("Set in an aside."))
+    }
+
+    @Test
+    fun `a chapter is not a note, however it was linked to`() {
+        val html = """
+            <body><section id="chapter-4" epub:type="chapter"><p>Long ago.</p></section></body>
+        """.trimIndent()
+        assertNull(FootnoteResolver.noteAt(html, "chapter-4"))
+    }
+
+    @Test
+    fun `a paragraph a cross-reference points at is not a note`() {
+        val html = """<body><p id="para-9">See above.</p></body>"""
+        assertNull(FootnoteResolver.noteAt(html, "para-9"))
+    }
+
+    @Test
+    fun `a fragment naming nothing resolves to nothing`() {
+        assertNull(FootnoteResolver.noteAt(standardEbooks, "note-404"))
+    }
+
+    @Test
+    fun `an empty note is not worth popping up`() {
+        val html = """<body><aside id="fn1">   </aside></body>"""
+        assertNull(FootnoteResolver.noteAt(html, "fn1"))
+    }
+
+    @Test
+    fun `scripts do not survive the trip out of the book`() {
+        val html = """
+            <body><aside id="fn1"><p>Safe.</p><script>alert(1)</script></aside></body>
+        """.trimIndent()
+        val note = FootnoteResolver.noteAt(html, "fn1")!!
+        assertTrue(note, note.contains("Safe."))
+        assertTrue(note, !note.contains("alert"))
+    }
+
+    @Test
+    fun `the note keeps its own markup`() {
+        val html = """<body><aside id="fn1"><p>An <em>emphatic</em> note.</p></aside></body>"""
+        val note = FootnoteResolver.noteAt(html, "fn1")!!
+        assertTrue(note, note.contains("<em>emphatic</em>"))
+    }
+
+    @Test
+    fun `unparseable input is answered with nothing rather than a crash`() {
+        assertEquals(null, FootnoteResolver.noteAt("", "fn1"))
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteTextTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteTextTest.kt
@@ -1,0 +1,65 @@
+package com.chmouel.liseur.reader.footnotes
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FootnoteTextTest {
+
+    @Test
+    fun `the backlink goes, because there is nowhere to go back to`() {
+        val html = """<p>Is that my governess? <a href="chapter-11.xhtml#noteref-1">↩︎</a></p>"""
+        val card = FootnoteText.forCard(html)!!
+        assertTrue(card, !card.contains("↩"))
+        assertEquals("Is that my governess?", FootnoteText.plainText(card))
+    }
+
+    @Test
+    fun `a backlink still wearing its role goes too`() {
+        val html = """<p>A note. <a role="doc-backlink" href="#ref">back</a></p>"""
+        val card = FootnoteText.forCard(html)!!
+        assertEquals("A note.", FootnoteText.plainText(card))
+    }
+
+    @Test
+    fun `a link that is part of the note keeps its words`() {
+        val html = """<p>See <a href="other.xhtml">the appendix</a> for more.</p>"""
+        val card = FootnoteText.forCard(html)!!
+        assertEquals("See the appendix for more.", FootnoteText.plainText(card))
+        assertTrue(card, !card.contains("<a"))
+    }
+
+    @Test
+    fun `emphasis survives, because it is part of what was written`() {
+        val html = "<p>The <em>Ligue des Rats</em>, a fable.</p>"
+        val card = FootnoteText.forCard(html)!!
+        assertTrue(card, card.contains("<em>"))
+    }
+
+    @Test
+    fun `images go, since the card has no way to draw them`() {
+        val html = """<p>A plate.<img src="plate.jpg" alt="plate"/></p>"""
+        val card = FootnoteText.forCard(html)!!
+        assertTrue(card, !card.contains("img"))
+    }
+
+    @Test
+    fun `entities and hard spaces come out as the characters they name`() {
+        val html = "<p>Mesdames,&#160;vous &#234;tes servies!</p>"
+        assertEquals("Mesdames, vous êtes servies!", FootnoteText.plainText(FootnoteText.forCard(html)!!))
+    }
+
+    @Test
+    fun `a note that is only a backlink is nothing worth showing`() {
+        val html = """<p><a href="#ref">↩</a></p>"""
+        assertNull(FootnoteText.forCard(html))
+    }
+
+    @Test
+    fun `several paragraphs stay several paragraphs`() {
+        val html = "<p>First.</p><p>Second.</p>"
+        val card = FootnoteText.forCard(html)!!
+        assertEquals(2, Regex("<p>").findAll(card).count())
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ okhttp = "5.4.0"
 work = "2.11.2"
 desugar = "2.1.5"
 json = "20260719"
+jsoup = "1.22.2"
 coroutines = "1.11.0"
 reorderable = "3.1.0"
 robolectric = "4.16.1"
@@ -56,6 +57,7 @@ okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
 desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar" }
 json = { module = "org.json:json", version.ref = "json" }
+jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 junit = { module = "junit:junit", version.ref = "junit" }
 mockwebserver = { module = "com.squareup.okhttp3:mockwebserver3-junit4", version.ref = "okhttp" }


### PR DESCRIPTION
## Summary

Tapping a footnote marker threw the reader to the book's endnotes, several
hundred pages away, with nothing recording where the tap came from. This
shows the note as a small card over the page instead.

Readium had already done the hard half of the work: `R2BasicWebView.handleFootnote`
recognises `epub:type="noteref"`, fetches the target resource, extracts the
element by its fragment id, sanitises it and hands it back as a
`HyperlinkNavigator.FootnoteContext`. But `ReaderActivity` called
`createFragmentFactory` without a `listener`, so `EpubNavigatorViewModel` had
nobody to ask:

```kotlin
if (listener == null || listener.shouldFollowInternalLink(link, context)) {
    _events.send(Event.OpenInternalLink(link))
}
```

Every footnote navigated, and the note content Readium had just extracted was
thrown away.

Fixes #30.

## Changes

- **`ReaderNavigatorListener`** — the whole fix. Two paths converge on one card:
  - *Readium's*, when the marker carries `epub:type="noteref"` and the HTML
    arrives with the callback.
  - *Liseur's own*, for everything Readium does not recognise: `role="doc-noteref"`,
    endnotes and rearnotes, `<aside>`, and plain fragment links whose target turns
    out to be a note. `shouldFollowInternalLink` is not suspending, so these always
    answer "no" and resolve on `Dispatchers.IO`; a target that is *not* a note is
    navigated to by hand, landing the reader exactly where they would have been.
- **Jump-back on internal links.** That detour has a second use: following an
  internal link now calls `onJump()` first, so a cross-reference finally leaves a
  "Back to page N" pill behind — which it never did, footnote or not.
- **`FootnoteResolver` / `FootnoteText`** — pure Jsoup over strings, no Android
  types. The resolver decides what counts as a note; the text conversion drops
  the backlink arrow (Readium's `Jsoup.clean` strips `epub:type` and `role`, so
  backlinks survive as anchors whose only text is `↩`), drops images, unwraps
  remaining anchors and narrows the markup for `AnnotatedString.fromHtml`.
- **`FootnoteCard`** — painted in the reading theme rather than in Material
  colours, and its scrim always *darkens*, so a night page recedes instead of
  being washed pale. Anchored above or below the tapped marker, whichever side
  has room. Deliberately an overlay inside the reader's own box rather than a
  `Popup`: the scrim has to cover the same area the tap zones do, or the tap
  meant to dismiss a note turns a page. Long notes keep an escape hatch —
  "Go to note" navigates and leaves its own way back.
- **`ExternalLinkDialog`** — external links are no longer followed silently. A
  dialog names the host first, so the promise that the app only talks to your own
  book server is not quietly broken by a stray tap.
- **jsoup** declared in the version catalog. It was already on the classpath
  through `readium-navigator`; it is now declared rather than leaned on. MIT,
  Maven Central, no size cost.

## Testing

- [x] `./gradlew testDebugUnitTest` — 23 new tests (resolver, text conversion, card placement)
- [x] `./gradlew lintDebug` — 0 errors
- [x] `./gradlew assembleDebug`
- [x] Manually tested on `emulator-5554` (API 36), Jane Eyre chapter XI

Reproduction and verification both used the same route: Library → Jane Eyre →
Contents → XI → search "gouvernante" → tap the superscript `1`.

## Screenshots or recordings

### Before

| The marker | Where the tap landed |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/18d232a0-64f0-4b27-9331-eac2e352bf3c" width="300"> | <img src="https://github.com/user-attachments/assets/4556d88b-a27b-4f96-b17e-a0becbf068b3" width="300"> |

The reader is thrown to the **Endnotes** back matter. The only pill on screen
reads "Back to page 106" — that is left over from the *search* jump and expires
on a timer, so there is no way back from the note.

### After

| The note, in place | The same, at night |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/fef17889-7c2a-42ad-a9d0-cfc43be4c677" width="300"> | <img src="https://github.com/user-attachments/assets/b423b0f4-6f28-4443-9a59-e03bfd9ce28a" width="300"> |

The page does not move. The backlink arrow is stripped. The card takes its
colours from the reading theme, and the scrim darkens rather than tints.

| "Go to note" leaves a way back | External links ask first |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/297857eb-b8ea-42e2-91cb-4d4e476d4220" width="300"> | <img src="https://github.com/user-attachments/assets/6052e738-ac2c-46e0-8129-6171ba8118d1" width="300"> |

"Back to page 114" is the page the reader was actually on — the jump-back that
internal links never registered before.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
