### PR TITLE
feat(downloads): fetch a whole server library in one go

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Your library gathers onto a single shelf, whether your books live in messy folde
 
 When you switch between devices, you have the choice to have your place travel with you across your devices. Two-way synchronization with [calibre-web](https://github.com/janeczku/calibre-web), [Komga](https://komga.org) and [liseur-sync](https://github.com/chmouel/liseur-sync) keeps your progress aligned — down to the exact sentence on Komga and liseur-sync, so you never have to play the guessing game of where you were. liseur-sync goes one further: standalone EPUB files that never came from a catalog sync their position too, matched by the file itself. Its books come from folders it watches on the server, so anything you drop there shows up on the shelf.
 
+About to lose your connection? **Download all books** on the server account screen fetches everything in the catalog that isn't already on your device, in one go. Books you already have are left alone, archived ones are skipped, and it tells you how much room it will need before it starts.
+
 Everything runs privately and without distraction. There are no trackers, no
 analytics, no ads, and no attempts to sell you a monthly subscription for books
 you already own. Liseur only talks to the book servers and dictionary sources

--- a/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/37.json
+++ b/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/37.json
@@ -1,0 +1,1078 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 37,
+    "identityHash": "77de6429a3b8e3030a55f53f58e696f7",
+    "entities": [
+      {
+        "tableName": "reading_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `total_progression` REAL, `reading_speed` REAL, `reading_seconds_per_position` REAL, `reading_pace_samples` INTEGER NOT NULL DEFAULT 0, `reading_pace_elapsed_ms` INTEGER NOT NULL DEFAULT 0, `reading_pace_evidence` REAL NOT NULL DEFAULT 0, `updated_at` INTEGER NOT NULL, `status` TEXT, `synced_at` INTEGER, `local_revision` INTEGER NOT NULL DEFAULT 0, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `agreed_account` TEXT, `pending_progression` REAL, `pending_status` TEXT, `pending_updated_at` INTEGER, `pending_account` TEXT, `owner_account` TEXT, `remote_updated_at` INTEGER, `finished_override` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSpeed",
+            "columnName": "reading_speed",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSecondsPerPosition",
+            "columnName": "reading_seconds_per_position",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingPaceSamples",
+            "columnName": "reading_pace_samples",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceElapsedMs",
+            "columnName": "reading_pace_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceEvidence",
+            "columnName": "reading_pace_evidence",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localRevision",
+            "columnName": "local_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "agreedAccount",
+            "columnName": "agreed_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingAccount",
+            "columnName": "pending_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ownerAccount",
+            "columnName": "owner_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "finishedOverride",
+            "columnName": "finished_override",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `cover_path` TEXT, `source` TEXT, `added_at` INTEGER NOT NULL, `last_opened_at` INTEGER, `local_uri` TEXT, `remote_uuid` TEXT, `remote_book_id` INTEGER, `cover_url` TEXT, `download_href` TEXT, `download_state` TEXT NOT NULL, `remote_updated_at` INTEGER, `downloaded_at` INTEGER, `file_modified_at` INTEGER, `work_id` TEXT, `finished_at` INTEGER, `archived_at` INTEGER, `remote_page_count` INTEGER, `size_bytes` INTEGER, `series_name` TEXT, `series_index` REAL, `file_series_name` TEXT, `file_series_index` REAL, `series_id` TEXT, `series_checked` INTEGER NOT NULL, `catalog_series_name` TEXT, `catalog_series_index` REAL, `catalog_folder_id` TEXT, `catalog_series_source` TEXT, `user_series_name` TEXT, `user_series_index` REAL, `series_override` INTEGER NOT NULL, `user_series_updated_at` INTEGER, `series_claim_pending` INTEGER NOT NULL, `series_claim_reset` INTEGER NOT NULL, `personal_series_updated_at` INTEGER, `series_index_override` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "last_opened_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localUri",
+            "columnName": "local_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUuid",
+            "columnName": "remote_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteBookId",
+            "columnName": "remote_book_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadHref",
+            "columnName": "download_href",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadState",
+            "columnName": "download_state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloaded_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finished_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archived_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remotePageCount",
+            "columnName": "remote_page_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "size_bytes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fileSeriesName",
+            "columnName": "file_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileSeriesIndex",
+            "columnName": "file_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesChecked",
+            "columnName": "series_checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSeriesName",
+            "columnName": "catalog_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesIndex",
+            "columnName": "catalog_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "catalogFolderId",
+            "columnName": "catalog_folder_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesSource",
+            "columnName": "catalog_series_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesName",
+            "columnName": "user_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesIndex",
+            "columnName": "user_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesOverridden",
+            "columnName": "series_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userSeriesUpdatedAt",
+            "columnName": "user_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesClaimPending",
+            "columnName": "series_claim_pending",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesClaimReset",
+            "columnName": "series_claim_reset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personalSeriesUpdatedAt",
+            "columnName": "personal_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "indexOverridden",
+            "columnName": "series_index_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_books_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_books_url` ON `${TABLE_NAME}` (`url`)"
+          },
+          {
+            "name": "index_books_series_name",
+            "unique": false,
+            "columnNames": [
+              "series_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_series_name` ON `${TABLE_NAME}` (`series_name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "library_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `added_at` INTEGER NOT NULL, PRIMARY KEY(`url`))",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "url"
+          ]
+        }
+      },
+      {
+        "tableName": "remote_server",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `kind` TEXT NOT NULL, `base_url` TEXT NOT NULL, `username` TEXT, `password_cipher` TEXT, `api_key_cipher` TEXT, `account_id` TEXT, `user_id` INTEGER, `kobo_token` TEXT, `can_download` INTEGER NOT NULL, `can_manage_library` INTEGER NOT NULL, `can_upload` INTEGER NOT NULL, `can_delete` INTEGER NOT NULL, `can_admin` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `catalog_synced_at` INTEGER, `position_synced_at` INTEGER, `sync_token` TEXT, `liseur_token_cipher` TEXT, `liseur_account_id` TEXT, `sync_cursor_seq` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "passwordCipher",
+            "columnName": "password_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiKeyCipher",
+            "columnName": "api_key_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "koboTokenCipher",
+            "columnName": "kobo_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "canDownload",
+            "columnName": "can_download",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canManageLibrary",
+            "columnName": "can_manage_library",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canUpload",
+            "columnName": "can_upload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canDelete",
+            "columnName": "can_delete",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canAdmin",
+            "columnName": "can_admin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSyncedAt",
+            "columnName": "catalog_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "positionSyncedAt",
+            "columnName": "position_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncToken",
+            "columnName": "sync_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurTokenCipher",
+            "columnName": "liseur_token_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurAccountId",
+            "columnName": "liseur_account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncCursorSeq",
+            "columnName": "sync_cursor_seq",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `book_id` TEXT NOT NULL, `kind` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `text` TEXT, `note` TEXT, `tint` TEXT, `chapter` TEXT, `position` INTEGER, `total_progression` REAL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tint",
+            "columnName": "tint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapter",
+            "columnName": "chapter",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_typography",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `font` TEXT NOT NULL, `font_size` REAL NOT NULL, `line_height` REAL, `page_margins` REAL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "font",
+            "columnName": "font",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "font_size",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineHeight",
+            "columnName": "line_height",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pageMargins",
+            "columnName": "page_margins",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_screen",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `keep_screen_on` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keepScreenOn",
+            "columnName": "keep_screen_on",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_reading_mode",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `scroll` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scroll",
+            "columnName": "scroll",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `book_url` TEXT NOT NULL, `started_at` INTEGER NOT NULL, `ended_at` INTEGER, `last_checkpoint_at` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `start_progression` REAL, `end_progression` REAL, `uploaded_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "ended_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastCheckpointAt",
+            "columnName": "last_checkpoint_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startProgression",
+            "columnName": "start_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "endProgression",
+            "columnName": "end_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "uploadedAt",
+            "columnName": "uploaded_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_sessions_book_url",
+            "unique": false,
+            "columnNames": [
+              "book_url"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_book_url` ON `${TABLE_NAME}` (`book_url`)"
+          },
+          {
+            "name": "index_reading_sessions_started_at",
+            "unique": false,
+            "columnNames": [
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_started_at` ON `${TABLE_NAME}` (`started_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_peer_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `pending_progression` REAL, `pending_status` TEXT, `pending_updated_at` INTEGER, `has_pending` INTEGER NOT NULL DEFAULT 0, `remote_updated_at` INTEGER, `synced_at` INTEGER, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasPending",
+            "columnName": "has_pending",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_peer_state_peer_id",
+            "unique": false,
+            "columnNames": [
+              "peer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_peer_state_peer_id` ON `${TABLE_NAME}` (`peer_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_fingerprint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `sha256` TEXT NOT NULL, `partial_md5` TEXT NOT NULL, `file_size` INTEGER NOT NULL, `file_modified_at` INTEGER, `computed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256",
+            "columnName": "sha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partialMd5",
+            "columnName": "partial_md5",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "computedAt",
+            "columnName": "computed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "work_alias",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_id` TEXT NOT NULL, `confidence` TEXT NOT NULL, `confirmed` INTEGER NOT NULL, `seeded` INTEGER NOT NULL DEFAULT 0, `source_sent` INTEGER NOT NULL DEFAULT 0, `edition_sha` TEXT, `resolved_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confirmed",
+            "columnName": "confirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seeded",
+            "columnName": "seeded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceSent",
+            "columnName": "source_sent",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "editionSha",
+            "columnName": "edition_sha",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resolvedAt",
+            "columnName": "resolved_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "work_ambiguity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_ids` TEXT NOT NULL, `noticed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workIds",
+            "columnName": "work_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noticedAt",
+            "columnName": "noticed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_extra",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`series_id` TEXT NOT NULL, `summary` TEXT, `status` TEXT, `total_book_count` INTEGER, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`series_id`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalBookCount",
+            "columnName": "total_book_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "series_id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '77de6429a3b8e3030a55f53f58e696f7')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -8,6 +8,7 @@ import com.chmouel.liseur.data.ConnectionsState
 import com.chmouel.liseur.data.calibre.CalibreCatalogClient
 import com.chmouel.liseur.data.calibre.CalibreFileSource
 import com.chmouel.liseur.data.calibre.KoboSyncRepository
+import com.chmouel.liseur.data.calibre.BulkDownloadStore
 import com.chmouel.liseur.data.komga.KomgaCatalogClient
 import com.chmouel.liseur.data.komga.KomgaFileSource
 import com.chmouel.liseur.data.komga.KomgaSyncRepository
@@ -127,6 +128,9 @@ class AppContainer(context: Context) {
 
     val sessionState = SessionStateRepository(context.applicationContext)
 
+    /** The one bulk download that is running, or was last. */
+    val bulkDownloads = BulkDownloadStore(context.applicationContext)
+
     val remoteAccount = RemoteAccountRepository(
         dao = database.remoteServerDao(),
         bookDao = database.bookDao(),
@@ -151,6 +155,8 @@ class AppContainer(context: Context) {
         context = context.applicationContext,
         bookDao = database.bookDao(),
         bookRemoval = bookRemoval,
+        scope = applicationScope,
+        bulkStore = bulkDownloads,
     )
 
     val bookUploads = BookUploadRepository(context.applicationContext)

--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -455,6 +455,11 @@ private fun ServerAccountRoute(
         onDisconnect = viewModel::disconnect,
         onSyncNow = viewModel::syncPositions,
         onAnswerConfirmation = viewModel::answerConfirmation,
+        onAskDownloadAll = viewModel::askToDownloadAll,
+        onDismissDownloadAll = viewModel::dismissDownloadAll,
+        onDownloadAll = viewModel::downloadAll,
+        onCancelDownloadAll = viewModel::cancelDownloadAll,
+        onDismissBatch = viewModel::dismissBatch,
         onBack = onBack,
     )
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/calibre/BookDownloadRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/calibre/BookDownloadRepository.kt
@@ -2,6 +2,7 @@ package com.chmouel.liseur.data.calibre
 
 import android.content.Context
 import android.net.Uri
+import android.os.StatFs
 import android.provider.DocumentsContract
 import android.util.Log
 import androidx.core.net.toUri
@@ -13,6 +14,7 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
+import androidx.work.await
 import com.chmouel.liseur.data.db.Book
 import com.chmouel.liseur.data.db.BookDao
 import com.chmouel.liseur.data.db.DownloadState
@@ -21,11 +23,19 @@ import com.chmouel.liseur.data.remote.BookDeleter
 import com.chmouel.liseur.data.db.RemoteServer
 import com.chmouel.liseur.data.remote.ServerDeleteResult
 import java.io.File
+import java.util.UUID
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 
 /**
  * How far along a book's download is, as a fraction, or null if unknown.
@@ -46,10 +56,13 @@ data class DownloadProgress(
 data class StorageUse(val count: Int, val bytes: Long)
 
 /** Starts, watches and undoes book downloads. */
+@OptIn(ExperimentalCoroutinesApi::class)
 class BookDownloadRepository(
     private val context: Context,
     private val bookDao: BookDao,
     private val bookRemoval: BookRemoval,
+    private val scope: CoroutineScope,
+    private val bulkStore: BulkDownloadStore = BulkDownloadStore(context),
 ) {
     private val workManager get() = WorkManager.getInstance(context)
 
@@ -88,17 +101,205 @@ class BookDownloadRepository(
         workManager.enqueueUniqueWork(
             workName(book.url),
             ExistingWorkPolicy.KEEP,
-            OneTimeWorkRequestBuilder<BookDownloadWorker>()
-                .setInputData(Data.Builder().putString(KEY_BOOK_URL, book.url).build())
-                .addTag(TAG)
-                .addTag(BOOK_TAG_PREFIX + book.url)
-                .setConstraints(
-                    Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build(),
-                )
-                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
-                .build(),
+            request(book.url, accountKey = null, batchId = null),
         )
     }
+
+    /**
+     * Reads what a "download everything" run would cost, without
+     * starting one.
+     *
+     * Free space is measured on the volume the books are actually
+     * written to rather than on whatever `getExternalStorageDirectory`
+     * happens to be: internal storage and a removable card fill up
+     * independently, and only one of them is the one that matters here.
+     */
+    suspend fun bulkEstimate(): BulkDownloadEstimate = withContext(Dispatchers.IO) {
+        val candidates = booksToDownload(bookDao.allRemote())
+        estimateBulkDownload(candidates.map { it.sizeBytes }, freeBytes())
+    }
+
+    /**
+     * Fetches every catalogued book that is not already here.
+     *
+     * A batch is a set of ordinary [BookDownloadWorker]s, not one worker
+     * looping: that keeps per-book retry, resume across process death,
+     * and the `download:$bookUrl` uniqueness that stops a tap on a cover
+     * racing the run. What is added is the enumeration and a batch tag
+     * to gather them under.
+     *
+     * Runs to the end once started, whoever asked for it. The enumeration
+     * of a large library is thousands of database writes, and the batch
+     * record is already open by then with a total that only the whole
+     * selection can satisfy: a caller that goes away halfway — a screen
+     * left, most likely — would leave a batch that can never reach its
+     * own denominator, and so can never settle or be started again.
+     *
+     * Returns how many were actually accepted, which is not always how
+     * many were selected — see [confirmMembership].
+     */
+    suspend fun enqueueAll(accountKey: String): Int = scope.async(Dispatchers.IO) {
+        val candidates = booksToDownload(bookDao.allRemote())
+        if (candidates.isEmpty()) return@async 0
+        val batchId = UUID.randomUUID().toString()
+        val batchTag = batchTag(batchId)
+        // The record is opened before the first request goes in.
+        // WorkManager starts a worker the moment its constraints are
+        // met, which here is at once, and a worker that finds no record
+        // for the batch it names cannot tell a batch that has not been
+        // opened yet from one that is already over — so it stands down,
+        // and the run loses every book that got off the mark quickly.
+        // The total is provisional until membership is confirmed below.
+        bulkStore.start(batchId, candidates.size)
+        candidates.chunked(ENQUEUE_CHUNK).forEach { chunk ->
+            val enqueued = chunk.map { book ->
+                bookDao.setDownloadState(book.url, DownloadState.QUEUED, null)
+                workManager.enqueueUniqueWork(
+                    workName(book.url),
+                    ExistingWorkPolicy.KEEP,
+                    request(book.url, accountKey = accountKey, batchId = batchId),
+                )
+            }
+            // Waited for, chunk by chunk. `enqueueUniqueWork` hands the
+            // write off to WorkManager's own executor and returns before
+            // it has landed, so the tag [confirmMembership] reads by can
+            // still be empty when it looks. An undercount would give the
+            // batch a denominator smaller than the run it is describing;
+            // a count of nothing would clear the record out from under
+            // every worker already running under it, and the whole run
+            // would quietly stand down.
+            enqueued.forEach { it.await() }
+            yield()
+        }
+        val accepted = confirmMembership(batchTag)
+        // Everything we asked for was refused, every one of them by a
+        // download already in flight. There is no batch here, only a
+        // wait, and opening one would leave the action disabled until
+        // work that was never ours finished.
+        if (accepted == 0) {
+            bulkStore.clear()
+            return@async 0
+        }
+        bulkStore.setTotal(batchId, accepted)
+        accepted
+    }.await()
+
+    /**
+     * How many of the requests just made are really in the batch.
+     *
+     * `enqueueUniqueWork` under `KEEP` throws our request away without
+     * complaint when the unique name is already taken — by a single
+     * download the reader started by tapping a cover, most likely.
+     * Counting the selection instead of the acceptance would give the
+     * batch a denominator it could never reach, and would let a bulk
+     * cancel reach for work that was never part of it.
+     */
+    private suspend fun confirmMembership(batchTag: String): Int =
+        workManager.getWorkInfosByTagFlow(batchTag).first().size
+
+    /**
+     * Stops the current batch and puts the database back.
+     *
+     * Handed to a worker of its own rather than done here: cancelling
+     * work is asynchronous, and resetting rows before the cancellation
+     * has landed races a worker that is at that moment writing
+     * `DOWNLOADING`, leaving exactly the stale row the reset existed to
+     * clear. The cleanup worker carries no batch tag, so it survives the
+     * cancellation it sends out and can wait for it.
+     */
+    suspend fun cancelAll(reason: BulkStopReason = BulkStopReason.CANCELLED) {
+        val batch = bulkStore.current()?.takeIf { !it.settled } ?: return
+        bulkStore.recordStopReason(batch.id, reason)
+        BulkDownloadCleanupWorker.enqueue(context, batch.id)
+    }
+
+    /** Forgets the last batch, once its summary has been read.
+     *
+     * Refuses a batch that has not settled yet. A batch that has been
+     * asked to stop is still being taken apart — work still to cancel,
+     * rows still to put back — and the record is what the cleanup worker
+     * finds its way by: clearing it there would strand every book it had
+     * not reached at `QUEUED`, where nothing would ever pick them up
+     * again.
+     */
+    suspend fun dismissBatch() {
+        if (bulkStore.current()?.settled != true) return
+        bulkStore.clear()
+    }
+
+    /**
+     * The batch as it stands: counts from the live work while it runs,
+     * from the stored record once it has settled and its work rows are
+     * on their way to being pruned.
+     *
+     * A batch that runs to the end without anything stopping it settles
+     * here, the moment the last of its work reaches a terminal state.
+     * Nothing else would: the cleanup worker only runs when a batch is
+     * cut short, and a summary left to be derived from work rows reads
+     * "0 of 32" once WorkManager has pruned them. A batch that *was* cut
+     * short is left alone, so that `settled` keeps meaning "and taken
+     * apart": the cleanup worker settles that one, last, after the rows
+     * are back.
+     */
+    val bulkBatch: Flow<BulkBatch?> = bulkStore.batch.flatMapLatest { batch ->
+        if (batch == null || batch.settled) return@flatMapLatest flowOf(batch)
+        workManager.getWorkInfosByTagFlow(batchTag(batch.id)).map { infos ->
+            val done = countDone(infos)
+            val failed = countFailed(infos)
+            if (batch.stopReason == null) {
+                if (infos.size >= batch.total && infos.all { it.state.isFinished }) {
+                    bulkStore.settle(batch.id, done = done, failed = failed)
+                }
+            } else {
+                // Asks again for the teardown of a batch that has been
+                // stopped but not yet taken apart. The cleanup worker is
+                // the only thing that can end one, and it can be lost:
+                // it fails terminally on a device too full to write, or
+                // its request never reaches WorkManager because the
+                // process died in the moment between. Nothing else would
+                // ask again, and the reader would be left looking at a
+                // batch that can neither finish nor be dismissed.
+                //
+                // Free to repeat: the request is unique per batch under
+                // `KEEP`, so it is ignored while one is still pending
+                // and revives one that has already given up.
+                BulkDownloadCleanupWorker.enqueue(context, batch.id)
+            }
+            batch.copy(done = done, failed = failed)
+        }
+    }
+
+    /** Free bytes on the volume [booksDir] lives on. */
+    fun freeBytes(): Long = runCatching {
+        val stat = StatFs(booksDir().path)
+        stat.availableBlocksLong * stat.blockSizeLong
+    }.getOrDefault(0L)
+
+    private fun request(bookUrl: String, accountKey: String?, batchId: String?) =
+        OneTimeWorkRequestBuilder<BookDownloadWorker>()
+            .setInputData(
+                Data.Builder()
+                    .putString(KEY_BOOK_URL, bookUrl)
+                    .apply {
+                        accountKey?.let { putString(KEY_ACCOUNT_KEY, it) }
+                        batchId?.let { putString(KEY_BATCH_ID, it) }
+                    }
+                    .build(),
+            )
+            .addTag(TAG)
+            .addTag(BOOK_TAG_PREFIX + bookUrl)
+            .apply { batchId?.let { addTag(batchTag(it)) } }
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    // Bulk work only. A single download the reader asked
+                    // for by name should still start on a full-ish
+                    // device; a hundred of them should not.
+                    .apply { if (batchId != null) setRequiresStorageNotLow(true) }
+                    .build(),
+            )
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+            .build()
 
     suspend fun cancel(book: Book) {
         workManager.cancelUniqueWork(workName(book.url))
@@ -189,8 +390,46 @@ class BookDownloadRepository(
         const val TAG = "book-download"
         const val KEY_BOOK_URL = "book_url"
         const val KEY_FRACTION = "fraction"
-        private const val BOOK_TAG_PREFIX = "book:"
+        const val KEY_ACCOUNT_KEY = "account_key"
+        const val KEY_BATCH_ID = "batch_id"
+        const val KEY_STOOD_DOWN = "stood_down"
+        const val BOOK_TAG_PREFIX = "book:"
+        private const val BATCH_TAG_PREFIX = "batch:"
+
+        /**
+         * How many requests to send before letting the thread breathe.
+         *
+         * `enqueueUniqueWork` is one binder round trip and one database
+         * write each, and a large calibre library is thousands of books.
+         */
+        private const val ENQUEUE_CHUNK = 50
 
         fun workName(bookUrl: String) = "download:$bookUrl"
+
+        fun batchTag(batchId: String) = BATCH_TAG_PREFIX + batchId
+
+        /**
+         * Books whose bytes arrived.
+         *
+         * A worker that stood down — its batch was over, or the account
+         * had changed under it — also reports success, because it is not
+         * a failure and must not be shown as one. It says as much in its
+         * output, and that is what is subtracted here.
+         */
+        fun countDone(infos: List<WorkInfo>): Int = infos.count {
+            it.state == WorkInfo.State.SUCCEEDED &&
+                !it.outputData.getBoolean(KEY_STOOD_DOWN, false)
+        }
+
+        /**
+         * Books that genuinely could not be fetched.
+         *
+         * Cancelled work is not counted: after a batch is stopped every
+         * member that had not started is `CANCELLED`, and reading that
+         * back as "couldn't be downloaded" would tell the reader their
+         * library had failed when all they did was tap Stop.
+         */
+        fun countFailed(infos: List<WorkInfo>): Int =
+            infos.count { it.state == WorkInfo.State.FAILED }
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/calibre/BookDownloadWorker.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/calibre/BookDownloadWorker.kt
@@ -22,6 +22,18 @@ class BookDownloadWorker(
         val container = applicationContext.container
         val bookUrl = inputData.getString(BookDownloadRepository.KEY_BOOK_URL)
             ?: return give_up("no book url")
+        val batchId = inputData.getString(BookDownloadRepository.KEY_BATCH_ID)
+
+        // A batch that has already hit a wall is being cancelled, and
+        // cancellation takes a moment to arrive. Anything starting in
+        // that window would run into the same wall, and would do it
+        // while the cleanup was counting up what to put back.
+        if (batchId != null) {
+            val batch = container.bulkDownloads.current()
+            if (batch?.id != batchId || batch.stopReason != null || batch.settled) {
+                return stopped(bookUrl, "batch $batchId is over")
+            }
+        }
 
         val bookDao = container.database.bookDao()
         val book = bookDao.getByUrl(bookUrl) ?: return give_up("unknown book $bookUrl")
@@ -31,6 +43,16 @@ class BookDownloadWorker(
         // turn is how a key typed in just now ends up being handed to
         // the server that was connected a moment ago.
         val server = container.remoteAccount.current() ?: return give_up("no server")
+        // Book URLs are not account-qualified, so work queued against one
+        // server and run after the reader switched to another would hand
+        // the new server a URL belonging to the old one. The catalog
+        // refresh guards itself the same way and for the same reason:
+        // see RemoteCatalogRepository.forAccount.
+        val queuedFor = inputData.getString(BookDownloadRepository.KEY_ACCOUNT_KEY)
+        if (queuedFor != null && queuedFor != server.accountKey) {
+            batchId?.let { stopBatch(it, BulkStopReason.ACCOUNT_CHANGED) }
+            return stopped(bookUrl, "queued for an account that is no longer connected")
+        }
         val credentials = server.credentials ?: return give_up("no credentials")
         val files = container.remoteRouter.filesFor(server.kind) ?: return give_up("no file source")
 
@@ -44,7 +66,13 @@ class BookDownloadWorker(
         setProgress(progressData(bookUrl, null))
 
         val downloads = container.bookDownloads
-        val outcome = BookDownloader().download(
+        val outcome = BookDownloader(
+            // Bulk work is the only thing that can fill a device on its
+            // own, so it is the only thing asked to leave room behind. A
+            // single download the reader asked for by name keeps the
+            // behaviour it has always had.
+            freeSpace = if (batchId != null) downloads::freeBytes else null,
+        ).download(
             request = request,
             target = downloads.fileFor(uuid),
         ) { downloaded, total ->
@@ -79,8 +107,55 @@ class BookDownloadWorker(
                     fail(bookUrl)
                 }
                 DownloadFailure.Gone -> fail(bookUrl)
+                // Retrying would only fill the device again, and every
+                // book queued behind this one would fill it in turn, so
+                // the whole batch stops. On its own, a single download
+                // simply fails and says why.
+                DownloadFailure.OutOfSpace -> {
+                    Log.w(TAG, "no room left for $bookUrl")
+                    batchId?.let { stopBatch(it, BulkStopReason.OUT_OF_SPACE) }
+                    fail(bookUrl)
+                }
             }
         }
+    }
+
+    /**
+     * Records why the batch is stopping, then hands the stopping itself
+     * to a worker that is not in the batch.
+     *
+     * The reason goes down first, on purpose: cancelling the tag cancels
+     * this worker too, and cancelled work has no output data worth
+     * reading. Once the reason is stored, losing this worker's own
+     * account of things costs nothing.
+     */
+    private suspend fun stopBatch(batchId: String, reason: BulkStopReason) {
+        val container = applicationContext.container
+        container.bulkDownloads.recordStopReason(batchId, reason)
+        BulkDownloadCleanupWorker.enqueue(applicationContext, batchId)
+    }
+
+    /**
+     * Steps aside without marking the book as having failed.
+     *
+     * Nothing was wrong with the book: the batch it belonged to ended,
+     * or it was queued for a server that is no longer connected. Leaving
+     * it `REMOTE` is what lets it be picked up again next time.
+     *
+     * Reported as a success carrying a flag rather than as a failure,
+     * because a failure is what the summary counts and shows the reader
+     * as "couldn't be downloaded". Standing down is neither: the flag is
+     * what keeps it out of both columns.
+     */
+    private suspend fun stopped(bookUrl: String, why: String): Result {
+        Log.i(TAG, "download of $bookUrl stood down: $why")
+        applicationContext.container.database.bookDao()
+            .setDownloadState(bookUrl, DownloadState.REMOTE, null)
+        return Result.success(
+            Data.Builder()
+                .putBoolean(BookDownloadRepository.KEY_STOOD_DOWN, true)
+                .build(),
+        )
     }
 
     private fun give_up(why: String): Result {

--- a/app/src/main/kotlin/com/chmouel/liseur/data/calibre/BookDownloader.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/calibre/BookDownloader.kt
@@ -17,6 +17,9 @@ sealed interface DownloadFailure {
     /** The book is no longer downloadable from the catalog. */
     data object Gone : DownloadFailure
 
+    /** There is no room left on the device for the rest of the file. */
+    data object OutOfSpace : DownloadFailure
+
     data class Network(val message: String) : DownloadFailure
 }
 
@@ -35,7 +38,21 @@ sealed interface DownloadOutcome {
  * so a book edited on the server is fetched again rather than stitched
  * together from two different versions.
  */
-class BookDownloader(private val http: RemoteHttp = RemoteHttp()) {
+class BookDownloader(
+    private val http: RemoteHttp = RemoteHttp(),
+    /**
+     * How many bytes are still free where the file is being written, or
+     * null to write without looking.
+     *
+     * Checked as the bytes go down rather than once before they start,
+     * because several downloads can run at once and a check made before
+     * writing is exactly the check they all pass together. Nothing needs
+     * to be coordinated between them: this is not a prediction but a
+     * reading, and every sibling's part-file has already been taken out
+     * of it by the time it is read.
+     */
+    private val freeSpace: (() -> Long)? = null,
+) {
 
     suspend fun download(
         request: Request.Builder,
@@ -96,6 +113,7 @@ class BookDownloader(private val http: RemoteHttp = RemoteHttp()) {
                         val buffer = ByteArray(BUFFER)
                         var written = alreadyHave
                         var sinceReport = 0L
+                        var sinceSpaceCheck = 0L
                         while (true) {
                             coroutineContext.ensureActive()
                             val read = input.read(buffer)
@@ -103,6 +121,15 @@ class BookDownloader(private val http: RemoteHttp = RemoteHttp()) {
                             output.write(buffer, 0, read)
                             written += read
                             sinceReport += read
+                            sinceSpaceCheck += read
+                            if (sinceSpaceCheck >= CHECK_SPACE_EVERY) {
+                                sinceSpaceCheck = 0
+                                if (outOfSpace()) {
+                                    return@withContext DownloadOutcome.Failed(
+                                        DownloadFailure.OutOfSpace,
+                                    )
+                                }
+                            }
                             if (sinceReport >= REPORT_EVERY) {
                                 onProgress(written, total)
                                 sinceReport = 0
@@ -123,12 +150,48 @@ class BookDownloader(private val http: RemoteHttp = RemoteHttp()) {
             etagFile.delete()
             DownloadOutcome.Done(target)
         } catch (e: IOException) {
-            DownloadOutcome.Failed(DownloadFailure.Network(e.message ?: "The download stopped"))
+            // A periodic check can be overtaken between two readings,
+            // and the filesystem gets the last word either way. Telling
+            // this apart from a dropped connection matters: one is worth
+            // retrying and the other is worth stopping for.
+            if (isOutOfSpace(e)) {
+                DownloadOutcome.Failed(DownloadFailure.OutOfSpace)
+            } else {
+                DownloadOutcome.Failed(DownloadFailure.Network(e.message ?: "The download stopped"))
+            }
         }
+    }
+
+    private fun outOfSpace(): Boolean {
+        val free = freeSpace?.invoke() ?: return false
+        return free < BULK_DOWNLOAD_RESERVE_BYTES
     }
 
     private companion object {
         const val BUFFER = 64 * 1024
         const val REPORT_EVERY = 256 * 1024
+        const val CHECK_SPACE_EVERY = 4L * 1024 * 1024
     }
+}
+
+/**
+ * Whether the filesystem, rather than the network, is what stopped a
+ * write.
+ *
+ * There is no typed exception for it: `ENOSPC` surfaces as a plain
+ * [IOException] whose message the C library wrote, so the message is all
+ * there is to go on. Matched loosely and case-insensitively, and read as
+ * a hint — a miss falls back to treating it as a network failure, which
+ * is retried, and a device that is genuinely full will simply say so
+ * again.
+ */
+internal fun isOutOfSpace(e: IOException): Boolean {
+    val message = generateSequence(e as Throwable) { it.cause }
+        .mapNotNull { it.message }
+        .joinToString(" ")
+        .lowercase()
+    return "enospc" in message ||
+        "no space left" in message ||
+        "not enough space" in message ||
+        "disk full" in message
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/calibre/BulkDownload.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/calibre/BulkDownload.kt
@@ -1,0 +1,164 @@
+package com.chmouel.liseur.data.calibre
+
+import com.chmouel.liseur.data.db.Book
+import com.chmouel.liseur.data.db.DownloadState
+
+/** Why a bulk download stopped before it had fetched everything. */
+enum class BulkStopReason(val id: String) {
+    /** The reader asked for it to stop. */
+    CANCELLED("cancelled"),
+
+    /** The device ran out of room, or would have. */
+    OUT_OF_SPACE("out_of_space"),
+
+    /** The account was disconnected or swapped out from under the batch. */
+    ACCOUNT_CHANGED("account_changed"),
+    ;
+
+    companion object {
+        fun fromId(id: String?): BulkStopReason? = entries.firstOrNull { it.id == id }
+    }
+}
+
+/**
+ * What a bulk download run is, as far as anything outside WorkManager
+ * needs to know.
+ *
+ * [total] is what was actually accepted by WorkManager, not what was
+ * selected: `KEEP` silently discards a request whose unique name a tap
+ * on a cover already claimed, and counting those would leave a batch
+ * that could never reach its own denominator.
+ *
+ * [done] and [failed] are derived from the tagged work while the batch
+ * is live and read from here once [settled] — WorkManager prunes
+ * finished work, and a summary that vanishes with it is no summary.
+ */
+data class BulkBatch(
+    val id: String,
+    val total: Int,
+    val settled: Boolean = false,
+    val done: Int = 0,
+    val failed: Int = 0,
+    val stopReason: BulkStopReason? = null,
+)
+
+/** Whether a bulk download looks like it will fit. */
+enum class SpaceVerdict {
+    /** Comfortably, with the reserve and then some left over. */
+    FITS,
+
+    /** It should fit, but leaves little behind. Worth saying so. */
+    TIGHT,
+
+    /** Not without filling the device. */
+    WILL_NOT_FIT,
+
+    /** No book reported a size, so there is nothing honest to say. */
+    UNKNOWN,
+}
+
+/**
+ * What "download everything" would cost, as far as anyone can tell
+ * before starting.
+ *
+ * [bytes] is null exactly when [verdict] is [SpaceVerdict.UNKNOWN]. It
+ * is an estimate built from what servers claim, so it is presented as
+ * approximate and never treated as a promise.
+ */
+data class BulkDownloadEstimate(
+    val count: Int,
+    val bytes: Long?,
+    val freeBytes: Long,
+    val verdict: SpaceVerdict,
+)
+
+/**
+ * How much room a bulk download is required to leave behind.
+ *
+ * `setRequiresStorageNotLow` already keeps WorkManager from starting on
+ * a device Android considers low, but that is Android's threshold and
+ * it will not stop a run in progress. This one is the reader's, and the
+ * same number is used by the estimate below and by the workers as they
+ * write, so the preflight and the run cannot disagree.
+ */
+const val BULK_DOWNLOAD_RESERVE_BYTES: Long = 256L * 1024 * 1024
+
+/**
+ * The largest single book size worth believing, at 4 GiB.
+ *
+ * Sizes come off a catalog feed, which is input from outside the app.
+ * A mis-parsed or hostile figure that sails through would either scare
+ * the reader off a download that would have fitted, or poison the
+ * median for every book that reported nothing.
+ */
+private const val MAX_PLAUSIBLE_BOOK_BYTES: Long = 4L * 1024 * 1024 * 1024
+
+/**
+ * The books a "download all" run should fetch.
+ *
+ * Four things have to hold, and the last two are the interesting ones.
+ * A book with no `remoteUuid` has nowhere on disk to land, and one with
+ * no `downloadHref` cannot be fetched at all — liseur-sync sets it null
+ * for books its watched folders no longer hold. Enqueueing either
+ * schedules work that is certain to fail, so they are excluded here
+ * rather than discovered one failure at a time.
+ */
+fun booksToDownload(books: List<Book>): List<Book> = books.filter { book ->
+    (book.downloadState == DownloadState.REMOTE || book.downloadState == DownloadState.FAILED) &&
+        !book.archived &&
+        book.remoteUuid != null &&
+        !book.downloadHref.isNullOrBlank()
+}
+
+/**
+ * Prices a bulk download against the room actually left on the volume
+ * the books are written to.
+ *
+ * Books whose size the server did not report — or reported
+ * implausibly — are charged the median of the ones it did, which is
+ * steadier than the mean when one outsized volume sits in a shelf of
+ * novels. If nothing reported a size at all there is no median to
+ * borrow, and the answer is [SpaceVerdict.UNKNOWN] rather than a number
+ * with nothing behind it.
+ */
+fun estimateBulkDownload(sizes: List<Long?>, freeBytes: Long): BulkDownloadEstimate {
+    val known = sizes.filter { it != null && it in 1..MAX_PLAUSIBLE_BOOK_BYTES }
+        .map { it as Long }
+        .sorted()
+    if (known.isEmpty()) {
+        return BulkDownloadEstimate(
+            count = sizes.size,
+            bytes = null,
+            freeBytes = freeBytes,
+            verdict = SpaceVerdict.UNKNOWN,
+        )
+    }
+    val median = known[known.size / 2]
+    // Saturating rather than wrapping: a total that overflowed into a
+    // negative would read as "plenty of room" at exactly the moment
+    // there is none.
+    var total = 0L
+    sizes.forEach { size ->
+        val charge = size?.takeIf { it in 1..MAX_PLAUSIBLE_BOOK_BYTES } ?: median
+        total = if (total > Long.MAX_VALUE - charge) Long.MAX_VALUE else total + charge
+    }
+    val required = if (total > Long.MAX_VALUE - BULK_DOWNLOAD_RESERVE_BYTES) {
+        Long.MAX_VALUE
+    } else {
+        total + BULK_DOWNLOAD_RESERVE_BYTES
+    }
+    val verdict = when {
+        required > freeBytes -> SpaceVerdict.WILL_NOT_FIT
+        // It fits, but not by much. Worth a different word, because a
+        // batch that lands with 300 MB to spare is one photo album away
+        // from the reader wondering where their storage went.
+        required + BULK_DOWNLOAD_RESERVE_BYTES > freeBytes -> SpaceVerdict.TIGHT
+        else -> SpaceVerdict.FITS
+    }
+    return BulkDownloadEstimate(
+        count = sizes.size,
+        bytes = total,
+        freeBytes = freeBytes,
+        verdict = verdict,
+    )
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/calibre/BulkDownloadCleanupWorker.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/calibre/BulkDownloadCleanupWorker.kt
@@ -1,0 +1,137 @@
+package com.chmouel.liseur.data.calibre
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import androidx.work.await
+import com.chmouel.liseur.container
+import com.chmouel.liseur.data.db.DownloadState
+import kotlinx.coroutines.flow.first
+
+/**
+ * Ends a bulk download and puts the database back where it was.
+ *
+ * Deliberately not a member of the batch it stops. Cancelling work is
+ * asynchronous, and the worker that notices the trouble — a full disk,
+ * an account swapped out — is one of the ones being cancelled: it can be
+ * torn down between sending the cancellation and waiting for it, leaving
+ * every remaining book stuck at `QUEUED` or `DOWNLOADING` with nothing
+ * left running to clear them. Standing outside the batch is what makes
+ * the wait possible.
+ *
+ * The order is fixed and the first step is the one that matters:
+ *
+ *  1. read the membership off the tagged work, while the tag still
+ *     resolves — the stored batch record holds no book URLs, and after
+ *     process death the work items are the only account of who was in it;
+ *  2. cancel the tag, and wait for it;
+ *  3. reset the rows that never finished;
+ *  4. write the closing counts, which have to outlive WorkManager
+ *     pruning the rows they were counted from.
+ */
+class BulkDownloadCleanupWorker(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        val batchId = inputData.getString(KEY_BATCH_ID) ?: return Result.failure()
+        return runCatching { tearDown(batchId) }.getOrElse { failure ->
+            // Asked for again rather than given up on. This is now the
+            // only thing that can end a batch that was stopped, and a
+            // batch that never ends is one the reader cannot dismiss or
+            // replace. The likeliest failure is also the least
+            // surprising: a batch stopped for want of room tears down
+            // with hundreds of database writes, on a device that has
+            // just said it is full.
+            Log.w(TAG, "bulk download $batchId could not be ended yet", failure)
+            Result.retry()
+        }
+    }
+
+    private suspend fun tearDown(batchId: String): Result {
+        val container = applicationContext.container
+        val store = container.bulkDownloads
+        val batch = store.current()
+        if (batch == null || batch.id != batchId || batch.settled) return Result.success()
+
+        val workManager = WorkManager.getInstance(applicationContext)
+        val tag = BookDownloadRepository.batchTag(batchId)
+
+        val infos = workManager.getWorkInfosByTagFlow(tag).first()
+        val members = infos.mapNotNull { info ->
+            info.tags.firstOrNull { it.startsWith(BookDownloadRepository.BOOK_TAG_PREFIX) }
+                ?.removePrefix(BookDownloadRepository.BOOK_TAG_PREFIX)
+        }
+        workManager.cancelAllWorkByTag(tag).await()
+
+        // Counted only once the cancellation has landed. A book whose
+        // bytes arrived in the moment between the two would be missing
+        // from a tally taken before it, and the summary would credit the
+        // run with less than the library actually holds. Membership
+        // still comes from the earlier read, which is the one taken
+        // while the tag was whole.
+        val afterCancel = workManager.getWorkInfosByTagFlow(tag).first().ifEmpty { infos }
+        val done = BookDownloadRepository.countDone(afterCancel)
+        val failed = BookDownloadRepository.countFailed(afterCancel)
+
+        // Only the ones that never landed. A book whose bytes arrived
+        // before the cancellation did is downloaded, and saying
+        // otherwise would throw the file away by telling the library it
+        // is not there.
+        //
+        // Read a chunk at a time: `IN (:urls)` binds one SQL variable
+        // per book, and before API 31 SQLite refuses more than 999 of
+        // them. A batch is routinely larger than that, and the throw
+        // would land here, after the cancellation and before the rows
+        // were put back — the one window where the books have nothing
+        // left running to clear them.
+        val bookDao = container.database.bookDao()
+        members.chunked(RESET_CHUNK).forEach { chunk ->
+            bookDao.getByUrls(chunk)
+                .filter { it.downloadState != DownloadState.DOWNLOADED }
+                .forEach { bookDao.setDownloadState(it.url, DownloadState.REMOTE, null) }
+        }
+
+        // Last, and only once the rows are back: a settled batch is one
+        // that has been taken apart, and the rest of the app reads it
+        // that way — the summary is offered for dismissal on the
+        // strength of it.
+        store.settle(batchId, done = done, failed = failed)
+        Log.i(TAG, "bulk download $batchId ended: $done done, $failed failed")
+        return Result.success()
+    }
+
+    companion object {
+        private const val TAG = "LiseurBulkCleanup"
+        private const val KEY_BATCH_ID = "batch_id"
+
+        /**
+         * How many books to look up at once when putting rows back.
+         *
+         * Well under the 999 bound variables SQLite allows before API
+         * 31, with room to spare for however the query is composed.
+         */
+        private const val RESET_CHUNK = 500
+
+        /**
+         * Unique per batch, under `KEEP`: several workers can hit the
+         * same wall at the same moment, and one cleanup is the whole
+         * point of it being separate.
+         */
+        fun enqueue(context: Context, batchId: String) {
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                "bulk-download-cleanup:$batchId",
+                ExistingWorkPolicy.KEEP,
+                OneTimeWorkRequestBuilder<BulkDownloadCleanupWorker>()
+                    .setInputData(Data.Builder().putString(KEY_BATCH_ID, batchId).build())
+                    .build(),
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/calibre/BulkDownloadStore.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/calibre/BulkDownloadStore.kt
@@ -1,0 +1,120 @@
+package com.chmouel.liseur.data.calibre
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+private val Context.bulkDownloadStore: DataStore<Preferences> by preferencesDataStore(
+    name = "bulk_download",
+)
+
+/**
+ * Remembers the one bulk download that is current, or was last.
+ *
+ * This is a second source of truth about work WorkManager also knows
+ * about, and it earns its place by outliving it in both directions.
+ * WorkManager forgets a batch's rows once it prunes them, which would
+ * take the closing "N of M downloaded" with it; and a worker that stops
+ * a batch cancels itself in the act, so its own output data cannot be
+ * relied on to carry the reason why. Both survive here.
+ *
+ * Only what cannot be derived is kept. Which books are in the batch is
+ * not: the tagged work items carry their own book URL, and while the
+ * batch is live they are the authoritative membership.
+ */
+class BulkDownloadStore(private val context: Context) {
+
+    private object Keys {
+        val BATCH_ID = stringPreferencesKey("batch_id")
+        val TOTAL = intPreferencesKey("total")
+        val SETTLED = booleanPreferencesKey("settled")
+        val DONE = intPreferencesKey("done")
+        val FAILED = intPreferencesKey("failed")
+        val STOP_REASON = stringPreferencesKey("stop_reason")
+    }
+
+    val batch: Flow<BulkBatch?> = context.bulkDownloadStore.data.map { p ->
+        val id = p[Keys.BATCH_ID] ?: return@map null
+        BulkBatch(
+            id = id,
+            total = p[Keys.TOTAL] ?: 0,
+            settled = p[Keys.SETTLED] ?: false,
+            done = p[Keys.DONE] ?: 0,
+            failed = p[Keys.FAILED] ?: 0,
+            stopReason = BulkStopReason.fromId(p[Keys.STOP_REASON]),
+        )
+    }
+
+    suspend fun current(): BulkBatch? = batch.first()
+
+    /** Opens a batch, clearing whatever the last one left behind. */
+    suspend fun start(id: String, total: Int) {
+        context.bulkDownloadStore.edit { p ->
+            p[Keys.BATCH_ID] = id
+            p[Keys.TOTAL] = total
+            p[Keys.SETTLED] = false
+            p[Keys.DONE] = 0
+            p[Keys.FAILED] = 0
+            p.remove(Keys.STOP_REASON)
+        }
+    }
+
+    /**
+     * Corrects the total once membership is known.
+     *
+     * The batch is opened before its work is enqueued — a worker that
+     * starts before the record exists has no way to tell an unopened
+     * batch from a finished one, and stands down — so the total it is
+     * opened with is the selection, and this narrows it to what was
+     * actually accepted.
+     */
+    suspend fun setTotal(batchId: String, total: Int) {
+        context.bulkDownloadStore.edit { p ->
+            if (p[Keys.BATCH_ID] != batchId || p[Keys.SETTLED] == true) return@edit
+            p[Keys.TOTAL] = total
+        }
+    }
+
+    /**
+     * Records why a batch is stopping, before anything is cancelled.
+     *
+     * The order matters: the worker that notices trouble is about to be
+     * cancelled along with its siblings, so the reason has to be durable
+     * before the cancellation goes out. Written only for the batch that
+     * is still current, and only once — the first reason is the real
+     * one, and later workers noticing the same wall are echoes.
+     */
+    suspend fun recordStopReason(batchId: String, reason: BulkStopReason): Boolean {
+        var recorded = false
+        context.bulkDownloadStore.edit { p ->
+            if (p[Keys.BATCH_ID] != batchId || p[Keys.SETTLED] == true) return@edit
+            if (p[Keys.STOP_REASON] != null) return@edit
+            p[Keys.STOP_REASON] = reason.id
+            recorded = true
+        }
+        return recorded
+    }
+
+    /** Closes a batch, keeping the counts that outlive its work rows. */
+    suspend fun settle(batchId: String, done: Int, failed: Int) {
+        context.bulkDownloadStore.edit { p ->
+            if (p[Keys.BATCH_ID] != batchId) return@edit
+            p[Keys.SETTLED] = true
+            p[Keys.DONE] = done
+            p[Keys.FAILED] = failed
+        }
+    }
+
+    /** Forgets the last batch, once the reader has seen how it went. */
+    suspend fun clear() {
+        context.bulkDownloadStore.edit { it.clear() }
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/Book.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/Book.kt
@@ -80,6 +80,16 @@ data class Book(
      */
     @ColumnInfo(name = "remote_page_count") val remotePageCount: Int? = null,
     /**
+     * How big the server says the file is, in bytes. Kept so that
+     * "download everything" can say what that will cost before it
+     * starts, rather than finding out a book at a time.
+     *
+     * Null when the server does not say, and for every local book: the
+     * figure is the catalog's claim, not a measurement, and is treated
+     * as untrusted input wherever it is added up.
+     */
+    @ColumnInfo(name = "size_bytes") val sizeBytes: Long? = null,
+    /**
      * The series this book belongs to, spelled the way its source spells
      * it. Which books make up that series is worked out from this name
      * rather than from [seriesId], so a book downloaded from a server
@@ -585,6 +595,7 @@ interface BookDao {
             remote_book_id = :remoteBookId, cover_url = :coverUrl,
             download_href = :downloadHref, remote_updated_at = :remoteUpdatedAt,
             remote_page_count = :remotePageCount,
+            size_bytes = COALESCE(:sizeBytes, size_bytes),
             catalog_series_name = :catalogSeriesName,
             catalog_series_index = :catalogSeriesIndex,
             catalog_folder_id = :catalogFolderId,
@@ -700,6 +711,7 @@ interface BookDao {
         expectedUserSeriesUpdatedAt: Long?,
         seriesId: String?,
         personalSeriesUpdatedAt: Long? = null,
+        sizeBytes: Long? = null,
     )
 
     @Query("DELETE FROM books WHERE url IN (:urls)")

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
@@ -24,7 +24,7 @@ import androidx.sqlite.execSQL
         WorkAmbiguity::class,
         SeriesExtra::class,
     ],
-    version = 36,
+    version = 37,
     exportSchema = true,
 )
 abstract class LiseurDatabase : RoomDatabase() {
@@ -995,6 +995,18 @@ abstract class LiseurDatabase : RoomDatabase() {
         }
 
         /**
+         * Records how big the server says each book's file is, so that a
+         * bulk download can price itself before it starts. Null for
+         * every existing row; the next catalog refresh fills in what the
+         * server is willing to say.
+         */
+        val MIGRATION_36_37 = object : Migration(36, 37) {
+            override fun migrate(connection: SQLiteConnection) {
+                connection.execSQL("ALTER TABLE `books` ADD COLUMN `size_bytes` INTEGER")
+            }
+        }
+
+        /**
          * Every migration, in order, as one list so that what the app
          * runs and what the tests replay cannot drift apart.
          */
@@ -1034,6 +1046,7 @@ abstract class LiseurDatabase : RoomDatabase() {
             MIGRATION_33_34,
             MIGRATION_34_35,
             MIGRATION_35_36,
+            MIGRATION_36_37,
         )
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepository.kt
@@ -358,6 +358,7 @@ class RemoteCatalogRepository(
                 expectedUserSeriesUpdatedAt = update.snapshotUserSeriesUpdatedAt,
                 seriesId = book.seriesId,
                 personalSeriesUpdatedAt = book.personalSeriesUpdatedAt,
+                sizeBytes = book.sizeBytes,
             )
         }
         if (inserts.isNotEmpty()) bookDao.upsertAll(inserts.values.toList())
@@ -570,6 +571,11 @@ internal fun mergeCatalogEntry(
         downloadHref = remote.downloadHref,
         remoteUpdatedAt = remote.updatedAt,
         remotePageCount = remote.pageCount,
+        // A catalog page that leaves the size out should not erase a
+        // figure an earlier one gave: only calibre-web's paged feed
+        // carries it consistently, and losing it silently would make
+        // the bulk-download estimate worse over time, not better.
+        sizeBytes = remote.sizeBytes ?: book.sizeBytes,
         seriesName = filed.name,
         seriesIndex = filed.index,
         // A shelf id is what the reorder route speaks through, so losing one

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountScreen.kt
@@ -35,12 +35,17 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import com.chmouel.liseur.data.calibre.BulkBatch
+import com.chmouel.liseur.data.calibre.BulkDownloadEstimate
+import com.chmouel.liseur.data.calibre.BulkStopReason
+import com.chmouel.liseur.data.calibre.SpaceVerdict
 import com.chmouel.liseur.ui.BusyIndicator
 import com.chmouel.liseur.ui.LocalEInk
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -106,6 +111,11 @@ fun ServerAccountScreen(
     onDisconnect: () -> Unit,
     onSyncNow: () -> Unit,
     onAnswerConfirmation: (String, Boolean) -> Unit,
+    onAskDownloadAll: () -> Unit,
+    onDismissDownloadAll: () -> Unit,
+    onDownloadAll: () -> Unit,
+    onCancelDownloadAll: () -> Unit,
+    onDismissBatch: () -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -175,6 +185,11 @@ fun ServerAccountScreen(
                         onDisconnect = onDisconnect,
                         uploadPolicy = state.uploadPolicy,
                         onSetUploadPolicy = onSetUploadPolicy,
+                        batch = state.bulkBatch,
+                        estimating = state.estimating,
+                        onAskDownloadAll = onAskDownloadAll,
+                        onCancelDownloadAll = onCancelDownloadAll,
+                        onDismissBatch = onDismissBatch,
                     )
                     if (server.kind == ServerKind.LISEUR_SYNC) {
                         if (state.confirmations.isNotEmpty()) {
@@ -206,6 +221,159 @@ fun ServerAccountScreen(
                 )
             }
         }
+    }
+
+    state.bulkEstimate?.let { estimate ->
+        DownloadAllDialog(
+            estimate = estimate,
+            onConfirm = onDownloadAll,
+            onDismiss = onDismissDownloadAll,
+        )
+    }
+}
+
+/**
+ * Says what fetching everything will cost, before it starts.
+ *
+ * A batch that will not fit is still offered rather than refused: it
+ * will stop of its own accord once the device runs low, and the books it
+ * did fetch are worth having. What the reader needs is to know that in
+ * advance, not to be argued with.
+ */
+@Composable
+private fun DownloadAllDialog(
+    estimate: BulkDownloadEstimate,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val free = Formatter.formatShortFileSize(context, estimate.freeBytes)
+    val size = estimate.bytes?.let { Formatter.formatShortFileSize(context, it) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                if (estimate.count == 0) {
+                    stringResource(R.string.download_all)
+                } else {
+                    pluralStringResource(
+                        R.plurals.download_all_confirm,
+                        estimate.count,
+                        estimate.count,
+                    )
+                },
+            )
+        },
+        text = {
+            Text(
+                when {
+                    estimate.count == 0 -> stringResource(R.string.download_all_none)
+                    size == null -> stringResource(R.string.download_all_size_unknown, free)
+                    estimate.verdict == SpaceVerdict.WILL_NOT_FIT ->
+                        stringResource(R.string.download_all_will_not_fit, size, free)
+                    estimate.verdict == SpaceVerdict.TIGHT ->
+                        stringResource(R.string.download_all_tight, size, free)
+                    else -> stringResource(R.string.download_all_size, size, free)
+                },
+            )
+        },
+        confirmButton = {
+            if (estimate.count > 0) {
+                TextButton(onClick = onConfirm) {
+                    Text(stringResource(R.string.download_all_start))
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(
+                    stringResource(
+                        if (estimate.count == 0) R.string.close else R.string.cancel,
+                    ),
+                )
+            }
+        },
+    )
+}
+
+/**
+ * The bulk download, whichever half of its life it is in: a bar and a
+ * way to stop it while it runs, a summary and a way to dismiss that
+ * once it has ended.
+ *
+ * Partial success is the ordinary outcome here — a batch that stopped
+ * for room, or that the reader stopped, still leaves books behind that
+ * are worth having — so it is reported as a count rather than as a
+ * failure.
+ *
+ * A batch that has been asked to stop is not over yet: there is work
+ * still to cancel and rows still to put back, and dismissing it in that
+ * moment would take away the record the teardown navigates by. It says
+ * why it is stopping and offers nothing until it has.
+ */
+@Composable
+private fun BulkDownloadStatus(
+    batch: BulkBatch,
+    onCancel: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val finished = batch.done + batch.failed
+    val stopping = batch.stopReason != null && !batch.settled
+    if (batch.settled || batch.stopReason != null || finished >= batch.total) {
+        Text(
+            text = if (stopping) {
+                stringResource(R.string.download_all_stopping)
+            } else {
+                stringResource(R.string.download_all_done, batch.done, batch.total)
+            },
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        batch.stopReason?.let { reason ->
+            Notice(
+                text = stringResource(
+                    when (reason) {
+                        BulkStopReason.CANCELLED -> R.string.download_all_stopped_cancelled
+                        BulkStopReason.OUT_OF_SPACE -> R.string.download_all_stopped_space
+                        BulkStopReason.ACCOUNT_CHANGED -> R.string.download_all_stopped_account
+                    },
+                ),
+                tone = if (reason == BulkStopReason.CANCELLED) {
+                    NoticeTone.NEUTRAL
+                } else {
+                    NoticeTone.PROBLEM
+                },
+            )
+        }
+        if (stopping) return
+        if (batch.failed > 0) {
+            Text(
+                text = pluralStringResource(
+                    R.plurals.download_all_failed,
+                    batch.failed,
+                    batch.failed,
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        TextButton(onClick = onDismiss) {
+            Text(stringResource(R.string.dismiss))
+        }
+        return
+    }
+
+    Text(
+        text = stringResource(R.string.download_all_progress, finished, batch.total),
+        style = MaterialTheme.typography.bodyMedium,
+    )
+    if (!LocalEInk.current) {
+        LinearProgressIndicator(
+            progress = { if (batch.total == 0) 0f else finished.toFloat() / batch.total },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+    TextButton(onClick = onCancel) {
+        Text(stringResource(R.string.download_all_cancel))
     }
 }
 
@@ -427,6 +595,11 @@ private fun ConnectedCard(
     onSyncNow: () -> Unit,
     uploadPolicy: UploadPolicy,
     onSetUploadPolicy: (UploadPolicy) -> Unit,
+    batch: BulkBatch?,
+    estimating: Boolean,
+    onAskDownloadAll: () -> Unit,
+    onCancelDownloadAll: () -> Unit,
+    onDismissBatch: () -> Unit,
 ) {
     Card(
         colors = CardDefaults.cardColors(
@@ -477,6 +650,38 @@ private fun ConnectedCard(
         )
         TextButton(onClick = onRetryCapabilities, enabled = !busy) {
             Text(stringResource(R.string.server_check_again))
+        }
+    }
+
+    // Only where the account may actually fetch a file, and only one
+    // batch at a time: a second run started over the first would share
+    // its unique work names and end up counting somebody else's books.
+    if (server.canDownload) {
+        Text(
+            text = stringResource(R.string.download_all),
+            style = MaterialTheme.typography.titleSmall,
+        )
+        Text(
+            text = stringResource(R.string.download_all_summary),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (batch != null) {
+            BulkDownloadStatus(
+                batch = batch,
+                onCancel = onCancelDownloadAll,
+                onDismiss = onDismissBatch,
+            )
+        } else if (estimating) {
+            Text(
+                text = stringResource(R.string.download_all_working),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else {
+            TextButton(onClick = onAskDownloadAll, enabled = !busy) {
+                Text(stringResource(R.string.download_all))
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountViewModel.kt
@@ -1,5 +1,6 @@
 package com.chmouel.liseur.ui.settings
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
@@ -11,6 +12,9 @@ import com.chmouel.liseur.data.db.BookDao
 import com.chmouel.liseur.data.db.WorkIdentityDao
 import com.chmouel.liseur.data.remote.RemoteAccountRepository
 import com.chmouel.liseur.data.calibre.BookDownloadRepository
+import com.chmouel.liseur.data.calibre.BulkBatch
+import com.chmouel.liseur.data.calibre.BulkDownloadEstimate
+import com.chmouel.liseur.data.calibre.BulkStopReason
 import com.chmouel.liseur.data.remote.RemoteCatalogRepository
 import com.chmouel.liseur.data.remote.PositionSyncStatus
 import com.chmouel.liseur.data.remote.SetupFailure
@@ -95,12 +99,18 @@ data class ServerAccountUiState(
     val ambiguities: Int = 0,
     /** What to do with a book that arrives on this device. */
     val uploadPolicy: UploadPolicy = UploadPolicy.Default,
+    /** The bulk download that is running, or the last one's summary. */
+    val bulkBatch: BulkBatch? = null,
+    /** What a "download everything" would cost, once the reader asks. */
+    val bulkEstimate: BulkDownloadEstimate? = null,
+    /** True while the estimate is being worked out. */
+    val estimating: Boolean = false,
 )
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ServerAccountViewModel(
     private val repository: RemoteAccountRepository,
-    downloads: BookDownloadRepository,
+    private val downloads: BookDownloadRepository,
     private val reporting: SyncReporting,
     private val positionSync: PositionSyncCoordinator,
     private val catalog: RemoteCatalogRepository,
@@ -144,6 +154,11 @@ class ServerAccountViewModel(
         viewModelScope.launch {
             reporting.report.collect { report ->
                 _state.update { it.copy(syncReport = report) }
+            }
+        }
+        viewModelScope.launch {
+            downloads.bulkBatch.collect { batch ->
+                _state.update { it.copy(bulkBatch = batch) }
             }
         }
         viewModelScope.launch {
@@ -324,8 +339,51 @@ class ServerAccountViewModel(
         }
     }
 
+    /**
+     * Works out what fetching everything would cost, and shows it.
+     *
+     * Reading free space touches the filesystem, so it is asked for
+     * only when the reader reaches for the action rather than kept
+     * fresh in the background.
+     */
+    fun askToDownloadAll() {
+        if (_state.value.estimating) return
+        _state.update { it.copy(estimating = true) }
+        viewModelScope.launch {
+            // Cleared however it goes. The flag is also what keeps a
+            // second tap from starting a second estimate, so a throw
+            // that left it standing would take the action with it until
+            // the process was restarted.
+            val estimate = runCatching { downloads.bulkEstimate() }
+                .onFailure { Log.w(TAG, "could not work out what downloading everything would cost", it) }
+                .getOrNull()
+            _state.update { it.copy(estimating = false, bulkEstimate = estimate) }
+        }
+    }
+
+    fun dismissDownloadAll() = _state.update { it.copy(bulkEstimate = null) }
+
+    fun downloadAll() {
+        val accountKey = _state.value.server?.accountKey ?: return
+        _state.update { it.copy(bulkEstimate = null) }
+        viewModelScope.launch { downloads.enqueueAll(accountKey) }
+    }
+
+    fun cancelDownloadAll() {
+        viewModelScope.launch { downloads.cancelAll() }
+    }
+
+    /** Clears the summary of a batch that has ended. */
+    fun dismissBatch() {
+        viewModelScope.launch { downloads.dismissBatch() }
+    }
+
     fun disconnect() {
         viewModelScope.launch {
+            // Before the account goes: work queued against it would
+            // otherwise be handed to whatever is connected next, and the
+            // books it left mid-flight would sit queued forever.
+            downloads.cancelAll(BulkStopReason.ACCOUNT_CHANGED)
             repository.disconnect()
             _state.value = ServerAccountUiState()
         }
@@ -342,6 +400,8 @@ class ServerAccountViewModel(
     }
 
     companion object {
+        private const val TAG = "ServerAccountViewModel"
+
         val Factory: ViewModelProvider.Factory = viewModelFactory {
             initializer {
                 val container = checkNotNull(this[APPLICATION_KEY]).container

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -230,6 +230,31 @@
     <string name="cancel_download">Cancel download</string>
     <string name="remove_download">Remove download</string>
     <string name="server_credentials_lost">Sign in to your book server again.</string>
+
+    <string name="download_all">Download all books</string>
+    <string name="download_all_summary">Fetch every book in this library that isn\'t already on your device. Books you\'ve archived are left where they are.</string>
+    <string name="download_all_working">Working out how much room that needs…</string>
+    <string name="download_all_none">Every book is already on this device.</string>
+    <plurals name="download_all_confirm">
+        <item quantity="one">Download %1$d book?</item>
+        <item quantity="other">Download %1$d books?</item>
+    </plurals>
+    <string name="download_all_size">About %1$s, with %2$s free. It\'s an estimate from what the server reports, so treat it as rough.</string>
+    <string name="download_all_size_unknown">The server doesn\'t say how big its books are, so there\'s no telling how much room this needs. You have %1$s free.</string>
+    <string name="download_all_tight">About %1$s, with %2$s free. That fits, but not with much to spare.</string>
+    <string name="download_all_will_not_fit">About %1$s, and only %2$s free. Downloading will stop once the device runs low.</string>
+    <string name="download_all_start">Download</string>
+    <string name="download_all_progress">Downloading books: %1$d of %2$d</string>
+    <string name="download_all_cancel">Stop downloading</string>
+    <string name="download_all_done">Downloaded %1$d of %2$d books.</string>
+    <string name="download_all_stopping">Finishing up…</string>
+    <string name="download_all_stopped_cancelled">Stopped. The books already downloaded stay where they are.</string>
+    <string name="download_all_stopped_space">Stopped: the device ran out of room. Free some up and start again to pick up the rest.</string>
+    <string name="download_all_stopped_account">Stopped: the server account changed.</string>
+    <plurals name="download_all_failed">
+        <item quantity="one">%1$d book couldn\'t be downloaded.</item>
+        <item quantity="other">%1$d books couldn\'t be downloaded.</item>
+    </plurals>
     <plurals name="server_storage">
         <item quantity="one">%1$d book downloaded · %2$s</item>
         <item quantity="other">%1$d books downloaded · %2$s</item>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/calibre/BulkDownloadStoreTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/calibre/BulkDownloadStoreTest.kt
@@ -1,0 +1,151 @@
+package com.chmouel.liseur.data.calibre
+
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The record that says which bulk download is current.
+ *
+ * It exists because neither of the other two places the answer could
+ * live can be trusted for it: WorkManager prunes finished work, taking
+ * the closing counts with it, and a worker that stops a batch cancels
+ * itself in the act.
+ *
+ * The order the record is written in is load-bearing, and got it wrong
+ * once: it used to be opened *after* its work was enqueued, and every
+ * worker that got off the mark in that window found no record for the
+ * batch it named and stood down. Two thirds of a run were lost that way
+ * on a fast connection. The batch is now opened first, with the
+ * selection as a provisional total, and narrowed by [setTotal] once
+ * membership is known.
+ */
+@Config(sdk = [35], application = android.app.Application::class)
+@RunWith(RobolectricTestRunner::class)
+class BulkDownloadStoreTest {
+
+    private lateinit var store: BulkDownloadStore
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        store = BulkDownloadStore(context)
+    }
+
+    @Test
+    fun `a batch is readable the moment it is opened`() = runTest {
+        store.start("batch-1", total = 32)
+
+        val batch = store.current()
+        assertEquals("batch-1", batch?.id)
+        assertEquals(32, batch?.total)
+        assertFalse(batch!!.settled)
+        assertNull(batch.stopReason)
+    }
+
+    @Test
+    fun `the total narrows to what was accepted`() = runTest {
+        store.start("batch-1", total = 32)
+
+        store.setTotal("batch-1", 30)
+
+        assertEquals(30, store.current()?.total)
+    }
+
+    @Test
+    fun `a stale total does not reach the batch that replaced it`() = runTest {
+        store.start("batch-1", total = 32)
+        store.start("batch-2", total = 8)
+
+        store.setTotal("batch-1", 30)
+
+        assertEquals(8, store.current()?.total)
+    }
+
+    @Test
+    fun `a settled batch keeps the total it settled with`() = runTest {
+        store.start("batch-1", total = 32)
+        store.settle("batch-1", done = 20, failed = 12)
+
+        store.setTotal("batch-1", 30)
+
+        assertEquals(32, store.current()?.total)
+    }
+
+    @Test
+    fun `the first reason a batch stops is the one that is kept`() = runTest {
+        store.start("batch-1", total = 32)
+
+        assertTrue(store.recordStopReason("batch-1", BulkStopReason.OUT_OF_SPACE))
+        assertFalse(store.recordStopReason("batch-1", BulkStopReason.CANCELLED))
+
+        assertEquals(BulkStopReason.OUT_OF_SPACE, store.current()?.stopReason)
+    }
+
+    @Test
+    fun `a reason for a batch that is not current is ignored`() = runTest {
+        store.start("batch-1", total = 32)
+
+        assertFalse(store.recordStopReason("batch-0", BulkStopReason.CANCELLED))
+
+        assertNull(store.current()?.stopReason)
+    }
+
+    @Test
+    fun `counts outlive the work they were counted from`() = runTest {
+        store.start("batch-1", total = 32)
+        store.settle("batch-1", done = 20, failed = 12)
+
+        val batch = store.current()
+        assertTrue(batch!!.settled)
+        assertEquals(20, batch.done)
+        assertEquals(12, batch.failed)
+    }
+
+    @Test
+    fun `a new batch does not inherit the last one's counts`() = runTest {
+        store.start("batch-1", total = 32)
+        store.recordStopReason("batch-1", BulkStopReason.CANCELLED)
+        store.settle("batch-1", done = 20, failed = 12)
+
+        store.start("batch-2", total = 4)
+
+        val batch = store.current()
+        assertEquals("batch-2", batch?.id)
+        assertEquals(4, batch?.total)
+        assertEquals(0, batch?.done)
+        assertEquals(0, batch?.failed)
+        assertFalse(batch!!.settled)
+        assertNull(batch.stopReason)
+    }
+
+    @Test
+    fun `settling a batch that is no longer current changes nothing`() = runTest {
+        store.start("batch-1", total = 32)
+        store.start("batch-2", total = 4)
+
+        store.settle("batch-1", done = 20, failed = 12)
+
+        val batch = store.current()
+        assertFalse(batch!!.settled)
+        assertEquals(0, batch.done)
+    }
+
+    @Test
+    fun `a dismissed batch leaves nothing behind`() = runTest {
+        store.start("batch-1", total = 32)
+        store.settle("batch-1", done = 32, failed = 0)
+
+        store.clear()
+
+        assertNull(store.current())
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/calibre/BulkDownloadTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/calibre/BulkDownloadTest.kt
@@ -1,0 +1,187 @@
+package com.chmouel.liseur.data.calibre
+
+import com.chmouel.liseur.data.db.Book
+import com.chmouel.liseur.data.db.DownloadState
+import java.io.IOException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * What "download everything" will and will not reach for, and what it is
+ * willing to claim about the cost.
+ *
+ * Both halves are pure on purpose: the selection decides what gets
+ * queued against a server, and the estimate is the only thing standing
+ * between a tap and a full device.
+ */
+class BulkDownloadTest {
+
+    private fun book(
+        url: String,
+        state: DownloadState = DownloadState.REMOTE,
+        archivedAt: Long? = null,
+        remoteUuid: String? = "uuid-$url",
+        downloadHref: String? = "/download/$url",
+        sizeBytes: Long? = null,
+    ) = Book(
+        url = url,
+        title = url,
+        author = null,
+        coverPath = null,
+        source = null,
+        addedAt = 0L,
+        lastOpenedAt = null,
+        remoteUuid = remoteUuid,
+        downloadHref = downloadHref,
+        downloadState = state,
+        archivedAt = archivedAt,
+        sizeBytes = sizeBytes,
+    )
+
+    @Test
+    fun `takes books that are only on the server`() {
+        val picked = booksToDownload(listOf(book("a"), book("b")))
+        assertEquals(listOf("a", "b"), picked.map { it.url })
+    }
+
+    @Test
+    fun `retries a book whose download failed`() {
+        val picked = booksToDownload(listOf(book("a", state = DownloadState.FAILED)))
+        assertEquals(listOf("a"), picked.map { it.url })
+    }
+
+    @Test
+    fun `skips a book already on the device`() {
+        assertTrue(booksToDownload(listOf(book("a", state = DownloadState.DOWNLOADED))).isEmpty())
+    }
+
+    @Test
+    fun `skips a download already in flight`() {
+        // Both would collide with the unique work name that is already
+        // taken, and the collision is silent under KEEP.
+        val inFlight = listOf(
+            book("a", state = DownloadState.QUEUED),
+            book("b", state = DownloadState.DOWNLOADING),
+        )
+        assertTrue(booksToDownload(inFlight).isEmpty())
+    }
+
+    @Test
+    fun `skips an archived book`() {
+        // Taking it off the shelf is a statement about wanting it out of
+        // the way; fetching it back is the opposite of honouring that.
+        assertTrue(booksToDownload(listOf(book("a", archivedAt = 1L))).isEmpty())
+    }
+
+    @Test
+    fun `skips a book the server cannot serve`() {
+        // liseur-sync nulls the href for books its watched folders no
+        // longer hold. Queuing one schedules work that cannot succeed.
+        assertTrue(booksToDownload(listOf(book("a", downloadHref = null))).isEmpty())
+        assertTrue(booksToDownload(listOf(book("a", downloadHref = "  "))).isEmpty())
+    }
+
+    @Test
+    fun `skips a book with nowhere to land`() {
+        assertTrue(booksToDownload(listOf(book("a", remoteUuid = null))).isEmpty())
+    }
+
+    @Test
+    fun `adds up the sizes it was given`() {
+        val estimate = estimateBulkDownload(listOf(1_000L, 2_000L, 3_000L), freeBytes = GIB * 10)
+        assertEquals(6_000L, estimate.bytes)
+        assertEquals(SpaceVerdict.FITS, estimate.verdict)
+        assertEquals(3, estimate.count)
+    }
+
+    @Test
+    fun `charges the median for a book the server did not measure`() {
+        // Median rather than mean: one outsized volume in a shelf of
+        // novels should not decide what the unmeasured ones cost.
+        val estimate = estimateBulkDownload(
+            listOf(1_000L, 2_000L, 100_000_000L, null),
+            freeBytes = GIB * 10,
+        )
+        assertEquals(1_000L + 2_000L + 100_000_000L + 2_000L, estimate.bytes)
+    }
+
+    @Test
+    fun `says nothing rather than guessing when no book has a size`() {
+        val estimate = estimateBulkDownload(listOf(null, null), freeBytes = GIB)
+        assertNull(estimate.bytes)
+        assertEquals(SpaceVerdict.UNKNOWN, estimate.verdict)
+        assertEquals(2, estimate.count)
+    }
+
+    @Test
+    fun `discards a size the server could not have meant`() {
+        // Zero, negative and absurd all come off the wire. Believing any
+        // of them either scares the reader off a download that fits or
+        // poisons the median for every book that reported nothing.
+        val estimate = estimateBulkDownload(
+            listOf(4_000L, 0L, -1L, Long.MAX_VALUE),
+            freeBytes = GIB * 10,
+        )
+        assertEquals(4_000L * 4, estimate.bytes)
+    }
+
+    @Test
+    fun `does not overflow into looking like it fits`() {
+        val huge = List(64) { 4L * GIB }
+        val estimate = estimateBulkDownload(huge, freeBytes = GIB)
+        assertTrue((estimate.bytes ?: 0L) > 0L)
+        assertEquals(SpaceVerdict.WILL_NOT_FIT, estimate.verdict)
+    }
+
+    @Test
+    fun `refuses to promise a fit that would eat the reserve`() {
+        val estimate = estimateBulkDownload(
+            listOf(GIB),
+            freeBytes = GIB + BULK_DOWNLOAD_RESERVE_BYTES - 1,
+        )
+        assertEquals(SpaceVerdict.WILL_NOT_FIT, estimate.verdict)
+    }
+
+    @Test
+    fun `warns when it fits with little to spare`() {
+        val estimate = estimateBulkDownload(
+            listOf(GIB),
+            freeBytes = GIB + BULK_DOWNLOAD_RESERVE_BYTES + 1,
+        )
+        assertEquals(SpaceVerdict.TIGHT, estimate.verdict)
+    }
+
+    @Test
+    fun `is content when there is room to spare`() {
+        val estimate = estimateBulkDownload(listOf(GIB), freeBytes = GIB * 10)
+        assertEquals(SpaceVerdict.FITS, estimate.verdict)
+    }
+
+    @Test
+    fun `reads a full disk off the exception the filesystem threw`() {
+        // There is no typed exception for ENOSPC, and telling it from a
+        // dropped connection is what decides whether the batch retries
+        // or stops.
+        assertTrue(isOutOfSpace(IOException("write failed: ENOSPC (No space left on device)")))
+        assertTrue(isOutOfSpace(IOException("Not enough space")))
+        assertTrue(isOutOfSpace(IOException(null, IOException("ENOSPC"))))
+        assertFalse(isOutOfSpace(IOException("Connection reset by peer")))
+        assertFalse(isOutOfSpace(IOException(null as String?)))
+    }
+
+    @Test
+    fun `round-trips a stop reason through its stored id`() {
+        BulkStopReason.entries.forEach { reason ->
+            assertEquals(reason, BulkStopReason.fromId(reason.id))
+        }
+        assertNull(BulkStopReason.fromId(null))
+        assertNull(BulkStopReason.fromId("something else"))
+    }
+
+    private companion object {
+        const val GIB = 1024L * 1024 * 1024
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
@@ -114,6 +114,36 @@ class MigrationTest {
     }
 
     @Test
+    fun `a book from before sizes were kept arrives with none`() {
+        // The column has to land empty rather than at zero: zero is a
+        // size, and a shelf of them would price a bulk download at
+        // nothing at all.
+        helper.createDatabase(TEST_DB, 36).use { old ->
+            old.execSQL(
+                """
+                INSERT INTO books (
+                    url, title, author, cover_path, source, added_at, last_opened_at,
+                    download_state, series_checked, series_override, series_claim_pending,
+                    series_claim_reset, series_index_override
+                ) VALUES (
+                    'calibre:sized', 'Red Rising', 'Pierce Brown', NULL, NULL, 1, 2,
+                    'REMOTE', 0, 0, 0, 0, 0
+                )
+                """.trimIndent(),
+            )
+        }
+
+        helper.runMigrationsAndValidate(TEST_DB, LATEST, true, *LiseurDatabase.MIGRATIONS)
+            .use { db ->
+                db.query("SELECT size_bytes FROM books WHERE url = 'calibre:sized'")
+                    .use { cursor ->
+                        assertTrue(cursor.moveToFirst())
+                        assertTrue(cursor.isNull(0))
+                    }
+            }
+    }
+
+    @Test
     fun `a book survives every upgrade`() {
         helper.createDatabase(TEST_DB, 1).use { old ->
             old.execSQL(
@@ -690,6 +720,6 @@ class MigrationTest {
         const val TEST_DB = "migration-test.db"
 
         /** Kept in step with the `version` on [LiseurDatabase]. */
-        const val LATEST = 36
+        const val LATEST = 37
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/CatalogMergeTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/CatalogMergeTest.kt
@@ -215,4 +215,38 @@ class CatalogMergeTest {
         assertEquals("My Shelf", merged.seriesName)
         assertEquals(null, merged.seriesIndex)
     }
+
+    @Test
+    fun `carries the size the server reported`() {
+        // Nothing reads it until a bulk download is priced, and by then
+        // the catalog walk is long over: dropping it here is dropping it
+        // for good.
+        val merged = mergeCatalogEntry(
+            entry,
+            null,
+            url = "calibre:abc-123",
+            baseUrl = "https://books.example.com",
+            now = 9_999L,
+        )
+
+        assertEquals(1_000_000L, merged.sizeBytes)
+    }
+
+    @Test
+    fun `keeps a size a later page forgot to mention`() {
+        // Only calibre-web's feed carries a length on every entry. A
+        // refresh from a server that mentions it once should not make
+        // the estimate worse each time it runs.
+        val known = downloadedAndFinished.copy(sizeBytes = 1_000_000L)
+
+        val merged = mergeCatalogEntry(
+            entry.copy(sizeBytes = null),
+            known,
+            url = "calibre:abc-123",
+            baseUrl = "https://books.example.com",
+            now = 9_999L,
+        )
+
+        assertEquals(1_000_000L, merged.sizeBytes)
+    }
 }


### PR DESCRIPTION
## Summary

Getting a whole library onto a device meant tapping every cover in turn and waiting for each one — a poor way to spend the evening before a flight, and worse on a library of any size.

The server account screen gains a one-off **Download all books** action. It says up front how many books it would fetch, roughly what they weigh and what room is left, then fetches every catalogued book that is not already on the device. Books already here are skipped and archived books are left alone. It runs once and stops: no policy, no schedule, no keep-in-sync button.

Closes #35

## Changes

- **The action.** `Download all books` on the account screen, behind `canDownload`, with a confirmation that states the count, the estimated size and the free space, and warns when the two are close or the batch plainly will not fit. It is offered even then — a batch that stops partway still leaves books worth having — because what the reader needs is to know in advance, not to be argued with.
- **A batch is a set of ordinary per-book workers** gathered under a tag of its own, not one worker looping. Per-book retry, resume across process death and the existing one-download-per-book guarantee all still hold. The batch adds the enumeration, a total, a progress line, a way to stop, and a summary.
- **The total is confirmed membership, not the selection.** `enqueueUniqueWork(…, KEEP, …)` silently drops a request when a cover tap already holds the name, so membership is read back off the tag. A denominator the batch could never reach would leave it running forever.
- **The batch record is opened before its work is enqueued.** WorkManager starts a worker the moment its constraints are met, and a worker that finds no record for the batch it names cannot tell an unopened batch from a finished one. Found on device: two thirds of a run stood down and were lost.
- **Stopping.** The reason is written down before anything is cancelled, because cancelled work has no output left to ask. The cancelling is done by a worker that is *not* in the batch, so it survives the cancellation it sends and can wait for it. Only once every row is back does a batch count as settled — which is what the summary and its Dismiss button are offered on. A batch stopped but not yet taken apart asks for its own teardown again whenever it is observed, so a device too full to finish the job cannot leave one that neither ends nor can be dismissed.
- **Cancelled is not failed.** A book that stood down because its batch ended reports success carrying a flag, so it lands in neither column. Tapping Stop no longer tells the reader that 24 books "couldn't be downloaded".
- **Room is watched while the bytes arrive** rather than guessed at beforehand: a bulk download stops with the volume down to its last 256 MiB, and takes `ENOSPC` as a second opinion. Only bulk work is held back by low storage; a single download asked for by name behaves as it always has.
- **Catalogued sizes are kept now** (schema 37). All three servers already reported them; Liseur was dropping them for want of a column. That is where the estimate comes from.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

Exercised end to end on `emulator-5554` against a real liseur-sync server holding 32 EPUBs: a full run lands 32 of 32 files with no stray `.part`; a run stopped mid-flight reports honestly and returns every unfinished row to `REMOTE`; dismissing restores the action; a second run inherits nothing from the first; and with everything already here the action says so instead of starting an empty batch. A slow relay in front of the server made the progress and cancel states long enough to catch.

New unit tests cover the selection rules and the storage estimate (`BulkDownloadTest`) and the batch record's ordering and ownership rules (`BulkDownloadStoreTest`), including the two bugs above.

## Screenshots or recordings

| The action | What it will cost |
| --- | --- |
| ![action](https://github.com/user-attachments/assets/56237407-ffd5-446e-ac57-013d5fd31c2a) | ![confirm](https://github.com/user-attachments/assets/0a6a421a-e7eb-4a16-894e-cabb218f714b) |

| While it runs | Stopped partway |
| --- | --- |
| ![progress](https://github.com/user-attachments/assets/92e09a2e-d69a-4447-bea2-78bcb9af4e02) | ![stopped](https://github.com/user-attachments/assets/c73e62ea-4f91-4eb4-8a48-92fd77029508) |

| Finished | Nothing left to fetch |
| --- | --- |
| ![done](https://github.com/user-attachments/assets/657acd7d-300d-4d76-bf8c-eef02b5096dc) | ![nothing left](https://github.com/user-attachments/assets/ffb8406e-9cfb-40ad-a53b-e692603179d2) |

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
---

**Review follow-up.** Three points came back from review, all valid and all fixed:

- `enqueueUniqueWork` hands its write off to WorkManager's executor and returns before it lands, so the tag the total is read back from could still be empty when it was looked at. Each `Operation` is now awaited before membership is confirmed. Left alone, an empty read would have cleared the batch record out from under workers already running under it — the same failure this change already fixes from the other end.
- A stopped batch counted its results before the cancellation had landed, so a book whose bytes arrived in between was missing from the summary while sitting in the library. The counts are now taken after the wait; membership still comes from the read taken while the tag was whole. The screenshot above is that fix: 24 of 32 reported, 24 books in the library, 24 files on disk.
- The estimate's in-progress flag was only cleared on the way out through success. It is now cleared however the call goes.
