### PR TITLE
feat: Support exact locator anchors for position sync

### DIFF
--- a/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/38.json
+++ b/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/38.json
@@ -1,0 +1,1093 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 38,
+    "identityHash": "0e35692a790d9a98ceeccc1bf3d9af9f",
+    "entities": [
+      {
+        "tableName": "reading_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `total_progression` REAL, `reading_speed` REAL, `reading_seconds_per_position` REAL, `reading_pace_samples` INTEGER NOT NULL DEFAULT 0, `reading_pace_elapsed_ms` INTEGER NOT NULL DEFAULT 0, `reading_pace_evidence` REAL NOT NULL DEFAULT 0, `updated_at` INTEGER NOT NULL, `status` TEXT, `synced_at` INTEGER, `local_revision` INTEGER NOT NULL DEFAULT 0, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `agreed_account` TEXT, `pending_progression` REAL, `pending_locator_json` TEXT, `pending_status` TEXT, `pending_updated_at` INTEGER, `pending_account` TEXT, `owner_account` TEXT, `remote_updated_at` INTEGER, `finished_override` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSpeed",
+            "columnName": "reading_speed",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSecondsPerPosition",
+            "columnName": "reading_seconds_per_position",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingPaceSamples",
+            "columnName": "reading_pace_samples",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceElapsedMs",
+            "columnName": "reading_pace_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceEvidence",
+            "columnName": "reading_pace_evidence",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localRevision",
+            "columnName": "local_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "agreedAccount",
+            "columnName": "agreed_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingLocatorJson",
+            "columnName": "pending_locator_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingAccount",
+            "columnName": "pending_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ownerAccount",
+            "columnName": "owner_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "finishedOverride",
+            "columnName": "finished_override",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `cover_path` TEXT, `source` TEXT, `added_at` INTEGER NOT NULL, `last_opened_at` INTEGER, `local_uri` TEXT, `remote_uuid` TEXT, `remote_book_id` INTEGER, `cover_url` TEXT, `download_href` TEXT, `download_state` TEXT NOT NULL, `remote_updated_at` INTEGER, `downloaded_at` INTEGER, `file_modified_at` INTEGER, `work_id` TEXT, `finished_at` INTEGER, `archived_at` INTEGER, `remote_page_count` INTEGER, `size_bytes` INTEGER, `series_name` TEXT, `series_index` REAL, `file_series_name` TEXT, `file_series_index` REAL, `series_id` TEXT, `series_checked` INTEGER NOT NULL, `catalog_series_name` TEXT, `catalog_series_index` REAL, `catalog_folder_id` TEXT, `catalog_series_source` TEXT, `user_series_name` TEXT, `user_series_index` REAL, `series_override` INTEGER NOT NULL, `user_series_updated_at` INTEGER, `series_claim_pending` INTEGER NOT NULL, `series_claim_reset` INTEGER NOT NULL, `personal_series_updated_at` INTEGER, `series_index_override` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "last_opened_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localUri",
+            "columnName": "local_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUuid",
+            "columnName": "remote_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteBookId",
+            "columnName": "remote_book_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadHref",
+            "columnName": "download_href",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadState",
+            "columnName": "download_state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloaded_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finished_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archived_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remotePageCount",
+            "columnName": "remote_page_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "size_bytes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fileSeriesName",
+            "columnName": "file_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileSeriesIndex",
+            "columnName": "file_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesChecked",
+            "columnName": "series_checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSeriesName",
+            "columnName": "catalog_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesIndex",
+            "columnName": "catalog_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "catalogFolderId",
+            "columnName": "catalog_folder_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesSource",
+            "columnName": "catalog_series_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesName",
+            "columnName": "user_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesIndex",
+            "columnName": "user_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesOverridden",
+            "columnName": "series_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userSeriesUpdatedAt",
+            "columnName": "user_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesClaimPending",
+            "columnName": "series_claim_pending",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesClaimReset",
+            "columnName": "series_claim_reset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personalSeriesUpdatedAt",
+            "columnName": "personal_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "indexOverridden",
+            "columnName": "series_index_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_books_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_books_url` ON `${TABLE_NAME}` (`url`)"
+          },
+          {
+            "name": "index_books_series_name",
+            "unique": false,
+            "columnNames": [
+              "series_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_series_name` ON `${TABLE_NAME}` (`series_name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "library_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `added_at` INTEGER NOT NULL, PRIMARY KEY(`url`))",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "url"
+          ]
+        }
+      },
+      {
+        "tableName": "remote_server",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `kind` TEXT NOT NULL, `base_url` TEXT NOT NULL, `username` TEXT, `password_cipher` TEXT, `api_key_cipher` TEXT, `account_id` TEXT, `user_id` INTEGER, `kobo_token` TEXT, `can_download` INTEGER NOT NULL, `can_manage_library` INTEGER NOT NULL, `can_upload` INTEGER NOT NULL, `can_delete` INTEGER NOT NULL, `can_admin` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `catalog_synced_at` INTEGER, `position_synced_at` INTEGER, `sync_token` TEXT, `liseur_token_cipher` TEXT, `liseur_account_id` TEXT, `sync_cursor_seq` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "passwordCipher",
+            "columnName": "password_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiKeyCipher",
+            "columnName": "api_key_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "koboTokenCipher",
+            "columnName": "kobo_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "canDownload",
+            "columnName": "can_download",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canManageLibrary",
+            "columnName": "can_manage_library",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canUpload",
+            "columnName": "can_upload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canDelete",
+            "columnName": "can_delete",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canAdmin",
+            "columnName": "can_admin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSyncedAt",
+            "columnName": "catalog_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "positionSyncedAt",
+            "columnName": "position_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncToken",
+            "columnName": "sync_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurTokenCipher",
+            "columnName": "liseur_token_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurAccountId",
+            "columnName": "liseur_account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncCursorSeq",
+            "columnName": "sync_cursor_seq",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `book_id` TEXT NOT NULL, `kind` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `text` TEXT, `note` TEXT, `tint` TEXT, `chapter` TEXT, `position` INTEGER, `total_progression` REAL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tint",
+            "columnName": "tint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapter",
+            "columnName": "chapter",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_typography",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `font` TEXT NOT NULL, `font_size` REAL NOT NULL, `line_height` REAL, `page_margins` REAL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "font",
+            "columnName": "font",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "font_size",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineHeight",
+            "columnName": "line_height",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pageMargins",
+            "columnName": "page_margins",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_screen",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `keep_screen_on` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keepScreenOn",
+            "columnName": "keep_screen_on",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_reading_mode",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `scroll` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scroll",
+            "columnName": "scroll",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `book_url` TEXT NOT NULL, `started_at` INTEGER NOT NULL, `ended_at` INTEGER, `last_checkpoint_at` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `start_progression` REAL, `end_progression` REAL, `uploaded_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "ended_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastCheckpointAt",
+            "columnName": "last_checkpoint_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startProgression",
+            "columnName": "start_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "endProgression",
+            "columnName": "end_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "uploadedAt",
+            "columnName": "uploaded_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_sessions_book_url",
+            "unique": false,
+            "columnNames": [
+              "book_url"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_book_url` ON `${TABLE_NAME}` (`book_url`)"
+          },
+          {
+            "name": "index_reading_sessions_started_at",
+            "unique": false,
+            "columnNames": [
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_started_at` ON `${TABLE_NAME}` (`started_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_peer_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `pending_progression` REAL, `pending_locator_json` TEXT, `pending_edition_sha` TEXT, `pending_status` TEXT, `pending_updated_at` INTEGER, `has_pending` INTEGER NOT NULL DEFAULT 0, `remote_updated_at` INTEGER, `synced_at` INTEGER, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingLocatorJson",
+            "columnName": "pending_locator_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingEditionSha",
+            "columnName": "pending_edition_sha",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasPending",
+            "columnName": "has_pending",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_peer_state_peer_id",
+            "unique": false,
+            "columnNames": [
+              "peer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_peer_state_peer_id` ON `${TABLE_NAME}` (`peer_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_fingerprint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `sha256` TEXT NOT NULL, `partial_md5` TEXT NOT NULL, `file_size` INTEGER NOT NULL, `file_modified_at` INTEGER, `computed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256",
+            "columnName": "sha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partialMd5",
+            "columnName": "partial_md5",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "computedAt",
+            "columnName": "computed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "work_alias",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_id` TEXT NOT NULL, `confidence` TEXT NOT NULL, `confirmed` INTEGER NOT NULL, `seeded` INTEGER NOT NULL DEFAULT 0, `source_sent` INTEGER NOT NULL DEFAULT 0, `edition_sha` TEXT, `resolved_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confirmed",
+            "columnName": "confirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seeded",
+            "columnName": "seeded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceSent",
+            "columnName": "source_sent",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "editionSha",
+            "columnName": "edition_sha",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resolvedAt",
+            "columnName": "resolved_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "work_ambiguity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_ids` TEXT NOT NULL, `noticed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workIds",
+            "columnName": "work_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noticedAt",
+            "columnName": "noticed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_extra",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`series_id` TEXT NOT NULL, `summary` TEXT, `status` TEXT, `total_book_count` INTEGER, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`series_id`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalBookCount",
+            "columnName": "total_book_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "series_id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0e35692a790d9a98ceeccc1bf3d9af9f')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
@@ -24,7 +24,7 @@ import androidx.sqlite.execSQL
         WorkAmbiguity::class,
         SeriesExtra::class,
     ],
-    version = 37,
+    version = 38,
     exportSchema = true,
 )
 abstract class LiseurDatabase : RoomDatabase() {
@@ -1006,6 +1006,21 @@ abstract class LiseurDatabase : RoomDatabase() {
             }
         }
 
+        /** Keeps each pending progression paired with the locator that supplied it. */
+        val MIGRATION_37_38 = object : Migration(37, 38) {
+            override fun migrate(connection: SQLiteConnection) {
+                connection.execSQL(
+                    "ALTER TABLE `reading_progress` ADD COLUMN `pending_locator_json` TEXT",
+                )
+                connection.execSQL(
+                    "ALTER TABLE `sync_peer_state` ADD COLUMN `pending_locator_json` TEXT",
+                )
+                connection.execSQL(
+                    "ALTER TABLE `sync_peer_state` ADD COLUMN `pending_edition_sha` TEXT",
+                )
+            }
+        }
+
         /**
          * Every migration, in order, as one list so that what the app
          * runs and what the tests replay cannot drift apart.
@@ -1047,6 +1062,7 @@ abstract class LiseurDatabase : RoomDatabase() {
             MIGRATION_34_35,
             MIGRATION_35_36,
             MIGRATION_36_37,
+            MIGRATION_37_38,
         )
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/ReadingProgress.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/ReadingProgress.kt
@@ -61,6 +61,8 @@ data class ReadingProgress(
     /** Which account the baseline was agreed with. */
     @ColumnInfo(name = "agreed_account") val agreedAccount: String? = null,
     @ColumnInfo(name = "pending_progression") val pendingProgression: Double? = null,
+    /** Exact locator paired with [pendingProgression], when the peer supplied one. */
+    @ColumnInfo(name = "pending_locator_json") val pendingLocatorJson: String? = null,
     @ColumnInfo(name = "pending_status") val pendingStatus: String? = null,
     @ColumnInfo(name = "pending_updated_at") val pendingUpdatedAt: Long? = null,
     /** Which account reported the pending state. */
@@ -241,12 +243,14 @@ abstract class ReadingProgressDao {
         INSERT INTO reading_progress (
             book_url, locator_json, total_progression, updated_at,
             local_revision, acked_revision,
-            pending_progression, pending_status, pending_updated_at, pending_account
+            pending_progression, pending_locator_json,
+            pending_status, pending_updated_at, pending_account
         )
         VALUES (:bookUrl, '{}', NULL, :now, 0, 0,
-                :progression, :status, :remoteUpdatedAt, :account)
+                :progression, :locatorJson, :status, :remoteUpdatedAt, :account)
         ON CONFLICT(book_url) DO UPDATE SET
             pending_progression = :progression,
+            pending_locator_json = :locatorJson,
             pending_status = :status,
             pending_updated_at = :remoteUpdatedAt,
             pending_account = :account
@@ -259,6 +263,7 @@ abstract class ReadingProgressDao {
         remoteUpdatedAt: Long?,
         account: String,
         now: Long,
+        locatorJson: String? = null,
     )
 
     /** Every row still holding an unsettled state from this account. */
@@ -268,7 +273,7 @@ abstract class ReadingProgressDao {
     @Query(
         """
         UPDATE reading_progress SET
-            pending_progression = NULL, pending_status = NULL,
+            pending_progression = NULL, pending_locator_json = NULL, pending_status = NULL,
             pending_updated_at = NULL, pending_account = NULL
         WHERE book_url = :bookUrl
         """,
@@ -290,9 +295,8 @@ abstract class ReadingProgressDao {
      * [locatorJson] is the exact place the server was left at, for the
      * servers that keep one. A percentage can only reopen a book roughly
      * where it was; a locator reopens it on the right word. Servers that
-     * have nothing so precise to offer pass null, and whatever locator
-     * this device already had is left alone rather than replaced with a
-     * guess.
+     * have nothing so precise to offer pass null, which invalidates the
+     * old locator so it cannot be mistaken for the newly adopted place.
      *
      * The revision goes up, and the acknowledgement goes up with it, so
      * this partner still counts as in step while every *other* partner
@@ -331,7 +335,7 @@ abstract class ReadingProgressDao {
         """
         UPDATE reading_progress SET
             total_progression = :progression,
-            locator_json = COALESCE(:locatorJson, locator_json),
+            locator_json = COALESCE(:locatorJson, '{}'),
             status = :status,
             updated_at = :now,
             synced_at = :now,
@@ -510,6 +514,7 @@ abstract class ReadingProgressDao {
         status: String,
         now: Long,
         locatorJson: String? = null,
+        remoteUpdatedAt: Long? = null,
     ): Boolean {
         // The row is made to exist first, because a book first read on
         // another device has never been opened here and there is nothing
@@ -524,6 +529,7 @@ abstract class ReadingProgressDao {
             status = status,
             now = now,
             locatorJson = locatorJson,
+            remoteUpdatedAt = remoteUpdatedAt,
         ) > 0
     }
 
@@ -542,10 +548,11 @@ abstract class ReadingProgressDao {
         """
         UPDATE reading_progress SET
             total_progression = :progression,
-            locator_json = COALESCE(:locatorJson, locator_json),
+            locator_json = COALESCE(:locatorJson, '{}'),
             status = :status,
             updated_at = :now,
             synced_at = :now,
+            remote_updated_at = :remoteUpdatedAt,
             local_revision = local_revision + 1
         WHERE book_url = :bookUrl AND local_revision = :expectedRevision
         """,
@@ -557,6 +564,7 @@ abstract class ReadingProgressDao {
         status: String,
         now: Long,
         locatorJson: String?,
+        remoteUpdatedAt: Long?,
     ): Int
 
     /**
@@ -643,7 +651,7 @@ abstract class ReadingProgressDao {
         """
         UPDATE reading_progress SET
             agreed_progression = NULL, agreed_status = NULL, agreed_account = NULL,
-            pending_progression = NULL, pending_status = NULL,
+            pending_progression = NULL, pending_locator_json = NULL, pending_status = NULL,
             pending_updated_at = NULL, pending_account = NULL,
             synced_at = NULL,
             acked_revision = local_revision

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/SyncPeerState.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/SyncPeerState.kt
@@ -41,6 +41,9 @@ data class SyncPeerState(
     @ColumnInfo(name = "agreed_status") val agreedStatus: String? = null,
     /** Reported by the partner and not yet settled. */
     @ColumnInfo(name = "pending_progression") val pendingProgression: Double? = null,
+    /** Locator and edition from the same op as [pendingProgression]. */
+    @ColumnInfo(name = "pending_locator_json") val pendingLocatorJson: String? = null,
+    @ColumnInfo(name = "pending_edition_sha") val pendingEditionSha: String? = null,
     @ColumnInfo(name = "pending_status") val pendingStatus: String? = null,
     @ColumnInfo(name = "pending_updated_at") val pendingUpdatedAt: Long? = null,
     /** True once a partner has reported something waiting to be settled. */
@@ -85,13 +88,17 @@ abstract class SyncPeerStateDao {
         """
         INSERT INTO sync_peer_state (
             book_url, peer_id, acked_revision,
-            pending_progression, pending_status, pending_updated_at,
+            pending_progression, pending_locator_json, pending_edition_sha,
+            pending_status, pending_updated_at,
             has_pending, remote_updated_at
         )
-        VALUES (:bookUrl, :peerId, 0, :progression, :status, :remoteUpdatedAt, 1,
+        VALUES (:bookUrl, :peerId, 0, :progression, :locatorJson, :editionSha,
+                :status, :remoteUpdatedAt, 1,
                 :remoteUpdatedAt)
         ON CONFLICT(book_url, peer_id) DO UPDATE SET
             pending_progression = :progression,
+            pending_locator_json = :locatorJson,
+            pending_edition_sha = :editionSha,
             pending_status = :status,
             pending_updated_at = :remoteUpdatedAt,
             has_pending = 1,
@@ -104,12 +111,15 @@ abstract class SyncPeerStateDao {
         progression: Double?,
         status: String?,
         remoteUpdatedAt: Long?,
+        locatorJson: String? = null,
+        editionSha: String? = null,
     )
 
     @Query(
         """
         UPDATE sync_peer_state SET
-            pending_progression = NULL, pending_status = NULL,
+            pending_progression = NULL, pending_locator_json = NULL,
+            pending_edition_sha = NULL, pending_status = NULL,
             pending_updated_at = NULL, has_pending = 0
         WHERE book_url = :bookUrl AND peer_id = :peerId
         """,
@@ -136,6 +146,8 @@ abstract class SyncPeerStateDao {
             agreed_progression = :progression,
             agreed_status = :status,
             pending_progression = NULL,
+            pending_locator_json = NULL,
+            pending_edition_sha = NULL,
             pending_status = NULL,
             pending_updated_at = NULL,
             has_pending = 0,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepository.kt
@@ -114,6 +114,9 @@ class KomgaSyncRepository(
             is RemoteResult.Failed -> return PreviewOutcome.Failed(asked.reason)
             is RemoteResult.Ok -> asked.value
         }
+        val remoteLocatorJson = remote?.locator
+            ?.let(KomgaLocator::toReadium)
+            ?.toString()
         if (remote != null) {
             forAccount(server) {
                 progressDao.persistPending(
@@ -123,29 +126,27 @@ class KomgaSyncRepository(
                     remoteUpdatedAt = remote.state.updatedAt,
                     account = server.accountKey,
                     now = System.currentTimeMillis(),
-                    locatorJson = remote.locator?.let(KomgaLocator::toReadium)?.toString(),
+                    locatorJson = remoteLocatorJson,
                 )
             }
         }
+        val stored = progressDao.get(bookUrl)
+        val exact = remoteLocatorJson?.takeIf(ExactLocatorAnchor::isExactJson)
         return PreviewOutcome.Ready(
             SyncPreview(
-                local = progressDao.get(bookUrl)?.totalProgression,
+                local = stored?.totalProgression,
                 remote = remote?.state?.progression,
                 remoteAt = remote?.state?.updatedAt?.takeIf { it > 0 },
-                excerpt = remote?.locator
-                    ?.let(KomgaLocator::toReadium)
-                    ?.toString()
-                    ?.let(ExactLocatorAnchor::excerpt),
-                confidence = if (
-                    remote?.locator
-                        ?.let(KomgaLocator::toReadium)
-                        ?.toString()
-                        ?.let(ExactLocatorAnchor::isExactJson) == true
-                ) {
+                excerpt = ExactLocatorAnchor.excerpt(exact),
+                confidence = if (exact != null) {
                     ResumeConfidence.EXACT
                 } else {
                     ResumeConfidence.APPROXIMATE
                 },
+                exactPositionAgreement = ExactLocatorAnchor.agreement(
+                    stored?.locatorJson,
+                    exact,
+                ),
             ),
         )
     }
@@ -169,6 +170,10 @@ class KomgaSyncRepository(
             } else {
                 ResumeConfidence.APPROXIMATE
             },
+            exactPositionAgreement = ExactLocatorAnchor.agreement(
+                stored.locatorJson,
+                stored.pendingLocatorJson,
+            ),
         ).takeIf { !it.agrees }
     }
 
@@ -401,12 +406,20 @@ class KomgaSyncRepository(
             return BookOutcome()
         }
 
+        val exactRemote = remote?.locator
+            ?.let(KomgaLocator::toReadium)
+            ?.toString()
+            ?.takeIf(ExactLocatorAnchor::isExactJson)
         val decision = reconcileReadingState(
             local = stored?.asReadingState(),
             remote = remote?.state,
             baseline = stored?.baselineFor(account),
             localDirty = dirty,
             localUnreadOverride = stored?.override == FinishedOverride.UNREAD,
+            exactPositionAgreement = ExactLocatorAnchor.agreement(
+                stored?.locatorJson,
+                exactRemote,
+            ),
         )
         return apply(server, credentials, id, book.url, stored, remote, decision)
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepository.kt
@@ -15,6 +15,7 @@ import com.chmouel.liseur.data.remote.PreviewOutcome
 import com.chmouel.liseur.data.remote.RemoteCredentials
 import com.chmouel.liseur.data.remote.RemoteResult
 import com.chmouel.liseur.data.remote.ResolveOutcome
+import com.chmouel.liseur.data.remote.ResumeConfidence
 import com.chmouel.liseur.data.remote.SyncFailure
 import com.chmouel.liseur.data.remote.SyncIdentity
 import com.chmouel.liseur.data.remote.SyncMove
@@ -24,7 +25,6 @@ import com.chmouel.liseur.data.remote.SyncPreview
 import com.chmouel.liseur.data.remote.SyncReport
 import com.chmouel.liseur.data.remote.SyncReporting
 import com.chmouel.liseur.data.remote.remoteCall
-import com.chmouel.liseur.data.remote.valueOrNull
 import com.chmouel.liseur.domain.FinishedOverride
 import com.chmouel.liseur.domain.ReadingBaseline
 import com.chmouel.liseur.domain.ReadingState
@@ -33,6 +33,7 @@ import com.chmouel.liseur.domain.SyncDecision
 import com.chmouel.liseur.domain.needsReconciling
 import com.chmouel.liseur.domain.readingStatusFor
 import com.chmouel.liseur.domain.reconcileReadingState
+import com.chmouel.liseur.reader.progress.ExactLocatorAnchor
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -122,6 +123,7 @@ class KomgaSyncRepository(
                     remoteUpdatedAt = remote.state.updatedAt,
                     account = server.accountKey,
                     now = System.currentTimeMillis(),
+                    locatorJson = remote.locator?.let(KomgaLocator::toReadium)?.toString(),
                 )
             }
         }
@@ -130,6 +132,20 @@ class KomgaSyncRepository(
                 local = progressDao.get(bookUrl)?.totalProgression,
                 remote = remote?.state?.progression,
                 remoteAt = remote?.state?.updatedAt?.takeIf { it > 0 },
+                excerpt = remote?.locator
+                    ?.let(KomgaLocator::toReadium)
+                    ?.toString()
+                    ?.let(ExactLocatorAnchor::excerpt),
+                confidence = if (
+                    remote?.locator
+                        ?.let(KomgaLocator::toReadium)
+                        ?.toString()
+                        ?.let(ExactLocatorAnchor::isExactJson) == true
+                ) {
+                    ResumeConfidence.EXACT
+                } else {
+                    ResumeConfidence.APPROXIMATE
+                },
             ),
         )
     }
@@ -147,6 +163,12 @@ class KomgaSyncRepository(
             local = stored.totalProgression,
             remote = there,
             remoteAt = stored.remoteUpdatedAt?.takeIf { it > 0 },
+            excerpt = ExactLocatorAnchor.excerpt(stored.pendingLocatorJson),
+            confidence = if (ExactLocatorAnchor.isExactJson(stored.pendingLocatorJson)) {
+                ResumeConfidence.EXACT
+            } else {
+                ResumeConfidence.APPROXIMATE
+            },
         ).takeIf { !it.agrees }
     }
 
@@ -154,22 +176,13 @@ class KomgaSyncRepository(
      * Takes the position the server reported for one book, because
      * someone said to.
      *
-     * The exact place is asked for again rather than remembered, since
-     * the disagreement may have been sitting on disk since a previous
-     * run. Failing to get it is not a reason to refuse: the percentage
-     * that was recorded is still a better answer than staying put, and
-     * it is what calibre-web could offer at best.
+     * The exact place is the one persisted with the pending percentage,
+     * so a restart cannot pair the choice with a later server answer.
      */
     override suspend fun takeRemotePosition(bookUrl: String, atRevision: Long): ResolveOutcome {
         val server = serverDao.get() ?: return ResolveOutcome.Done
         val stored = progressDao.get(bookUrl) ?: return ResolveOutcome.Done
         val progression = stored.pendingProgression ?: return ResolveOutcome.Done
-        val id = bookDao.getByUrl(bookUrl)?.remoteUuid
-
-        val locator = server.credentials?.let { credentials ->
-            id?.let { positions.read(server.baseUrl, credentials, it).valueOrNull() }
-        }
-
         val applied = progressDao.applyPull(
             bookUrl = bookUrl,
             expectedRevision = atRevision,
@@ -178,7 +191,7 @@ class KomgaSyncRepository(
             account = server.accountKey,
             remoteUpdatedAt = stored.pendingUpdatedAt,
             now = System.currentTimeMillis(),
-            locatorJson = locator?.let(KomgaLocator::toReadium)?.toString(),
+            locatorJson = stored.pendingLocatorJson.takeIf(ExactLocatorAnchor::isExactJson),
         )
         if (!applied) return ResolveOutcome.Superseded
         finishedState.refreshFromProgress(bookUrl)
@@ -360,7 +373,14 @@ class KomgaSyncRepository(
         // Something unsettled from an earlier run is still the server's
         // word, and outlives the run that heard it.
         if (remote == null) {
-            remote = stored?.pendingStateFor(account)?.let { RemoteSide(it) }
+            remote = stored?.pendingStateFor(account)?.let {
+                RemoteSide(
+                    state = it,
+                    locator = stored.pendingLocatorJson?.let { json ->
+                        runCatching { JSONObject(json) }.getOrNull()
+                    },
+                )
+            }
         } else {
             forAccount(server) {
                 progressDao.persistPending(
@@ -370,6 +390,7 @@ class KomgaSyncRepository(
                     remoteUpdatedAt = remote.state.updatedAt,
                     account = account,
                     now = System.currentTimeMillis(),
+                    locatorJson = remote.locator?.let(KomgaLocator::toReadium)?.toString(),
                 )
             }
             stored = progressDao.get(book.url)
@@ -418,7 +439,7 @@ class KomgaSyncRepository(
                     ReadingState(
                         progression = stored.agreedProgression,
                         status = statusOf(progress, stored.agreedProgression),
-                        updatedAt = progress.readDate ?: 0L,
+                        updatedAt = progress.readDate,
                     ),
                     unchanged = true,
                 ),
@@ -566,7 +587,9 @@ class KomgaSyncRepository(
                         // cannot: reopen the book exactly where the other
                         // device left it rather than at a percentage.
                         locatorJson = remote?.locator
-                            ?.let(KomgaLocator::toReadium)?.toString(),
+                            ?.let(KomgaLocator::toReadium)
+                            ?.toString()
+                            ?.takeIf(ExactLocatorAnchor::isExactJson),
                     )
                 }
                 finishedState.refreshFromProgress(bookUrl)

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
@@ -131,6 +131,10 @@ class LiseurSyncPositionSync(
                 } else {
                     ResumeConfidence.APPROXIMATE
                 },
+                exactPositionAgreement = ExactLocatorAnchor.agreement(
+                    stored?.locatorJson,
+                    exact,
+                ),
             ),
         )
     }
@@ -152,6 +156,10 @@ class LiseurSyncPositionSync(
             } else {
                 ResumeConfidence.APPROXIMATE
             },
+            exactPositionAgreement = ExactLocatorAnchor.agreement(
+                progressDao.get(bookUrl)?.locatorJson,
+                exact,
+            ),
         ).takeIf { !it.agrees }
     }
 
@@ -598,6 +606,7 @@ class LiseurSyncPositionSync(
         val (book, alias) = named
         val stored = progressDao.get(book.url)
         val state = peerStateDao.get(book.url, account.peerId)
+        val exactRemote = state?.exactLocatorFor(alias)
         val dirty = state?.isDirty(stored?.localRevision ?: 0)
             ?: ((stored?.localRevision ?: 0) > 0)
 
@@ -609,8 +618,12 @@ class LiseurSyncPositionSync(
             baseline = state?.baseline(),
             localDirty = dirty,
             localUnreadOverride = stored?.override == FinishedOverride.UNREAD,
+            exactPositionAgreement = ExactLocatorAnchor.agreement(
+                stored?.locatorJson,
+                exactRemote,
+            ),
         )
-        return act(account, book, alias, stored, state, decision)
+        return act(account, book, alias, stored, state, exactRemote, decision)
     }
 
     private suspend fun act(
@@ -619,6 +632,7 @@ class LiseurSyncPositionSync(
         alias: WorkAlias,
         stored: ReadingProgress?,
         state: SyncPeerState?,
+        exactRemote: String?,
         decision: SyncDecision,
     ): Reconciled {
         val at = now()
@@ -651,7 +665,7 @@ class LiseurSyncPositionSync(
                         progression = progression,
                         status = decision.state.status.wireName,
                         now = at,
-                        locatorJson = state?.exactLocatorFor(alias),
+                        locatorJson = exactRemote,
                         remoteUpdatedAt = state?.pendingUpdatedAt,
                     )
                     if (applied) {

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
@@ -19,6 +19,7 @@ import com.chmouel.liseur.data.remote.PreviewOutcome
 import com.chmouel.liseur.data.remote.RemoteCredentials
 import com.chmouel.liseur.data.remote.RemoteHttpFailure
 import com.chmouel.liseur.data.remote.ResolveOutcome
+import com.chmouel.liseur.data.remote.ResumeConfidence
 import com.chmouel.liseur.data.remote.ServerKind
 import com.chmouel.liseur.data.remote.SyncFailure
 import com.chmouel.liseur.data.remote.SyncIdentity
@@ -35,6 +36,7 @@ import com.chmouel.liseur.domain.SyncDecision
 import com.chmouel.liseur.domain.needsReconciling
 import com.chmouel.liseur.domain.readingStatusFor
 import com.chmouel.liseur.domain.reconcileReadingState
+import com.chmouel.liseur.reader.progress.ExactLocatorAnchor
 import java.io.IOException
 import org.json.JSONArray
 import org.json.JSONObject
@@ -113,11 +115,22 @@ class LiseurSyncPositionSync(
         }
 
         val stored = progressDao.get(bookUrl)
+        val exact = head.locatorJson.takeIf {
+            head.editionSha != null &&
+                head.editionSha == alias.editionSha &&
+                ExactLocatorAnchor.isExactJson(it)
+        }
         return PreviewOutcome.Ready(
             SyncPreview(
                 local = stored?.totalProgression,
                 remote = head.progression,
                 remoteAt = head.clientTs.takeIf { it > 0 },
+                excerpt = ExactLocatorAnchor.excerpt(exact),
+                confidence = if (exact != null) {
+                    ResumeConfidence.EXACT
+                } else {
+                    ResumeConfidence.APPROXIMATE
+                },
             ),
         )
     }
@@ -127,10 +140,18 @@ class LiseurSyncPositionSync(
         val state = peerStateDao.get(bookUrl, account.peerId) ?: return null
         if (!state.hasPending) return null
         val there = state.pendingProgression ?: return null
+        val alias = identityDao.alias(bookUrl, account.peerId)
+        val exact = state.exactLocatorFor(alias)
         return SyncPreview(
             local = progressDao.get(bookUrl)?.totalProgression,
             remote = there,
             remoteAt = state.remoteUpdatedAt?.takeIf { it > 0 },
+            excerpt = ExactLocatorAnchor.excerpt(exact),
+            confidence = if (exact != null) {
+                ResumeConfidence.EXACT
+            } else {
+                ResumeConfidence.APPROXIMATE
+            },
         ).takeIf { !it.agrees }
     }
 
@@ -146,12 +167,9 @@ class LiseurSyncPositionSync(
         val state = peerStateDao.get(bookUrl, account.peerId) ?: return ResolveOutcome.Done
         val progression = state.pendingProgression ?: return ResolveOutcome.Done
 
-        val locator = bookDao.getByUrl(bookUrl)
+        val alias = bookDao.getByUrl(bookUrl)
             ?.let { works.cached(it, account.peerId) }
-            ?.let {
-                runCatching { latestOp(account.baseUrl, account.credentials, it.workId) }
-                    .getOrNull()?.locatorJson
-            }
+        val locator = state.exactLocatorFor(alias)
 
         var applied = false
         val status = ReadingStatus.fromWire(state.pendingStatus)
@@ -163,6 +181,7 @@ class LiseurSyncPositionSync(
                 status = status.wireName,
                 now = now(),
                 locatorJson = locator,
+                remoteUpdatedAt = state.pendingUpdatedAt,
             )
             if (applied) {
                 peerStateDao.settle(
@@ -532,8 +551,11 @@ class LiseurSyncPositionSync(
         val byWork = identityDao.aliasesFor(account.peerId).associateBy { it.workId }
         inTransaction {
             if (serverDao.get()?.accountKey != account.accountKey) return@inTransaction
-            for (op in ops) {
-                if (op.deviceId != null && op.deviceId == account.deviceId) continue
+            val newestByWork = ops
+                .filterNot { it.deviceId != null && it.deviceId == account.deviceId }
+                .groupBy(SyncOp::workId)
+                .mapNotNull { (_, candidates) -> candidates.maxByOrNull(SyncOp::seq) }
+            for (op in newestByWork) {
                 val bookUrl = byWork[op.workId]?.takeIf { it.usable }?.bookUrl ?: continue
                 land(account, bookUrl, op)
             }
@@ -548,8 +570,9 @@ class LiseurSyncPositionSync(
             progression = op.progression,
             status = readingStatusFor(op.progression).wireName,
             remoteUpdatedAt = op.clientTs.takeIf { it > 0 },
+            locatorJson = op.locatorJson,
+            editionSha = op.editionSha,
         )
-        op.locatorJson?.let { pendingLocators[bookUrl] = it }
     }
 
     // -- Settling one book ------------------------------------------------
@@ -628,7 +651,8 @@ class LiseurSyncPositionSync(
                         progression = progression,
                         status = decision.state.status.wireName,
                         now = at,
-                        locatorJson = pendingLocators.remove(book.url),
+                        locatorJson = state?.exactLocatorFor(alias),
+                        remoteUpdatedAt = state?.pendingUpdatedAt,
                     )
                     if (applied) {
                         peerStateDao.settle(
@@ -1160,18 +1184,13 @@ class LiseurSyncPositionSync(
         )
     }
 
-    /**
-     * Locators from ops that have not been acted on yet.
-     *
-     * Held in memory rather than on disk on purpose. A locator is only
-     * ever a nicety — the progression is what the two sides are compared
-     * on, and a book pulled without one simply reopens at roughly the
-     * right place instead of on the exact word. Giving every unsettled
-     * op a column would be a schema change to make a good outcome
-     * slightly better, and losing one costs nothing that a page turn
-     * does not fix.
-     */
-    private val pendingLocators = mutableMapOf<String, String>()
+    /** Exact placement is safe only for byte-identical editions. */
+    private fun SyncPeerState.exactLocatorFor(alias: WorkAlias?): String? =
+        pendingLocatorJson.takeIf {
+            pendingEditionSha != null &&
+                pendingEditionSha == alias?.editionSha &&
+                ExactLocatorAnchor.isExactJson(it)
+        }
 
     private companion object {
         /** Refusals no amount of retrying will turn into an acceptance. */

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/PositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/PositionSync.kt
@@ -79,6 +79,9 @@ data class SyncPreview(
     val remote: Double?,
     /** The server's own timestamp for its position, for display only. */
     val remoteAt: Long?,
+    /** A short quote around the remote anchor, when one travelled with it. */
+    val excerpt: String? = null,
+    val confidence: ResumeConfidence = ResumeConfidence.APPROXIMATE,
 ) {
     /** True when there is nothing to choose between. */
     val agrees: Boolean
@@ -88,6 +91,8 @@ data class SyncPreview(
             return kotlin.math.abs(here - there) < EPSILON
         }
 }
+
+enum class ResumeConfidence { EXACT, APPROXIMATE }
 
 /** What came of acting on a choice between two positions. */
 sealed interface ResolveOutcome {

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/PositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/PositionSync.kt
@@ -82,10 +82,13 @@ data class SyncPreview(
     /** A short quote around the remote anchor, when one travelled with it. */
     val excerpt: String? = null,
     val confidence: ResumeConfidence = ResumeConfidence.APPROXIMATE,
+    /** Exact anchor equality, or null when this partner only supplied a percentage. */
+    val exactPositionAgreement: Boolean? = null,
 ) {
     /** True when there is nothing to choose between. */
     val agrees: Boolean
         get() {
+            exactPositionAgreement?.let { return it }
             val here = local ?: return remote == null
             val there = remote ?: return false
             return kotlin.math.abs(here - there) < EPSILON

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/ReadingStateMerge.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/ReadingStateMerge.kt
@@ -157,6 +157,7 @@ fun reconcileReadingState(
     baseline: ReadingBaseline?,
     localDirty: Boolean,
     localUnreadOverride: Boolean = false,
+    exactPositionAgreement: Boolean? = null,
 ): SyncDecision {
     if (local == null && remote == null) return SyncDecision.InSync
     if (local == null) return SyncDecision.Pull(checkNotNull(remote))
@@ -164,7 +165,7 @@ fun reconcileReadingState(
         return if (localDirty) SyncDecision.Push(local) else SyncDecision.InSync
     }
 
-    if (sameSpot(local, remote)) return SyncDecision.InSync
+    if (sameSpot(local, remote, exactPositionAgreement)) return SyncDecision.InSync
 
     // A deliberate "not read after all" here beats a leftover flag there.
     if (localUnreadOverride && remote.status == ReadingStatus.FINISHED) {
@@ -180,6 +181,20 @@ fun reconcileReadingState(
             // calling this settled would drop it for good.
             localDirty && local.progression != null -> SyncDecision.Push(local)
             else -> SyncDecision.InSync
+        }
+    }
+
+    // Percentage-only partners need a tolerance for rounding and layout.
+    // An exact same-edition anchor does not: if it differs, silently calling
+    // the two places equal is precisely the position loss exact sync avoids.
+    // A clean local side can take it immediately. If this device also moved,
+    // preserve both sides as a conflict rather than guessing which action was
+    // intentional.
+    if (exactPositionAgreement == false) {
+        return if (localDirty) {
+            SyncDecision.Conflict(local, remote)
+        } else {
+            SyncDecision.Pull(remote)
         }
     }
 
@@ -212,8 +227,13 @@ private fun movedFrom(
     return kotlin.math.abs(agreed - now) >= tolerance
 }
 
-private fun sameSpot(local: ReadingState, remote: ReadingState): Boolean {
+private fun sameSpot(
+    local: ReadingState,
+    remote: ReadingState,
+    exactPositionAgreement: Boolean?,
+): Boolean {
     if (local.status != remote.status) return false
+    if (exactPositionAgreement != null) return exactPositionAgreement
     val here = local.progression ?: return remote.progression == null
     val there = remote.progression ?: return false
     return kotlin.math.abs(here - there) < EPSILON

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/NavigatorPositionEvent.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/NavigatorPositionEvent.kt
@@ -1,0 +1,15 @@
+package com.chmouel.liseur.reader
+
+/** Why the navigator emitted a position, and which side effects it is allowed to cause. */
+enum class NavigatorPositionEvent(
+    val persists: Boolean,
+    val teachesPace: Boolean,
+    val recordsReadingTime: Boolean,
+) {
+    READER_MOVEMENT(persists = true, teachesPace = true, recordsReadingTime = true),
+    LOCAL_JUMP(persists = true, teachesPace = false, recordsReadingTime = false),
+    REMOTE_ADOPTION(persists = false, teachesPace = false, recordsReadingTime = false),
+    PREFERENCE_REFLOW(persists = false, teachesPace = false, recordsReadingTime = false),
+    FRAGMENT_RECREATION(persists = false, teachesPace = false, recordsReadingTime = false),
+    LIFECYCLE_REPLAY(persists = false, teachesPace = false, recordsReadingTime = false),
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
@@ -299,6 +299,11 @@ class ReaderActivity : FragmentActivity() {
                                             chapterTitleAtPosition = viewModel::chapterTitleAtPosition,
                                             positionAtProgression = viewModel::positionAtProgression,
                                             locatorAtPosition = viewModel::locatorAtPosition,
+                                            locatorAtOrBeforeProgression =
+                                                viewModel::locatorAtOrBeforeProgression,
+                                            prepareLocator = viewModel::prepareLocator,
+                                            onApproximateResume = viewModel::onApproximateResume,
+                                            currentLocator = { viewModel.lastLocator },
                                         )
                                     },
                                     annotationsFlow = viewModel.annotations,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -114,6 +115,7 @@ import com.chmouel.liseur.reader.chrome.Endpaper
 import com.chmouel.liseur.reader.chrome.FootnoteCard
 import com.chmouel.liseur.reader.chrome.TypographySheet
 import com.chmouel.liseur.reader.progress.ReaderProgress
+import com.chmouel.liseur.reader.progress.ExactLocatorAnchor
 import com.chmouel.liseur.reader.search.SearchScreen
 import com.chmouel.liseur.ui.LocalEInk
 import com.chmouel.liseur.ui.BusyIndicator
@@ -125,6 +127,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -158,7 +161,7 @@ fun ReaderScreen(
     onContinueNext: () -> Unit,
     onReachedEndpaper: () -> Unit,
     onLeftEndpaper: () -> Unit,
-    onLocatorChanged: (Locator) -> Unit,
+    onLocatorChanged: (Locator, NavigatorPositionEvent) -> Unit,
     onNavigatorChanged: (EpubNavigatorFragment?) -> Unit,
     onPageTurnerChanged: (PageTurner?) -> Unit,
     onChromeVisibleChanged: (Boolean) -> Unit = {},
@@ -235,6 +238,55 @@ fun ReaderScreen(
     val context = LocalContext.current
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     val effectScope = rememberCoroutineScope()
+    var pendingPositionEvent by remember { mutableStateOf<NavigatorPositionEvent?>(null) }
+
+    suspend fun capture(nav: EpubNavigatorFragment, locator: Locator): Locator =
+        onProgressAction.prepareLocator(ExactLocatorAnchor.capture(nav, locator))
+
+    suspend fun settleLayout() {
+        withFrameNanos { }
+        withFrameNanos { }
+    }
+
+    suspend fun navigate(
+        nav: EpubNavigatorFragment,
+        locator: Locator,
+        event: NavigatorPositionEvent,
+        verify: Boolean = false,
+    ) {
+        pendingPositionEvent = event
+        nav.go(locator, animated = false)
+        if (!verify || !ExactLocatorAnchor.isExact(locator)) return
+        settleLayout()
+        if (ExactLocatorAnchor.verify(nav, locator)) return
+        val progression = locator.locations.totalProgression ?: return
+        val fallback = onProgressAction.locatorAtOrBeforeProgression(progression) ?: return
+        pendingPositionEvent = event
+        nav.go(fallback, animated = false)
+        onProgressAction.onApproximateResume()
+    }
+
+    fun navigateLater(
+        locator: Locator,
+        event: NavigatorPositionEvent,
+        verify: Boolean = false,
+    ) {
+        val nav = navigatorNow ?: return
+        effectScope.launch { navigate(nav, locator, event, verify) }
+    }
+
+    fun beforeReflow(action: () -> Unit) {
+        val nav = navigatorNow
+        if (nav == null) {
+            action()
+            return
+        }
+        effectScope.launch {
+            val anchor = capture(nav, nav.currentLocator.value)
+            onLocatorChanged(anchor, NavigatorPositionEvent.PREFERENCE_REFLOW)
+            action()
+        }
+    }
     val eInk = LocalEInk.current
     val eInkNow by rememberUpdatedState(eInk)
     var showingEnd by remember { mutableStateOf(false) }
@@ -286,8 +338,26 @@ fun ReaderScreen(
             // emission is discarded too: merely bringing the reader back
             // must not look like this device turned a page and turn a
             // one-sided remote update into a conflict.
-            nav.currentLocator.drop(1).collect(onLocatorChanged)
+            nav.currentLocator.drop(1).collect { native ->
+                val event = pendingPositionEvent ?: NavigatorPositionEvent.READER_MOVEMENT
+                pendingPositionEvent = null
+                onLocatorChanged(capture(nav, native), event)
+            }
         }
+    }
+
+    LaunchedEffect(navigator) {
+        val nav = navigator ?: return@LaunchedEffect
+        val requested = onProgressAction.currentLocator() ?: return@LaunchedEffect
+        if (!ExactLocatorAnchor.isExact(requested)) return@LaunchedEffect
+        settleLayout()
+        if (ExactLocatorAnchor.verify(nav, requested)) return@LaunchedEffect
+        val progression = requested.locations.totalProgression ?: return@LaunchedEffect
+        val fallback = onProgressAction.locatorAtOrBeforeProgression(progression)
+            ?: return@LaunchedEffect
+        pendingPositionEvent = NavigatorPositionEvent.FRAGMENT_RECREATION
+        nav.go(fallback, animated = false)
+        onProgressAction.onApproximateResume()
     }
 
     // Apply preference changes to the rendered book as they happen.
@@ -309,7 +379,19 @@ fun ReaderScreen(
             p.toEpubPreferences(theme, columnMode, scrollMode)
         }
             .drop(1)
-            .collect { nav.submitPreferences(it) }
+            .collect {
+                val anchor = capture(nav, nav.currentLocator.value)
+                onLocatorChanged(anchor, NavigatorPositionEvent.PREFERENCE_REFLOW)
+                pendingPositionEvent = NavigatorPositionEvent.PREFERENCE_REFLOW
+                nav.submitPreferences(it)
+                settleLayout()
+                navigate(
+                    nav = nav,
+                    locator = anchor,
+                    event = NavigatorPositionEvent.PREFERENCE_REFLOW,
+                    verify = true,
+                )
+            }
     }
 
     // Picking the selection up from the navigator when it tells us the
@@ -520,10 +602,14 @@ fun ReaderScreen(
                     JumpBackPill(
                         position = target.position,
                         fromSync = target.fromSync,
+                        excerpt = target.excerpt,
+                        remoteAt = target.remoteAt,
+                        confidence = target.confidence,
+                        resumePosition = target.resumePosition,
                         theme = readingTheme,
                         onJumpBack = {
                             onProgressAction.dismissJumpBack()
-                            navigator?.go(target.locator, animated = false)
+                            navigateLater(target.locator, NavigatorPositionEvent.LOCAL_JUMP)
                         },
                         onDismiss = onProgressAction.dismissJumpBack,
                     )
@@ -534,6 +620,9 @@ fun ReaderScreen(
                     catchUp?.let { offer ->
                         CatchUpPill(
                             position = offer.position,
+                            excerpt = offer.excerpt,
+                            remoteAt = offer.remoteAt,
+                            confidence = offer.confidence,
                             theme = readingTheme,
                             onCatchUp = onProgressAction.acceptCatchUp,
                             onDismiss = onProgressAction.dismissCatchUp,
@@ -552,7 +641,7 @@ fun ReaderScreen(
                         onSeek = { position ->
                             onProgressAction.locatorAtPosition(position)?.let {
                                 onProgressAction.onJump()
-                                navigator?.go(it, animated = false)
+                                navigateLater(it, NavigatorPositionEvent.LOCAL_JUMP)
                             }
                         },
                     )
@@ -742,20 +831,24 @@ fun ReaderScreen(
             prefs = prefs,
             readingTheme = readingTheme,
             typographyIsOwn = typographyIsOwn,
-            onTypographyIsOwnChanged = onPrefsAction.setTypographyIsOwn,
-            onFontSelected = onPrefsAction.setFont,
-            onFontSizeChanged = onPrefsAction.setFontSize,
-            onThemeSelected = onPrefsAction.setTheme,
-            onLineHeightChanged = onPrefsAction.setLineHeight,
-            onPageMarginsChanged = onPrefsAction.setPageMargins,
+            onTypographyIsOwnChanged = { value ->
+                beforeReflow { onPrefsAction.setTypographyIsOwn(value) }
+            },
+            onFontSelected = { value -> beforeReflow { onPrefsAction.setFont(value) } },
+            onFontSizeChanged = { value -> beforeReflow { onPrefsAction.setFontSize(value) } },
+            onThemeSelected = { value -> beforeReflow { onPrefsAction.setTheme(value) } },
+            onLineHeightChanged = { value -> beforeReflow { onPrefsAction.setLineHeight(value) } },
+            onPageMarginsChanged = { value ->
+                beforeReflow { onPrefsAction.setPageMargins(value) }
+            },
             onBrightnessChanged = onPrefsAction.setBrightness,
             onPageTurnAnimationChanged = onPrefsAction.setPageTurnAnimation,
             onFooterModeChanged = onProgressAction.setFooterMode,
-            onColumnModeChanged = onPrefsAction.setColumnMode,
+            onColumnModeChanged = { value -> beforeReflow { onPrefsAction.setColumnMode(value) } },
             keepScreenOn = keepScreenOn,
             onKeepScreenOnChanged = onKeepScreenOnChanged,
             scrollMode = scrollMode,
-            onScrollModeChanged = onScrollModeChanged,
+            onScrollModeChanged = { value -> beforeReflow { onScrollModeChanged(value) } },
             onDismiss = { showTypography = false },
         )
     }
@@ -781,7 +874,7 @@ fun ReaderScreen(
                 searchHit = hit
                 chromeVisible = false
                 onProgressAction.onJump()
-                navigator?.go(hit, animated = false)
+                navigateLater(hit, NavigatorPositionEvent.LOCAL_JUMP)
             },
             onClose = {
                 searchFor = null
@@ -800,7 +893,14 @@ fun ReaderScreen(
             onLeftEndpaper()
             showToc = false
             chromeVisible = false
-            navigatorNow?.go(locator, animated = false)
+            navigatorNow?.let { nav ->
+                navigate(
+                    nav = nav,
+                    locator = locator,
+                    event = NavigatorPositionEvent.REMOTE_ADOPTION,
+                    verify = true,
+                )
+            }
         }
     }
 
@@ -818,7 +918,7 @@ fun ReaderScreen(
                     showToc = false
                     chromeVisible = false
                     onProgressAction.onJump()
-                    navigator?.go(it, animated = false)
+                    navigateLater(it, NavigatorPositionEvent.LOCAL_JUMP)
                 }
             },
             onAnnotationDeleted = onAnnotationAction.remove,
@@ -835,7 +935,7 @@ fun ReaderScreen(
                 chromeVisible = false
                 publication.locatorFromLink(link)?.let {
                     onProgressAction.onJump()
-                    navigator?.go(it, animated = false)
+                    navigateLater(it, NavigatorPositionEvent.LOCAL_JUMP)
                 }
             },
         )
@@ -910,6 +1010,10 @@ class ReaderProgressActions(
     val chapterTitleAtPosition: (Int) -> String?,
     val positionAtProgression: (Float) -> Int,
     val locatorAtPosition: (Int) -> Locator?,
+    val locatorAtOrBeforeProgression: (Double) -> Locator?,
+    val prepareLocator: (Locator) -> Locator,
+    val onApproximateResume: () -> Unit,
+    val currentLocator: () -> Locator?,
 )
 
 /** Syncing this one book on purpose, from the Navigate screen. */

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -275,18 +275,6 @@ fun ReaderScreen(
         effectScope.launch { navigate(nav, locator, event, verify) }
     }
 
-    fun beforeReflow(action: () -> Unit) {
-        val nav = navigatorNow
-        if (nav == null) {
-            action()
-            return
-        }
-        effectScope.launch {
-            val anchor = capture(nav, nav.currentLocator.value)
-            onLocatorChanged(anchor, NavigatorPositionEvent.PREFERENCE_REFLOW)
-            action()
-        }
-    }
     val eInk = LocalEInk.current
     val eInkNow by rememberUpdatedState(eInk)
     var showingEnd by remember { mutableStateOf(false) }
@@ -364,7 +352,7 @@ fun ReaderScreen(
     // The column mode is filtered through the window width for the same
     // reason it is in ReaderActivity: a narrow window cannot carry a
     // choice made on a wide one, and the control to undo it is hidden.
-    LaunchedEffect(navigator, columnMode, scrollMode) {
+    LaunchedEffect(navigator) {
         val nav = navigator ?: return@LaunchedEffect
         // The factory already built this navigator with the current
         // preferences. Submitting that same value once more reflows the
@@ -375,8 +363,11 @@ fun ReaderScreen(
         // change without the preferences changing at all: a reader on
         // the app's theme who leaves their phone to turn itself dark at
         // dusk has chosen nothing, and the open book should still follow.
-        combine(prefsFlow, snapshotFlow { readingThemeNow }) { p, theme ->
-            p.toEpubPreferences(theme, columnMode, scrollMode)
+        combine(
+            prefsFlow,
+            snapshotFlow { Triple(readingThemeNow, columnMode, scrollMode) },
+        ) { p, (theme, columns, scrolling) ->
+            p.toEpubPreferences(theme, columns, scrolling)
         }
             .drop(1)
             .collect {
@@ -831,24 +822,20 @@ fun ReaderScreen(
             prefs = prefs,
             readingTheme = readingTheme,
             typographyIsOwn = typographyIsOwn,
-            onTypographyIsOwnChanged = { value ->
-                beforeReflow { onPrefsAction.setTypographyIsOwn(value) }
-            },
-            onFontSelected = { value -> beforeReflow { onPrefsAction.setFont(value) } },
-            onFontSizeChanged = { value -> beforeReflow { onPrefsAction.setFontSize(value) } },
-            onThemeSelected = { value -> beforeReflow { onPrefsAction.setTheme(value) } },
-            onLineHeightChanged = { value -> beforeReflow { onPrefsAction.setLineHeight(value) } },
-            onPageMarginsChanged = { value ->
-                beforeReflow { onPrefsAction.setPageMargins(value) }
-            },
+            onTypographyIsOwnChanged = onPrefsAction.setTypographyIsOwn,
+            onFontSelected = onPrefsAction.setFont,
+            onFontSizeChanged = onPrefsAction.setFontSize,
+            onThemeSelected = onPrefsAction.setTheme,
+            onLineHeightChanged = onPrefsAction.setLineHeight,
+            onPageMarginsChanged = onPrefsAction.setPageMargins,
             onBrightnessChanged = onPrefsAction.setBrightness,
             onPageTurnAnimationChanged = onPrefsAction.setPageTurnAnimation,
             onFooterModeChanged = onProgressAction.setFooterMode,
-            onColumnModeChanged = { value -> beforeReflow { onPrefsAction.setColumnMode(value) } },
+            onColumnModeChanged = onPrefsAction.setColumnMode,
             keepScreenOn = keepScreenOn,
             onKeepScreenOnChanged = onKeepScreenOnChanged,
             scrollMode = scrollMode,
-            onScrollModeChanged = { value -> beforeReflow { onScrollModeChanged(value) } },
+            onScrollModeChanged = onScrollModeChanged,
             onDismiss = { showTypography = false },
         )
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -13,6 +13,7 @@ import com.chmouel.liseur.data.calibre.BookDownloadRepository
 import com.chmouel.liseur.data.remote.PreviewOutcome
 import com.chmouel.liseur.data.remote.RemoteAccountRepository
 import com.chmouel.liseur.data.remote.ResolveOutcome
+import com.chmouel.liseur.data.remote.ResumeConfidence
 import com.chmouel.liseur.data.remote.SeriesExtrasRepository
 import com.chmouel.liseur.data.remote.SyncPreview
 import com.chmouel.liseur.data.db.AnnotationKind
@@ -57,6 +58,7 @@ import com.chmouel.liseur.reader.annotations.locator
 import com.chmouel.liseur.reader.annotations.markedPassage
 import com.chmouel.liseur.ui.messageRes
 import com.chmouel.liseur.reader.progress.BookPositions
+import com.chmouel.liseur.reader.progress.ExactLocatorAnchor
 import com.chmouel.liseur.reader.footnotes.FootnoteResolver
 import com.chmouel.liseur.reader.progress.ReaderProgress
 import com.chmouel.liseur.reader.progress.ReadingPace
@@ -312,7 +314,13 @@ class ReaderViewModel(
     )
 
     /** An offer to continue where another device has read further. */
-    data class CatchUp(val progression: Double, val position: Int?)
+    data class CatchUp(
+        val progression: Double,
+        val position: Int?,
+        val excerpt: String?,
+        val remoteAt: Long?,
+        val confidence: ResumeConfidence,
+    )
 
     private val _catchUp = MutableStateFlow<CatchUp?>(null)
 
@@ -438,10 +446,7 @@ class ReaderViewModel(
 
             ResolveOutcome.Done -> {
                 if (takeRemote) {
-                    // The jump raises the way-back pill through onJump(),
-                    // which is the whole announcement: where you are now,
-                    // and one tap back to where you were.
-                    progressDao.get(bookId)?.totalProgression?.let { goToProgression(it) }
+                    goToRemotePosition(preview)
                     BookSync.Idle
                 } else {
                     BookSync.Note(R.string.reader_sync_book_sent)
@@ -469,6 +474,8 @@ class ReaderViewModel(
         val there = preview.remote ?: return
         val here = preview.local ?: 0.0
         val takeRemote = there > here
+        val localLocator = progressDao.get(bookId)?.locatorJson
+            ?.let { runCatching { Locator.fromJSON(JSONObject(it)) }.getOrNull() }
         val outcome = positionSync.resolve(
             bookId,
             takeRemote,
@@ -478,7 +485,7 @@ class ReaderViewModel(
         // settled on the next open; the book still opens now.
         if (outcome != ResolveOutcome.Done || !takeRemote) return
         if (bookPositions == null) bookPositions = BookPositions.of(publication)
-        offerWayBack(here)
+        offerWayBack(localLocator, here, preview)
     }
 
     /**
@@ -487,11 +494,29 @@ class ReaderViewModel(
      * moved it. [onJump] cannot do this: the book is not open yet, so
      * there is no last locator to remember.
      */
-    private fun offerWayBack(progression: Double) {
+    private fun offerWayBack(
+        exactLocal: Locator?,
+        progression: Double,
+        preview: SyncPreview,
+    ) {
         val positions = bookPositions?.takeIf { it.isUsable } ?: return
-        val position = positions.positionAtProgression(progression.toFloat())
-        val locator = positions.locatorAt(position) ?: return
-        _jumpBack.value = JumpBack(locator = locator, position = position, fromSync = true)
+        val locator = exactLocal?.takeIf(ExactLocatorAnchor::isExact)
+            ?: positions.locatorAtOrBeforeProgression(progression)
+            ?: return
+        val position = positions.resolve(locator)?.position
+        _jumpBack.value = JumpBack(
+            locator = prepareLocator(locator),
+            position = position,
+            fromSync = true,
+            excerpt = preview.excerpt,
+            remoteAt = preview.remoteAt,
+            confidence = preview.confidence,
+            resumePosition = preview.remote?.let {
+                positions.locatorAtOrBeforeProgression(it)
+                    ?.let(positions::resolve)
+                    ?.position
+            },
+        )
         jumpBackTimer?.cancel()
         jumpBackTimer = viewModelScope.launch {
             delay(JUMP_BACK_TIMEOUT_MS)
@@ -499,18 +524,33 @@ class ReaderViewModel(
         }
     }
 
-    private suspend fun goToProgression(progression: Double) {
+    /** Navigates to the exact adopted locator, or conservatively before its percentage. */
+    private suspend fun goToRemotePosition(preview: SyncPreview) {
         val positions = bookPositions ?: BookPositions.of(publication ?: return)
             .also { bookPositions = it }
-        if (!positions.isUsable) return
-        positions.locatorAt(positions.positionAtProgression(progression.toFloat()))?.let {
-            // Remember where we were before the destination overwrites it,
-            // or the way back would point at the page just arrived on.
-            onJump()
-            lastLocator = it
-            _progress.value = progressAt(it)
-            _goTo.emit(it)
-        }
+        val stored = progressDao.get(bookId) ?: return
+        val exact = runCatching { Locator.fromJSON(JSONObject(stored.locatorJson)) }
+            .getOrNull()
+            ?.takeIf(ExactLocatorAnchor::isExact)
+        val target = exact
+            ?: stored.totalProgression?.let(positions::locatorAtOrBeforeProgression)
+            ?: return
+        onJump()
+        _jumpBack.value = _jumpBack.value?.copy(
+            fromSync = true,
+            excerpt = preview.excerpt,
+            remoteAt = preview.remoteAt,
+            confidence = if (exact != null) {
+                preview.confidence
+            } else {
+                ResumeConfidence.APPROXIMATE
+            },
+            resumePosition = positions.resolve(target)?.position,
+        )
+        pendingPositionEvent = NavigatorPositionEvent.REMOTE_ADOPTION
+        lastLocator = prepareLocator(target)
+        _progress.value = progressAt(target)
+        _goTo.emit(lastLocator ?: target)
     }
 
     private var publication: Publication? = null
@@ -520,6 +560,7 @@ class ReaderViewModel(
     private var catchUpChecking = false
     private var catchUpDeclined: Double? = null
     private var readerActive = false
+    private var pendingPositionEvent: NavigatorPositionEvent? = null
 
     private val ownTypography: StateFlow<BookTypography?> = typographyDao.observe(bookId)
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
@@ -605,12 +646,34 @@ class ReaderViewModel(
                     _state.value = UiState.Failure(it.message)
                     return@launch
                 }
+            val beforeSync = progressDao.get(bookId)
             // Ask the server where this book was left before deciding
             // where to open it. Bounded, and the answer is optional: a slow
             // or absent server delays the book by a moment at most, never
             // stops it opening.
             withTimeoutOrNull(OPEN_SYNC_TIMEOUT_MS) {
                 runCatching { positionSync.request(SyncScope.Book(bookId)) }
+            }
+            val afterSync = progressDao.get(bookId)
+            val pulledAutomatically = afterSync?.takeIf { after ->
+                after.localRevision > (beforeSync?.localRevision ?: 0L) &&
+                    after.totalProgression != null &&
+                    beforeSync?.totalProgression?.let {
+                        kotlin.math.abs(it - after.totalProgression) >= EPSILON
+                    } != false
+            }?.let { after ->
+                val exact = after.locatorJson.takeIf(ExactLocatorAnchor::isExactJson)
+                SyncPreview(
+                    local = beforeSync?.totalProgression,
+                    remote = after.totalProgression,
+                    remoteAt = after.remoteUpdatedAt,
+                    excerpt = ExactLocatorAnchor.excerpt(exact),
+                    confidence = if (exact != null) {
+                        ResumeConfidence.EXACT
+                    } else {
+                        ResumeConfidence.APPROXIMATE
+                    },
+                )
             }
 
             // Sync preserves a disagreement rather than guessing across
@@ -625,21 +688,28 @@ class ReaderViewModel(
                 bookPace = stored?.readingPace
                     ?: ReadingPace.Unknown,
             )
-            var initialLocator = stored?.locatorJson
-                ?.let { runCatching { Locator.fromJSON(JSONObject(it)) }.getOrNull() }
-
-            // A position that came from another device is only a
-            // percentage, so it no longer matches the locator saved here.
-            // Turning it into a real place means laying the book out
-            // before showing it: a moment's wait, but only on the first
-            // open after syncing.
-            val wanted = stored?.totalProgression
-            if (wanted != null && !initialLocator.isAt(wanted)) {
-                val positions = BookPositions.of(publication)
-                bookPositions = positions
-                positions.locatorAt(positions.positionAtProgression(wanted.toFloat()))
-                    ?.let { initialLocator = it }
+            val positions = BookPositions.of(publication)
+            bookPositions = positions
+            if (pulledAutomatically != null) {
+                val localLocator = beforeSync?.locatorJson
+                    ?.let { runCatching { Locator.fromJSON(JSONObject(it)) }.getOrNull() }
+                offerWayBack(
+                    exactLocal = localLocator,
+                    progression = beforeSync?.totalProgression ?: 0.0,
+                    preview = pulledAutomatically,
+                )
             }
+            val savedLocator = stored?.locatorJson
+                ?.let { runCatching { Locator.fromJSON(JSONObject(it)) }.getOrNull() }
+            // Unmarked Readium text may describe the following synthetic
+            // position. It is approximate and deliberately resumes at or
+            // before the stable progression instead.
+            val initialLocator = if (ExactLocatorAnchor.isExact(savedLocator)) {
+                savedLocator
+            } else {
+                stored?.totalProgression?.let(positions::locatorAtOrBeforeProgression)
+                    ?: savedLocator
+            }?.let(::prepareLocator)
             lastLocator = initialLocator
             library.markOpened(bookId)
             this@ReaderViewModel.publication = publication
@@ -651,35 +721,42 @@ class ReaderViewModel(
             // onResume arrives before a publication has necessarily
             // opened. Only now can foreground time be reading time.
             sessions.onReaderReady()
-            // Computing positions parses the whole book, so it runs
-            // after the reader is on screen.
-            if (bookPositions == null) bookPositions = BookPositions.of(publication)
             lastLocator?.let { _progress.value = progressAt(it) }
         }
     }
 
-    /** True when this locator already sits at [progression] within a page. */
-    private fun Locator?.isAt(progression: Double): Boolean {
-        val here = this?.locations?.totalProgression ?: return false
-        return kotlin.math.abs(here - progression) < EPSILON
+    /** Adds the layout-independent whole-book progression to a captured locator. */
+    fun prepareLocator(locator: Locator): Locator {
+        val stable = bookPositions?.resolve(locator) ?: return locator
+        return ExactLocatorAnchor.withStableProgression(locator, stable.progression)
     }
 
-    fun onLocatorChanged(locator: Locator) {
+    fun onLocatorChanged(
+        locator: Locator,
+        event: NavigatorPositionEvent = NavigatorPositionEvent.READER_MOVEMENT,
+    ) {
+        val effectiveEvent = if (event == NavigatorPositionEvent.READER_MOVEMENT) {
+            pendingPositionEvent ?: event
+        } else {
+            event
+        }
+        pendingPositionEvent = null
         // Fragment pause/resume and a viewport reflow can publish a new
         // current locator without any reader action. Treating that as a
         // page turn makes this device dirty just as another device's
         // position arrives, manufacturing a sync conflict.
-        if (!readerActive) return
-        val samePosition = lastLocator?.sameReadingPositionAs(locator) == true
-        lastLocator = locator
-        val stable = bookPositions?.resolve(locator)
-        _progress.value = progressAt(locator, stable)
+        if (!readerActive && effectiveEvent == NavigatorPositionEvent.READER_MOVEMENT) return
+        val prepared = prepareLocator(locator)
+        val samePosition = lastLocator?.sameReadingPositionAs(prepared) == true
+        lastLocator = prepared
+        val stable = bookPositions?.resolve(prepared)
+        _progress.value = progressAt(prepared, stable)
         // Readium recalculates totalProgression for a different viewport,
         // even when its stable resource position has not moved. Keep the
         // display current, but do not turn that layout detail into reading.
-        if (samePosition) return
-        val totalProgression = locator.locations.totalProgression
-        if (stable != null) {
+        if (samePosition || !effectiveEvent.persists) return
+        val totalProgression = stable?.progression ?: return
+        if (effectiveEvent.teachesPace) {
             val sample = speed.record(
                 position = stable.coordinate,
                 atMillis = SystemClock.elapsedRealtime(),
@@ -687,15 +764,17 @@ class ReaderViewModel(
             // A page that was really read teaches this reader's pace to
             // every book, not just this one.
             if (sample != null) viewModelScope.launch { readingPace.record(sample) }
+        } else {
+            speed.forgetLastPosition()
         }
         // Capture the page's moment before suspendable position writes,
         // so database latency cannot become reading time.
-        sessions.onPageTurned(totalProgression)
+        if (effectiveEvent.recordsReadingTime) sessions.onPageTurned(totalProgression)
         val accepted = positionPublisher.publish(
             PositionUpdate(
                 bookUrl = bookId,
-                locatorJson = locator.toJSON().toString(),
-                progression = locator.locations.totalProgression,
+                locatorJson = prepared.toJSON().toString(),
+                progression = totalProgression,
                 readingSecondsPerPosition = speed.secondsPerPosition,
                 readingPaceSamples = speed.pace.samples,
                 readingPaceElapsedMs = speed.pace.elapsedMs,
@@ -785,6 +864,9 @@ class ReaderViewModel(
                 _catchUp.value = CatchUp(
                     progression = there,
                     position = positions?.positionAtProgression(there.toFloat()),
+                    excerpt = preview.excerpt,
+                    remoteAt = preview.remoteAt,
+                    confidence = preview.confidence,
                 )
             } finally {
                 catchUpChecking = false
@@ -794,7 +876,7 @@ class ReaderViewModel(
 
     /** Takes the offer: the further position wins, and the page turns. */
     fun acceptCatchUp() {
-        if (_catchUp.value == null) return
+        val offer = _catchUp.value ?: return
         _catchUp.value = null
         viewModelScope.launch {
             val outcome = positionSync.resolve(
@@ -805,7 +887,15 @@ class ReaderViewModel(
             // Anything but a clean adoption leaves the book where it is;
             // the offer will simply be made again if it still stands.
             if (outcome != ResolveOutcome.Done) return@launch
-            progressDao.get(bookId)?.totalProgression?.let { goToProgression(it) }
+            goToRemotePosition(
+                SyncPreview(
+                    local = null,
+                    remote = offer.progression,
+                    remoteAt = offer.remoteAt,
+                    excerpt = offer.excerpt,
+                    confidence = offer.confidence,
+                ),
+            )
         }
     }
 
@@ -822,6 +912,7 @@ class ReaderViewModel(
         // The jump itself is not reading, and neither is finding your
         // way back, so it must not affect the speed estimate.
         speed.forgetLastPosition()
+        pendingPositionEvent = NavigatorPositionEvent.LOCAL_JUMP
         _jumpBack.value = JumpBack(locator = from, position = progress?.position)
         jumpBackTimer?.cancel()
         jumpBackTimer = viewModelScope.launch {
@@ -837,6 +928,13 @@ class ReaderViewModel(
 
     /** The locator for a position on the scrubber, numbered from 1. */
     fun locatorAtPosition(position: Int): Locator? = bookPositions?.locatorAt(position)
+
+    fun locatorAtOrBeforeProgression(progression: Double): Locator? =
+        bookPositions?.locatorAtOrBeforeProgression(progression)
+
+    fun onApproximateResume() {
+        _jumpBack.value = _jumpBack.value?.copy(confidence = ResumeConfidence.APPROXIMATE)
+    }
 
     /** The position matching a whole-book progression between 0 and 1. */
     fun positionAtProgression(progression: Float): Int =
@@ -1177,6 +1275,10 @@ class ReaderViewModel(
         val locator: Locator,
         val position: Int?,
         val fromSync: Boolean = false,
+        val excerpt: String? = null,
+        val remoteAt: Long? = null,
+        val confidence: ResumeConfidence = ResumeConfidence.EXACT,
+        val resumePosition: Int? = null,
     )
 
     companion object {

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -656,11 +656,16 @@ class ReaderViewModel(
             }
             val afterSync = progressDao.get(bookId)
             val pulledAutomatically = afterSync?.takeIf { after ->
+                val exactMoved = ExactLocatorAnchor.agreement(
+                    beforeSync?.locatorJson,
+                    after.locatorJson,
+                ) == false
+                val progressionMoved = beforeSync?.totalProgression?.let {
+                    kotlin.math.abs(it - (after.totalProgression ?: it)) >= EPSILON
+                } != false
                 after.localRevision > (beforeSync?.localRevision ?: 0L) &&
                     after.totalProgression != null &&
-                    beforeSync?.totalProgression?.let {
-                        kotlin.math.abs(it - after.totalProgression) >= EPSILON
-                    } != false
+                    (progressionMoved || exactMoved)
             }?.let { after ->
                 val exact = after.locatorJson.takeIf(ExactLocatorAnchor::isExactJson)
                 SyncPreview(
@@ -854,7 +859,7 @@ class ReaderViewModel(
                 val here = preview.local
                     ?: lastLocator?.locations?.totalProgression
                     ?: 0.0
-                if (there <= here + EPSILON) return@launch
+                if (preview.agrees || there <= here) return@launch
                 // Declining an offer declines that place; only reading
                 // done elsewhere since brings the pill back.
                 if (catchUpDeclined?.let { kotlin.math.abs(it - there) < EPSILON } == true) {

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReadingProgressUi.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReadingProgressUi.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.chmouel.liseur.R
+import com.chmouel.liseur.data.remote.ResumeConfidence
 import com.chmouel.liseur.data.settings.FooterMode
 import com.chmouel.liseur.data.settings.ReaderTheme
 import com.chmouel.liseur.reader.progress.FooterMiddle
@@ -241,6 +242,10 @@ private fun Modifier.chapterTicks(ticks: List<Float>, color: Color): Modifier =
 fun JumpBackPill(
     position: Int?,
     fromSync: Boolean,
+    excerpt: String?,
+    remoteAt: Long?,
+    confidence: ResumeConfidence,
+    resumePosition: Int?,
     theme: ReaderTheme,
     onJumpBack: () -> Unit,
     onDismiss: () -> Unit,
@@ -261,22 +266,42 @@ fun JumpBackPill(
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.clickableWithoutRipple(onJumpBack),
+                modifier = Modifier
+                    .weight(1f, fill = false)
+                    .clickableWithoutRipple(onJumpBack),
             ) {
                 Icon(
                     imageVector = if (fromSync) Icons.Outlined.CloudSync else Icons.Outlined.Undo,
                     contentDescription = null,
                 )
-                Text(
-                    text = if (fromSync) {
-                        stringResource(R.string.position_synced_from_device)
-                    } else if (position != null) {
-                        stringResource(R.string.jump_back_to_page, position)
-                    } else {
-                        stringResource(R.string.jump_back)
-                    },
-                    style = MaterialTheme.typography.labelLarge,
-                )
+                Column {
+                    Text(
+                        text = if (fromSync) {
+                            resumeHeadline(resumePosition, remoteAt, confidence)
+                        } else if (position != null) {
+                            stringResource(R.string.jump_back_to_page, position)
+                        } else {
+                            stringResource(R.string.jump_back)
+                        },
+                        style = MaterialTheme.typography.labelLarge,
+                    )
+                    if (fromSync && !excerpt.isNullOrBlank()) {
+                        Text(
+                            text = excerpt,
+                            style = MaterialTheme.typography.labelSmall,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                    if (fromSync) {
+                        Text(
+                            text = position?.let {
+                                stringResource(R.string.jump_back_to_page, it)
+                            } ?: stringResource(R.string.jump_back),
+                            style = MaterialTheme.typography.labelMedium,
+                        )
+                    }
+                }
                 if (fromSync) {
                     Icon(
                         imageVector = Icons.Outlined.Undo,
@@ -365,6 +390,9 @@ fun NextInSeriesPill(
 @Composable
 fun CatchUpPill(
     position: Int?,
+    excerpt: String?,
+    remoteAt: Long?,
+    confidence: ResumeConfidence,
     theme: ReaderTheme,
     onCatchUp: () -> Unit,
     onDismiss: () -> Unit,
@@ -388,14 +416,29 @@ fun CatchUpPill(
                 modifier = Modifier.clickableWithoutRipple(onCatchUp),
             ) {
                 Icon(Icons.Outlined.Redo, contentDescription = null)
-                Text(
-                    text = if (position != null) {
-                        stringResource(R.string.catch_up_to_page, position)
-                    } else {
-                        stringResource(R.string.catch_up)
-                    },
-                    style = MaterialTheme.typography.labelLarge,
-                )
+                Column {
+                    Text(
+                        text = if (position != null) {
+                            val base = if (confidence == ResumeConfidence.EXACT) {
+                                stringResource(R.string.catch_up_to_page, position)
+                            } else {
+                                stringResource(R.string.catch_up_near_page, position)
+                            }
+                            relativeAge(remoteAt)?.let { "$base · $it" } ?: base
+                        } else {
+                            stringResource(R.string.catch_up)
+                        },
+                        style = MaterialTheme.typography.labelLarge,
+                    )
+                    if (!excerpt.isNullOrBlank()) {
+                        Text(
+                            text = excerpt,
+                            style = MaterialTheme.typography.labelSmall,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
             }
             Icon(
                 Icons.Default.Close,
@@ -405,5 +448,31 @@ fun CatchUpPill(
                     .padding(4.dp),
             )
         }
+    }
+}
+
+@Composable
+private fun resumeHeadline(
+    position: Int?,
+    remoteAt: Long?,
+    confidence: ResumeConfidence,
+): String {
+    val base = if (confidence == ResumeConfidence.APPROXIMATE && position != null) {
+        stringResource(R.string.resumed_near_page, position)
+    } else {
+        stringResource(R.string.resumed_from_device)
+    }
+    return relativeAge(remoteAt)?.let { "$base · $it" } ?: base
+}
+
+@Composable
+private fun relativeAge(timestamp: Long?): String? {
+    timestamp ?: return null
+    val minutes = ((System.currentTimeMillis() - timestamp).coerceAtLeast(0L) / 60_000L).toInt()
+    return when {
+        minutes < 1 -> stringResource(R.string.remote_age_now)
+        minutes < 60 -> stringResource(R.string.remote_age_minutes, minutes)
+        minutes < 1_440 -> stringResource(R.string.remote_age_hours, minutes / 60)
+        else -> stringResource(R.string.remote_age_days, minutes / 1_440)
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/progress/BookPositions.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/progress/BookPositions.kt
@@ -4,6 +4,7 @@ import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.services.positionsByReadingOrder
+import kotlin.math.floor
 import kotlin.math.roundToInt
 
 /** A chapter of the book and the range of positions it covers. */
@@ -88,6 +89,18 @@ class BookPositions(
         return (1 + progression.coerceIn(0f, 1f) * (totalPositions - 1))
             .roundToInt()
             .coerceIn(1, totalPositions)
+    }
+
+    /**
+     * A conservative synthetic locator which never starts after [progression].
+     * Used when an exact text quote is unavailable or belongs to another edition.
+     */
+    fun locatorAtOrBeforeProgression(progression: Double): Locator? {
+        if (!isUsable) return null
+        if (totalPositions == 1) return locators.first()
+        val coordinate = 1.0 + progression.coerceIn(0.0, 1.0) * (totalPositions - 1)
+        val position = floor(coordinate).toInt().coerceIn(1, totalPositions)
+        return locatorAt(position)
     }
 
     private fun progressAtCoordinate(coordinate: Double): StableBookProgress {

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/progress/ExactLocatorAnchor.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/progress/ExactLocatorAnchor.kt
@@ -80,14 +80,29 @@ object ExactLocatorAnchor {
     }
 
     fun isExactJson(locatorJson: String?): Boolean =
-        locatorJson?.let { json ->
-            runCatching { Locator.fromJSON(JSONObject(json)) }.getOrNull()
-        }?.let(::isExact) == true
+        parse(locatorJson)?.let(::isExact) == true
+
+    /**
+     * Whether two stored locators name the same app-owned text anchor.
+     *
+     * A null answer means the remote locator is only approximate, so the
+     * caller must keep using progression tolerance. Once the peer supplies
+     * an exact anchor, a missing or different local anchor is a real
+     * disagreement even when both percentages round to the same number.
+     */
+    fun agreement(localJson: String?, remoteJson: String?): Boolean? {
+        val remote = parse(remoteJson)?.takeIf(::isExact) ?: return null
+        val local = parse(localJson)?.takeIf(::isExact) ?: return false
+        return local.href == remote.href &&
+            local.locations.otherLocations[CSS_SELECTOR] ==
+            remote.locations.otherLocations[CSS_SELECTOR] &&
+            local.text.before == remote.text.before &&
+            local.text.highlight == remote.text.highlight &&
+            local.text.after == remote.text.after
+    }
 
     fun excerpt(locatorJson: String?): String? {
-        val locator = locatorJson?.let { json ->
-            runCatching { Locator.fromJSON(JSONObject(json)) }.getOrNull()
-        } ?: return null
+        val locator = parse(locatorJson) ?: return null
         if (!isExact(locator)) return null
         return listOf(locator.text.before, locator.text.highlight, locator.text.after)
             .filterNotNull()
@@ -159,6 +174,9 @@ object ExactLocatorAnchor {
 
     private fun fitsSyncLimit(locator: Locator): Boolean =
         locator.toJSON().toString().toByteArray(StandardCharsets.UTF_8).size < MAX_LOCATOR_BYTES
+
+    private fun parse(json: String?): Locator? =
+        json?.let { runCatching { Locator.fromJSON(JSONObject(it)) }.getOrNull() }
 
     private fun String.takeCodePoints(count: Int): String {
         if (codePointCount(0, length) <= count) return this

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/progress/ExactLocatorAnchor.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/progress/ExactLocatorAnchor.kt
@@ -1,0 +1,266 @@
+package com.chmouel.liseur.reader.progress
+
+import java.nio.charset.StandardCharsets
+import org.json.JSONObject
+import org.json.JSONTokener
+import org.readium.r2.navigator.epub.EpubNavigatorFragment
+import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Locator
+
+/** A text quote pinned to the first visible word in a reflowable resource. */
+data class ViewportTextAnchor(
+    val cssSelector: String,
+    val before: String,
+    val highlight: String,
+    val after: String,
+)
+
+/** App-owned exact locators, independent of fonts, columns, and viewport size. */
+object ExactLocatorAnchor {
+    const val MARKER = "liseurAnchor"
+    const val CSS_SELECTOR = "cssSelector"
+    const val MAX_BEFORE = 32
+    const val MAX_HIGHLIGHT = 64
+    const val MAX_AFTER = 32
+    private const val MAX_SELECTOR = 2_048
+    private const val MAX_LOCATOR_BYTES = 16 * 1024
+
+    fun parseJavascriptResult(result: String?): ViewportTextAnchor? {
+        if (result.isNullOrBlank() || result == "null") return null
+        val decoded = runCatching { JSONTokener(result).nextValue() }.getOrNull()
+        val json = when (decoded) {
+            is JSONObject -> decoded
+            is String -> runCatching { JSONObject(decoded) }.getOrNull()
+            else -> null
+        } ?: return null
+        val selector = json.optString("cssSelector").takeIf {
+            it.isNotBlank() && it.length <= MAX_SELECTOR
+        } ?: return null
+        val highlight = json.optString("highlight").takeIf { it.isNotBlank() } ?: return null
+        return ViewportTextAnchor(
+            cssSelector = selector,
+            before = json.optString("before").takeLastCodePoints(MAX_BEFORE),
+            highlight = highlight.takeCodePoints(MAX_HIGHLIGHT),
+            after = json.optString("after").takeCodePoints(MAX_AFTER),
+        )
+    }
+
+    fun mark(locator: Locator, anchor: ViewportTextAnchor): Locator {
+        val other = locator.locations.otherLocations + mapOf(
+            MARKER to 1,
+            CSS_SELECTOR to anchor.cssSelector,
+        )
+        val exact = locator.copy(
+            locations = locator.locations.copy(otherLocations = other),
+            text = Locator.Text(
+                before = anchor.before,
+                highlight = anchor.highlight,
+                after = anchor.after,
+            ),
+        )
+        return exact.takeIf(::fitsSyncLimit) ?: locator
+    }
+
+    fun withStableProgression(locator: Locator, progression: Double): Locator =
+        locator.copy(
+            locations = locator.locations.copy(
+                totalProgression = progression.coerceIn(0.0, 1.0),
+            ),
+        )
+
+    fun isExact(locator: Locator?): Boolean {
+        locator ?: return false
+        val marker = locator.locations.otherLocations[MARKER]
+        val marked = marker is Number && marker.toInt() == 1
+        return marked &&
+            locator.locations.otherLocations[CSS_SELECTOR] is String &&
+            (locator.locations.otherLocations[CSS_SELECTOR] as String).isNotBlank() &&
+            !locator.text.highlight.isNullOrBlank() &&
+            fitsSyncLimit(locator)
+    }
+
+    fun isExactJson(locatorJson: String?): Boolean =
+        locatorJson?.let { json ->
+            runCatching { Locator.fromJSON(JSONObject(json)) }.getOrNull()
+        }?.let(::isExact) == true
+
+    fun excerpt(locatorJson: String?): String? {
+        val locator = locatorJson?.let { json ->
+            runCatching { Locator.fromJSON(JSONObject(json)) }.getOrNull()
+        } ?: return null
+        if (!isExact(locator)) return null
+        return listOf(locator.text.before, locator.text.highlight, locator.text.after)
+            .filterNotNull()
+            .joinToString(" ")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+            .takeCodePoints(140)
+            .takeIf(String::isNotEmpty)
+    }
+
+    @OptIn(ExperimentalReadiumApi::class)
+    suspend fun capture(navigator: EpubNavigatorFragment, native: Locator): Locator {
+        val result = runCatching { navigator.evaluateJavascript(CAPTURE_SCRIPT) }.getOrNull()
+        return parseJavascriptResult(result)?.let { mark(native, it) } ?: native
+    }
+
+    @OptIn(ExperimentalReadiumApi::class)
+    suspend fun verify(navigator: EpubNavigatorFragment, locator: Locator): Boolean {
+        if (!isExact(locator)) return false
+        val selector = locator.locations.otherLocations[CSS_SELECTOR] as String
+        val script = """
+            (() => {
+              const block = document.querySelector(${JSONObject.quote(selector)});
+              if (!block) return false;
+              const text = block.textContent || "";
+              const quote = ${JSONObject.quote(
+                  locator.text.before.orEmpty() +
+                      locator.text.highlight.orEmpty() +
+                      locator.text.after.orEmpty(),
+              )};
+              const quoteStart = text.indexOf(quote);
+              if (quoteStart < 0) return false;
+              const startOffset = quoteStart + ${locator.text.before.orEmpty().length};
+              const endOffset = startOffset + ${locator.text.highlight.orEmpty().length};
+              const walker = document.createTreeWalker(block, NodeFilter.SHOW_TEXT);
+              let node;
+              let consumed = 0;
+              let startNode = null;
+              let endNode = null;
+              let startInNode = 0;
+              let endInNode = 0;
+              while ((node = walker.nextNode())) {
+                const next = consumed + node.data.length;
+                if (!startNode && startOffset >= consumed && startOffset <= next) {
+                  startNode = node;
+                  startInNode = startOffset - consumed;
+                }
+                if (endOffset >= consumed && endOffset <= next) {
+                  endNode = node;
+                  endInNode = endOffset - consumed;
+                  break;
+                }
+                consumed = next;
+              }
+              if (!startNode || !endNode) return false;
+              const range = document.createRange();
+              range.setStart(startNode, startInNode);
+              range.setEnd(endNode, endInNode);
+              return Array.from(range.getClientRects()).some(rect =>
+                rect.width > 0 && rect.height > 0 &&
+                rect.right > 0 && rect.bottom > 0 &&
+                rect.left < window.innerWidth && rect.top < window.innerHeight
+              );
+            })()
+        """.trimIndent()
+        return runCatching { navigator.evaluateJavascript(script)?.trim() == "true" }
+            .getOrDefault(false)
+    }
+
+    private fun fitsSyncLimit(locator: Locator): Boolean =
+        locator.toJSON().toString().toByteArray(StandardCharsets.UTF_8).size < MAX_LOCATOR_BYTES
+
+    private fun String.takeCodePoints(count: Int): String {
+        if (codePointCount(0, length) <= count) return this
+        return substring(0, offsetByCodePoints(0, count))
+    }
+
+    private fun String.takeLastCodePoints(count: Int): String {
+        val size = codePointCount(0, length)
+        if (size <= count) return this
+        return substring(offsetByCodePoints(0, size - count))
+    }
+
+    private val CAPTURE_SCRIPT = """
+        (() => {
+          const blocked = new Set(["SCRIPT", "STYLE", "NOSCRIPT", "TEMPLATE"]);
+          const blockTags = new Set([
+            "P", "LI", "BLOCKQUOTE", "PRE", "TD", "TH", "FIGCAPTION",
+            "H1", "H2", "H3", "H4", "H5", "H6", "DIV"
+          ]);
+          const visible = rect => rect.width > 0 && rect.height > 0 &&
+            rect.right > 0 && rect.bottom > 0 &&
+            rect.left < window.innerWidth && rect.top < window.innerHeight;
+          const escape = value => window.CSS && CSS.escape
+            ? CSS.escape(value)
+            : value.replace(/[^a-zA-Z0-9_-]/g, ch => "\\\\" + ch);
+          const selector = element => {
+            if (element.id) {
+              const byId = "#" + escape(element.id);
+              if (document.querySelectorAll(byId).length === 1) return byId;
+            }
+            const parts = [];
+            let current = element;
+            while (current && current !== document.body) {
+              let part = current.localName;
+              if (!part) break;
+              let index = 1;
+              let sibling = current;
+              while ((sibling = sibling.previousElementSibling)) {
+                if (sibling.localName === current.localName) index++;
+              }
+              part += ":nth-of-type(" + index + ")";
+              parts.unshift(part);
+              current = current.parentElement;
+            }
+            return "body" + (parts.length ? " > " + parts.join(" > ") : "");
+          };
+          const segments = text => {
+            if (window.Intl && Intl.Segmenter) {
+              return Array.from(new Intl.Segmenter(undefined, {granularity: "word"})
+                .segment(text))
+                .filter(item => item.isWordLike)
+                .map(item => ({index: item.index, text: item.segment}));
+            }
+            let regex;
+            try {
+              regex = new RegExp("[\\p{L}\\p{N}\\p{M}]+(?:[’'][\\p{L}\\p{N}\\p{M}]+)*", "gu");
+            } catch (_) {
+              regex = /\\S+/g;
+            }
+            const found = [];
+            let match;
+            while ((match = regex.exec(text)) !== null) {
+              found.push({index: match.index, text: match[0]});
+            }
+            return found;
+          };
+          const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+            acceptNode: node => {
+              const parent = node.parentElement;
+              if (!parent || blocked.has(parent.tagName) || !node.data.trim()) {
+                return NodeFilter.FILTER_REJECT;
+              }
+              return NodeFilter.FILTER_ACCEPT;
+            }
+          });
+          let node;
+          while ((node = walker.nextNode())) {
+            for (const word of segments(node.data)) {
+              const range = document.createRange();
+              range.setStart(node, word.index);
+              range.setEnd(node, word.index + word.text.length);
+              if (!Array.from(range.getClientRects()).some(visible)) continue;
+              let block = node.parentElement;
+              while (block && block !== document.body && !blockTags.has(block.tagName)) {
+                block = block.parentElement;
+              }
+              block = block || document.body;
+              const beforeRange = document.createRange();
+              beforeRange.selectNodeContents(block);
+              beforeRange.setEnd(node, word.index);
+              const afterRange = document.createRange();
+              afterRange.selectNodeContents(block);
+              afterRange.setStart(node, word.index + word.text.length);
+              const before = Array.from(beforeRange.toString()).slice(-32).join("");
+              const highlight = Array.from(word.text).slice(0, 64).join("");
+              const after = Array.from(afterRange.toString()).slice(0, 32).join("");
+              return JSON.stringify({
+                cssSelector: selector(block), before, highlight, after
+              });
+            }
+          }
+          return null;
+        })()
+    """.trimIndent()
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -135,6 +135,13 @@
     <string name="position_synced_from_device">Synced from another device</string>
     <string name="catch_up">Continue where you left off elsewhere</string>
     <string name="catch_up_to_page">Continue to page %d</string>
+    <string name="catch_up_near_page">Continue near page %d</string>
+    <string name="resumed_from_device">Resumed from another device</string>
+    <string name="resumed_near_page">Resumed near page %d</string>
+    <string name="remote_age_now">just now</string>
+    <string name="remote_age_minutes">%d min ago</string>
+    <string name="remote_age_hours">%d hr ago</string>
+    <string name="remote_age_days">%d d ago</string>
     <string name="back">Back</string>
     <string name="liseur_sync_get_one">Haven\'t got one? Run your own</string>
     <string name="liseur_sync_sign_in_password">Sign in</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
@@ -144,6 +144,49 @@ class MigrationTest {
     }
 
     @Test
+    fun `pending sync state survives schema 38 with empty locator fields`() {
+        helper.createDatabase(TEST_DB, 37).use { old ->
+            old.execSQL(
+                """
+                INSERT INTO reading_progress (
+                    book_url, locator_json, total_progression, updated_at,
+                    pending_progression, pending_status, pending_account
+                ) VALUES ('file:///book.epub', '{"href":"chapter"}', 0.2, 1000,
+                          0.7, 'Reading', 'komga-peer')
+                """.trimIndent(),
+            )
+            old.execSQL(
+                """
+                INSERT INTO sync_peer_state (
+                    book_url, peer_id, pending_progression, pending_status, has_pending
+                ) VALUES ('file:///book.epub', 'sync-peer', 0.8, 'Reading', 1)
+                """.trimIndent(),
+            )
+        }
+
+        helper.runMigrationsAndValidate(TEST_DB, LATEST, true, *LiseurDatabase.MIGRATIONS)
+            .use { db ->
+                db.query(
+                    "SELECT pending_progression, pending_locator_json " +
+                        "FROM reading_progress WHERE book_url = 'file:///book.epub'",
+                ).use { cursor ->
+                    assertTrue(cursor.moveToFirst())
+                    assertEquals(0.7, cursor.getDouble(0), 0.0)
+                    assertTrue(cursor.isNull(1))
+                }
+                db.query(
+                    "SELECT pending_progression, pending_locator_json, pending_edition_sha " +
+                        "FROM sync_peer_state WHERE book_url = 'file:///book.epub'",
+                ).use { cursor ->
+                    assertTrue(cursor.moveToFirst())
+                    assertEquals(0.8, cursor.getDouble(0), 0.0)
+                    assertTrue(cursor.isNull(1))
+                    assertTrue(cursor.isNull(2))
+                }
+            }
+    }
+
+    @Test
     fun `a book survives every upgrade`() {
         helper.createDatabase(TEST_DB, 1).use { old ->
             old.execSQL(
@@ -720,6 +763,6 @@ class MigrationTest {
         const val TEST_DB = "migration-test.db"
 
         /** Kept in step with the `version` on [LiseurDatabase]. */
-        const val LATEST = 37
+        const val LATEST = 38
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/ReadingProgressDaoTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/ReadingProgressDaoTest.kt
@@ -244,16 +244,15 @@ class ReadingProgressDaoTest {
     }
 
     @Test
-    fun `a pull with no place to offer leaves the one this device had`() = runTest {
+    fun `a pull with no place invalidates the stale local locator`() = runTest {
         read(0.2)
         dao.persistPending(book, 0.9, "Reading", 4_000, account, now = 4_000)
 
         assertTrue(dao.applyPull(book, 1, 0.9, "Reading", account, 4_000, now = 5_000))
 
-        // Servers that only carry a percentage pass nothing, and
-        // overwriting a real locator with an empty one would lose the
-        // only precise thing on the row.
-        assertEquals("""{"at":0.2}""", row().locatorJson)
+        // The old locator belongs to 0.2 and must not be paired with the
+        // newly adopted 0.9. The reader reconstructs 0.9 conservatively.
+        assertEquals("{}", row().locatorJson)
     }
 
     // -- Durability -------------------------------------------------------
@@ -263,10 +262,19 @@ class ReadingProgressDaoTest {
         // The whole reason persistPending exists: the sync token moves
         // past a change once, so if the process dies between reading the
         // feed and acting on it, this row is the only copy.
-        dao.persistPending(book, 0.7, "Reading", 4_000, account, now = 4_000)
+        dao.persistPending(
+            book,
+            0.7,
+            "Reading",
+            4_000,
+            account,
+            now = 4_000,
+            locatorJson = """{"href":"chapter-7"}""",
+        )
 
         val row = row()
         assertEquals(0.7, row.pendingProgression!!, 1e-9)
+        assertEquals("""{"href":"chapter-7"}""", row.pendingLocatorJson)
         assertEquals(account, row.pendingAccount)
         assertTrue(row.hasPending)
     }
@@ -275,12 +283,21 @@ class ReadingProgressDaoTest {
     fun `a landed state can drive a pull with no feed at all`() = runTest {
         // Crash recovery. The token already moved, so the next feed is
         // empty; the pending row alone has to be enough.
-        dao.persistPending(book, 0.7, "Reading", 4_000, account, now = 4_000)
+        dao.persistPending(
+            book,
+            0.7,
+            "Reading",
+            4_000,
+            account,
+            now = 4_000,
+            locatorJson = """{"href":"chapter-7"}""",
+        )
         val recovered = requireNotNull(dao.pendingFor(account).singleOrNull())
         assertEquals(book, recovered.bookUrl)
 
         assertTrue(dao.applyPull(book, 0, 0.7, "Reading", account, 4_000, now = 5_000))
         assertTrue(dao.pendingFor(account).isEmpty())
+        assertNull(row().pendingLocatorJson)
     }
 
     @Test
@@ -307,7 +324,15 @@ class ReadingProgressDaoTest {
     fun `switching account leaves the reading but drops the baseline`() = runTest {
         read(0.6)
         dao.ackPush(book, 1, 0.6, "Reading", account, now = 5_000)
-        dao.persistPending(book, 0.9, "Reading", 6_000, account, now = 6_000)
+        dao.persistPending(
+            book,
+            0.9,
+            "Reading",
+            6_000,
+            account,
+            now = 6_000,
+            locatorJson = """{"href":"remote"}""",
+        )
 
         dao.retireAccountState()
 
@@ -319,6 +344,7 @@ class ReadingProgressDaoTest {
         assertNull(row.agreedProgression)
         // And their pending state must never be applied under the new one.
         assertFalse(row.hasPending)
+        assertNull(row.pendingLocatorJson)
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepositoryTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepositoryTest.kt
@@ -137,7 +137,13 @@ class KomgaSyncRepositoryTest {
         {
           "href": "$href",
           "type": "application/xhtml+xml",
-          "locations": {"progression": $progression, "totalProgression": $total}
+          "locations": {
+            "progression": $progression,
+            "totalProgression": $total,
+            "cssSelector": "#reading-anchor",
+            "liseurAnchor": 1
+          },
+          "text": {"highlight": "remembered word"}
         }
     """.trimIndent()
 
@@ -331,7 +337,7 @@ class KomgaSyncRepositoryTest {
         // has to happen before the place is sent again.
         val sent = requests()
         val cleared = sent.single { it.method == "DELETE" }
-        assertTrue(cleared.target!!.endsWith("/api/v1/books/$bookId/read-progress"))
+        assertTrue(cleared.target.endsWith("/api/v1/books/$bookId/read-progress"))
         assertTrue(sent.indexOf(cleared) < sent.indexOfFirst { it.method == "PUT" })
         // And it must settle, or the row would stay dirty for ever.
         assertFalse(requireNotNull(db.readingProgressDao().get(bookUrl)).isDirty)
@@ -355,7 +361,7 @@ class KomgaSyncRepositoryTest {
 
         val sent = requests().last()
         assertEquals("PUT", sent.method)
-        assertTrue(sent.target!!.endsWith("/api/v1/books/$bookId/progression"))
+        assertTrue(sent.target.endsWith("/api/v1/books/$bookId/progression"))
         val body = JSONObject(sent.body!!.utf8())
         // Komga refuses an href that starts with a slash, and refuses one
         // with no progression beside it.
@@ -465,7 +471,7 @@ class KomgaSyncRepositoryTest {
     }
 
     @Test
-    fun `taking the server's side restores the exact place, not a percentage`() = runTest {
+    fun `taking the server's side restores the locator paired before process death`() = runTest {
         connect()
         val progress = db.readingProgressDao()
         progress.recordLocal(
@@ -476,14 +482,49 @@ class KomgaSyncRepositoryTest {
             status = "Reading",
             updatedAt = 1_000,
         )
-        progress.persistPending(bookUrl, 0.6, "Reading", 4_000, account, now = 4_000)
-        server.enqueue(json(progressionJson(locatorJson("OEBPS/ch7.xhtml", 0.5, 0.6))))
+        progress.persistPending(
+            bookUrl,
+            0.6,
+            "Reading",
+            4_000,
+            account,
+            now = 4_000,
+            locatorJson = locatorJson("OEBPS/ch7.xhtml", 0.5, 0.6),
+        )
 
         sync.takeRemotePosition(bookUrl, atRevision = requireNotNull(progress.get(bookUrl)).localRevision)
 
         val row = requireNotNull(progress.get(bookUrl))
         assertEquals(0.6, row.totalProgression!!, 1e-9)
         assertEquals("OEBPS/ch7.xhtml", JSONObject(row.locatorJson).getString("href"))
+    }
+
+    @Test
+    fun `legacy unmarked locator is treated as approximate`() = runTest {
+        connect()
+        val progress = db.readingProgressDao()
+        val local = locatorJson("OEBPS/ch2.xhtml", 0.5, 0.2)
+        progress.recordLocal(bookUrl, local, 0.2, null, "Reading", 1_000)
+        progress.persistPending(
+            bookUrl = bookUrl,
+            progression = 0.6,
+            status = "Reading",
+            remoteUpdatedAt = 4_000,
+            account = account,
+            now = 4_000,
+            locatorJson = """{
+                "href":"OEBPS/ch7.xhtml",
+                "type":"application/xhtml+xml",
+                "locations":{"totalProgression":0.6},
+                "text":{"highlight":"the following position"}
+            }""".trimIndent(),
+        )
+
+        sync.takeRemotePosition(bookUrl, requireNotNull(progress.get(bookUrl)).localRevision)
+
+        val row = requireNotNull(progress.get(bookUrl))
+        assertEquals(0.6, row.totalProgression ?: 0.0, 0.0)
+        assertEquals("{}", row.locatorJson)
     }
 
     // -- Being economical --------------------------------------------------

--- a/app/src/test/kotlin/com/chmouel/liseur/data/library/BookRemovalTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/library/BookRemovalTest.kt
@@ -50,6 +50,24 @@ class BookRemovalTest {
         db.bookDao().upsert(book("kept"))
         db.readingSessionDao().insert(session("gone"))
         db.readingSessionDao().insert(session("kept"))
+        db.syncPeerStateDao().persistPending(
+            "gone",
+            "peer",
+            0.8,
+            "Reading",
+            1_000,
+            locatorJson = """{"href":"gone","locations":{"liseurAnchor":1}}""",
+            editionSha = "sha-gone",
+        )
+        db.syncPeerStateDao().persistPending(
+            "kept",
+            "peer",
+            0.4,
+            "Reading",
+            1_000,
+            locatorJson = """{"href":"kept","locations":{"liseurAnchor":1}}""",
+            editionSha = "sha-kept",
+        )
 
         // Account switching and catalog pruning already hold a transaction;
         // Room must safely fold this removal into that same boundary.
@@ -57,6 +75,8 @@ class BookRemovalTest {
 
         assertNull(db.bookDao().getByUrl("gone"))
         assertNotNull(db.bookDao().getByUrl("kept"))
+        assertNull(db.syncPeerStateDao().get("gone", "peer"))
+        assertEquals("sha-kept", db.syncPeerStateDao().get("kept", "peer")?.pendingEditionSha)
         assertEquals(listOf("kept"), db.readingSessionDao().observeAll().first().map { it.bookUrl })
     }
 

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
@@ -342,10 +342,88 @@ class LiseurSyncPositionSyncTest {
         assertTrue(preview is PreviewOutcome.Ready)
         assertNotNull(sync.preservedConflict(LOCAL))
 
-        // Taking the server's side re-fetches the exact place.
-        server.enqueue(json("""{"ops":[${op(seq = 7, progression = 0.8)}]}"""))
+        // Taking the server's side uses the answer paired on disk.
         assertEquals(ResolveOutcome.Done, sync.takeRemotePosition(LOCAL, 0))
         assertEquals(0.8, db.readingProgressDao().get(LOCAL)?.totalProgression!!, 0.0001)
+    }
+
+    @Test
+    fun `pending locator survives process death and stays paired with its progression`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        alias(editionSha = "sha-a")
+        db.syncPeerStateDao().settle(LOCAL, peer(), 0, 0.2, "reading", NOW)
+        db.readingProgressDao().recordLocal(LOCAL, LOCATOR, 0.3, null, "reading", NOW)
+        val exact = exactLocator("remembered word")
+        server.enqueue(
+            json(
+                """{"ops":[${
+                    op(8, 0.8, locatorJson = exact, editionSha = "sha-a")
+                }],"high_water":8}""",
+            ),
+        )
+
+        sync().syncAll(null)
+        val pending = requireNotNull(db.syncPeerStateDao().get(LOCAL, peer()))
+        assertEquals(exact, pending.pendingLocatorJson)
+        assertEquals("sha-a", pending.pendingEditionSha)
+
+        // A new repository instance has no in-memory state and makes no request.
+        assertEquals(ResolveOutcome.Done, sync().takeRemotePosition(LOCAL, 1))
+        assertEquals(exact, db.readingProgressDao().get(LOCAL)?.locatorJson)
+        val settled = requireNotNull(db.syncPeerStateDao().get(LOCAL, peer()))
+        assertNull(settled.pendingLocatorJson)
+        assertNull(settled.pendingEditionSha)
+    }
+
+    @Test
+    fun `different edition and legacy locators fall back to progression`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        alias(editionSha = "sha-local")
+        db.syncPeerStateDao().persistPending(
+            bookUrl = LOCAL,
+            peerId = peer(),
+            progression = 0.8,
+            status = "reading",
+            remoteUpdatedAt = NOW,
+            locatorJson = exactLocator("other edition"),
+            editionSha = "sha-remote",
+        )
+        db.readingProgressDao().recordLocal(LOCAL, LOCATOR, 0.2, null, "reading", NOW)
+
+        assertEquals(ResolveOutcome.Done, sync().takeRemotePosition(LOCAL, 1))
+        assertEquals("{}", db.readingProgressDao().get(LOCAL)?.locatorJson)
+
+        db.syncPeerStateDao().persistPending(
+            bookUrl = LOCAL,
+            peerId = peer(),
+            progression = 0.9,
+            status = "reading",
+            remoteUpdatedAt = NOW,
+            locatorJson = """{"href":"/forward-biased.xhtml","text":{"highlight":"next"}}""",
+            editionSha = "sha-local",
+        )
+        assertEquals(ResolveOutcome.Done, sync().takeRemotePosition(LOCAL, 2))
+        assertEquals("{}", db.readingProgressDao().get(LOCAL)?.locatorJson)
+    }
+
+    @Test
+    fun `snapshot lands only the highest non-local sequence for each work`() = runTest {
+        connect(cursor = 5)
+        db.bookDao().upsert(local())
+        alias()
+        server.enqueue(MockResponse(code = 410, body = """{"error":"resync_required"}"""))
+        server.enqueue(
+            json(
+                """{"ops":[${op(40, 0.6)},${op(30, 0.9)}],"snapshot_seq":42}""",
+            ),
+        )
+
+        sync().syncAll(null)
+
+        assertEquals(0.6, db.readingProgressDao().get(LOCAL)?.totalProgression!!, 0.0)
+        assertEquals(42L, db.remoteServerDao().get()?.syncCursorSeq)
     }
 
     @Test
@@ -645,6 +723,7 @@ class LiseurSyncPositionSyncTest {
         confidence: String = "high",
         deviceId: String? = null,
         bookUrl: String = LOCAL,
+        editionSha: String? = null,
     ) =
         db.workIdentityDao().upsert(
             com.chmouel.liseur.data.db.WorkAlias(
@@ -654,19 +733,42 @@ class LiseurSyncPositionSyncTest {
                 confidence = confidence,
                 confirmed = true,
                 seeded = seeded,
+                editionSha = editionSha,
                 resolvedAt = NOW,
             ),
         )
 
-    private fun op(seq: Long, progression: Double, deviceId: String? = null): String {
+    private fun op(
+        seq: Long,
+        progression: Double,
+        deviceId: String? = null,
+        locatorJson: String? = null,
+        editionSha: String? = null,
+    ): String {
         val device = deviceId?.let { ""","device_id":"$it"""" } ?: ""
+        val locator = locatorJson?.let { ""","locator":$it""" } ?: ""
+        val edition = editionSha?.let { ""","edition_sha":"$it"""" } ?: ""
         return """{"op_id":"o-$seq","work_id":"w-1","seq":$seq,
             "progression":$progression,
-            "client_ts":"${SyncOps.formatTime(NOW)}"$device}
+            "client_ts":"${SyncOps.formatTime(NOW)}"$device$locator$edition}
         """.trimIndent()
     }
 
     private fun json(body: String) = MockResponse(code = 200, body = body)
+
+    private fun exactLocator(highlight: String): String = JSONObject()
+        .put("href", "/c1.xhtml")
+        .put("type", "application/xhtml+xml")
+        .put(
+            "locations",
+            JSONObject()
+                .put("progression", 0.8)
+                .put("totalProgression", 0.8)
+                .put("cssSelector", "#p1")
+                .put("liseurAnchor", 1),
+        )
+        .put("text", JSONObject().put("highlight", highlight))
+        .toString()
 
     /** Every request the server has seen, including earlier runs'. */
     private fun requests(): List<RecordedRequest> {

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
@@ -10,6 +10,7 @@ import com.chmouel.liseur.data.remote.ServerKind
 import com.chmouel.liseur.data.library.BookFingerprintStore
 import com.chmouel.liseur.data.library.FinishedState
 import com.chmouel.liseur.data.remote.PreviewOutcome
+import com.chmouel.liseur.data.remote.ResumeConfidence
 import com.chmouel.liseur.data.remote.ResolveOutcome
 import com.chmouel.liseur.data.remote.SyncOutcome
 import java.io.File
@@ -374,6 +375,63 @@ class LiseurSyncPositionSyncTest {
         val settled = requireNotNull(db.syncPeerStateDao().get(LOCAL, peer()))
         assertNull(settled.pendingLocatorJson)
         assertNull(settled.pendingEditionSha)
+    }
+
+    @Test
+    fun `different exact passages with the same displayed percent are pulled`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        alias(editionSha = "sha-a")
+        val local = exactLocator("local passage", progression = 0.071)
+        val remote = exactLocator("remote passage", progression = 0.074)
+        db.readingProgressDao().recordLocal(LOCAL, local, 0.071, null, "reading", NOW)
+        db.syncPeerStateDao().settle(LOCAL, peer(), 1, 0.071, "reading", NOW)
+        server.enqueue(
+            json(
+                """{"ops":[${
+                    op(9, 0.074, locatorJson = remote, editionSha = "sha-a")
+                }],"high_water":9}""",
+            ),
+        )
+
+        assertEquals(SyncOutcome.Success, sync().syncAll(null))
+
+        val stored = requireNotNull(db.readingProgressDao().get(LOCAL))
+        assertEquals(0.074, stored.totalProgression!!, 0.0)
+        assertEquals(remote, stored.locatorJson)
+        assertEquals(0, db.syncPeerStateDao().countPending(peer()))
+    }
+
+    @Test
+    fun `preview does not call different exact passages in step`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        alias(editionSha = "sha-a")
+        db.readingProgressDao().recordLocal(
+            LOCAL,
+            exactLocator("local passage", progression = 0.071),
+            0.071,
+            null,
+            "reading",
+            NOW,
+        )
+        server.enqueue(
+            json(
+                """{"ops":[${
+                    op(
+                        10,
+                        0.074,
+                        locatorJson = exactLocator("remote passage", progression = 0.074),
+                        editionSha = "sha-a",
+                    )
+                }]}""",
+            ),
+        )
+
+        val preview = (sync().previewBook(LOCAL) as PreviewOutcome.Ready).preview
+
+        assertFalse(preview.agrees)
+        assertEquals(ResumeConfidence.EXACT, preview.confidence)
     }
 
     @Test
@@ -756,14 +814,14 @@ class LiseurSyncPositionSyncTest {
 
     private fun json(body: String) = MockResponse(code = 200, body = body)
 
-    private fun exactLocator(highlight: String): String = JSONObject()
+    private fun exactLocator(highlight: String, progression: Double = 0.8): String = JSONObject()
         .put("href", "/c1.xhtml")
         .put("type", "application/xhtml+xml")
         .put(
             "locations",
             JSONObject()
-                .put("progression", 0.8)
-                .put("totalProgression", 0.8)
+                .put("progression", progression)
+                .put("totalProgression", progression)
                 .put("cssSelector", "#p1")
                 .put("liseurAnchor", 1),
         )

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepositoryTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepositoryTest.kt
@@ -233,6 +233,26 @@ class RemoteAccountRepositoryTest {
     }
 
     @Test
+    fun `disconnect clears durable locator state for the liseur sync account`() = runTest {
+        val repository = repository(db.remoteServerDao(), RotatingLiseurSync(accountId = "acc-1"))
+        repository.connectLiseurSyncToken(BASE, "token-1")
+        val peer = requireNotNull(db.remoteServerDao().get()).accountKey
+        db.syncPeerStateDao().persistPending(
+            bookUrl = "file:///book.epub",
+            peerId = peer,
+            progression = 0.8,
+            status = "Reading",
+            remoteUpdatedAt = 1_000,
+            locatorJson = """{"href":"chapter","locations":{"liseurAnchor":1}}""",
+            editionSha = "sha",
+        )
+
+        repository.disconnect()
+
+        assertNull(db.syncPeerStateDao().get("file:///book.epub", peer))
+    }
+
+    @Test
     fun `a different account behind the same address still switches`() = runTest {
         val repository = repository(db.remoteServerDao(), RotatingLiseurSync(accountId = "acc-1"))
         repository.connectLiseurSyncToken(BASE, "token-1")
@@ -249,6 +269,8 @@ class RemoteAccountRepositoryTest {
                 db.workIdentityDao(),
             ),
             seriesExtraDao = db.seriesExtraDao(),
+            peerStateDao = db.syncPeerStateDao(),
+            identityDao = db.workIdentityDao(),
             setups = mapOf(ServerKind.LISEUR_SYNC to RotatingLiseurSync(accountId = "acc-2")),
         )
         other.connectLiseurSyncToken(BASE, "token-x")
@@ -272,6 +294,8 @@ class RemoteAccountRepositoryTest {
             db.workIdentityDao(),
         ),
         seriesExtraDao = db.seriesExtraDao(),
+        peerStateDao = db.syncPeerStateDao(),
+        identityDao = db.workIdentityDao(),
         setups = mapOf(ServerKind.LISEUR_SYNC to liseurSyncSetup),
     )
 

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/ReadingStateMergeTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/ReadingStateMergeTest.kt
@@ -75,6 +75,46 @@ class ReadingStateMergeTest {
     }
 
     @Test
+    fun `different exact anchors inside percentage tolerance are pulled`() {
+        val decision = reconcileReadingState(
+            local = state(0.071),
+            remote = state(0.074),
+            baseline = baseline(0.071),
+            localDirty = false,
+            exactPositionAgreement = false,
+        )
+
+        assertEquals(0.074, (decision as SyncDecision.Pull).state.progression)
+    }
+
+    @Test
+    fun `different exact anchors preserve two locally changed positions`() {
+        val decision = reconcileReadingState(
+            local = state(0.072),
+            remote = state(0.074),
+            baseline = baseline(0.071),
+            localDirty = true,
+            exactPositionAgreement = false,
+        )
+
+        assertTrue(decision is SyncDecision.Conflict)
+    }
+
+    @Test
+    fun `the same exact anchor agrees despite percentage layout differences`() {
+        assertEquals(
+            SyncDecision.InSync,
+            reconcileReadingState(
+                local = state(0.071),
+                remote = state(0.078),
+                baseline = baseline(0.071),
+                localDirty = false,
+                exactPositionAgreement = true,
+            ),
+        )
+    }
+
+    @Test
     fun `only the server moved, so its position is taken`() {
         val decision = reconcileReadingState(
             local = state(0.3),

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/NavigatorPositionEventTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/NavigatorPositionEventTest.kt
@@ -1,0 +1,33 @@
+package com.chmouel.liseur.reader
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NavigatorPositionEventTest {
+
+    @Test
+    fun `only genuine reading teaches pace and records reading time`() {
+        assertTrue(NavigatorPositionEvent.READER_MOVEMENT.persists)
+        assertTrue(NavigatorPositionEvent.READER_MOVEMENT.teachesPace)
+        assertTrue(NavigatorPositionEvent.READER_MOVEMENT.recordsReadingTime)
+
+        assertTrue(NavigatorPositionEvent.LOCAL_JUMP.persists)
+        assertFalse(NavigatorPositionEvent.LOCAL_JUMP.teachesPace)
+        assertFalse(NavigatorPositionEvent.LOCAL_JUMP.recordsReadingTime)
+    }
+
+    @Test
+    fun `remote and layout events only update the display`() {
+        listOf(
+            NavigatorPositionEvent.REMOTE_ADOPTION,
+            NavigatorPositionEvent.PREFERENCE_REFLOW,
+            NavigatorPositionEvent.FRAGMENT_RECREATION,
+            NavigatorPositionEvent.LIFECYCLE_REPLAY,
+        ).forEach { event ->
+            assertFalse(event.persists)
+            assertFalse(event.teachesPace)
+            assertFalse(event.recordsReadingTime)
+        }
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/progress/BookPositionsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/progress/BookPositionsTest.kt
@@ -147,4 +147,16 @@ class BookPositionsTest {
         assertEquals(3, book.positionAtProgression(0.5f))
         assertEquals(5, book.positionAtProgression(1f))
     }
+
+    @Test
+    fun `conservative fallback never starts after the target`() {
+        val resource = (1..5).map { position ->
+            locator("book.xhtml", (position - 1) / 4.0, position)
+        }
+        val book = positions(listOf(resource))
+
+        assertEquals(2, book.locatorAtOrBeforeProgression(0.49)?.locations?.position)
+        assertEquals(3, book.locatorAtOrBeforeProgression(0.50)?.locations?.position)
+        assertEquals(5, book.locatorAtOrBeforeProgression(1.0)?.locations?.position)
+    }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/progress/ExactLocatorAnchorTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/progress/ExactLocatorAnchorTest.kt
@@ -1,0 +1,90 @@
+package com.chmouel.liseur.reader.progress
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.readium.r2.shared.publication.Locator
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(sdk = [35], application = android.app.Application::class)
+@RunWith(RobolectricTestRunner::class)
+class ExactLocatorAnchorTest {
+
+    @Test
+    fun `javascript anchor keeps exact unicode context lengths`() {
+        val before = "🙂".repeat(40)
+        val highlight = "界".repeat(70)
+        val after = "é".repeat(40)
+        val json = JSONObject()
+            .put("cssSelector", "#chapter > p:nth-of-type(2)")
+            .put("before", before)
+            .put("highlight", highlight)
+            .put("after", after)
+            .toString()
+
+        val anchor = ExactLocatorAnchor.parseJavascriptResult(JSONObject.quote(json))
+
+        assertNotNull(anchor)
+        assertEquals("🙂".repeat(32), anchor?.before)
+        assertEquals("界".repeat(64), anchor?.highlight)
+        assertEquals("é".repeat(32), anchor?.after)
+    }
+
+    @Test
+    fun `marked locator survives json and carries stable progression`() {
+        val exact = ExactLocatorAnchor.mark(
+            locator(),
+            ViewportTextAnchor("#chapter", "before ", "visible", " after"),
+        ).let { ExactLocatorAnchor.withStableProgression(it, 0.42) }
+        val restored = Locator.fromJSON(exact.toJSON())
+
+        assertTrue(ExactLocatorAnchor.isExact(restored))
+        assertTrue(ExactLocatorAnchor.isExactJson(exact.toJSON().toString()))
+        assertEquals(0.42, restored?.locations?.totalProgression ?: 0.0, 0.0)
+        assertEquals("visible", restored?.text?.highlight)
+    }
+
+    @Test
+    fun `legacy text locator is approximate`() {
+        val legacy = locator().copy(
+            text = Locator.Text(before = "before", highlight = "next", after = "after"),
+        )
+
+        assertFalse(ExactLocatorAnchor.isExact(legacy))
+        assertFalse(ExactLocatorAnchor.isExactJson(legacy.toJSON().toString()))
+    }
+
+    @Test
+    fun `excerpt is normalized and only comes from an exact anchor`() {
+        val exact = ExactLocatorAnchor.mark(
+            locator(),
+            ViewportTextAnchor("#chapter", "  before\n", " visible ", "\t after  "),
+        )
+
+        assertEquals(
+            "before visible after",
+            ExactLocatorAnchor.excerpt(exact.toJSON().toString()),
+        )
+        assertEquals(null, ExactLocatorAnchor.excerpt(locator().toJSON().toString()))
+    }
+
+    private fun locator(): Locator = requireNotNull(
+        Locator.fromJSON(
+            JSONObject()
+                .put("href", "https://example.com/chapter.xhtml")
+                .put("type", "application/xhtml+xml")
+                .put(
+                    "locations",
+                    JSONObject()
+                        .put("progression", 0.5)
+                        .put("position", 3)
+                        .put("totalProgression", 0.9),
+                ),
+        ),
+    )
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/progress/ExactLocatorAnchorTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/progress/ExactLocatorAnchorTest.kt
@@ -60,6 +60,32 @@ class ExactLocatorAnchorTest {
     }
 
     @Test
+    fun `agreement compares the passage instead of layout progressions`() {
+        val local = ExactLocatorAnchor.mark(
+            locator(),
+            ViewportTextAnchor("#chapter", "before ", "same word", " after"),
+        )
+        val same = ExactLocatorAnchor.withStableProgression(local, 0.074)
+        val different = ExactLocatorAnchor.mark(
+            locator(),
+            ViewportTextAnchor("#chapter", "before ", "other word", " after"),
+        )
+
+        assertEquals(
+            true,
+            ExactLocatorAnchor.agreement(local.toJSON().toString(), same.toJSON().toString()),
+        )
+        assertEquals(
+            false,
+            ExactLocatorAnchor.agreement(local.toJSON().toString(), different.toJSON().toString()),
+        )
+        assertEquals(
+            null,
+            ExactLocatorAnchor.agreement(local.toJSON().toString(), locator().toJSON().toString()),
+        )
+    }
+
+    @Test
     fun `excerpt is normalized and only comes from an exact anchor`() {
         val exact = ExactLocatorAnchor.mark(
             locator(),


### PR DESCRIPTION
## Summary

Adds exact text anchors to synced reading positions so matching editions reopen at the precise passage on another device. When exact matching is not safe, resume falls back to a stable approximate position that does not skip ahead.

Exact-anchor identity now takes precedence over rounded percentages. Two different passages such as 7.1% and 7.4% may both display as 7%, but are no longer incorrectly treated as already synchronized.

## Changes

- Capture bounded text context and a CSS selector from the visible passage, validate it on restore, and attach a stable whole-book progression.
- Persist pending remote locators and edition identity so exact resume survives process restarts and only applies to matching editions.
- Use exact locators in Komga and liseur-sync while retaining percentage tolerance for unsupported, legacy, and cross-edition positions.
- Compare exact passage anchors during reconciliation instead of relying only on rounded progression.
- Pull the precise remote passage when only the other device moved; preserve both positions when both devices moved.
- Distinguish real reading movement from reflow, lifecycle, preference, and remote-adoption events.
- Show whether a remote resume is exact or approximate and include the surrounding excerpt when available.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Tested exact-locator transport with two disposable emulators and a local liseur-sync server.
- [x] Added regression coverage for different exact passages at 7.1% and 7.4%, which both display as 7%.
- [x] Retested the final correction across multiple physical devices.

## Screenshots or recordings

Reader, server-account, and web-reader screenshots were captured during the emulator run. They show the affected surfaces, while synchronization itself is verified by the server operations, cross-device testing, and regression tests.

## Checklist

- [x] I have kept this change focused and documented the user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
