### PR TITLE
docs: add architectural decision records for reading features

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,6 +7,10 @@ down. Nothing here blocks a release; the release checklist lives in
 Each entry says what the problem is and where in the tree it lives, so
 that picking one up does not start with a search.
 
+Larger reading-experience features are designed before they are built;
+those decisions live in [`adr/`](adr/), starting from
+[the advanced reading menu](adr/0001-advanced-reading-menu.md).
+
 ## Before the first release
 
 ### Say why the account vanished

--- a/docs/adr/0001-advanced-reading-menu.md
+++ b/docs/adr/0001-advanced-reading-menu.md
@@ -1,0 +1,53 @@
+# 1. One Advanced entry, and nothing else
+
+Status: accepted
+
+## Context
+
+Nine reading-comfort features are missing from the reader: finer
+typography, read-aloud, user fonts, warm light, auto-scroll, a peek
+while scrubbing, highlight styles, tap-zone presets and translation.
+Each one, added the obvious way, brings its own switch, its own row,
+sometimes its own screen. Nine features added the obvious way turn the
+typography sheet into a settings app, and the typography sheet is the
+one surface that has stayed Kindle-simple on purpose: theme, font,
+size, a few layout choices, done.
+
+## Decision
+
+The typography sheet gains exactly one new row, **Advanced**, at the
+bottom. Everything that genuinely needs a setting lives behind it.
+Nothing else in the app grows a menu, a screen or a piece of chrome for
+these features.
+
+Most of the nine do not even get a row there, because they can be a
+gesture or fold into something that already exists:
+
+- Scrubber peek ([ADR 7](0007-scrubber-page-peek.md)) is pure gesture.
+  No setting at all.
+- Warm light ([ADR 5](0005-warm-light.md)) is a second slider under the
+  brightness slider already in the sheet.
+- Highlight styles ([ADR 8](0008-highlight-styles.md)) live in the
+  selection popup, next to the tints.
+- Translation ([ADR 10](0010-translation-on-selection.md)) is one
+  action in the selection popup, switched on from the dictionary
+  settings that already exist.
+
+That leaves the Advanced sheet holding what actually needs a home:
+fine typography ([ADR 2](0002-typography-fine-tuning.md)), read-aloud
+([ADR 3](0003-read-aloud-tts.md)), user fonts
+([ADR 4](0004-user-imported-fonts.md)), auto-scroll
+([ADR 6](0006-auto-scroll.md)) and the tap-zone preset
+([ADR 9](0009-tap-zone-customization.md)).
+
+## Consequences
+
+A feature that cannot state, in one line of its ADR, where it surfaces
+and why that adds nothing new to the UI, is not ready to build. Each of
+the nine ADRs carries that line in its Decision section.
+
+The Advanced sheet itself is a second bottom sheet reached from the
+first, not a navigation destination: dismissing it lands back on the
+typography sheet, and dismissing that lands back on the page.
+
+*Where:* `reader/chrome/TypographySheet.kt`.

--- a/docs/adr/0002-typography-fine-tuning.md
+++ b/docs/adr/0002-typography-fine-tuning.md
@@ -1,0 +1,52 @@
+# 2. Typography fine-tuning
+
+Status: proposed
+
+## Context
+
+The sheet exposes font, size, line height, margins and columns. Readium
+can also justify text, hyphenate it, and adjust letter, word and
+paragraph spacing and font weight, and none of that is reachable. For
+most readers the defaults are right; for a reader with a dyslexic
+child, or one who cannot stand a ragged right edge, the missing knob is
+the difference between using the app and not.
+
+## Decision
+
+Expose justification, hyphenation, letter spacing, word spacing,
+paragraph spacing and font weight as rows in the Advanced sheet.
+
+Fit with Liseur's simplicity: these controls are why the Advanced sheet
+exists ([ADR 1](0001-advanced-reading-menu.md)); the main typography
+sheet does not change.
+
+## Design
+
+Each control becomes a nullable field on `ReaderPrefs`, exactly as
+`lineHeight` and `pageMargins` already are: null means the publisher's
+styles, a value means the reader asked for something. The mapping is a
+handful of lines in `toEpubPreferences` — `EpubPreferences` already has
+`textAlign`, `hyphens`, `letterSpacing`, `wordSpacing`,
+`paragraphSpacing` and `fontWeight`.
+
+The existing `publisherStyles` rule extends to the new fields: any
+non-null value turns publisher styles off, no value leaves the page
+exactly as Readium would have laid it out. That rule already lives in
+one place in the mapper and stays there.
+
+Persistence follows `lineHeight`: one DataStore key per field in
+`ReaderPreferencesRepository`, absent when null.
+
+## Consequences
+
+Six new preference keys, one enum for text alignment, no new types
+otherwise. The mapper's publisher-styles condition grows from three
+clauses to nine, which is the moment to fold it into a small
+`overridesPublisherStyles()` on `ReaderPrefs`, testable on the JVM.
+
+Hyphenation only works where Readium's CSS supports the language;
+the row does not promise otherwise.
+
+*Where:* `data/settings/ReaderPrefs.kt`,
+`data/settings/ReaderPreferencesRepository.kt`,
+`reader/ReaderPreferencesMapper.kt`, `reader/chrome/TypographySheet.kt`.

