### PR TITLE
feat(release): let a release leave Google Play out

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -172,6 +172,7 @@ want:
 ```bash
 hack/release --yes 0.2.1 "Fix page fitting on tall screens."
 hack/release --fdroid-only 0.2.1     # re-run just the F-Droid step
+hack/release --no-play 0.2.1 "..."   # leave Google Play out of this one
 ```
 
 It refuses to run on a dirty tree, off `main`, out of sync with the
@@ -181,13 +182,30 @@ invoking it again with the same version.
 
 Pushing the tag is what starts `.github/workflows/release.yml`, which
 builds and signs the APK in the `release` GitHub environment and
-attaches it to the release. That environment must hold
+attaches it to the release. Signing is what that environment must hold:
 `LISEUR_KEYSTORE_BASE64`, `LISEUR_KEYSTORE_PASSWORD`,
-`LISEUR_KEY_ALIAS`, `LISEUR_KEY_PASSWORD` and
-`LISEUR_PLAY_SERVICE_ACCOUNT_JSON`; `hack/release` creates the
-environment and uploads whichever of them are missing straight from
-`pass`, so an unlocked password store is the only setup a fresh clone
-needs. To refresh them all, after rotating the key for instance:
+`LISEUR_KEY_ALIAS`, `LISEUR_KEY_PASSWORD` and, for the release notes,
+`GEMINI_API_KEY`. Without them there is no release.
+
+`LISEUR_PLAY_SERVICE_ACCOUNT_JSON` is the odd one out. It buys the third
+channel rather than the release itself, and the workflow skips Google
+Play entirely when it is absent. `hack/release` uploads it with the rest
+all the same, so in practice a release goes to Play unless you say
+otherwise:
+
+```bash
+hack/release --no-play 0.9.0 "..."
+```
+
+That is the only way to keep Play out of a release once the credential
+has been uploaded once. Deleting the secret by hand does not do it —
+`hack/release` reads one missing secret as a stale environment and
+uploads them all again from `pass`, Play credential included.
+
+`hack/release` creates the environment and uploads whichever secrets are
+missing straight from `pass`, so an unlocked password store is the only
+setup a fresh clone needs. To refresh them all, after rotating the key
+for instance:
 
 ```bash
 hack/release --sync-secrets
@@ -213,7 +231,9 @@ publishing plugin is applied, and the bundle is an extra output rather
 than a replacement — which is also why the Play step in
 `.github/workflows/release.yml` is `continue-on-error` and skips itself
 entirely when the service account secret is absent. A fork, or a rejected
-upload, must not be what makes a release fail.
+upload, must not be what makes a release fail. `hack/release --no-play`
+turns that skip into something you can ask for, by leaving the credential
+off the release environment instead of topping it up.
 
 The upload runs `fastlane android internal` with
 `SUPPLY_JSON_KEY` pointing at a service account credential written to

--- a/hack/release
+++ b/hack/release
@@ -28,14 +28,20 @@ readonly REQUIRED_SECRETS=(
     GEMINI_API_KEY
     LISEUR_PLAY_SERVICE_ACCOUNT_JSON
 )
+# Set by --no-play. The release workflow skips Google Play entirely when
+# it finds no service account, so leaving the credential off the release
+# environment is the whole of the opt-out — but only if this script does
+# not put it back, which it otherwise does the moment it notices it
+# missing.
+skip_play=false
 
 usage() {
     cat <<'EOF'
 Usage:
-  hack/release [--no-fdroid]
-  hack/release [--yes] [--no-fdroid] VERSION RELEASE NOTES...
+  hack/release [--no-fdroid] [--no-play]
+  hack/release [--yes] [--no-fdroid] [--no-play] VERSION RELEASE NOTES...
   hack/release --fdroid-only VERSION
-  hack/release --sync-secrets
+  hack/release [--no-play] --sync-secrets
 
 With no version it shows what has landed since the last release, offers
 the next major, minor and patch, and opens an editor on a changelog
@@ -45,6 +51,7 @@ Examples:
   hack/release 0.2.0 "Add in-book search and a Wiktionary lookup card."
   hack/release --yes 0.2.1 "Fix page fitting on tall screens."
   hack/release --no-fdroid 0.1.0 "The first release."
+  hack/release --no-play 0.2.2 "Leave Google Play out of this one."
   hack/release --fdroid-only 0.2.1
   hack/release --sync-secrets
 
@@ -57,6 +64,12 @@ android/liseur.keystore-password and android/liseur.keystore-alias, and the
 Play upload credential under android/google.play.service.serviceaccount. Any
 release secret missing from the GitHub release environment is uploaded
 from there, so a fresh clone needs nothing but an unlocked password store.
+
+--no-play leaves the Play credential alone: it is neither required nor
+uploaded, and the release workflow skips Google Play whenever it finds
+none. Use it while the Play listing is not ready to receive builds. It
+changes nothing else — the GitHub release and the F-Droid submission go
+out as usual.
 EOF
 }
 
@@ -112,14 +125,20 @@ set_release_secret() {
 
 sync_release_secrets() {
     local force=${1:-false}
-    local available missing=() secret
+    local available missing=() secret wanted=()
 
     gh api --silent --method PUT "repos/$GH_REPO/environments/release" ||
         die "could not create the release environment on $GH_REPO"
 
+    for secret in "${REQUIRED_SECRETS[@]}"; do
+        [[ "$skip_play" == true &&
+            "$secret" == LISEUR_PLAY_SERVICE_ACCOUNT_JSON ]] && continue
+        wanted+=("$secret")
+    done
+
     available=$(gh secret list --repo "$GH_REPO" --env release |
         cut -f1) || available=""
-    for secret in "${REQUIRED_SECRETS[@]}"; do
+    for secret in "${wanted[@]}"; do
         grep -qx "$secret" <<<"$available" || missing+=("$secret")
     done
 
@@ -135,8 +154,10 @@ sync_release_secrets() {
     set_release_secret LISEUR_KEY_PASSWORD \
         "$(pass_show "$PASS_KEYSTORE_PASSWORD")"
     set_release_secret GEMINI_API_KEY "$(pass_show "$PASS_GEMINI_KEY")"
-    set_release_secret LISEUR_PLAY_SERVICE_ACCOUNT_JSON \
-        "$(pass_show "$PASS_PLAY_SERVICE_ACCOUNT")"
+    if [[ "$skip_play" == false ]]; then
+        set_release_secret LISEUR_PLAY_SERVICE_ACCOUNT_JSON \
+            "$(pass_show "$PASS_PLAY_SERVICE_ACCOUNT")"
+    fi
 }
 
 github_release_is_published() {
@@ -596,6 +617,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --no-fdroid)
             skip_fdroid=true
+            shift
+            ;;
+        --no-play)
+            skip_play=true
             shift
             ;;
         --sync-secrets)


### PR DESCRIPTION
## Summary

The release workflow already skips Google Play when it finds no service account, and that skip was the only thing standing between a release and the store. It turned out not to be reachable.

`hack/release` counts `LISEUR_PLAY_SERVICE_ACCOUNT_JSON` among the secrets a release needs, and uploads every secret from `pass` the moment it finds one of them missing. So taking the credential off the release environment did not keep Play out of the next release — it guaranteed the credential would be put back, along with everything else.

`--no-play` takes it out of that set: neither required nor uploaded, and the workflow's existing "no credential, no Play" branch does the rest.

Wanted for the release going out now, while the listing is not ready to take builds.

## Changes

- `--no-play` on `hack/release`, honoured in both places that matter: the missing-secret check that decides whether to reach for `pass` at all, and the upload itself.
- Usage text and `DEVELOPER.md` say what the flag does and, more usefully, why deleting the secret by hand does not work.
- A run without the flag is unchanged, byte for byte.

## Testing

- [x] `bash -n hack/release`
- [x] `shellcheck hack/release` — clean
- [x] `hack/release --no-play --help` parses and prints the new usage
- [ ] `./gradlew testDebugUnitTest` — not applicable, no app code changed
- [ ] `./gradlew lintDebug` — not applicable
- [ ] `./gradlew assembleDebug` — not applicable

The flag's real effect is on which secrets get uploaded, which cannot be exercised without writing to the release environment. It is a single condition in each of the two places, and the secret is already absent there, so the release this is for will show whether the skip holds.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