--- a/docs/adr/0003-read-aloud-tts.md
+++ b/docs/adr/0003-read-aloud-tts.md
@@ -1,0 +1,50 @@
+# 3. Read aloud
+
+Status: proposed
+
+## Context
+
+There is no way to have a book read to you. Commuting, cooking, tired
+eyes at night: all of them end the session where a Kindle keeps going.
+Readium ships a TTS navigator, and Android ships a speech engine on
+every device, so the pieces exist; only the wiring does not.
+
+## Decision
+
+Read-aloud through Readium's `TtsNavigator` backed by the system
+`TextToSpeech` engine. Play and pause, skip forward and back by
+utterance, and the sentence being spoken highlighted on the page.
+Nothing more: no voice store, no bundled voices, no speed presets
+beyond the engine's own rate slider.
+
+Fit with Liseur's simplicity: one "Read aloud" row in the Advanced
+sheet starts it; while it runs, a small play/pause bar sits where the
+reading footer is, and stopping it gives the footer back.
+
+## Design
+
+The system engine keeps the feature inside the hard constraints: no
+network, no proprietary blob, whatever voices the user already has.
+An AOSP device without an engine gets the row greyed out with one line
+saying why.
+
+`ReaderViewModel` owns the TTS session the way it owns search: started,
+observed as a `StateFlow` of the current utterance's locator, stopped
+when the reader closes. The spoken sentence reuses the decoration
+machinery from `reader/annotations/Annotations.kt` with a transient
+decoration that is never persisted.
+
+Position: pausing writes the current utterance's locator through the
+same path as a page turn, so a book stopped by ear reopens at the same
+place by eye, and position sync needs no new rules.
+
+## Consequences
+
+A media session and audio focus have to be handled, which is the real
+cost of the feature; keeping playback tied to the open reader (no
+background service, screen may stay on via the existing keep-screen-on
+toggle) keeps that cost small for a first version. Background playback
+is a separate decision for a separate ADR if anyone asks for it.
+
+*Where:* `reader/ReaderViewModel.kt`, `reader/ReaderScreen.kt`,
+`reader/chrome/TypographySheet.kt`, new `reader/tts/`.

--- a/docs/adr/0004-user-imported-fonts.md
+++ b/docs/adr/0004-user-imported-fonts.md
@@ -1,0 +1,53 @@
+# 4. User-imported fonts
+
+Status: proposed
+
+## Context
+
+Four bundled families cover most tastes, but not the reader who has
+paid for a font they love, needs OpenDyslexic, or reads a script the
+bundled four render badly. The bundle cannot grow to meet them all —
+every family is APK weight everyone carries.
+
+## Decision
+
+Let the reader import a font file. Picked through the system file
+picker, copied into the app's own storage, offered in the font row like
+the bundled four, applied when the next book opens.
+
+Fit with Liseur's simplicity: one "Add a font…" entry at the end of the
+existing font list in the Advanced sheet. Imported fonts appear in the
+same list with a remove affordance; no manager screen.
+
+## Design
+
+Import is `ACTION_OPEN_DOCUMENT` for `font/ttf` and `font/otf`, the
+bytes copied to `filesDir/fonts/` — copied, not referenced, so the
+choice survives the source file moving or the SAF grant lapsing. The
+family name is read from the font's name table; a file that has none
+falls back to its filename.
+
+`ReaderFont` stops being the whole story: the enum keeps the bundled
+families and `PUBLISHER`, and the font preference becomes an id that is
+either one of those or a user font's filename. `ReaderFont.fromId`
+already tolerates unknown ids by falling back to the default, which is
+exactly what happens if the file behind a chosen font is gone.
+
+Declaration goes through the same `addFontFamilyDeclaration` path the
+bundled fonts use in `epubNavigatorConfiguration`, with the served-asset
+scope widened to cover the app's font directory. That configuration is
+read when a book opens, so an import lands on the next book — the same
+behaviour column mode already has, documented in the same place.
+
+## Consequences
+
+One imported file is one face: no italic, no bold axis unless the file
+is variable. The page falls back to synthesised styles, which is what
+every other reader does with a single-face import.
+
+Licensing stays the reader's own business, as with any file they put on
+their device; nothing is redistributed.
+
+*Where:* `data/settings/ReaderPrefs.kt`,
+`reader/ReaderPreferencesMapper.kt`, `reader/chrome/TypographySheet.kt`,
+new `data/settings/UserFontRepository.kt`.

--- a/docs/adr/0005-warm-light.md
+++ b/docs/adr/0005-warm-light.md
@@ -1,0 +1,44 @@
+# 5. Warm light
+
+Status: proposed
+
+## Context
+
+Night reading on the Dark and Black themes is easier on the eyes than
+white, but the light is still blue. Android's own Night Light does not
+reach every device, and a reader should not have to leave the book to
+find a system toggle. Every serious reading app ends up with a warmth
+control for this reason.
+
+## Decision
+
+One warmth slider that draws an amber tint over the page, from nothing
+to distinctly candle-lit, remembered like brightness.
+
+Fit with Liseur's simplicity: the slider sits directly under the
+brightness slider in the typography sheet — the two answer the same
+question, "how does the light feel" — and there is no schedule, no
+automation, no per-theme value.
+
+## Design
+
+The tint is a Compose overlay in `ReaderScreen`, a full-size box over
+the navigator filled with an amber whose alpha the slider sets, drawn
+under the chrome so sheets and dialogs stay true-colour. Zero alpha
+draws nothing. This is the same shape as the existing brightness
+override: a `Float?` on `ReaderPrefs`, null meaning off, one DataStore
+key, one row in the sheet.
+
+An overlay dims slightly as it warms; that is acceptable and matches
+what an amber gel does to a real lamp. Tinting through the WebView or
+Readium's colours instead would keep luminance but would also recolour
+images and fight the theme palette. Not worth it.
+
+## Consequences
+
+The scrim covers the page but not the system bars, which are already
+hidden in the reader. On e-ink (the existing monochrome mode) the tint
+becomes a grey veil with no benefit, so the slider is ignored there.
+
+*Where:* `data/settings/ReaderPrefs.kt`, `reader/ReaderScreen.kt`,
+`reader/chrome/TypographySheet.kt`.

--- a/docs/adr/0006-auto-scroll.md
+++ b/docs/adr/0006-auto-scroll.md
@@ -1,0 +1,47 @@
+# 6. Auto-scroll
+
+Status: proposed
+
+## Context
+
+Scroll mode exists, but the thumb still has to move the page. Reading
+over lunch, on a treadmill, or with one hand in a strap on the train,
+a page that carries itself at reading pace is the difference between
+reading and not. Paginated mode has no equivalent need — the tap zones
+and volume keys already turn pages without reaching.
+
+## Decision
+
+Auto-scroll for scroll mode only: a start row, a speed slider, and any
+touch on the page pauses it. Turning it on in a paginated book is not
+possible because the row only appears when the book is scrolled.
+
+Fit with Liseur's simplicity: one row in the Advanced sheet, visible
+only in scroll mode. While scrolling, the reader chrome is the pause
+control it already is — a tap shows the chrome and stops the movement.
+
+## Design
+
+A coroutine in `ReaderViewModel`, alive only while reading, ticks a
+small `scrollBy` into the navigator's web view on a frame cadence
+derived from the speed setting. Speed is stored as a `Float` DataStore
+key; the slider maps to a range slow enough for dense prose and fast
+enough for skimming.
+
+Pause is the existing tap handling in `ReaderTapZones`: any tap that
+reveals the chrome also cancels the coroutine. Reaching the end of a
+resource behaves like a manual scroll reaching it — the existing
+`ScrollEdgeTurner` carries into the next one.
+
+Position saving needs nothing new: the navigator already reports
+locator changes as the page moves, and auto-scroll moves the page.
+
+## Consequences
+
+The reading-speed estimator will see unusually steady progress; that is
+genuine reading and needs no special-casing. The screen must not sleep
+mid-scroll, so starting auto-scroll implies keep-screen-on for the
+session regardless of the toggle.
+
+*Where:* `reader/ReaderViewModel.kt`, `reader/chrome/ReaderTapZones.kt`,
+`reader/chrome/TypographySheet.kt`.

--- a/docs/adr/0007-scrubber-page-peek.md
+++ b/docs/adr/0007-scrubber-page-peek.md
@@ -1,0 +1,49 @@
+# 7. Scrubber page peek
+
+Status: proposed
+
+## Context
+
+Dragging the scrubber moves the book immediately: every position the
+thumb passes through is navigated to, and letting go in the wrong place
+means hunting for where you were. Checking how far the chapter runs, or
+glancing back at a map three chapters ago, should not gamble the
+reading position.
+
+## Decision
+
+While the thumb is down, the scrubber only shows — a small label above
+it with the chapter title and page — and the book does not move until
+release. After a release that moved the book, a single "Back to page N"
+chip offers the way home, and turning a page dismisses it.
+
+Fit with Liseur's simplicity: this is a change to how the existing
+scrubber behaves, not a new control. No setting; there is no reader who
+wants navigation to fire on every passing position.
+
+## Design
+
+`ReadingScrubber` in `ReadingProgressUi.kt` already knows the position
+list and chapter mapping (`BookPositions`); the drag callback stops
+calling the navigator and feeds the label instead, and only the release
+callback navigates. The label content is the same title/page pairing
+the footer already computes.
+
+The return chip is the jump-back flow that link-following already uses
+in `ReaderViewModel`: record the pre-drag locator when a drag starts,
+surface the existing jump-back affordance if release landed elsewhere.
+No new state shape, one more caller of a mechanism that exists.
+
+Thumbnails were considered and dropped: rendering page images for the
+whole book costs a background pipeline and storage for a glance the
+title-and-page label already serves.
+
+## Consequences
+
+Skimming becomes free: dragging across the whole book is now a lookup,
+not a journey. The one behavioural loss is live page flipping under the
+thumb, which nobody used on purpose because every flip was a navigation
+they would have to undo.
+
+*Where:* `reader/chrome/ReadingProgressUi.kt`,
+`reader/progress/BookPositions.kt`, `reader/ReaderViewModel.kt`.

--- a/docs/adr/0008-highlight-styles.md
+++ b/docs/adr/0008-highlight-styles.md
@@ -1,0 +1,47 @@
+# 8. Highlight styles
+
+Status: proposed
+
+## Context
+
+Highlights come in four tints and one shape: a filled band. A reader
+who marks vocabulary one way and arguments another has only colour to
+say so, and on the Black theme a filled band is the loudest thing on
+the page. An underline is the quiet alternative every margin-writer
+reaches for.
+
+## Decision
+
+Two styles, fill and underline, chosen in the selection popup next to
+the four tints. A highlight keeps its style when its tint changes.
+
+Fit with Liseur's simplicity: the selection popup gains one small
+fill/underline toggle beside the tint dots it already shows. No
+setting, no new screen; the contents screen lists both styles together
+as it does today.
+
+## Design
+
+One nullable `style` column on the annotation entity, defaulting to
+fill, one Room migration. `HighlightTint` stays what it is; a parallel
+two-value enum carries the style from the popup through the ViewModel
+to the row.
+
+Rendering is a second decoration shape in
+`reader/annotations/Annotations.kt`: Readium's decoration API has an
+underline style alongside the highlight style, so the change is a
+`when` at the single place decorations are built.
+
+The Markdown notebook export does not distinguish styles; a style is a
+visual register on the page, not a category worth exporting.
+
+## Consequences
+
+The popup gets slightly busier, which is the entire UI cost. The Room
+schema version bumps, joining the migrations that `docs/ROADMAP.md`
+already wants tested. Two styles is deliberate — squiggles and boxes
+invite a formatting hobby that has nothing to do with reading.
+
+*Where:* `data/db/BookAnnotation.kt`, `data/db/LiseurDatabase.kt`,
+`reader/annotations/Annotations.kt`,
+`reader/annotations/SelectionPopup.kt`, `reader/ReaderViewModel.kt`.

--- a/docs/adr/0009-tap-zone-customization.md
+++ b/docs/adr/0009-tap-zone-customization.md
@@ -1,0 +1,41 @@
+# 9. Tap-zone presets
+
+Status: proposed
+
+## Context
+
+The tap zones are fixed: left edge back, right edge forward, middle for
+chrome. A left-handed reader holding a phone in one hand has the
+forward turn under the wrong thumb every single page. The fix most
+readers actually want is not a zone editor, it is "both edges turn
+forward" or "swap the edges".
+
+## Decision
+
+One three-way preference: **Standard** (today's layout), **Both edges
+forward** (going back stays on the volume keys and the scrubber), and
+**Swapped** (left forward, right back).
+
+Fit with Liseur's simplicity: one row with three choices in the
+Advanced sheet. No draggable zone editor, no per-zone action picker —
+that is a settings hobby, and the three presets cover the readers who
+exist.
+
+## Design
+
+`ReaderTapZones` already resolves a tap position to an action in one
+place; the preset is an enum on `ReaderPrefs` consulted in that
+resolution. The volume keys are untouched — they already give a
+physical back/forward pair whatever the thumbs do.
+
+Scroll mode keeps its own scroll-aware tap behaviour; the preset only
+reinterprets the paginated edges.
+
+## Consequences
+
+Three presets instead of a matrix means someone will ask for a fourth.
+The bar for adding one is the same as for these: a hand position that
+actually occurs, not a preference for novelty.
+
+*Where:* `data/settings/ReaderPrefs.kt`,
+`reader/chrome/ReaderTapZones.kt`, `reader/chrome/TypographySheet.kt`.

--- a/docs/adr/0010-translation-on-selection.md
+++ b/docs/adr/0010-translation-on-selection.md
@@ -1,0 +1,54 @@
+# 10. Translation on selection
+
+Status: proposed
+
+## Context
+
+Reading in a second language means meeting sentences, not just words.
+The Wiktionary lookup answers "what does this word mean" but not "what
+does this clause say", and switching to a translator app loses the
+selection and the place. The constraint is real, though: Liseur's
+network story is the book server plus opt-in dictionary lookups, and a
+translation feature must not quietly widen it.
+
+## Decision
+
+A **Translate** action in the selection popup, sending the selection to
+a translation endpoint the user configures themselves — a LibreTranslate
+instance or anything speaking its API. Off until an endpoint is entered;
+no default server, not even a FOSS one, because a default turns opt-in
+into opt-out.
+
+Fit with Liseur's simplicity: one action in the existing selection
+popup, one endpoint field on the existing dictionary settings screen.
+The result appears in the same bottom sheet the dictionary uses.
+
+## Design
+
+The settings live beside the dictionary lookup opt-in in
+`data/settings/AppSettings.kt`: an endpoint URL and a target language,
+both empty by default. The popup only shows Translate when the endpoint
+is set, the same visibility rule the dictionary action follows.
+
+The client is a sibling of `WiktionaryClient`: one POST, blocking work
+on `Dispatchers.IO` inside the client as the convention requires, every
+failure surfacing as a quiet "couldn't reach the translator" line in
+the sheet rather than an error dialog mid-book. The result sheet is
+`DefinitionSheet` generalised, or a near-copy if generalising it costs
+more than it saves.
+
+This extends the documented network exception, so `docs/PRIVACY.md`
+gains a line: selections you translate are sent to the server you
+configured, and nowhere otherwise.
+
+## Consequences
+
+Selected passages leave the device — to a server the reader chose,
+named in settings, and only when they press Translate. A reader who
+self-hosts LibreTranslate gets translation with no third party at all.
+There is no offline mode; bundling a translation model is the offline
+dictionary decision again, already turned down in `docs/ROADMAP.md`.
+
+*Where:* `data/settings/AppSettings.kt`,
+`reader/annotations/SelectionPopup.kt`, `reader/dictionary/`,
+`ui/settings/`, `docs/PRIVACY.md`.


### PR DESCRIPTION
Added ten architectural decision records detailing advanced reading features, design decisions, and consequences. Updated the roadmap to reference these new documents for complex features.

## Summary

<!-- What does this change do, and why? Link related issues with "Fixes #123". -->

## Changes

-

## Testing

- [ ] `./gradlew testDebugUnitTest`
- [ ] `./gradlew lintDebug`
- [ ] `./gradlew assembleDebug`
- [ ] Manually tested on a device or emulator, if applicable

## Screenshots or recordings

<!-- Include before/after visuals for UI changes. Remove personal information. -->

## Checklist

- [ ] I have kept this change focused and documented any user-facing behaviour.
- [ ] I have added or updated tests where needed.
- [ ] I have checked that dependencies remain FOSS and available from allowed repositories.
- [ ] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
