### PR TITLE
Open a book promptly when the server stops answering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PACKAGE := com.chmouel.liseur
 ACTIVITY := $(PACKAGE)/.MainActivity
 DEBUG_APK := app/build/outputs/apk/debug/app-debug.apk
 
-.PHONY: help build debug release bundle test lint check clean emulator stop shutdown install run run-bg reset screenshots icon feature-graphic
+.PHONY: help build debug release bundle test lint check e2e clean emulator stop shutdown install run run-bg reset screenshots icon feature-graphic
 
 help:
 	@printf '%s\n' \
@@ -22,6 +22,7 @@ help:
 		'make test              Run JVM unit tests' \
 		'make lint              Run Android Lint' \
 		'make check             Run tests, lint, and debug build' \
+		'make e2e               Run the device scenarios in tests/' \
 		'make emulator          Start the configured Android emulator' \
 		'make stop              Stop the configured Android emulator' \
 		'make shutdown          Shut down the configured Android emulator' \
@@ -54,6 +55,12 @@ lint:
 	$(GRADLE) lintDebug
 
 check: test lint build
+
+# The device scenarios in tests/. Deliberately not part of check: they
+# need a device with a debug build and a seeded library, which a CI
+# checkout does not have.
+e2e:
+	tests/run-all $(if $(SERIAL),-s $(SERIAL))
 
 clean:
 	$(GRADLE) clean

--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -3,8 +3,9 @@ package com.chmouel.liseur
 import android.content.Context
 import androidx.room.Room
 import androidx.room.withTransaction
-import com.chmouel.liseur.data.calibre.BookDownloadRepository
+import com.chmouel.liseur.data.AndroidNetworkAvailability
 import com.chmouel.liseur.data.ConnectionsState
+import com.chmouel.liseur.data.calibre.BookDownloadRepository
 import com.chmouel.liseur.data.calibre.CalibreCatalogClient
 import com.chmouel.liseur.data.calibre.CalibreFileSource
 import com.chmouel.liseur.data.calibre.KoboSyncRepository
@@ -62,6 +63,8 @@ import kotlinx.coroutines.SupervisorJob
  * dependencies. Reachable from any Context via [container].
  */
 class AppContainer(context: Context) {
+    val networkAvailability = AndroidNetworkAvailability(context.applicationContext)
+
     private val httpClient = DefaultHttpClient()
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -181,6 +184,7 @@ class AppContainer(context: Context) {
         progressDao = database.readingProgressDao(),
         finishedState = finishedState,
         reporting = syncReporting,
+        networkAvailability = networkAvailability,
         // What the server reported and the token that stops it being
         // reported again have to land together or not at all.
         inTransaction = { work -> database.withTransaction { work() } },
@@ -193,6 +197,7 @@ class AppContainer(context: Context) {
         finishedState = finishedState,
         device = deviceIdentity,
         reporting = syncReporting,
+        networkAvailability = networkAvailability,
         inTransaction = { work -> database.withTransaction { work() } },
     )
 
@@ -229,6 +234,7 @@ class AppContainer(context: Context) {
         deviceKey = { deviceIdentity.current().id },
         finishedState = finishedState,
         reporting = syncReporting,
+        networkAvailability = networkAvailability,
         inTransaction = { work -> database.withTransaction { work() } },
     )
 
@@ -340,11 +346,13 @@ class AppContainer(context: Context) {
         bookDao = database.bookDao(),
         bookRemoval = bookRemoval,
         inTransaction = { work -> database.withTransaction { work() } },
+        networkAvailability = networkAvailability,
     )
 
     val seriesExtras = SeriesExtrasRepository(
         account = remoteAccount,
         dao = database.seriesExtraDao(),
+        networkAvailability = networkAvailability,
     )
 }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/NetworkAvailability.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/NetworkAvailability.kt
@@ -1,0 +1,56 @@
+package com.chmouel.liseur.data
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+
+/**
+ * A cheap snapshot of whether Android currently has a network to use.
+ *
+ * The question is only ever "is there any point trying", and the wrong
+ * answer in one direction is far worse than in the other: a false "no"
+ * silently stops a book server on the same Wi-Fi from ever being
+ * reached, while a false "yes" costs the timeout it would have cost
+ * anyway. Everything here therefore leans towards saying yes.
+ *
+ * It is asked afresh at each boundary rather than observed, for the same
+ * reason: a stale "yes" costs nothing that was not already being spent.
+ */
+fun interface NetworkAvailability {
+    fun isAvailable(): Boolean
+}
+
+class AndroidNetworkAvailability(context: Context) : NetworkAvailability {
+    private val connectivityManager =
+        context.applicationContext.getSystemService(ConnectivityManager::class.java)
+
+    /**
+     * With no ConnectivityManager to ask, this says yes. Guessing "offline"
+     * would switch the whole app's networking off over a missing system
+     * service; guessing "online" only gives up the shortcut.
+     */
+    override fun isAvailable(): Boolean {
+        val manager = connectivityManager ?: return true
+        val network = manager.activeNetwork ?: return false
+        val capabilities = manager.getNetworkCapabilities(network) ?: return true
+        // Anything that can carry a packet to a book server counts.
+        //
+        // NET_CAPABILITY_INTERNET is not required and VALIDATED is
+        // firmly not: a self-hosted server frequently lives on a LAN
+        // with no route out, on a Wi-Fi Android knows perfectly well is
+        // not reaching the internet. Asking for either would take that
+        // reader's whole library away.
+        return LOCAL_TRANSPORTS.any(capabilities::hasTransport) ||
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+
+    private companion object {
+        /** Transports that can reach a machine on the same network. */
+        val LOCAL_TRANSPORTS = intArrayOf(
+            NetworkCapabilities.TRANSPORT_WIFI,
+            NetworkCapabilities.TRANSPORT_ETHERNET,
+            NetworkCapabilities.TRANSPORT_VPN,
+            NetworkCapabilities.TRANSPORT_BLUETOOTH,
+        ).asList()
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/calibre/KoboSyncRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/calibre/KoboSyncRepository.kt
@@ -1,6 +1,7 @@
 package com.chmouel.liseur.data.calibre
 
 import android.util.Log
+import com.chmouel.liseur.data.NetworkAvailability
 import com.chmouel.liseur.data.db.Book
 import com.chmouel.liseur.data.db.BookDao
 import com.chmouel.liseur.data.db.RemoteServerDao
@@ -63,6 +64,7 @@ class KoboSyncRepository(
     private val client: KoboClient = KoboClient(),
     private val finishedState: FinishedState,
     private val reporting: SyncReporting = SyncReporting(),
+    private val networkAvailability: NetworkAvailability = NetworkAvailability { true },
     private val inTransaction: suspend (suspend () -> Unit) -> Unit = { it() },
 ) : PositionSync {
 
@@ -103,6 +105,7 @@ class KoboSyncRepository(
         val server = serverDao.get() ?: return PreviewOutcome.NotSynced
         val token = server.koboToken ?: return PreviewOutcome.NotSynced
         val uuid = bookDao.getByUrl(bookUrl)?.remoteUuid ?: return PreviewOutcome.NotSynced
+        if (!networkAvailability.isAvailable()) return PreviewOutcome.Failed(SyncFailure.Offline)
         val base = "${server.baseUrl}/kobo/$token"
         val account = server.accountKey
 
@@ -193,6 +196,7 @@ class KoboSyncRepository(
         // Read afresh, so a page turned while the question was open is
         // what gets sent rather than the position it was asked about.
         val stored = progressDao.get(bookUrl) ?: return ResolveOutcome.Done
+        if (!networkAvailability.isAvailable()) return ResolveOutcome.Failed(SyncFailure.Offline)
 
         val outcome = apply(
             base = "${server.baseUrl}/kobo/$token",
@@ -213,6 +217,10 @@ class KoboSyncRepository(
         val token = server.koboToken ?: run {
             reporting.report(PositionSyncStatus.Unavailable)
             return SyncOutcome.NotApplicable
+        }
+        if (!networkAvailability.isAvailable()) {
+            reporting.report(PositionSyncStatus.Failed(SyncFailure.Offline))
+            return SyncOutcome.Failure(SyncFailure.Offline)
         }
 
         reporting.report(PositionSyncStatus.Syncing)

--- a/app/src/main/kotlin/com/chmouel/liseur/data/calibre/KoboSyncRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/calibre/KoboSyncRepository.kt
@@ -485,14 +485,16 @@ class KoboSyncRepository(
 
             is SyncDecision.Pull -> {
                 val progression = decision.state.progression ?: stored?.totalProgression
+                var applied = false
                 if (progression == null) {
                     progressDao.clearPending(bookUrl)
                 } else {
                     // Refused means a page was turned here while this was
-                    // being decided, which makes it a disagreement rather
+                    // being decided, or that the book is open on screen
+                    // right now: either way it is a disagreement rather
                     // than a handover. The remote state stays put for the
                     // next run, and now for someone to be asked about.
-                    progressDao.applyPull(
+                    applied = progressDao.applyUnattendedPull(
                         bookUrl = bookUrl,
                         expectedRevision = stored?.localRevision ?: 0,
                         progression = progression,
@@ -505,7 +507,7 @@ class KoboSyncRepository(
                 // Taking the server's word for it can finish a book, and
                 // the library has to agree with the reader about that.
                 finishedState.refreshFromProgress(bookUrl)
-                BookOutcome(moved = SyncMove.PULLED)
+                BookOutcome(moved = if (applied) SyncMove.PULLED else null)
             }
 
             is SyncDecision.Push -> BookOutcome()

--- a/app/src/main/kotlin/com/chmouel/liseur/data/calibre/KoboSyncRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/calibre/KoboSyncRepository.kt
@@ -36,6 +36,11 @@ import com.chmouel.liseur.domain.reconcileReadingState
 private data class BookOutcome(
     val moved: SyncMove? = null,
     val failure: SyncFailure? = null,
+    /**
+     * Set when the failure was the server saying nothing at all, which
+     * is the shelf's cue to stop rather than ask about the next book.
+     */
+    val unreachable: SyncFailure? = null,
 )
 
 /**
@@ -240,6 +245,7 @@ class KoboSyncRepository(
 
         val books = bookDao.allRemote().filter { book == null || it.url == book }
         var firstFailure: SyncFailure? = null
+        var unreachable: SyncFailure? = null
         var pulled = 0
         var pushed = 0
         for (candidate in books) {
@@ -250,6 +256,15 @@ class KoboSyncRepository(
                 SyncMove.UNRESOLVED, null -> Unit
             }
             if (outcome.failure != null && firstFailure == null) firstFailure = outcome.failure
+            // Nothing more is learned by asking about the next book of
+            // a server that has stopped answering, and each question
+            // costs a whole connect timeout. Whatever the shelf managed
+            // before that is still counted and reported below.
+            unreachable = outcome.unreachable
+            if (unreachable != null) {
+                Log.i(TAG, "Stopping the run early: ${unreachable.label}")
+                break
+            }
         }
 
         val now = System.currentTimeMillis()
@@ -263,7 +278,12 @@ class KoboSyncRepository(
                 unresolved = progressDao.pendingFor(account).size,
             ),
         )
-        return if (firstFailure == null) {
+        // A server that went quiet outranks anything it managed to say
+        // earlier: reporting a 404 on one book would tell the retry
+        // machinery there is nothing to come back for, when in fact the
+        // connection died with positions still unsent.
+        val failure = unreachable ?: firstFailure
+        return if (failure == null) {
             // Only a run that settled everything counts as having synced,
             // and only ever for the account that is still connected: if it
             // went away while this ran, writing it back would sign the user
@@ -277,9 +297,9 @@ class KoboSyncRepository(
             reporting.report(PositionSyncStatus.Synced(now))
             SyncOutcome.Success
         } else {
-            Log.i(TAG, "Some positions did not settle: ${firstFailure.label}")
-            reporting.report(PositionSyncStatus.Failed(firstFailure))
-            SyncOutcome.Partial(firstFailure)
+            Log.i(TAG, "Some positions did not settle: ${failure.label}")
+            reporting.report(PositionSyncStatus.Failed(failure))
+            SyncOutcome.Partial(failure)
         }
     }
 
@@ -354,7 +374,7 @@ class KoboSyncRepository(
         // position yet is simply unknown, not absent — ask outright, once.
         if (remote == null && stored?.agreedAccountMatches(account) != true) {
             when (val asked = client.readState(base, uuid)) {
-                is RemoteResult.Failed -> return BookOutcome(failure = asked.reason)
+                is RemoteResult.Failed -> return BookOutcome(failure = asked.reason, unreachable = asked.unreachable)
                 is RemoteResult.Ok -> remote = asked.value?.also {
                     forAccount(account) {
                         progressDao.persistPending(
@@ -402,7 +422,7 @@ class KoboSyncRepository(
             if (!stillConnected(account)) return BookOutcome()
             val sent = stored?.localRevision ?: 0
             return when (val pushed = client.pushState(base, uuid, decision.state)) {
-                is RemoteResult.Failed -> BookOutcome(failure = pushed.reason)
+                is RemoteResult.Failed -> BookOutcome(failure = pushed.reason, unreachable = pushed.unreachable)
                 is RemoteResult.Ok -> {
                     var acked = false
                     forAccount(account) {

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/ReadingProgress.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/ReadingProgress.kt
@@ -7,6 +7,7 @@ import androidx.room.PrimaryKey
 import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Upsert
+import com.chmouel.liseur.data.remote.OpenBooks
 import com.chmouel.liseur.reader.progress.ReadingPace
 
 /**
@@ -113,6 +114,16 @@ data class BookProgression(
 
 @Dao
 abstract class ReadingProgressDao {
+
+    /**
+     * The books being read right now, shared with the reader.
+     *
+     * Room hands every caller the same instance of this DAO, so a
+     * default here is one object app-wide without any wiring: the
+     * reader tells it a book is open, and the unattended writes below
+     * decline while it is.
+     */
+    val openBooks = OpenBooks()
     /**
      * Throws away everything remembered about a book: where you were, the
      * baseline both sides agreed on, and anything the server reported.
@@ -592,6 +603,64 @@ abstract class ReadingProgressDao {
         account: String,
         now: Long,
     )
+
+    /**
+     * [applyPull] for a sync run with nobody waiting on it.
+     *
+     * The reader reads a position once, when the book opens, and shows
+     * it for the rest of the session. A pull landing after that read is
+     * invisible — until the next page turn quietly writes over it. So a
+     * run acting on its own declines while the book is open, and what
+     * the server said stays pending on disk, put to the reader on the
+     * next open instead. Nothing about the revisions moves on a refusal.
+     *
+     * A pull someone is waiting on — opening the book, or answering the
+     * conflict dialog — goes through [applyPull] and [applyPeerPull]
+     * directly: the reader is present for those, which is the whole
+     * difference.
+     */
+    open suspend fun applyUnattendedPull(
+        bookUrl: String,
+        expectedRevision: Long,
+        progression: Double,
+        status: String,
+        account: String,
+        remoteUpdatedAt: Long?,
+        now: Long,
+        locatorJson: String? = null,
+    ): Boolean = openBooks.unlessOpen(bookUrl) {
+        applyPull(
+            bookUrl = bookUrl,
+            expectedRevision = expectedRevision,
+            progression = progression,
+            status = status,
+            account = account,
+            remoteUpdatedAt = remoteUpdatedAt,
+            now = now,
+            locatorJson = locatorJson,
+        )
+    } ?: false
+
+    /** [applyPeerPull] for a sync run with nobody waiting on it. */
+    open suspend fun applyUnattendedPeerPull(
+        bookUrl: String,
+        expectedRevision: Long,
+        progression: Double,
+        status: String,
+        now: Long,
+        locatorJson: String? = null,
+        remoteUpdatedAt: Long? = null,
+    ): Boolean = openBooks.unlessOpen(bookUrl) {
+        applyPeerPull(
+            bookUrl = bookUrl,
+            expectedRevision = expectedRevision,
+            progression = progression,
+            status = status,
+            now = now,
+            locatorJson = locatorJson,
+            remoteUpdatedAt = remoteUpdatedAt,
+        )
+    } ?: false
 
     // -- Sync partners other than the catalog server ----------------------
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/ReadingProgress.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/ReadingProgress.kt
@@ -161,25 +161,22 @@ abstract class ReadingProgressDao {
      * Records a position read on this device, bumping the revision in the
      * same statement.
      *
-     * Doing it as one statement is the point. Reading the row into Kotlin
-     * and writing it back lets two page turns interleave, and lets a
-     * stale `synced_at` be carried back over a fresh acknowledgement.
-     * Everything to do with the server — the baseline, the pending state,
-     * the acknowledgement — is deliberately left alone here.
+     * Never reading the row into Kotlin is the point. Reading it back and
+     * writing it whole lets two page turns interleave, and lets a stale
+     * `synced_at` be carried back over a fresh acknowledgement. Everything
+     * to do with the server — the baseline, the pending state, the
+     * acknowledgement — is deliberately left alone here.
+     *
+     * It is an update followed, only if the book has never been opened, by
+     * an insert, rather than the single upsert this used to be. Upserts
+     * need SQLite 3.24, which arrived in Android 10; on anything older the
+     * statement failed and every page turn raised "the reading position
+     * could not be saved". The two statements share one transaction, so
+     * they are still indivisible.
      */
     @Query(
         """
-        INSERT INTO reading_progress (
-            book_url, locator_json, total_progression, reading_speed,
-            reading_seconds_per_position, reading_pace_samples,
-            reading_pace_elapsed_ms, reading_pace_evidence,
-            updated_at, status, synced_at, local_revision, acked_revision
-        )
-        VALUES (:bookUrl, :locatorJson, :progression, NULL,
-                :readingSecondsPerPosition, COALESCE(:readingPaceSamples, 0),
-                COALESCE(:readingPaceElapsedMs, 0), COALESCE(:readingPaceEvidence, 0),
-                :updatedAt, :status, NULL, 1, 0)
-        ON CONFLICT(book_url) DO UPDATE SET
+        UPDATE reading_progress SET
             locator_json = :locatorJson,
             total_progression = :progression,
             reading_seconds_per_position =
@@ -192,9 +189,36 @@ abstract class ReadingProgressDao {
             updated_at = :updatedAt,
             status = :status,
             local_revision = local_revision + 1
+        WHERE book_url = :bookUrl
         """,
     )
-    abstract suspend fun recordLocal(
+    abstract suspend fun updateLocal(
+        bookUrl: String,
+        locatorJson: String,
+        progression: Double?,
+        readingSecondsPerPosition: Double?,
+        readingPaceSamples: Int?,
+        readingPaceElapsedMs: Long?,
+        readingPaceEvidence: Double?,
+        status: String?,
+        updatedAt: Long,
+    ): Int
+
+    @Query(
+        """
+        INSERT OR IGNORE INTO reading_progress (
+            book_url, locator_json, total_progression, reading_speed,
+            reading_seconds_per_position, reading_pace_samples,
+            reading_pace_elapsed_ms, reading_pace_evidence,
+            updated_at, status, synced_at, local_revision, acked_revision
+        )
+        VALUES (:bookUrl, :locatorJson, :progression, NULL,
+                :readingSecondsPerPosition, COALESCE(:readingPaceSamples, 0),
+                COALESCE(:readingPaceElapsedMs, 0), COALESCE(:readingPaceEvidence, 0),
+                :updatedAt, :status, NULL, 1, 0)
+        """,
+    )
+    abstract suspend fun insertLocal(
         bookUrl: String,
         locatorJson: String,
         progression: Double?,
@@ -205,6 +229,44 @@ abstract class ReadingProgressDao {
         status: String?,
         updatedAt: Long,
     )
+
+    @Transaction
+    open suspend fun recordLocal(
+        bookUrl: String,
+        locatorJson: String,
+        progression: Double?,
+        readingSecondsPerPosition: Double?,
+        readingPaceSamples: Int?,
+        readingPaceElapsedMs: Long?,
+        readingPaceEvidence: Double?,
+        status: String?,
+        updatedAt: Long,
+    ) {
+        val updated = updateLocal(
+            bookUrl = bookUrl,
+            locatorJson = locatorJson,
+            progression = progression,
+            readingSecondsPerPosition = readingSecondsPerPosition,
+            readingPaceSamples = readingPaceSamples,
+            readingPaceElapsedMs = readingPaceElapsedMs,
+            readingPaceEvidence = readingPaceEvidence,
+            status = status,
+            updatedAt = updatedAt,
+        )
+        if (updated == 0) {
+            insertLocal(
+                bookUrl = bookUrl,
+                locatorJson = locatorJson,
+                progression = progression,
+                readingSecondsPerPosition = readingSecondsPerPosition,
+                readingPaceSamples = readingPaceSamples,
+                readingPaceElapsedMs = readingPaceElapsedMs,
+                readingPaceEvidence = readingPaceEvidence,
+                status = status,
+                updatedAt = updatedAt,
+            )
+        }
+    }
 
     /**
      * Compatibility overload for callers that do not measure v2 pace.
@@ -240,7 +302,27 @@ abstract class ReadingProgressDao {
      */
     @Query(
         """
-        INSERT INTO reading_progress (
+        UPDATE reading_progress SET
+            pending_progression = :progression,
+            pending_locator_json = :locatorJson,
+            pending_status = :status,
+            pending_updated_at = :remoteUpdatedAt,
+            pending_account = :account
+        WHERE book_url = :bookUrl
+        """,
+    )
+    abstract suspend fun updatePending(
+        bookUrl: String,
+        progression: Double?,
+        status: String?,
+        remoteUpdatedAt: Long?,
+        account: String,
+        locatorJson: String? = null,
+    ): Int
+
+    @Query(
+        """
+        INSERT OR IGNORE INTO reading_progress (
             book_url, locator_json, total_progression, updated_at,
             local_revision, acked_revision,
             pending_progression, pending_locator_json,
@@ -248,15 +330,9 @@ abstract class ReadingProgressDao {
         )
         VALUES (:bookUrl, '{}', NULL, :now, 0, 0,
                 :progression, :locatorJson, :status, :remoteUpdatedAt, :account)
-        ON CONFLICT(book_url) DO UPDATE SET
-            pending_progression = :progression,
-            pending_locator_json = :locatorJson,
-            pending_status = :status,
-            pending_updated_at = :remoteUpdatedAt,
-            pending_account = :account
         """,
     )
-    abstract suspend fun persistPending(
+    abstract suspend fun insertPending(
         bookUrl: String,
         progression: Double?,
         status: String?,
@@ -265,6 +341,37 @@ abstract class ReadingProgressDao {
         now: Long,
         locatorJson: String? = null,
     )
+
+    @Transaction
+    open suspend fun persistPending(
+        bookUrl: String,
+        progression: Double?,
+        status: String?,
+        remoteUpdatedAt: Long?,
+        account: String,
+        now: Long,
+        locatorJson: String? = null,
+    ) {
+        val updated = updatePending(
+            bookUrl = bookUrl,
+            progression = progression,
+            status = status,
+            remoteUpdatedAt = remoteUpdatedAt,
+            account = account,
+            locatorJson = locatorJson,
+        )
+        if (updated == 0) {
+            insertPending(
+                bookUrl = bookUrl,
+                progression = progression,
+                status = status,
+                remoteUpdatedAt = remoteUpdatedAt,
+                account = account,
+                now = now,
+                locatorJson = locatorJson,
+            )
+        }
+    }
 
     /** Every row still holding an unsettled state from this account. */
     @Query("SELECT * FROM reading_progress WHERE pending_account = :account")
@@ -606,25 +713,62 @@ abstract class ReadingProgressDao {
      */
     @Query(
         """
-        INSERT INTO reading_progress (
-            book_url, locator_json, total_progression, updated_at,
-            status, finished_override, local_revision, acked_revision
-        )
-        VALUES (:bookUrl, '{}', :progression, :now, :status, :override, 1, 0)
-        ON CONFLICT(book_url) DO UPDATE SET
+        UPDATE reading_progress SET
             status = :status,
             finished_override = :override,
             updated_at = :now,
             local_revision = local_revision + 1
+        WHERE book_url = :bookUrl
         """,
     )
-    abstract suspend fun setFinishedOverride(
+    abstract suspend fun updateFinishedOverride(
+        bookUrl: String,
+        override: Int,
+        status: String,
+        now: Long,
+    ): Int
+
+    @Query(
+        """
+        INSERT OR IGNORE INTO reading_progress (
+            book_url, locator_json, total_progression, updated_at,
+            status, finished_override, local_revision, acked_revision
+        )
+        VALUES (:bookUrl, '{}', :progression, :now, :status, :override, 1, 0)
+        """,
+    )
+    abstract suspend fun insertFinishedOverride(
         bookUrl: String,
         override: Int,
         status: String,
         progression: Double?,
         now: Long,
     )
+
+    @Transaction
+    open suspend fun setFinishedOverride(
+        bookUrl: String,
+        override: Int,
+        status: String,
+        progression: Double?,
+        now: Long,
+    ) {
+        val updated = updateFinishedOverride(
+            bookUrl = bookUrl,
+            override = override,
+            status = status,
+            now = now,
+        )
+        if (updated == 0) {
+            insertFinishedOverride(
+                bookUrl = bookUrl,
+                override = override,
+                status = status,
+                progression = progression,
+                now = now,
+            )
+        }
+    }
 
     @Query("SELECT finished_override FROM reading_progress WHERE book_url = :bookUrl")
     abstract suspend fun overrideFor(bookUrl: String): Int?

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/SyncPeerState.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/SyncPeerState.kt
@@ -5,6 +5,7 @@ import androidx.room.Dao
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Upsert
 
 /**
@@ -79,14 +80,38 @@ abstract class SyncPeerStateDao {
      * Lands something a partner reported, before its cursor is allowed
      * to move past it.
      *
-     * Written as one statement rather than read-modify-write for the
-     * same reason the local position is: whatever else is in the row is
-     * this partner's agreement, and carrying a stale copy of it back
-     * over a fresh one would undo an acknowledgement.
+     * Never read-modified-written for the same reason the local position
+     * is not: whatever else is in the row is this partner's agreement,
+     * and carrying a stale copy of it back over a fresh one would undo an
+     * acknowledgement. The update and the insert behind it share one
+     * transaction, so together they are still indivisible.
      */
     @Query(
         """
-        INSERT INTO sync_peer_state (
+        UPDATE sync_peer_state SET
+            pending_progression = :progression,
+            pending_locator_json = :locatorJson,
+            pending_edition_sha = :editionSha,
+            pending_status = :status,
+            pending_updated_at = :remoteUpdatedAt,
+            has_pending = 1,
+            remote_updated_at = :remoteUpdatedAt
+        WHERE book_url = :bookUrl AND peer_id = :peerId
+        """,
+    )
+    abstract suspend fun updatePending(
+        bookUrl: String,
+        peerId: String,
+        progression: Double?,
+        status: String?,
+        remoteUpdatedAt: Long?,
+        locatorJson: String? = null,
+        editionSha: String? = null,
+    ): Int
+
+    @Query(
+        """
+        INSERT OR IGNORE INTO sync_peer_state (
             book_url, peer_id, acked_revision,
             pending_progression, pending_locator_json, pending_edition_sha,
             pending_status, pending_updated_at,
@@ -95,17 +120,9 @@ abstract class SyncPeerStateDao {
         VALUES (:bookUrl, :peerId, 0, :progression, :locatorJson, :editionSha,
                 :status, :remoteUpdatedAt, 1,
                 :remoteUpdatedAt)
-        ON CONFLICT(book_url, peer_id) DO UPDATE SET
-            pending_progression = :progression,
-            pending_locator_json = :locatorJson,
-            pending_edition_sha = :editionSha,
-            pending_status = :status,
-            pending_updated_at = :remoteUpdatedAt,
-            has_pending = 1,
-            remote_updated_at = :remoteUpdatedAt
         """,
     )
-    abstract suspend fun persistPending(
+    abstract suspend fun insertPending(
         bookUrl: String,
         peerId: String,
         progression: Double?,
@@ -114,6 +131,38 @@ abstract class SyncPeerStateDao {
         locatorJson: String? = null,
         editionSha: String? = null,
     )
+
+    @Transaction
+    open suspend fun persistPending(
+        bookUrl: String,
+        peerId: String,
+        progression: Double?,
+        status: String?,
+        remoteUpdatedAt: Long?,
+        locatorJson: String? = null,
+        editionSha: String? = null,
+    ) {
+        val updated = updatePending(
+            bookUrl = bookUrl,
+            peerId = peerId,
+            progression = progression,
+            status = status,
+            remoteUpdatedAt = remoteUpdatedAt,
+            locatorJson = locatorJson,
+            editionSha = editionSha,
+        )
+        if (updated == 0) {
+            insertPending(
+                bookUrl = bookUrl,
+                peerId = peerId,
+                progression = progression,
+                status = status,
+                remoteUpdatedAt = remoteUpdatedAt,
+                locatorJson = locatorJson,
+                editionSha = editionSha,
+            )
+        }
+    }
 
     @Query(
         """
@@ -136,12 +185,7 @@ abstract class SyncPeerStateDao {
      */
     @Query(
         """
-        INSERT INTO sync_peer_state (
-            book_url, peer_id, acked_revision,
-            agreed_progression, agreed_status, has_pending, synced_at
-        )
-        VALUES (:bookUrl, :peerId, :ackedRevision, :progression, :status, 0, :now)
-        ON CONFLICT(book_url, peer_id) DO UPDATE SET
+        UPDATE sync_peer_state SET
             acked_revision = :ackedRevision,
             agreed_progression = :progression,
             agreed_status = :status,
@@ -152,9 +196,28 @@ abstract class SyncPeerStateDao {
             pending_updated_at = NULL,
             has_pending = 0,
             synced_at = :now
+        WHERE book_url = :bookUrl AND peer_id = :peerId
         """,
     )
-    abstract suspend fun settle(
+    abstract suspend fun updateSettled(
+        bookUrl: String,
+        peerId: String,
+        ackedRevision: Long,
+        progression: Double?,
+        status: String?,
+        now: Long,
+    ): Int
+
+    @Query(
+        """
+        INSERT OR IGNORE INTO sync_peer_state (
+            book_url, peer_id, acked_revision,
+            agreed_progression, agreed_status, has_pending, synced_at
+        )
+        VALUES (:bookUrl, :peerId, :ackedRevision, :progression, :status, 0, :now)
+        """,
+    )
+    abstract suspend fun insertSettled(
         bookUrl: String,
         peerId: String,
         ackedRevision: Long,
@@ -162,6 +225,35 @@ abstract class SyncPeerStateDao {
         status: String?,
         now: Long,
     )
+
+    @Transaction
+    open suspend fun settle(
+        bookUrl: String,
+        peerId: String,
+        ackedRevision: Long,
+        progression: Double?,
+        status: String?,
+        now: Long,
+    ) {
+        val updated = updateSettled(
+            bookUrl = bookUrl,
+            peerId = peerId,
+            ackedRevision = ackedRevision,
+            progression = progression,
+            status = status,
+            now = now,
+        )
+        if (updated == 0) {
+            insertSettled(
+                bookUrl = bookUrl,
+                peerId = peerId,
+                ackedRevision = ackedRevision,
+                progression = progression,
+                status = status,
+                now = now,
+            )
+        }
+    }
 
     @Query("DELETE FROM sync_peer_state WHERE book_url = :bookUrl")
     abstract suspend fun forget(bookUrl: String)

--- a/app/src/main/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepository.kt
@@ -1,6 +1,7 @@
 package com.chmouel.liseur.data.komga
 
 import android.util.Log
+import com.chmouel.liseur.data.NetworkAvailability
 import com.chmouel.liseur.data.db.Book
 import com.chmouel.liseur.data.db.BookDao
 import com.chmouel.liseur.data.db.ReadingProgress
@@ -81,6 +82,7 @@ class KomgaSyncRepository(
     private val finishedState: FinishedState,
     private val device: DeviceIdentityRepository,
     private val reporting: SyncReporting = SyncReporting(),
+    private val networkAvailability: NetworkAvailability = NetworkAvailability { true },
     private val catalog: KomgaCatalogClient = KomgaCatalogClient(),
     private val positions: KomgaProgressionClient = KomgaProgressionClient(),
     private val inTransaction: suspend (suspend () -> Unit) -> Unit = { it() },
@@ -109,6 +111,7 @@ class KomgaSyncRepository(
         val server = serverDao.get() ?: return PreviewOutcome.NotSynced
         val credentials = server.credentials ?: return PreviewOutcome.NotSynced
         val id = bookDao.getByUrl(bookUrl)?.remoteUuid ?: return PreviewOutcome.NotSynced
+        if (!networkAvailability.isAvailable()) return PreviewOutcome.Failed(SyncFailure.Offline)
 
         val remote = when (val asked = fetchRemote(server, credentials, id)) {
             is RemoteResult.Failed -> return PreviewOutcome.Failed(asked.reason)
@@ -214,6 +217,7 @@ class KomgaSyncRepository(
         // Read afresh, so a page turned while the question was open is
         // what gets sent rather than the position it was asked about.
         val stored = progressDao.get(bookUrl) ?: return ResolveOutcome.Done
+        if (!networkAvailability.isAvailable()) return ResolveOutcome.Failed(SyncFailure.Offline)
 
         val outcome = apply(
             server = server,
@@ -248,6 +252,10 @@ class KomgaSyncRepository(
         val credentials = server.credentials ?: run {
             reporting.report(PositionSyncStatus.Unavailable)
             return SyncOutcome.NotApplicable
+        }
+        if (!networkAvailability.isAvailable()) {
+            reporting.report(PositionSyncStatus.Failed(SyncFailure.Offline))
+            return SyncOutcome.Failure(SyncFailure.Offline)
         }
 
         reporting.report(PositionSyncStatus.Syncing)

--- a/app/src/main/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepository.kt
@@ -42,6 +42,11 @@ import org.json.JSONObject
 private data class BookOutcome(
     val moved: SyncMove? = null,
     val failure: SyncFailure? = null,
+    /**
+     * Set when the failure was the server saying nothing at all, which
+     * is the shelf's cue to stop rather than ask about the next book.
+     */
+    val unreachable: SyncFailure? = null,
 )
 
 /** The server's side of one book: where it is, and when it got there. */
@@ -276,6 +281,7 @@ class KomgaSyncRepository(
         }
 
         var firstFailure: SyncFailure? = null
+        var unreachable: SyncFailure? = null
         var pulled = 0
         var pushed = 0
         for (candidate in books) {
@@ -286,6 +292,15 @@ class KomgaSyncRepository(
                 SyncMove.UNRESOLVED, null -> Unit
             }
             if (outcome.failure != null && firstFailure == null) firstFailure = outcome.failure
+            // Nothing more is learned by asking about the next book of
+            // a server that has stopped answering, and each question
+            // costs a whole connect timeout. Whatever the shelf managed
+            // before that is still counted and reported below.
+            unreachable = outcome.unreachable
+            if (unreachable != null) {
+                Log.i(TAG, "Stopping the run early: ${unreachable.label}")
+                break
+            }
         }
 
         val now = System.currentTimeMillis()
@@ -299,7 +314,12 @@ class KomgaSyncRepository(
                 unresolved = progressDao.pendingFor(server.accountKey).size,
             ),
         )
-        return if (firstFailure == null) {
+        // A server that went quiet outranks anything it managed to say
+        // earlier: reporting a 404 on one book would tell the retry
+        // machinery there is nothing to come back for, when in fact the
+        // connection died with positions still unsent.
+        val failure = unreachable ?: firstFailure
+        return if (failure == null) {
             // Only a run that settled everything counts as having synced,
             // and only ever for the account that is still connected: if it
             // went away while this ran, writing it back would sign the user
@@ -313,9 +333,9 @@ class KomgaSyncRepository(
             reporting.report(PositionSyncStatus.Synced(now))
             SyncOutcome.Success
         } else {
-            Log.i(TAG, "Some positions did not settle: ${firstFailure.label}")
-            reporting.report(PositionSyncStatus.Failed(firstFailure))
-            SyncOutcome.Partial(firstFailure)
+            Log.i(TAG, "Some positions did not settle: ${failure.label}")
+            reporting.report(PositionSyncStatus.Failed(failure))
+            SyncOutcome.Partial(failure)
         }
     }
 
@@ -366,7 +386,7 @@ class KomgaSyncRepository(
         var stored = progressDao.get(book.url)
 
         var remote = when (val side = remoteSide(server, credentials, id, progress[id], stored)) {
-            is RemoteResult.Failed -> return BookOutcome(failure = side.reason)
+            is RemoteResult.Failed -> return BookOutcome(failure = side.reason, unreachable = side.unreachable)
             is RemoteResult.Ok -> side.value
         }
 
@@ -664,7 +684,7 @@ class KomgaSyncRepository(
         val unread = !finished && stored?.override == FinishedOverride.UNREAD
         if (unread) {
             when (val cleared = positions.clear(server.baseUrl, credentials, id)) {
-                is RemoteResult.Failed -> return BookOutcome(failure = cleared.reason)
+                is RemoteResult.Failed -> return BookOutcome(failure = cleared.reason, unreachable = cleared.unreachable)
                 is RemoteResult.Ok -> Unit
             }
         }
@@ -685,7 +705,7 @@ class KomgaSyncRepository(
         }
 
         when (placed) {
-            is RemoteResult.Failed -> return BookOutcome(failure = placed.reason)
+            is RemoteResult.Failed -> return BookOutcome(failure = placed.reason, unreachable = placed.unreachable)
             is RemoteResult.Ok -> when (placed.value) {
                 // The server already holds something at least as new.
                 // Overwriting it would be wrong, so the row stays dirty
@@ -708,7 +728,7 @@ class KomgaSyncRepository(
 
         if (finished) {
             when (val marked = positions.markCompleted(server.baseUrl, credentials, id)) {
-                is RemoteResult.Failed -> return BookOutcome(failure = marked.reason)
+                is RemoteResult.Failed -> return BookOutcome(failure = marked.reason, unreachable = marked.unreachable)
                 is RemoteResult.Ok -> Unit
             }
         }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepository.kt
@@ -609,14 +609,16 @@ class KomgaSyncRepository(
 
             is SyncDecision.Pull -> {
                 val progression = decision.state.progression ?: stored?.totalProgression
+                var applied = false
                 if (progression == null) {
                     progressDao.clearPending(bookUrl)
                 } else {
                     // Refused means a page was turned here while this was
-                    // being decided, which makes it a disagreement rather
+                    // being decided, or that the book is open on screen
+                    // right now: either way it is a disagreement rather
                     // than a handover. The remote state stays put for the
                     // next run, and now for someone to be asked about.
-                    progressDao.applyPull(
+                    applied = progressDao.applyUnattendedPull(
                         bookUrl = bookUrl,
                         expectedRevision = stored?.localRevision ?: 0,
                         progression = progression,
@@ -634,7 +636,7 @@ class KomgaSyncRepository(
                     )
                 }
                 finishedState.refreshFromProgress(bookUrl)
-                BookOutcome(moved = SyncMove.PULLED)
+                BookOutcome(moved = if (applied) SyncMove.PULLED else null)
             }
 
             is SyncDecision.Push -> BookOutcome()

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncHttp.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncHttp.kt
@@ -1,6 +1,7 @@
 package com.chmouel.liseur.data.liseursync
 
 import android.util.Log
+import com.chmouel.liseur.data.remote.AnsweredFailure
 import com.chmouel.liseur.data.remote.RemoteCredentials
 import com.chmouel.liseur.data.remote.RemoteHttp
 import com.chmouel.liseur.data.remote.RemoteHttpFailure
@@ -28,7 +29,7 @@ import org.json.JSONObject
 class LiseurSyncRejection(
     val code: Int,
     val body: JSONObject?,
-) : java.io.IOException("liseur-sync refused with $code") {
+) : java.io.IOException("liseur-sync refused with $code"), AnsweredFailure {
 
     /** The server's own word for what was wrong, if it gave one. */
     val error: String? get() = body?.optString("error")?.takeIf { it.isNotEmpty() }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
@@ -742,7 +742,7 @@ class LiseurSyncPositionSync(
                 val expected = stored?.localRevision ?: 0
                 var applied = false
                 forAccount(account) {
-                    applied = progressDao.applyPeerPull(
+                    applied = progressDao.applyUnattendedPeerPull(
                         bookUrl = book.url,
                         expectedRevision = expected,
                         progression = progression,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
@@ -1,6 +1,7 @@
 package com.chmouel.liseur.data.liseursync
 
 import android.util.Log
+import com.chmouel.liseur.data.NetworkAvailability
 import com.chmouel.liseur.data.db.Book
 import com.chmouel.liseur.data.db.BookDao
 import com.chmouel.liseur.data.db.ReadingProgress
@@ -72,6 +73,7 @@ class LiseurSyncPositionSync(
     private val deviceKey: suspend () -> String,
     private val finishedState: FinishedState,
     private val reporting: SyncReporting = SyncReporting(),
+    private val networkAvailability: NetworkAvailability = NetworkAvailability { true },
     private val http: LiseurSyncHttp = LiseurSyncHttp(),
     private val now: () -> Long = System::currentTimeMillis,
     private val inTransaction: suspend (suspend () -> Unit) -> Unit = { it() },
@@ -103,6 +105,7 @@ class LiseurSyncPositionSync(
         val account = account() ?: return PreviewOutcome.NotSynced
         val book = bookDao.getByUrl(bookUrl) ?: return PreviewOutcome.NotSynced
         val alias = works.cached(book, account.peerId) ?: return PreviewOutcome.NotSynced
+        if (!networkAvailability.isAvailable()) return PreviewOutcome.Failed(SyncFailure.Offline)
 
         val head = try {
             latestOp(account.baseUrl, account.credentials, alias.workId)
@@ -307,6 +310,10 @@ class LiseurSyncPositionSync(
             // open, and there is nothing to do about it here.
             reporting.report(PositionSyncStatus.Unavailable)
             return SyncOutcome.NotApplicable
+        }
+        if (!networkAvailability.isAvailable()) {
+            reporting.report(PositionSyncStatus.Failed(SyncFailure.Offline))
+            return SyncOutcome.Failure(SyncFailure.Offline)
         }
         val account = Account(
             baseUrl = server.baseUrl,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
@@ -14,11 +14,13 @@ import com.chmouel.liseur.data.db.SyncPeerStateDao
 import com.chmouel.liseur.data.db.WorkAlias
 import com.chmouel.liseur.data.db.WorkIdentityDao
 import com.chmouel.liseur.data.library.FinishedState
+import com.chmouel.liseur.data.remote.failureForCode
 import com.chmouel.liseur.data.remote.PositionSync
 import com.chmouel.liseur.data.remote.PositionSyncStatus
 import com.chmouel.liseur.data.remote.PreviewOutcome
 import com.chmouel.liseur.data.remote.RemoteCredentials
 import com.chmouel.liseur.data.remote.RemoteHttpFailure
+import com.chmouel.liseur.data.remote.serverAnswered
 import com.chmouel.liseur.data.remote.ResolveOutcome
 import com.chmouel.liseur.data.remote.ResumeConfidence
 import com.chmouel.liseur.data.remote.ServerKind
@@ -333,19 +335,38 @@ class LiseurSyncPositionSync(
             listOfNotNull(bookDao.getByUrl(book))
         }
 
-        var firstFailure: SyncFailure? = null
+        val trouble = Trouble()
 
         // Names first: an op is about a work id, so a book with no name
         // can neither receive what arrived nor send what is owed.
-        val named = name(account, books, single = book != null)
-        firstFailure = firstFailure ?: named.failure
+        val aliases = name(account, books, single = book != null, trouble)
 
-        val pull = pull(account)
-        firstFailure = firstFailure ?: pull
+        /**
+         * Gives up when the server has stopped answering.
+         *
+         * Each remaining stage waits out its own connect timeout for
+         * nothing, so the run ends here and the next scheduled one finds
+         * the network back. This reads the network verdict rather than
+         * the first failure: a book the server refused says nothing
+         * about whether the server is still there.
+         */
+        fun giveUp(): SyncOutcome? {
+            val reason = trouble.unreachable ?: return null
+            Log.i(TAG, "Stopping the run early: ${reason.label}")
+            reporting.report(PositionSyncStatus.Failed(reason))
+            return SyncOutcome.Failure(reason)
+        }
+
+        giveUp()?.let { return it }
+
+        pull(account, trouble)
 
         var pulled = 0
         val pushes = mutableListOf<PendingPush>()
-        for (candidate in named.aliases) {
+        // Reconciling asks the server nothing, so it is worth doing even
+        // when the pull above came back empty-handed: it settles what
+        // earlier pages already delivered.
+        for (candidate in aliases) {
             when (val outcome = reconcile(account, candidate)) {
                 is Reconciled.Pulled -> pulled++
                 is Reconciled.Owed -> pushes += outcome.push
@@ -358,13 +379,29 @@ class LiseurSyncPositionSync(
         // is left for the next scheduled sync rather than chased.
         val recovered = mutableSetOf<String>()
 
-        val pushed = push(account, pushes, recovered) { firstFailure = firstFailure ?: it }
+        // The later stages are skipped rather than returned from, so
+        // that whatever the run did manage is still counted and
+        // reported. Each is dropped once the server has gone quiet, for
+        // the same reason the run gives up above.
+        val pushed = if (trouble.unreachable == null) {
+            push(account, pushes, recovered, trouble)
+        } else {
+            0
+        }
 
         // After the positions, because where the reader is now matters
         // more than how long they took to get there, and a run cut short
         // by a dead network should have spent what it had on the former.
-        uploadSessions(account, recovered) { firstFailure = firstFailure ?: it }
+        if (trouble.unreachable == null) {
+            uploadSessions(account, recovered, trouble)
+        }
 
+        // A server that went quiet outranks anything it managed to say
+        // earlier. The first failure may well be a 404 on one book, which
+        // is nobody's fault and not worth retrying; if the connection then
+        // died with positions still unsent, reporting that 404 would tell
+        // WorkManager there is nothing to come back for.
+        val firstFailure = trouble.unreachable ?: trouble.first
         val at = now()
         reporting.report(
             SyncReport(
@@ -392,11 +429,37 @@ class LiseurSyncPositionSync(
         }
     }
 
-    /** Books with a name on this server, and whatever stopped the rest. */
-    private data class Named(
-        val aliases: List<Pair<Book, WorkAlias>>,
-        val failure: SyncFailure?,
-    )
+    /**
+     * What went wrong over a run, and whether the server stopped
+     * answering at all.
+     *
+     * The two are worth telling apart. [first] is what the run reports,
+     * because the earliest thing to go wrong usually explains the rest.
+     * [unreachable] decides whether there is any point carrying on:
+     * every further request to a server whose packets go nowhere waits
+     * out a whole connect timeout and comes back knowing nothing, and a
+     * reader opening a book is waiting on this run to let go of its
+     * turn. A refusal is not that — it says something about the one
+     * book, and the next question is still worth asking.
+     */
+    private class Trouble {
+        var first: SyncFailure? = null
+            private set
+
+        var unreachable: SyncFailure? = null
+            private set
+
+        /** Notes something the server said itself. */
+        fun refused(reason: SyncFailure) {
+            first = first ?: reason
+        }
+
+        /** Notes a call that failed, and whether it ever got an answer. */
+        fun failed(cause: IOException, reason: SyncFailure) {
+            first = first ?: reason
+            if (!cause.serverAnswered()) unreachable = unreachable ?: reason
+        }
+    }
 
     /**
      * Makes sure the books of interest have a name on this server.
@@ -411,14 +474,21 @@ class LiseurSyncPositionSync(
         account: Account,
         books: List<Book>,
         single: Boolean,
-    ): Named {
+        trouble: Trouble,
+    ): List<Pair<Book, WorkAlias>> {
         val known = identityDao.aliasesFor(account.peerId).associateBy { it.bookUrl }
         val out = mutableListOf<Pair<Book, WorkAlias>>()
-        var failure: SyncFailure? = null
         var budget = if (single) books.size else MAX_RESOLVES_PER_RUN
+
+        /** Notes why something could not be had, and whether it was the network. */
+        fun note(cause: IOException?) {
+            val reason = cause?.let(::reasonFor) ?: return
+            trouble.failed(cause, reason)
+        }
 
         val ordered = books.sortedByDescending { it.lastOpenedAt ?: 0 }
         for (candidate in ordered) {
+            if (trouble.unreachable != null) break
             val cached = known[candidate.url]
             if (cached != null && cached.usable) {
                 var alias = cached
@@ -431,16 +501,20 @@ class LiseurSyncPositionSync(
                     budget--
                     val refreshed =
                         works.resolve(candidate, account.peerId, account.baseUrl, account.credentials)
-                    if (refreshed is WorkResolution.Named) alias = refreshed.alias
+                    if (refreshed is WorkResolution.Named) {
+                        alias = refreshed.alias
+                    } else {
+                        note((refreshed as? WorkResolution.Unresolved)?.cause)
+                    }
                 }
                 out += candidate to alias
                 // A name that arrived without the one-off question —
                 // a doubtful match confirmed by hand — still owes
                 // it: whatever the server heard before the name was
                 // usable is behind the cursor.
-                if (!alias.seeded && budget > 0) {
+                if (!alias.seeded && budget > 0 && trouble.unreachable == null) {
                     budget--
-                    seed(account, candidate, alias)
+                    note(seed(account, candidate, alias))
                 }
                 continue
             }
@@ -459,15 +533,14 @@ class LiseurSyncPositionSync(
                     // Everything that happened to this book before it had
                     // a name is behind the cursor, so it is asked for
                     // once, directly.
-                    seed(account, candidate, resolved.alias)
+                    note(seed(account, candidate, resolved.alias))
                 }
 
                 is WorkResolution.NeedsConfirming, is WorkResolution.Ambiguous -> Unit
-                is WorkResolution.Unresolved ->
-                    failure = failure ?: resolved.cause?.let(::reasonFor)
+                is WorkResolution.Unresolved -> note(resolved.cause)
             }
         }
-        return Named(out, failure)
+        return out
     }
 
     /**
@@ -483,14 +556,16 @@ class LiseurSyncPositionSync(
         account: Account,
         book: Book,
         alias: WorkAlias,
-    ) {
+    ): IOException? {
         val head = try {
             latestOp(account.baseUrl, account.credentials, alias.workId)
         } catch (e: IOException) {
             // Not marked seeded: the question was asked and never
-            // answered, so it is still owed.
+            // answered, so it is still owed. Handed back rather than
+            // only logged, because a seed costs the same connect
+            // timeout a resolve does and the caller is counting them.
             Log.i(TAG, "Could not fetch a newly named book's position", e)
-            return
+            return e
         }
         forAccount(account) {
             head?.let { land(account, book.url, it) }
@@ -498,6 +573,7 @@ class LiseurSyncPositionSync(
             // nothing about this book, and there is nothing to recover.
             identityDao.markSeeded(book.url, account.peerId)
         }
+        return null
     }
 
     /**
@@ -508,7 +584,7 @@ class LiseurSyncPositionSync(
      * reading nobody will ever see again, and unlike everything else
      * here it cannot be asked for a second time.
      */
-    private suspend fun pull(account: Account): SyncFailure? {
+    private suspend fun pull(account: Account, trouble: Trouble) {
         var cursor = account.cursorSeq
         var guard = MAX_PAGES
         while (guard-- > 0) {
@@ -519,10 +595,11 @@ class LiseurSyncPositionSync(
                     expected = setOf(LiseurSyncHttp.GONE),
                 )
             } catch (gone: LiseurSyncRejection) {
-                return resync(account)
+                return resync(account, trouble)
             } catch (e: IOException) {
                 Log.i(TAG, "Could not read what changed", e)
-                return reasonFor(e)
+                trouble.failed(e, reasonFor(e))
+                return
             }
 
             val ops = ops(page.optJSONArray("ops"))
@@ -532,13 +609,12 @@ class LiseurSyncPositionSync(
             apply(account, ops, next)
             cursor = next
 
-            if (!page.optBoolean("has_more", false)) return null
+            if (!page.optBoolean("has_more", false)) return
         }
         // A server that always says there is more would otherwise keep
         // this run going forever. Stopping is safe: the cursor is
         // durable and the next run carries on from it.
         Log.i(TAG, "Stopped reading changes after $MAX_PAGES pages")
-        return null
     }
 
     /**
@@ -550,15 +626,15 @@ class LiseurSyncPositionSync(
      * partial history. The snapshot is the newest position per book and
      * per device, which is exactly the baseline to start again from.
      */
-    private suspend fun resync(account: Account): SyncFailure? {
+    private suspend fun resync(account: Account, trouble: Trouble) {
         Log.i(TAG, "The cursor fell behind the server's horizon; starting from a snapshot")
         val snapshot = try {
             http.get(LiseurSyncApi.url(account.baseUrl, LiseurSyncApi.HEADS), account.credentials)
         } catch (e: IOException) {
-            return reasonFor(e)
+            trouble.failed(e, reasonFor(e))
+            return
         }
         apply(account, ops(snapshot.optJSONArray("ops")), snapshot.optLong("snapshot_seq"))
-        return null
     }
 
     /** Lands a page and moves the cursor, together or not at all. */
@@ -753,11 +829,15 @@ class LiseurSyncPositionSync(
         account: Account,
         pushes: List<PendingPush>,
         recovered: MutableSet<String>,
-        onFailure: (SyncFailure) -> Unit,
+        trouble: Trouble,
     ): Int {
         var pushed = 0
         val queue = ArrayDeque(pushes.chunked(SyncOps.MAX_BATCH))
         while (queue.isNotEmpty()) {
+            // A recovery in the middle of this may have discovered the
+            // server has gone quiet. Retrying then costs another whole
+            // connect timeout and learns nothing.
+            if (trouble.unreachable != null) return pushed
             val batch = queue.removeFirst()
             // A null answer means a recovery rebuilt the batch and it
             // goes back on the queue: nothing from the rejected request
@@ -773,26 +853,26 @@ class LiseurSyncPositionSync(
                     expected = setOf(LiseurSyncHttp.BAD_REQUEST),
                 )
             } catch (rejection: LiseurSyncRejection) {
-                when (val recovery = recoverPush(account, batch, rejection, recovered, onFailure)) {
+                when (val recovery = recoverPush(account, batch, rejection, recovered, trouble)) {
                     is PushRecovery.Retry -> {
                         if (recovery.batch.isNotEmpty()) queue.addFirst(recovery.batch)
                         null
                     }
 
                     PushRecovery.Exhausted -> {
-                        onFailure(SyncFailure.StaleIdentity)
+                        trouble.refused(SyncFailure.StaleIdentity)
                         return pushed
                     }
 
                     PushRecovery.Ordinary -> {
                         Log.i(TAG, "The server refused a positions batch")
-                        onFailure(SyncFailure.ServerError(rejection.code))
+                        trouble.refused(SyncFailure.ServerError(rejection.code))
                         return pushed
                     }
                 }
             } catch (e: IOException) {
                 Log.i(TAG, "Could not send positions", e)
-                onFailure(reasonFor(e))
+                trouble.failed(e, reasonFor(e))
                 return pushed
             } ?: continue
 
@@ -852,7 +932,7 @@ class LiseurSyncPositionSync(
         batch: List<PendingPush>,
         rejection: LiseurSyncRejection,
         recovered: MutableSet<String>,
-        onFailure: (SyncFailure) -> Unit,
+        trouble: Trouble,
     ): PushRecovery {
         if (!rejection.isUnknownWork) return PushRecovery.Ordinary
         val opId = rejection.opId ?: return PushRecovery.Ordinary
@@ -871,12 +951,12 @@ class LiseurSyncPositionSync(
             return PushRecovery.Exhausted
         }
 
-        val replacement = when (val refreshed = refreshStaleIdentity(account, stale.bookUrl, workId)) {
+        val replacement = when (val refreshed = refreshStaleIdentity(account, stale.bookUrl, workId, trouble)) {
             is IdentityRefresh.Refreshed ->
                 (reconcile(account, refreshed.book to refreshed.alias) as? Reconciled.Owed)?.push
 
             is IdentityRefresh.Failed -> {
-                onFailure(reasonFor(refreshed.cause))
+                trouble.failed(refreshed.cause, reasonFor(refreshed.cause))
                 null
             }
 
@@ -914,6 +994,7 @@ class LiseurSyncPositionSync(
         account: Account,
         bookUrl: String,
         staleWorkId: String,
+        trouble: Trouble,
     ): IdentityRefresh {
         forAccount(account) {
             identityDao.deleteAliasIfStale(bookUrl, account.peerId, staleWorkId)
@@ -923,7 +1004,10 @@ class LiseurSyncPositionSync(
             val resolved = works.resolve(book, account.peerId, account.baseUrl, account.credentials)
         ) {
             is WorkResolution.Named -> {
-                seed(account, book, resolved.alias)
+                // Seeding costs the same unanswered wait a resolve does,
+                // so a recovery must not quietly pay it and then go
+                // straight back to the request that failed.
+                seed(account, book, resolved.alias)?.let { trouble.failed(it, reasonFor(it)) }
                 IdentityRefresh.Refreshed(book, resolved.alias)
             }
 
@@ -974,7 +1058,7 @@ class LiseurSyncPositionSync(
     private suspend fun uploadSessions(
         account: Account,
         recovered: MutableSet<String>,
-        onFailure: (SyncFailure) -> Unit,
+        trouble: Trouble,
     ) {
         val sessions = sessionDao.awaitingUpload(SessionUploads.MAX_BATCH)
         if (sessions.isEmpty()) return
@@ -1003,6 +1087,9 @@ class LiseurSyncPositionSync(
 
         var answered = false
         while (!answered) {
+            // As with the pushes: a recovery may have found the server
+            // gone quiet, and going round again would only wait again.
+            if (trouble.unreachable != null) return
             answered = try {
                 http.post(
                     LiseurSyncApi.url(account.baseUrl, LiseurSyncApi.SESSIONS),
@@ -1015,16 +1102,18 @@ class LiseurSyncPositionSync(
                 )
                 true
             } catch (rejection: LiseurSyncRejection) {
-                when (val recovery = recoverSessions(account, sending, rejection, recovered)) {
+                when (
+                    val recovery = recoverSessions(account, sending, rejection, recovered, trouble)
+                ) {
                     is SessionRecovery.Retry -> {
-                        recovery.failure?.let(onFailure)
+                        recovery.failure?.let(trouble::refused)
                         if (recovery.sending.isEmpty()) return
                         sending = recovery.sending
                         false
                     }
 
                     SessionRecovery.Exhausted -> {
-                        onFailure(SyncFailure.StaleIdentity)
+                        trouble.refused(SyncFailure.StaleIdentity)
                         return
                     }
 
@@ -1038,14 +1127,14 @@ class LiseurSyncPositionSync(
             } catch (rejected: RemoteHttpFailure) {
                 if (!rejected.reason.isFinal()) {
                     Log.i(TAG, "Could not send reading sessions", rejected)
-                    onFailure(rejected.reason)
+                    trouble.refused(rejected.reason)
                     return
                 }
                 Log.i(TAG, "The server will never take these sessions; not asking again")
                 true
             } catch (e: IOException) {
                 Log.i(TAG, "Could not send reading sessions", e)
-                onFailure(reasonFor(e))
+                trouble.failed(e, reasonFor(e))
                 return
             }
         }
@@ -1089,6 +1178,7 @@ class LiseurSyncPositionSync(
         sending: List<PreparedSession>,
         rejection: LiseurSyncRejection,
         recovered: MutableSet<String>,
+        trouble: Trouble,
     ): SessionRecovery {
         if (!rejection.isUnknownWork) return SessionRecovery.Ordinary
         val sessionId = rejection.sessionId ?: return SessionRecovery.Ordinary
@@ -1108,11 +1198,20 @@ class LiseurSyncPositionSync(
         }
 
         val rest = sending.filter { it.bookUrl != culprit.bookUrl }
-        val refreshed = when (val outcome = refreshStaleIdentity(account, culprit.bookUrl, workId)) {
-            is IdentityRefresh.Refreshed -> outcome
-            is IdentityRefresh.Failed -> return SessionRecovery.Retry(rest, reasonFor(outcome.cause))
-            IdentityRefresh.Unnameable -> return SessionRecovery.Retry(rest)
-        }
+        val refreshed =
+            when (val outcome = refreshStaleIdentity(account, culprit.bookUrl, workId, trouble)) {
+                is IdentityRefresh.Refreshed -> outcome
+
+                is IdentityRefresh.Failed -> {
+                    // Recorded from the exception itself, so that a
+                    // server which said nothing is remembered as silent
+                    // rather than as one more thing it refused.
+                    trouble.failed(outcome.cause, reasonFor(outcome.cause))
+                    return SessionRecovery.Retry(rest)
+                }
+
+                IdentityRefresh.Unnameable -> return SessionRecovery.Retry(rest)
+            }
         val rebuilt = sending.filter { it.bookUrl == culprit.bookUrl }.mapNotNull { entry ->
             val session = sessionDao.get(entry.localId) ?: return@mapNotNull null
             SessionUploads.toJson(
@@ -1176,8 +1275,19 @@ class LiseurSyncPositionSync(
         }
     }
 
-    private fun reasonFor(error: IOException): SyncFailure =
-        (error as? RemoteHttpFailure)?.reason ?: SyncFailure.Offline
+    /**
+     * What to call a failure that stopped one request.
+     *
+     * Only something that never reached the server is [SyncFailure.Offline].
+     * A refusal is the server talking, and calling that offline both reads
+     * wrong to the reader and tells the retry machinery to come back for
+     * something that will be refused again just as firmly.
+     */
+    private fun reasonFor(error: IOException): SyncFailure = when (error) {
+        is RemoteHttpFailure -> error.reason
+        is LiseurSyncRejection -> failureForCode(error.code)
+        else -> SyncFailure.Offline
+    }
 
     private fun ReadingProgress.asReadingState() = ReadingState(
         progression = totalProgression,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/OpenBooks.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/OpenBooks.kt
@@ -1,0 +1,56 @@
+package com.chmouel.liseur.data.remote
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * The books someone is reading right now.
+ *
+ * A sync run and an open book share the same row, and a run that was
+ * given up on does not stop running: it may decide to move the book long
+ * after the reader stopped waiting for it. That move would land under a
+ * page already on screen, where nobody sees it, and the first page turn
+ * would write over it — losing where the other device had got to. So a
+ * pull nobody asked to see is only applied while nobody is looking.
+ *
+ * Entries are counted rather than flagged, so two readers of the same
+ * book — or one whose screens overlap during a rotation — cannot free
+ * each other's hold by leaving.
+ *
+ * Nothing here survives the process, deliberately. A dead process has no
+ * page on screen to protect, and the state a declined pull preserves is
+ * on disk already, waiting for the next open to ask about it.
+ */
+class OpenBooks {
+
+    private val lock = Mutex()
+    private val reading = mutableMapOf<String, Int>()
+
+    /** Says someone is now reading [bookUrl]. Pair with [leave]. */
+    suspend fun enter(bookUrl: String) {
+        lock.withLock { reading[bookUrl] = (reading[bookUrl] ?: 0) + 1 }
+    }
+
+    /** Says a reader of [bookUrl] has gone. */
+    suspend fun leave(bookUrl: String) {
+        lock.withLock {
+            val left = (reading[bookUrl] ?: 0) - 1
+            if (left > 0) reading[bookUrl] = left else reading.remove(bookUrl)
+        }
+    }
+
+    /**
+     * Runs [apply] unless [bookUrl] is being read, and answers null when
+     * it is.
+     *
+     * The book is held closed for the duration: a reader arriving while
+     * [apply] is mid-write waits in [enter] until the write has landed,
+     * and so reads what it wrote rather than what it was replacing. That
+     * only stays cheap if [apply] is quick — a database transaction, not
+     * a network call.
+     */
+    suspend fun <T> unlessOpen(bookUrl: String, apply: suspend () -> T): T? =
+        lock.withLock {
+            if (bookUrl in reading) null else apply()
+        }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepository.kt
@@ -1,6 +1,7 @@
 package com.chmouel.liseur.data.remote
 
 import android.util.Log
+import com.chmouel.liseur.data.NetworkAvailability
 import com.chmouel.liseur.data.db.Book
 import com.chmouel.liseur.data.db.BookDao
 import com.chmouel.liseur.data.db.DownloadState
@@ -68,6 +69,7 @@ class RemoteCatalogRepository(
      */
     private val inTransaction: suspend (suspend () -> Unit) -> Unit = { it() },
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+    private val networkAvailability: NetworkAvailability = NetworkAvailability { true },
 ) {
     private val _status = MutableStateFlow<CatalogStatus>(CatalogStatus.Idle)
     val status: StateFlow<CatalogStatus> = _status.asStateFlow()
@@ -121,6 +123,13 @@ class RemoteCatalogRepository(
             }
             val client = router.catalogFor(server.kind) ?: run {
                 _status.value = CatalogStatus.Idle
+                return CatalogRefresh.None
+            }
+            // Said rather than attempted: the pull would end here anyway,
+            // several stalled connections later, and a refresh that
+            // reports nothing looks like a gesture that did not register.
+            if (!networkAvailability.isAvailable()) {
+                _status.value = CatalogStatus.Failed(SyncFailure.Offline)
                 return CatalogRefresh.None
             }
 
@@ -202,6 +211,7 @@ class RemoteCatalogRepository(
     }
 
     suspend fun search(query: String): List<RemoteBook> {
+        if (!networkAvailability.isAvailable()) return emptyList()
         val server = serverDao.get() ?: return emptyList()
         val credentials = server.credentials ?: return emptyList()
         val client = router.catalogFor(server.kind) ?: return emptyList()
@@ -221,6 +231,7 @@ class RemoteCatalogRepository(
             bookDao.discardPendingSeriesClaims()
             return
         }
+        if (!networkAvailability.isAvailable()) return
         val credentials = server.credentials ?: return
         retryPendingSeriesClaims(server, credentials)
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/SeriesExtrasRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/SeriesExtrasRepository.kt
@@ -1,5 +1,6 @@
 package com.chmouel.liseur.data.remote
 
+import com.chmouel.liseur.data.NetworkAvailability
 import com.chmouel.liseur.data.db.SeriesExtra
 import com.chmouel.liseur.data.db.SeriesExtraDao
 import com.chmouel.liseur.data.komga.KomgaSeriesClient
@@ -22,12 +23,14 @@ class SeriesExtrasRepository(
     private val dao: SeriesExtraDao,
     private val komga: KomgaSeriesClient = KomgaSeriesClient(),
     private val now: () -> Long = System::currentTimeMillis,
+    private val networkAvailability: NetworkAvailability = NetworkAvailability { true },
 ) {
 
     suspend fun extras(seriesId: String?): SeriesExtras? {
         if (seriesId.isNullOrBlank()) return null
         val cached = dao.get(seriesId)
         if (cached != null && now() - cached.fetchedAt < FRESH_FOR_MS) return cached.toExtras()
+        if (!networkAvailability.isAvailable()) return cached?.toExtras()
 
         val server = account.current()
         if (server?.kind != ServerKind.KOMGA) return cached?.toExtras()

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/SyncFailure.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/SyncFailure.kt
@@ -91,10 +91,30 @@ sealed interface SyncFailure {
 /** Either what was asked for, or why it could not be had. */
 sealed interface RemoteResult<out T> {
     data class Ok<T>(val value: T) : RemoteResult<T>
-    data class Failed(val reason: SyncFailure) : RemoteResult<Nothing>
+
+    /**
+     * [answered] records whether the server said this or said nothing.
+     * It defaults to the former because most refusals are decided from
+     * a response in hand; only [remoteCall] can tell silence apart, and
+     * it says so explicitly. See [AnsweredFailure].
+     */
+    data class Failed(
+        val reason: SyncFailure,
+        val answered: Boolean = true,
+    ) : RemoteResult<Nothing>
 
     val failure: SyncFailure?
         get() = (this as? Failed)?.reason
+
+    /**
+     * Why this failed, but only when the server never answered.
+     *
+     * A caller walking a shelf book by book reads this to know when to
+     * stop: every further request to a server that has gone quiet waits
+     * out its own connect timeout and comes back knowing no more.
+     */
+    val unreachable: SyncFailure?
+        get() = (this as? Failed)?.takeUnless { it.answered }?.reason
 }
 
 /** What the value is, or null if the call failed. */
@@ -105,7 +125,26 @@ fun <T> RemoteResult<T>.valueOrNull(): T? = (this as? RemoteResult.Ok)?.value
  * can travel out of the middle of a paged walk; it never escapes
  * [remoteCall].
  */
-internal class RemoteHttpFailure(val reason: SyncFailure) : IOException()
+internal class RemoteHttpFailure(val reason: SyncFailure) : IOException(), AnsweredFailure
+
+/**
+ * Marks a failure that a response actually produced.
+ *
+ * Worn by every exception raised with the server's answer in hand: a
+ * status the caller did not expect, a body that would not parse, a
+ * refusal the protocol treats as ordinary. Anything without it — a
+ * connection refused, a socket that timed out, a name that would not
+ * resolve — reached this point without the server saying anything.
+ *
+ * The distinction decides whether a sync run is worth continuing.
+ * A refusal arrived over a connection that worked, so the next request
+ * is still worth making. Silence has already cost a whole connect
+ * timeout, and the next request will cost another and learn no more.
+ */
+interface AnsweredFailure
+
+/** Whether this failure proves the server answered. See [AnsweredFailure]. */
+internal fun IOException.serverAnswered(): Boolean = this is AnsweredFailure
 
 /**
  * Turns the exceptions OkHttp and the JSON parser throw into the reasons
@@ -118,15 +157,16 @@ internal inline fun <T> remoteCall(body: () -> T): RemoteResult<T> = try {
 } catch (e: RemoteHttpFailure) {
     RemoteResult.Failed(e.reason)
 } catch (_: SocketTimeoutException) {
-    RemoteResult.Failed(SyncFailure.Timeout)
+    RemoteResult.Failed(SyncFailure.Timeout, answered = false)
 } catch (_: UnknownHostException) {
-    RemoteResult.Failed(SyncFailure.Offline)
+    RemoteResult.Failed(SyncFailure.Offline, answered = false)
 } catch (_: ConnectException) {
-    RemoteResult.Failed(SyncFailure.Offline)
+    RemoteResult.Failed(SyncFailure.Offline, answered = false)
 } catch (_: JSONException) {
+    // The body arrived; it was the reading of it that failed.
     RemoteResult.Failed(SyncFailure.Malformed)
 } catch (_: IOException) {
-    RemoteResult.Failed(SyncFailure.Offline)
+    RemoteResult.Failed(SyncFailure.Offline, answered = false)
 }
 
 /** What an unsuccessful HTTP answer means. */

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -469,8 +469,11 @@ class ReaderViewModel(
      * raised over the first page shown: the announcement that the book
      * jumped ahead, and the one tap that undoes it for a reread.
      */
-    private suspend fun settlePreservedConflict(publication: Publication) {
-        val preview = positionSync.preservedConflict(bookId) ?: return
+    private suspend fun settlePreservedConflict(
+        publication: Publication,
+        abandonedRun: Boolean,
+    ) {
+        val preview = positionSync.preservedConflict(bookId, abandonedRun) ?: return
         val there = preview.remote ?: return
         val here = preview.local ?: 0.0
         val takeRemote = there > here
@@ -651,9 +654,9 @@ class ReaderViewModel(
             // where to open it. Bounded, and the answer is optional: a slow
             // or absent server delays the book by a moment at most, never
             // stops it opening.
-            withTimeoutOrNull(OPEN_SYNC_TIMEOUT_MS) {
+            val syncFinished = withTimeoutOrNull(OPEN_SYNC_TIMEOUT_MS) {
                 runCatching { positionSync.request(SyncScope.Book(bookId)) }
-            }
+            } != null
             val afterSync = progressDao.get(bookId)
             val pulledAutomatically = afterSync?.takeIf { after ->
                 val exactMoved = ExactLocatorAnchor.agreement(
@@ -685,7 +688,11 @@ class ReaderViewModel(
             // devices in the background. Settle it now, while the book is
             // still a loading screen, so it opens at the further position
             // instead of being yanked there after arriving.
-            settlePreservedConflict(publication)
+            //
+            // A sync that finished is waited for; one this already gave
+            // up on above is not waited for a second time, or the bound
+            // over it would mean nothing.
+            settlePreservedConflict(publication, abandonedRun = !syncFinished)
 
             val stored = progressDao.get(bookId)
             speed = ReadingSpeedEstimator(

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -65,6 +65,7 @@ import com.chmouel.liseur.reader.progress.ReadingPace
 import com.chmouel.liseur.reader.progress.ReadingSpeedEstimator
 import com.chmouel.liseur.reader.progress.StableBookProgress
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -128,6 +129,10 @@ class ReaderViewModel(
 
     private val sessions = sessionManager.recorder(bookId)
     private val timeSpent = sessionManager.observeTotal(bookId)
+
+    /** Whether [open] got far enough to declare this book being read. */
+    @Volatile
+    private var readingDeclared = false
 
     /**
      * What the Define action needs before it opens a card or another app.
@@ -693,6 +698,15 @@ class ReaderViewModel(
             // up on above is not waited for a second time, or the bound
             // over it would mean nothing.
             settlePreservedConflict(publication, abandonedRun = !syncFinished)
+
+            // From here the position about to be read is on screen for
+            // the whole session, and a sync run still going in the
+            // background — the very one just given up on above — must
+            // not move it under the page. Entering after the bounded
+            // sync and the settlement, not before: those two are meant
+            // to move it.
+            progressDao.openBooks.enter(bookId)
+            readingDeclared = true
 
             val stored = progressDao.get(bookId)
             speed = ReadingSpeedEstimator(
@@ -1280,6 +1294,22 @@ class ReaderViewModel(
     override fun onCleared() {
         sessions.close()
         (_state.value as? UiState.Ready)?.publication?.close()
+        if (readingDeclared) {
+            // Through the position queue, not a scope of its own: a page
+            // turned moments ago may still be in line to be written, and
+            // dropping the fence ahead of it would let a background pull
+            // land between that write and this — the very interleaving
+            // the fence exists to prevent. The queue survives this
+            // ViewModel, and the fallback covers a queue already closed.
+            val queued = positionPublisher.afterQueuedWrites {
+                progressDao.openBooks.leave(bookId)
+            }
+            if (!queued) {
+                CoroutineScope(Dispatchers.Default).launch {
+                    progressDao.openBooks.leave(bookId)
+                }
+            }
+        }
     }
 
     /** A place to return to after a jump, and the page it was on. */

--- a/app/src/main/kotlin/com/chmouel/liseur/sync/PositionSyncCoordinator.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/sync/PositionSyncCoordinator.kt
@@ -8,6 +8,10 @@ import com.chmouel.liseur.data.remote.SyncPreview
 import com.chmouel.liseur.data.remote.SyncSnapshot
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.sync.Mutex
@@ -93,10 +97,33 @@ class PositionSyncCoordinator(private val sync: PositionSync) {
             queued[scope] = fresh
             fresh to true
         }
-        if (!isLeader) return slot.await()
+        if (isLeader) {
+            // Deliberately not run inside the caller. Opening a book bounds
+            // how long it will wait here, and a bound is only a bound if
+            // giving up actually returns: the run makes blocking network
+            // calls that ignore cancellation, so a caller running the work
+            // itself stays inside them for the full connect timeout no
+            // matter what deadline it set. Detaching leaves the caller with
+            // nothing to do but await, which it can stop doing at once.
+            //
+            // The dispatcher is the caller's, so nothing about where the
+            // work happens changes; only the job does, which is what keeps
+            // the run alive after the caller has walked away.
+            CoroutineScope(currentCoroutineContext() + Job()).launch {
+                lead(scope, snapshot, slot)
+            }
+        }
+        return slot.await()
+    }
 
+    /** Takes the turn, runs [scope], and hands the answer to everyone waiting. */
+    private suspend fun lead(
+        scope: SyncScope,
+        snapshot: SyncSnapshot?,
+        slot: CompletableDeferred<SyncOutcome>,
+    ) {
         try {
-            return turn.withLock {
+            turn.withLock {
                 state.withLock {
                     queued.remove(scope)
                     inFlight = Running(scope, System.currentTimeMillis(), slot)
@@ -109,15 +136,15 @@ class PositionSyncCoordinator(private val sync: PositionSync) {
                 } catch (e: Throwable) {
                     clearInFlight(slot)
                     slot.completeExceptionally(e)
-                    throw e
+                    return@withLock
                 }
                 clearInFlight(slot)
                 slot.complete(outcome)
-                outcome
             }
         } catch (e: CancellationException) {
-            // A caller can disappear before its leader gets the turn. Do not
-            // leave that leader's deferred in queued forever.
+            // Only reachable if the run itself is stopped, which now takes
+            // the whole app going away. Do not leave the deferred in queued
+            // for a run that will never happen.
             withContext(NonCancellable) {
                 state.withLock {
                     if (queued[scope] === slot) queued.remove(scope)
@@ -162,10 +189,39 @@ class PositionSyncCoordinator(private val sync: PositionSync) {
     /**
      * The disagreement an ordinary sync preserved rather than resolved,
      * if there is one. Reads what is already on disk and asks the server
-     * nothing, so it is safe to call while opening a book.
+     * nothing.
+     *
+     * Ordinarily it waits for a run in flight, so it cannot read a
+     * position out from under one halfway through writing it.
+     *
+     * [abandonedRun] is for the one caller that has already stopped
+     * waiting for that run: opening a book bounds its own sync and
+     * carries on without it. Waiting on the turn afterwards would undo
+     * that bound entirely — blocking network calls are not interrupted
+     * by giving up on them, so a run against a server whose packets go
+     * nowhere keeps the turn for as long as the sockets take to expire,
+     * and the book stays on its loading screen for all of it. Told the
+     * run was abandoned, this takes the turn if it is free and otherwise
+     * answers "nothing to settle" at once.
+     *
+     * That answer is safe: the disagreement stays preserved on disk and
+     * is put to the reader on the next open, which is what preserving it
+     * was for. It is deliberately not a timeout — a run that is merely
+     * slow but working is still worth waiting for, and only its own
+     * caller knows whether it gave up on one.
      */
-    suspend fun preservedConflict(bookUrl: String): SyncPreview? =
-        turn.withLock { sync.preservedConflict(bookUrl) }
+    suspend fun preservedConflict(
+        bookUrl: String,
+        abandonedRun: Boolean = false,
+    ): SyncPreview? {
+        if (!abandonedRun) return turn.withLock { sync.preservedConflict(bookUrl) }
+        if (!turn.tryLock()) return null
+        return try {
+            sync.preservedConflict(bookUrl)
+        } finally {
+            turn.unlock()
+        }
+    }
 
     private suspend fun clearInFlight(result: CompletableDeferred<SyncOutcome>) {
         withContext(NonCancellable) {
@@ -196,4 +252,5 @@ class PositionSyncCoordinator(private val sync: PositionSync) {
             }
         }
     }
+
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/sync/ReadingPositionPublisher.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/sync/ReadingPositionPublisher.kt
@@ -44,6 +44,7 @@ class ReadingPositionPublisher(
         data class Position(val update: PositionUpdate) : Event
         data class Complete(val bookUrl: String) : Event
         data class Close(val bookUrl: String) : Event
+        data class Barrier(val action: suspend () -> Unit) : Event
     }
 
     private val events = Channel<Event>(Channel.UNLIMITED)
@@ -57,6 +58,7 @@ class ReadingPositionPublisher(
                     is Event.Position -> store(event.update)
                     is Event.Complete -> complete(event.bookUrl)
                     is Event.Close -> scheduleClose(event.bookUrl)
+                    is Event.Barrier -> event.action()
                 }
             }
         }
@@ -76,6 +78,18 @@ class ReadingPositionPublisher(
 
     fun closeBook(bookUrl: String): Boolean =
         events.trySend(Event.Close(bookUrl)).isSuccess
+
+    /**
+     * Runs [action] once every write accepted before this call has
+     * committed.
+     *
+     * The queue is the order pages were turned in, so anything that must
+     * not run ahead of a page still in flight — dropping the open-book
+     * fence, for one — takes its place in the same line rather than
+     * racing it from another scope.
+     */
+    fun afterQueuedWrites(action: suspend () -> Unit): Boolean =
+        events.trySend(Event.Barrier(action)).isSuccess
 
     private suspend fun store(update: PositionUpdate) {
         val stored = retry {

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/NoUpsertStatementsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/NoUpsertStatementsTest.kt
@@ -1,0 +1,39 @@
+package com.chmouel.liseur.data.db
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards against writing an SQL upsert again.
+ *
+ * `INSERT ... ON CONFLICT ... DO UPDATE` needs SQLite 3.24, which reached
+ * Android in version 10. Liseur still supports Android 8, where the
+ * statement is a syntax error — and because Room checks queries at build
+ * time against a modern SQLite, nothing complains until someone on an old
+ * phone loses their place on every page turn.
+ *
+ * Room's own `@Upsert` is fine and deliberately not caught here: it is
+ * compiled into an insert followed by an update, not into this statement.
+ * Anything else wants an update, then an insert if the update matched
+ * nothing, with the two inside one `@Transaction`.
+ */
+class NoUpsertStatementsTest {
+    @Test
+    fun `no query relies on an upsert older phones cannot run`() {
+        val sources = File(System.getProperty("user.dir"), "src/main/kotlin")
+        assertTrue("expected Kotlin sources at $sources", sources.isDirectory)
+
+        val offenders = sources.walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .filter { it.readText().contains("ON CONFLICT", ignoreCase = true) }
+            .map { it.relativeTo(sources).path }
+            .toList()
+
+        assertTrue(
+            "SQL upserts fail on Android 9 and older; rewrite as an update " +
+                "then an insert in one @Transaction: $offenders",
+            offenders.isEmpty(),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/ReadingProgressDaoTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/ReadingProgressDaoTest.kt
@@ -206,6 +206,122 @@ class ReadingProgressDaoTest {
         assertEquals(0.9, row.pendingProgression!!, 1e-9)
     }
 
+    // -- The open-book fence ----------------------------------------------
+
+    @Test
+    fun `a pull nobody asked for waits its turn while the book is open`() = runTest {
+        read(0.2)
+        dao.persistPending(book, 0.9, "Reading", 4_000, account, now = 4_000)
+        dao.openBooks.enter(book)
+
+        val applied = dao.applyUnattendedPull(
+            bookUrl = book,
+            expectedRevision = 1,
+            progression = 0.9,
+            status = "Reading",
+            account = account,
+            remoteUpdatedAt = 4_000,
+            now = 5_000,
+        )
+
+        assertFalse(applied)
+        val row = row()
+        // The page on screen is untouched, and nothing about the
+        // revisions moved: to every sync partner the row looks exactly
+        // as it did, so nothing is re-sent and nothing is dropped.
+        assertEquals(0.2, row.totalProgression!!, 1e-9)
+        assertEquals(1L, row.localRevision)
+        assertEquals(0L, row.ackedRevision)
+        // The server's position is still pending, so the next open asks
+        // about it rather than it being silently thrown away.
+        assertTrue(row.hasPending)
+        assertEquals(0.9, row.pendingProgression!!, 1e-9)
+    }
+
+    @Test
+    fun `closing the book lets the waiting pull through`() = runTest {
+        read(0.2)
+        dao.persistPending(book, 0.9, "Reading", 4_000, account, now = 4_000)
+        dao.openBooks.enter(book)
+        dao.openBooks.leave(book)
+
+        val applied = dao.applyUnattendedPull(book, 1, 0.9, "Reading", account, 4_000, now = 5_000)
+
+        assertTrue(applied)
+        assertEquals(0.9, row().totalProgression!!, 1e-9)
+    }
+
+    @Test
+    fun `a pull the reader is looking at goes through even while open`() = runTest {
+        // The conflict dialog is answered with the book on screen; that
+        // answer is deliberate and must not be gated with the rest.
+        read(0.2)
+        dao.persistPending(book, 0.9, "Reading", 4_000, account, now = 4_000)
+        dao.openBooks.enter(book)
+
+        val applied = dao.applyPull(book, 1, 0.9, "Reading", account, 4_000, now = 5_000)
+
+        assertTrue(applied)
+        assertEquals(0.9, row().totalProgression!!, 1e-9)
+    }
+
+    @Test
+    fun `an unattended peer pull declines while the book is open`() = runTest {
+        read(0.2)
+        dao.openBooks.enter(book)
+
+        val applied = dao.applyUnattendedPeerPull(
+            bookUrl = book,
+            expectedRevision = 1,
+            progression = 0.9,
+            status = "Reading",
+            now = 5_000,
+        )
+
+        assertFalse(applied)
+        assertEquals(0.2, row().totalProgression!!, 1e-9)
+        assertEquals(1L, row().localRevision)
+    }
+
+    @Test
+    fun `a peer pull for a book never opened here still declines while it is open`() = runTest {
+        // No row exists yet; the gate must decline before the row would
+        // be created, or the create alone would smuggle state in.
+        dao.openBooks.enter(book)
+
+        val applied = dao.applyUnattendedPeerPull(
+            bookUrl = book,
+            expectedRevision = 0,
+            progression = 0.9,
+            status = "Reading",
+            now = 5_000,
+        )
+
+        assertFalse(applied)
+        assertNull(dao.get(book))
+    }
+
+    @Test
+    fun `two readers of the same book both have to leave`() = runTest {
+        read(0.2)
+        dao.openBooks.enter(book)
+        dao.openBooks.enter(book)
+        dao.openBooks.leave(book)
+
+        assertFalse(dao.applyUnattendedPull(book, 1, 0.9, "Reading", account, 4_000, now = 5_000))
+
+        dao.openBooks.leave(book)
+        assertTrue(dao.applyUnattendedPull(book, 1, 0.9, "Reading", account, 4_000, now = 5_000))
+    }
+
+    @Test
+    fun `only the open book is fenced, not the whole library`() = runTest {
+        read(0.2)
+        dao.openBooks.enter("calibre:some-other-book")
+
+        assertTrue(dao.applyUnattendedPull(book, 1, 0.9, "Reading", account, 4_000, now = 5_000))
+    }
+
     @Test
     fun `a pull that is not raced applies and clears the pending state`() = runTest {
         read(0.2)

--- a/app/src/test/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepositoryTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepositoryTest.kt
@@ -9,8 +9,12 @@ import com.chmouel.liseur.data.db.LiseurDatabase
 import com.chmouel.liseur.data.db.RemoteServer
 import com.chmouel.liseur.data.library.FinishedState
 import com.chmouel.liseur.data.remote.DeviceIdentityRepository
+import com.chmouel.liseur.data.remote.PositionSyncStatus
+import com.chmouel.liseur.data.remote.ResolveOutcome
 import com.chmouel.liseur.data.remote.ServerKind
+import com.chmouel.liseur.data.remote.SyncFailure
 import com.chmouel.liseur.data.remote.SyncOutcome
+import com.chmouel.liseur.data.remote.SyncReporting
 import com.chmouel.liseur.data.remote.SyncSnapshot
 import kotlinx.coroutines.test.runTest
 import mockwebserver3.MockResponse
@@ -48,6 +52,7 @@ class KomgaSyncRepositoryTest {
 
     private val bookId = "0B7C3D"
     private val bookUrl = "komga:$bookId"
+    private val reporting = SyncReporting()
     private lateinit var account: String
 
     @Before
@@ -111,6 +116,72 @@ class KomgaSyncRepositoryTest {
                 remoteUuid = bookId,
             ),
         )
+    }
+
+    /** The same repository, told this device has no network. */
+    private fun offlineSync(): KomgaSyncRepository {
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        return KomgaSyncRepository(
+            serverDao = db.remoteServerDao(),
+            bookDao = db.bookDao(),
+            progressDao = db.readingProgressDao(),
+            finishedState = FinishedState(
+                bookDao = db.bookDao(),
+                progressDao = db.readingProgressDao(),
+            ),
+            device = DeviceIdentityRepository(context),
+            reporting = reporting,
+            networkAvailability = { false },
+        )
+    }
+
+    @Test
+    fun `an offline run says so without waiting on a connection`() = runTest {
+        connect()
+
+        assertEquals(SyncOutcome.Failure(SyncFailure.Offline), offlineSync().syncBook(bookUrl))
+        assertEquals(0, server.requestCount)
+        // Said out loud, so pressing "sync now" on a plane explains
+        // itself rather than leaving the last-synced line unchanged.
+        assertEquals(
+            PositionSyncStatus.Failed(SyncFailure.Offline),
+            reporting.status.value,
+        )
+    }
+
+    @Test
+    fun `offline, the server's position can still be taken but this one cannot be sent`() = runTest {
+        connect()
+        val progress = db.readingProgressDao()
+        progress.recordLocal(
+            bookUrl = bookUrl,
+            locatorJson = locatorJson("OEBPS/ch2.xhtml", 0.5, 0.2),
+            progression = 0.2,
+            readingSpeed = null,
+            status = "Reading",
+            updatedAt = 1_000,
+        )
+        progress.persistPending(
+            bookUrl,
+            0.6,
+            "Reading",
+            4_000,
+            account,
+            now = 4_000,
+            locatorJson = locatorJson("OEBPS/ch7.xhtml", 0.5, 0.6),
+        )
+        val offline = offlineSync()
+
+        // Sending needs the server, so refusing is the honest answer.
+        assertEquals(
+            ResolveOutcome.Failed(SyncFailure.Offline),
+            offline.keepLocalPosition(bookUrl),
+        )
+        // Taking only applies an answer already on disk.
+        val revision = requireNotNull(progress.get(bookUrl)).localRevision
+        assertEquals(ResolveOutcome.Done, offline.takeRemotePosition(bookUrl, revision))
+        assertEquals(0.6, requireNotNull(progress.get(bookUrl)).totalProgression!!, 1e-9)
+        assertEquals(0, server.requestCount)
     }
 
     /** One book, with the reading progress Komga reports inline. */

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
@@ -12,6 +12,7 @@ import com.chmouel.liseur.data.library.FinishedState
 import com.chmouel.liseur.data.remote.PreviewOutcome
 import com.chmouel.liseur.data.remote.ResumeConfidence
 import com.chmouel.liseur.data.remote.ResolveOutcome
+import com.chmouel.liseur.data.remote.SyncFailure
 import com.chmouel.liseur.data.remote.SyncOutcome
 import java.io.File
 import java.net.InetAddress
@@ -696,9 +697,39 @@ class LiseurSyncPositionSyncTest {
         assertEquals("w-old", db.workIdentityDao().alias(LOCAL, peer())?.workId)
     }
 
+    @Test
+    fun `an offline run says so without waiting on a connection`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+
+        assertEquals(
+            SyncOutcome.Failure(SyncFailure.Offline),
+            sync(online = false).syncAll(null),
+        )
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `keeping the local position works offline, because nothing is sent`() = runTest {
+        // Unlike the other two servers, this one settles a disagreement
+        // by clearing it and letting the next run push. That is a local
+        // write, and refusing it offline would leave the book asking the
+        // same question on every open for the rest of the flight.
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        server.enqueue(json("""{"ops":[${op(seq = 7, progression = 0.8)}]}"""))
+        sync().previewBook(LOCAL)
+        assertNotNull(sync().preservedConflict(LOCAL))
+
+        assertEquals(ResolveOutcome.Done, sync(online = false).keepLocalPosition(LOCAL))
+        assertNull(sync().preservedConflict(LOCAL))
+    }
+
     // -- Scaffolding ------------------------------------------------------
 
-    private fun sync(): LiseurSyncPositionSync {
+    private fun sync(online: Boolean = true): LiseurSyncPositionSync {
         val context = ApplicationProvider.getApplicationContext<android.app.Application>()
         return LiseurSyncPositionSync(
             serverDao = db.remoteServerDao(),
@@ -714,6 +745,7 @@ class LiseurSyncPositionSyncTest {
             ),
             deviceKey = { "device-a" },
             finishedState = FinishedState(db.bookDao(), db.readingProgressDao()),
+            networkAvailability = { online },
             now = { NOW },
         )
     }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.test.runTest
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import mockwebserver3.RecordedRequest
+import mockwebserver3.SocketEffect
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -347,6 +348,36 @@ class LiseurSyncPositionSyncTest {
         // Taking the server's side uses the answer paired on disk.
         assertEquals(ResolveOutcome.Done, sync.takeRemotePosition(LOCAL, 0))
         assertEquals(0.8, db.readingProgressDao().get(LOCAL)?.totalProgression!!, 0.0001)
+    }
+
+    @Test
+    fun `an offline run says so without waiting on a connection`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+
+        assertEquals(
+            SyncOutcome.Failure(SyncFailure.Offline),
+            sync(online = false).syncAll(null),
+        )
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `keeping the local position works offline, because nothing is sent`() = runTest {
+        // Unlike the other two servers, this one settles a disagreement
+        // by clearing it and letting the next run push. That is a local
+        // write, and refusing it offline would leave the book asking the
+        // same question on every open for the rest of the flight.
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        server.enqueue(json("""{"ops":[${op(seq = 7, progression = 0.8)}]}"""))
+        sync().previewBook(LOCAL)
+        assertNotNull(sync().preservedConflict(LOCAL))
+
+        assertEquals(ResolveOutcome.Done, sync(online = false).keepLocalPosition(LOCAL))
+        assertNull(sync().preservedConflict(LOCAL))
     }
 
     @Test
@@ -698,37 +729,147 @@ class LiseurSyncPositionSyncTest {
     }
 
     @Test
-    fun `an offline run says so without waiting on a connection`() = runTest {
+    fun `a server that cannot be reached ends the run instead of asking about every book`() =
+        runTest {
+            // Nothing is listening, so every connection is refused
+            // rather than answered. That is the shape of the failure a
+            // server on the far side of a network the device cannot
+            // route through produces, only without the wait.
+            connect(baseUrl = "http://127.0.0.1:$deadPort")
+            db.bookDao().upsert(local())
+            db.bookDao().upsert(local().copy(url = LOCAL2, lastOpenedAt = NOW - 1))
+            db.bookDao().upsert(local().copy(url = LOCAL3, lastOpenedAt = NOW - 2))
+
+            val outcome = sync().syncAll(null)
+
+            // Each unanswered question costs a whole connect timeout on
+            // a real network, and a reader opening a book waits behind
+            // every one of them, so the run gives up on the first.
+            assertEquals(SyncOutcome.Failure(SyncFailure.Offline), outcome)
+            // The pull, the pushes and the sessions were never tried
+            // either: they would have gone to the same dead address.
+            assertEquals(0, server.requestCount)
+        }
+
+    @Test
+    fun `a server that answers with a refusal is still asked about the next book`() = runTest {
         connect()
         db.bookDao().upsert(local())
-        alias()
+        db.bookDao().upsert(local().copy(url = LOCAL2, lastOpenedAt = NOW - 1))
+        db.bookDao().upsert(local().copy(url = LOCAL3, lastOpenedAt = NOW - 2))
+        // 408 is a *server* saying it grew tired of waiting. It arrived
+        // over a connection that worked, so it says something about the
+        // one request and nothing about whether the server is there.
+        repeat(3) { server.enqueue(MockResponse(code = 408)) }
+        server.enqueue(json("""{"ops":[]}"""))
+        repeat(4) { server.enqueue(json("""{}""")) }
 
-        assertEquals(
-            SyncOutcome.Failure(SyncFailure.Offline),
-            sync(online = false).syncAll(null),
-        )
-        assertEquals(0, server.requestCount)
+        sync().syncAll(null)
+
+        // Every book was asked about, rather than the run stopping at
+        // the first refusal.
+        val asked = requests().count { it.target.startsWith("/v1/works/resolve") }
+        assertTrue("asked $asked times for 3 books", asked >= 3)
+        // And it carried on to the rest of its work afterwards.
+        assertTrue(requests().any { it.target.startsWith("/v1/changes") })
     }
 
     @Test
-    fun `keeping the local position works offline, because nothing is sent`() = runTest {
-        // Unlike the other two servers, this one settles a disagreement
-        // by clearing it and letting the next run push. That is a local
-        // write, and refusing it offline would leave the book asking the
-        // same question on every open for the rest of the flight.
+    fun `a refusal the protocol treats as ordinary is not mistaken for silence`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        db.bookDao().upsert(local().copy(url = LOCAL2, lastOpenedAt = NOW - 1))
+        db.bookDao().upsert(local().copy(url = LOCAL3, lastOpenedAt = NOW - 2))
+        // A 409 that names fewer than two works: the server said this
+        // book is ambiguous but did not say between what, so the name
+        // cannot be settled. It is still an answer, over a connection
+        // that plainly worked, and says nothing about the next book.
+        repeat(3) { server.enqueue(MockResponse(code = 409, body = """{"works":[]}""")) }
+        server.enqueue(json("""{"ops":[]}"""))
+        repeat(4) { server.enqueue(json("""{}""")) }
+
+        sync().syncAll(null)
+
+        val asked = requests().count { it.target.startsWith("/v1/works/resolve") }
+        assertTrue("asked $asked times for 3 books", asked >= 3)
+        assertTrue(requests().any { it.target.startsWith("/v1/changes") })
+    }
+
+    @Test
+    fun `a server that goes quiet after the naming sends nothing further`() = runTest {
+        // Every book is already named, so naming asks nothing and the
+        // run reaches the pull with no idea the network has gone. The
+        // pull is where it finds out, and it must not then spend a
+        // connect timeout on the pushes and another on the sessions.
         connect()
         db.bookDao().upsert(local())
         alias()
-        server.enqueue(json("""{"ops":[${op(seq = 7, progression = 0.8)}]}"""))
-        sync().previewBook(LOCAL)
-        assertNotNull(sync().preservedConflict(LOCAL))
+        db.readingProgressDao().recordLocal(LOCAL, LOCATOR, 0.5, null, "reading", NOW)
+        // One page arrives and the next says there is more, so the pull
+        // asks again -- and that second request is dropped mid-flight,
+        // with nothing coming back that could be read as the server
+        // having said anything at all.
+        server.enqueue(json("""{"ops":[],"has_more":true,"high_water":1}"""))
+        repeat(4) {
+            server.enqueue(
+                MockResponse.Builder().onResponseStart(SocketEffect.CloseSocket()).build(),
+            )
+        }
 
-        assertEquals(ResolveOutcome.Done, sync(online = false).keepLocalPosition(LOCAL))
-        assertNull(sync().preservedConflict(LOCAL))
+        val outcome = sync().syncAll(null)
+
+        assertEquals(SyncOutcome.Failure(SyncFailure.Offline), outcome)
+        // The position this device owes and the session it recorded were
+        // both held back: each would have waited out a connect timeout
+        // of its own and come back knowing no more than the pull did.
+        assertTrue(requests().any { it.target.startsWith(LiseurSyncApi.CHANGES) })
+        assertTrue(requests().none { it.target.startsWith(LiseurSyncApi.OPS) })
+        assertTrue(requests().none { it.target.startsWith(LiseurSyncApi.SESSIONS) })
+    }
+
+    @Test
+    fun `a refusal on one book does not hide a network that died later`() = runTest {
+        // The server answers the naming with a refusal on one book, which
+        // is its own considered answer and not worth coming back for. Then
+        // the connection dies with this device's position still unsent.
+        // The run has to report the silence, because that is the part
+        // worth retrying -- reporting the refusal would say there is
+        // nothing to come back for.
+        connect()
+        db.bookDao().upsert(local())
+        db.readingProgressDao().recordLocal(LOCAL, LOCATOR, 0.5, null, "reading", NOW)
+        server.enqueue(MockResponse.Builder().code(404).body("""{"error":"no such work"}""").build())
+        repeat(4) {
+            server.enqueue(
+                MockResponse.Builder().onResponseStart(SocketEffect.CloseSocket()).build(),
+            )
+        }
+
+        val outcome = sync().syncAll(null)
+
+        assertEquals(SyncOutcome.Failure(SyncFailure.Offline), outcome)
+    }
+
+    @Test
+    fun `a refusal is reported as what the server said, not as being offline`() = runTest {
+        // Nothing here is unreachable: the server answered, and said no.
+        // Calling that offline reads wrong to the reader and sends the
+        // retry machinery back for something that will be refused again.
+        connect()
+        db.bookDao().upsert(local())
+        db.readingProgressDao().recordLocal(LOCAL, LOCATOR, 0.5, null, "reading", NOW)
+        repeat(6) {
+            server.enqueue(
+                MockResponse.Builder().code(404).body("""{"error":"no such work"}""").build(),
+            )
+        }
+
+        val outcome = sync().syncAll(null)
+
+        assertEquals(SyncOutcome.Failure(SyncFailure.NotFound), outcome)
     }
 
     // -- Scaffolding ------------------------------------------------------
-
     private fun sync(online: Boolean = true): LiseurSyncPositionSync {
         val context = ApplicationProvider.getApplicationContext<android.app.Application>()
         return LiseurSyncPositionSync(
@@ -750,11 +891,20 @@ class LiseurSyncPositionSyncTest {
         )
     }
 
-    private suspend fun connect(cursor: Long = 0, deviceId: String? = null) {
+    /** A port nothing is listening on, for a server that is simply not there. */
+    private val deadPort: Int by lazy {
+        java.net.ServerSocket(0).use { it.localPort }
+    }
+
+    private suspend fun connect(
+        cursor: Long = 0,
+        deviceId: String? = null,
+        baseUrl: String = "http://127.0.0.1:${server.port}",
+    ) {
         db.remoteServerDao().upsert(
             RemoteServer(
                 kind = ServerKind.LISEUR_SYNC,
-                baseUrl = "http://127.0.0.1:${server.port}",
+                baseUrl = baseUrl,
                 username = "ada",
                 passwordCipher = null,
                 apiKeyCipher = null,
@@ -901,6 +1051,7 @@ class LiseurSyncPositionSyncTest {
         const val NOW = 1_700_000_000_000L
         const val LOCAL = "content://sd/book.epub"
         const val LOCAL2 = "content://sd/other.epub"
+        const val LOCAL3 = "content://sd/third.epub"
         const val LOCATOR = """{"href":"/c1.xhtml"}"""
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/sync/PositionSyncCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/sync/PositionSyncCoordinatorTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -152,7 +153,14 @@ class PositionSyncCoordinatorTest {
     }
 
     @Test
-    fun `cancelling a queued leader does not strand later requests`() = runTest {
+    fun `a caller that stops waiting does not stop the run it asked for`() = runTest {
+        // Giving up on an answer is not revoking the question. Opening a
+        // book bounds how long it waits here, and that bound only works
+        // if walking away actually returns -- the run itself makes
+        // blocking network calls that outlive any caller's patience, so
+        // it belongs to nobody's deadline. And the run is still wanted:
+        // whatever positions it reconciles are read from disk on the
+        // next open regardless of who was listening when it finished.
         val sync = FakeSync()
         val gate = CompletableDeferred<Unit>()
         sync.gate = gate
@@ -160,21 +168,27 @@ class PositionSyncCoordinatorTest {
 
         val running = async { coordinator.request(SyncScope.Full, requestedAt = 0) }
         advanceUntilIdle()
-        val cancelled = async {
+        val abandoned = async {
             coordinator.request(SyncScope.Book("book"), requestedAt = Long.MAX_VALUE)
         }
         advanceUntilIdle()
-        cancelled.cancelAndJoin()
+        abandoned.cancelAndJoin()
 
         sync.gate = null
         gate.complete(Unit)
         running.await()
+        advanceUntilIdle()
 
+        // The abandoned request's run still happened, exactly once.
+        assertEquals(listOf(SyncScope.Full, SyncScope.Book("book")), sync.started)
+
+        // And nothing was left stranded: a fresh request is answered
+        // with a fresh run, not parked behind a ghost.
         assertEquals(
             SyncOutcome.Success,
             coordinator.request(SyncScope.Book("book"), requestedAt = Long.MAX_VALUE),
         )
-        assertEquals(listOf(SyncScope.Full, SyncScope.Book("book")), sync.started)
+        assertEquals(3, sync.started.size)
     }
 
     @Test
@@ -299,12 +313,48 @@ class PositionSyncCoordinatorTest {
         val running = async { coordinator.request(SyncScope.Full, requestedAt = 0) }
         advanceUntilIdle()
         val asked = async { coordinator.preservedConflict("b") }
-        advanceUntilIdle()
+        runCurrent()
         assertTrue(asked.isActive)
 
         gate.complete(Unit)
         running.await()
         assertNull(asked.await())
+    }
+
+    @Test
+    fun `a caller that gave up on a run does not queue behind it`() = runTest {
+        // A run against a server it cannot reach holds its turn for as
+        // long as the sockets take to give up, and a book on a loading
+        // screen must not be held there with it. Answering "nothing to
+        // settle" is safe: the disagreement stays preserved and is put
+        // to the reader on the next open, which is what preserving it
+        // was for.
+        val sync = FakeSync()
+        val gate = CompletableDeferred<Unit>()
+        sync.gate = gate
+        sync.conflict = SyncPreview(local = 0.2, remote = 0.8, remoteAt = null)
+        val coordinator = PositionSyncCoordinator(sync)
+
+        val running = async { coordinator.request(SyncScope.Full, requestedAt = 0) }
+        advanceUntilIdle()
+
+        assertNull(coordinator.preservedConflict("b", abandonedRun = true))
+
+        gate.complete(Unit)
+        running.await()
+    }
+
+    @Test
+    fun `a caller that gave up still reads the conflict when no run holds the turn`() = runTest {
+        // Having given up on a run is not a reason to skip the answer.
+        // Only a turn that is actually held is, and once the run is done
+        // there is nothing to wait for.
+        val sync = FakeSync()
+        val conflict = SyncPreview(local = 0.2, remote = 0.8, remoteAt = null)
+        sync.conflict = conflict
+        val coordinator = PositionSyncCoordinator(sync)
+
+        assertSame(conflict, coordinator.preservedConflict("b", abandonedRun = true))
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/sync/ReadingPositionPublisherTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/sync/ReadingPositionPublisherTest.kt
@@ -161,6 +161,38 @@ class ReadingPositionPublisherTest {
     }
 
     @Test
+    fun `a barrier runs only after every write queued before it`() = runTest {
+        val events = mutableListOf<String>()
+        val sync = LatestPositionSync(
+            scope = backgroundScope,
+            request = { SyncOutcome.Success },
+            scheduleRetry = {},
+            onError = { _, error -> throw error },
+        )
+        val publisher = ReadingPositionPublisher(
+            scope = backgroundScope,
+            overrideFor = { FinishedOverride.NONE },
+            persist = { update, _ -> events += "write:${update.progression}" },
+            refreshFinished = {},
+            markFinished = {},
+            latestSync = sync,
+            scheduleClose = {},
+            onError = { _, error -> throw error },
+        )
+
+        // The page turned just before the book was closed must be on
+        // disk before the barrier acts: the open-book fence is dropped
+        // through here, and dropping it ahead of that write would let a
+        // background pull slip between the two.
+        assertTrue(publisher.publish(update(0.1)))
+        assertTrue(publisher.afterQueuedWrites { events += "barrier" })
+        assertTrue(publisher.publish(update(0.2)))
+        runCurrent()
+
+        assertEquals(listOf("write:0.1", "barrier", "write:0.2"), events)
+    }
+
+    @Test
     fun `finished refresh failure does not repeat the committed write`() = runTest {
         var writes = 0
         var refreshes = 0

--- a/hack/README.md
+++ b/hack/README.md
@@ -60,3 +60,7 @@ target wrapping them — run `make help` for the short list. See
   to a flat PNG for the F-Droid listing and the README.
 - **`feature-graphic`** — Renders the 1024x500 store feature graphic
   from the app's own emblem.
+
+See also `tests/`, which holds the headless, assertion-shaped end-to-end
+scenarios — the ones that measure behaviour rather than walk the screen.
+The `e2e-*` scripts here drive the UI and need a visible device.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,126 @@
+# tests/
+
+End-to-end scenarios that run against a real device or emulator over
+`adb`. They exist for the behaviour that only shows up on a device —
+timing, connectivity, the reader actually appearing — which is
+everything the JVM unit tests in `app/src/test` cannot see.
+
+They are meant to be run by a person or by an agent, unattended:
+
+```bash
+tests/run-all                  # every scenario, on the only attached device
+tests/run-all -s emulator-5554 # or a named one
+tests/offline-open --help      # one scenario, and what it does
+```
+
+Every scenario prints one `PASS`/`FAIL`/`SKIP` line per check and exits
+`0` when it passed, `3` when it skipped itself, and anything else when
+it failed. An agent can branch on the exit code alone. Skipping is kept
+separate on purpose: a device that tested nothing must not be reported
+as a device that passed.
+
+## What is here
+
+| Scenario | What it proves |
+| --- | --- |
+| `offline-open` | A book opens promptly with no network, and — the case that regressed — with a network whose server is unroutable. |
+| `bench-open` | Not pass/fail: prints how long a book takes to open under each network condition. |
+
+## Preconditions
+
+- A device or emulator with a **debug** build installed (`make install`).
+  The scenarios read the app's database through `run-as`, which a
+  release build does not allow.
+- A seeded library. `make reset` gives you one.
+- For anything touching sync, a connected server row in `remote_server`.
+  A scenario with no server to work with skips itself rather than
+  failing.
+
+`make emulator` boots the default AVD; `make run-bg` installs and
+launches without `scrcpy`.
+
+## Writing a new one
+
+Copy the shape of `offline-open`:
+
+```bash
+#!/usr/bin/env bash
+#
+# tests/my-scenario -- one line on what must be true.
+#
+# ... prose on why this is worth a device test ...
+#
+# Usage: tests/my-scenario [-s SERIAL]
+
+source "$(dirname "$(readlink -f "$0")")/lib/device.sh"
+
+parse_common_args "$@"
+require_device
+# ... checks ...
+report
+```
+
+`--help` prints the header comment, so the documentation cannot drift
+away from the code. Make the file executable — `run-all` picks up
+whatever is executable in this directory.
+
+### What `lib/device.sh` gives you
+
+- `die`, `step`, `note` for output; `ok`, `bad`, `skip`, `report` for
+  results. `report` exits non-zero if anything called `bad`.
+- `adb` — a wrapper pinned to the chosen serial. Always use it.
+- `query "<sql>"` — SQL against the app's database, and `sql_quote` to
+  build a literal. Use it for anything that came off the device: a
+  configured server address is text the reader typed, and one
+  apostrophe pasted straight into a statement ends the string and runs
+  whatever follows.
+- `shell_quote` — the same care for the *device's* shell. Everything
+  handed to `adb shell` is re-parsed there, so a book title with an
+  apostrophe in its file name would otherwise end the argument and run
+  the rest as the shell user.
+- `set_server_url "<url>"` — points the connected server somewhere,
+  with the app stopped first and the result checked afterwards.
+- `airplane_mode_state` — `on` or `off`, to read before you change it.
+- `device_now_ms` — the *device's* clock, so adb round-trips are not
+  counted as time the app spent working.
+- `pick_downloaded_book` — sets `BOOK_URL` and `BOOK_LOCAL_URI`.
+- `time_book_open URL LOCAL_URI [CAP_MS]` — milliseconds, or `timeout`.
+- `expect_open_under LABEL MEASURED BUDGET_MS`.
+- `airplane_mode on|off`.
+
+### Two things to get right
+
+**Use the database as the oracle.** Screen scraping is slow and lies.
+Book-open timing keys off `books.last_opened_at`, which the reader
+writes one line before it shows the page, so it is the honest end of
+"the book opened".
+
+**Restore what you changed, from a trap.** These run against a device
+someone else will use next. Anything a scenario sets — airplane mode, a
+server address, app data — is put back on the way out, however the
+script leaves:
+
+```bash
+trap restore EXIT
+```
+
+Put back what was *there*, not what you assume: read airplane mode
+before turning it on, so a device that had it on keeps it. Stop the app
+before writing to its database, and check the value afterwards rather
+than announcing success — leaving a blackhole address behind quietly
+breaks the next thing anyone does with the device. `set_server_url`
+does all three.
+
+**Point a server nowhere real.** To make a server unreachable these
+scenarios change only its address, so the app keeps the credentials it
+had and sends them to whatever answers. Use `192.0.2.1` (TEST-NET-1,
+reserved by RFC 5737 and routed nowhere), never a private `10.x` or
+`192.168.x` address, which on somebody's network is perfectly capable
+of answering.
+
+## Related
+
+`hack/e2e-*` holds the older interactive UI walkthroughs (deletion,
+opening from another app, upload), which drive the screen with `input
+tap` and need a visible device. Scenarios here are the headless,
+assertion-shaped ones. See `hack/README.md`.

--- a/tests/bench-open
+++ b/tests/bench-open
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# tests/bench-open -- how long a book takes to open, per network condition.
+#
+# Not a pass/fail scenario: it prints a table. Opening a book waits on
+# the sync layer, and the point of the table is to show what each kind
+# of unreachable server costs, since they behave nothing like each
+# other:
+#
+#   reachable       the configured server as it is set up right now
+#   refused         a closed port, which answers ECONNREFUSED at once
+#   unroutable      an address that drops packets, so every request has
+#                   to wait out its connect timeout -- the expensive one,
+#                   and what a home server looks like from a plane
+#   airplane        no network at all, so connecting fails immediately
+#
+# Usage: tests/bench-open [-s SERIAL] [-n RUNS] [-c CONDITIONS]
+#
+#   -s SERIAL      device to run against (default: the only one attached)
+#   -n RUNS        openings per condition (default: 3)
+#   -c CONDITIONS  comma-separated subset of the four names above
+#
+# The device is left as it was found, on the way out however it leaves.
+
+source "$(dirname "$(readlink -f "$0")")/lib/device.sh"
+
+readonly REFUSED_URL="http://127.0.0.1:1"
+# TEST-NET-1 (RFC 5737), reserved for documentation and routed nowhere.
+# The app keeps its stored credentials while diverted, so before
+# anything is pointed away from the reader's own server the device
+# checks that nothing answers at the address (see divert_server_to).
+readonly BLACKHOLE_URL="http://192.0.2.1:8686"
+
+# Long enough to let an unfixed build show how bad it really is, rather
+# than reporting the cap as if it were the answer.
+readonly CAP_MS=180000
+
+runs=3
+conditions=reachable,refused,unroutable,airplane
+original_url=""
+original_airplane=""
+restored=0
+
+parse_common_args "$@"
+set -- ${REMAINING_ARGS+"${REMAINING_ARGS[@]}"}
+while (($#)); do
+  case "$1" in
+    -n | --runs)
+      runs="${2:-}"
+      [[ "$runs" =~ ^[1-9][0-9]*$ ]] || die "-n needs a positive number"
+      shift 2
+      ;;
+    -c | --conditions)
+      conditions="${2:-}"
+      [[ -n "$conditions" ]] || die "-c needs a comma-separated list"
+      shift 2
+      ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+restore() {
+  ((restored == 0)) || return 0
+  restored=1
+  restore_device "$original_url" "$original_airplane" || exit 1
+}
+trap restore EXIT
+
+step "Checking the device"
+require_device
+original_url=$(query "select base_url from remote_server limit 1;")
+[[ -n "$original_url" ]] ||
+  skip "no server is connected, so there is nothing to be slow about"
+original_airplane=$(airplane_mode_state)
+pick_downloaded_book
+note "server: $original_url"
+note "book:   $BOOK_URL"
+note "runs:   $runs per condition"
+
+# Sets the device up for a named condition, or returns 1 if the name is
+# not one of ours.
+arrange() {
+  case "$1" in
+    reachable)
+      airplane_mode off
+      set_server_url "$original_url"
+      ;;
+    refused)
+      airplane_mode off
+      # The device's own loopback: safe by construction (credentials
+      # cannot leave the device), and it must answer -- that is the
+      # point -- so it is not probed like the blackhole is.
+      set_server_url "$REFUSED_URL"
+      ;;
+    unroutable)
+      airplane_mode off
+      divert_server_to "$BLACKHOLE_URL"
+      ;;
+    airplane)
+      set_server_url "$original_url"
+      airplane_mode on
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+results=()
+IFS=',' read -r -a wanted <<<"$conditions"
+for condition in "${wanted[@]}"; do
+  step "$condition"
+  arrange "$condition" || die "unknown condition: $condition"
+
+  samples=()
+  for ((i = 1; i <= runs; i++)); do
+    measured=$(time_book_open "$BOOK_URL" "$BOOK_LOCAL_URI" "$CAP_MS")
+    samples+=("$measured")
+    if [[ "$measured" == "timeout" ]]; then
+      note "run $i: never opened (gave up after ${CAP_MS}ms)"
+    else
+      note "run $i: ${measured}ms"
+    fi
+  done
+
+  # The median, not the mean: one outlier from a background job on the
+  # device should not decide what the table says.
+  summary=$(printf '%s\n' "${samples[@]}" | sort -n | awk -v n="${#samples[@]}" '
+    /timeout/ { timeouts++; next }
+    { v[++c] = $1 }
+    END {
+      if (timeouts > 0) { printf ">%s", "'"$CAP_MS"'"; exit }
+      printf "%d", v[int((c + 1) / 2)]
+    }')
+  results+=("$condition|$summary|$(
+    IFS=' '
+    echo "${samples[*]}"
+  )")
+done
+
+restore
+
+printf '\n\033[1mTime to open a book (median of %d)\033[0m\n\n' "$runs"
+printf '%-12s %12s   %s\n' "condition" "median" "samples (ms)"
+printf '%-12s %12s   %s\n' "------------" "------------" "------------"
+for row in "${results[@]}"; do
+  IFS='|' read -r name median samples <<<"$row"
+  if [[ "$median" == \>* ]]; then
+    printf '%-12s %12s   %s\n' "$name" "never opened" "$samples"
+  else
+    printf '%-12s %12s   %s\n' "$name" "${median}ms" "$samples"
+  fi
+done
+printf '\n'

--- a/tests/lib/device.sh
+++ b/tests/lib/device.sh
@@ -1,0 +1,346 @@
+# shellcheck shell=bash
+#
+# Shared plumbing for the end-to-end scenarios in tests/.
+#
+# These run against a real device or emulator over adb, using the app's
+# own database as the oracle: whatever the reader wrote is what the
+# reader did, which is the only thing a black-box test can honestly
+# claim to know.
+#
+# A sourcing script is expected to call parse_common_args "$@" and then
+# require_device. Everything else here is opt-in.
+
+set -euo pipefail
+
+readonly APP_ID="com.chmouel.liseur"
+readonly READER_ACTIVITY="$APP_ID/.reader.ReaderActivity"
+readonly DB_PATH="/data/data/$APP_ID/databases/liseur.db"
+
+serial="${SERIAL:-}"
+_failures=0
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+step() { printf '\n\033[1m==> %s\033[0m\n' "$*"; }
+note() { printf '    %s\n' "$*"; }
+
+ok() { printf '    \033[32mPASS\033[0m %s\n' "$*"; }
+
+bad() {
+  printf '    \033[31mFAIL\033[0m %s\n' "$*"
+  _failures=$((_failures + 1))
+}
+
+# Skips rather than fails: a scenario whose precondition the device does
+# not meet has proved nothing, and pretending otherwise is worse than
+# saying so. Exits SKIP_EXIT so a runner can tell "nothing to test here"
+# from "everything passed" -- reporting an untested device as green is
+# how a broken setup goes unnoticed.
+readonly SKIP_EXIT=3
+skip() {
+  printf '    \033[33mSKIP\033[0m %s\n' "$*"
+  exit $SKIP_EXIT
+}
+
+# Prints the tally and exits with the truth about it, so a runner (or an
+# agent) can branch on the exit code alone.
+report() {
+  if ((_failures > 0)); then
+    printf '\n\033[31m%d check(s) failed\033[0m\n' "$_failures"
+    exit 1
+  fi
+  printf '\n\033[32mall checks passed\033[0m\n'
+}
+
+adb() { command adb ${serial:+-s "$serial"} "$@"; }
+
+# Consumes the flags every scenario understands and leaves the rest in
+# REMAINING_ARGS for the caller.
+parse_common_args() {
+  REMAINING_ARGS=()
+  while (($#)); do
+    case "$1" in
+      -s | --serial)
+        serial="${2:-}"
+        [[ -n "$serial" ]] || die "-s needs a device serial"
+        shift 2
+        ;;
+      -h | --help)
+        # The header comment of the calling script is its help text, so
+        # the documentation cannot drift away from the code.
+        sed -n '2,/^$/s/^# \{0,1\}//p' "$0"
+        exit 0
+        ;;
+      *)
+        REMAINING_ARGS+=("$1")
+        shift
+        ;;
+    esac
+  done
+}
+
+require_device() {
+  command -v adb >/dev/null || die "adb is not on PATH"
+  local devices
+  devices=$(command adb devices | awk 'NR>1 && $2=="device" {print $1}')
+  [[ -n "$devices" ]] || die "no device is attached; try: make emulator"
+  if [[ -z "$serial" ]]; then
+    if [[ $(wc -l <<<"$devices") -gt 1 ]]; then
+      die "several devices are attached; pick one with -s:"$'\n'"$devices"
+    fi
+    serial="$devices"
+  fi
+  note "device: $serial"
+  adb shell "pm path $APP_ID" >/dev/null 2>&1 ||
+    die "$APP_ID is not installed; try: make install"
+}
+
+# Runs SQL against the app's database. Needs a debuggable build, which
+# is what these scenarios are for.
+#
+# The statement crosses two shells -- the host's and the device's -- so
+# it is single-quoted for the device and the single quotes are escaped
+# for adb. Build any literal with sql_quote rather than pasting a value
+# straight in: a configured server URL is reader-supplied text, and one
+# apostrophe in it would otherwise end the string and run the rest.
+query() {
+  local sql=${1//\'/\'\\\'\'}
+  adb shell "run-as $APP_ID sqlite3 $DB_PATH '$sql'" | tr -d '\r'
+}
+
+# A value as a SQL string literal, with its quotes doubled.
+sql_quote() {
+  local v=${1//\'/\'\'}
+  printf "'%s'" "$v"
+}
+
+# A value as one argument for the device's shell.
+#
+# Everything handed to `adb shell` is a string the device re-parses, so
+# a value taken off the device -- a book's URL, a local file name -- has
+# to be quoted for that second parse or an apostrophe in a title ends
+# the argument and runs whatever follows as the shell user.
+shell_quote() {
+  local v=${1//\'/\'\\\'\'}
+  printf "'%s'" "$v"
+}
+
+# Points the connected server at a URL, with the app stopped.
+#
+# Stopped first because a sync already in flight would otherwise read
+# the old address or race this write, and the whole point of these
+# scenarios is to control which address the reader tries. Checked
+# afterwards rather than announced: leaving a dead address behind
+# quietly breaks the next thing anyone does with the device.
+set_server_url() {
+  local url="$1" seen
+  adb shell "am force-stop $APP_ID" >/dev/null
+  query "update remote_server set base_url = $(sql_quote "$url");" >/dev/null
+  seen=$(query "select base_url from remote_server limit 1;")
+  [[ "$seen" == "$url" ]] || die "could not point the server at $url (it reads $seen)"
+}
+
+# The stored server credentials go wherever the base URL points, so a
+# diversion must never point at a machine that could answer. Blanking
+# them for the diversion sounds safer but is impossible here: the app
+# deletes any account whose secret cannot be decrypted (that is what a
+# database restored without its Keystore looks like), so a blanked
+# credential silently disconnects the server and the scenario measures
+# nothing. Instead, the device itself checks that the diversion address
+# is dark before anything is pointed at it.
+#
+# ICMP is a proxy for "something lives there" -- a host that answers
+# ping is a host that might answer TCP. TEST-NET addresses are dropped
+# by every well-behaved network, so an answer means this network is not
+# one, and the only safe move is to not divert at all.
+#
+# Two ways this check could lie are closed off. A configured HTTP proxy
+# would carry the request (and the credentials on it) somewhere else
+# entirely, ping or no ping — and Android can get one globally, from
+# the network itself, or as a PAC script, so all three are looked for
+# and any sign of one refuses the diversion. And the ping must
+# demonstrably have run and heard nothing: a missing binary, a
+# permission error or an unknown host is not darkness, and fails the
+# same way an answer does.
+assert_address_dark() {
+  local host="$1" proxy links out
+  proxy=$(adb shell settings get global http_proxy 2>/dev/null | tr -d '\r')
+  case "$proxy" in
+    "" | null | :0) ;;
+    *) die "this device routes HTTP through a proxy ($proxy); \
+a diverted request would go there, not to $host" ;;
+  esac
+  # Per-network proxies and PAC scripts never appear in that setting;
+  # they show up on the network's link, which only mentions a proxy
+  # when one is set. An unreadable answer is treated as a proxy.
+  links=$(adb shell dumpsys connectivity 2>/dev/null | tr -d '\r')
+  if [[ -z "$links" ]] || grep -qi 'HttpProxy\|PacFileUrl\|PAC Script' <<<"$links"; then
+    die "cannot show this device's network has no proxy of its own; \
+a diverted request might not go to $host at all"
+  fi
+  out=$(adb shell "ping -c 1 -W 2 $host" 2>&1 | tr -d '\r') || true
+  if ! grep -q '100% packet loss' <<<"$out"; then
+    die "cannot show $host is dark from this device; \
+refusing to point the app (and its credentials) there"
+  fi
+}
+
+# Points the server at a URL after checking, from the device, that
+# nothing answers there.
+divert_server_to() {
+  local url="$1" host
+  host=${url#*://}
+  host=${host%%:*}
+  host=${host%%/*}
+  assert_address_dark "$host"
+  set_server_url "$url"
+}
+
+# The device's own clock in milliseconds. Timings are computed from this
+# rather than the host's, so adb round-trips are not counted as time the
+# reader spent working.
+device_now_ms() { adb shell 'date +%s%3N' | tr -d '\r'; }
+
+# Whether airplane mode is on right now: "on" or "off". Read before
+# changing it, so a scenario puts the device back the way its owner had
+# it rather than the way the scenario assumed.
+#
+# Only the two settings the device actually stores are accepted. An adb
+# that failed, or a device that answered something else, must not read
+# as "off": a scenario would then restore a state it never established
+# and announce it had put things back.
+airplane_mode_state() {
+  local raw
+  raw=$(adb shell settings get global airplane_mode_on 2>/dev/null | tr -d '\r') ||
+    return 1
+  case "$raw" in
+    1) printf 'on\n' ;;
+    0) printf 'off\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+airplane_mode() {
+  local current
+  current=$(airplane_mode_state) || die "could not read the airplane mode setting"
+  [[ "$current" != "$1" ]] || return 0
+  case "$1" in
+    on) adb shell cmd connectivity airplane-mode enable >/dev/null ;;
+    off) adb shell cmd connectivity airplane-mode disable >/dev/null ;;
+    *) die "airplane_mode takes on or off" ;;
+  esac
+  # The radios take a moment to follow the setting.
+  sleep 3
+}
+
+# Puts the device back the way a scenario found it, and says so only if
+# that is true.
+#
+# Both arguments may be empty, meaning there is nothing to put back.
+# Every step is attempted even after an earlier one fails, because a
+# half-restored device is worse than a loud one, and each is read back
+# rather than assumed: a scenario that leaves a device pointed at a
+# blackhole or with its radios off must not be able to report success.
+# Returns non-zero if anything is still wrong.
+restore_device() {
+  local want_url="$1" want_airplane="$2" seen failed=0
+
+  adb shell "am force-stop $APP_ID" >/dev/null 2>&1 || true
+
+  if [[ -n "$want_url" ]]; then
+    query "update remote_server set base_url = $(sql_quote "$want_url");" \
+      >/dev/null 2>&1 || true
+    seen=$(query "select base_url from remote_server limit 1;" 2>/dev/null || true)
+    if [[ "$seen" == "$want_url" ]]; then
+      note "server address restored to $want_url"
+    else
+      printf '    \033[31mcould not restore the server address\033[0m\n' >&2
+      printf '    it is now %s; set it back to %s by hand\n' \
+        "${seen:-unreadable}" "$want_url" >&2
+      failed=1
+    fi
+  fi
+
+  if [[ -n "$want_airplane" ]]; then
+    airplane_mode "$want_airplane" >/dev/null 2>&1 || true
+    seen=$(airplane_mode_state 2>/dev/null || true)
+    if [[ "$seen" == "$want_airplane" ]]; then
+      note "airplane mode back to $want_airplane"
+    else
+      printf '    \033[31mcould not put airplane mode back to %s\033[0m\n' \
+        "$want_airplane" >&2
+      printf '    it is %s; set it by hand\n' "${seen:-unreadable}" >&2
+      failed=1
+    fi
+  fi
+
+  return "$failed"
+}
+
+# Picks a downloaded book to open: the most recently read one, because
+# it is the likeliest to have sync state worth exercising. Sets
+# BOOK_URL and BOOK_LOCAL_URI.
+# shellcheck disable=SC2034 # both are read by the sourcing scenario
+pick_downloaded_book() {
+  local row
+  row=$(query "select url || char(9) || local_uri from books \
+where local_uri is not null and local_uri != '' \
+order by coalesce(last_opened_at, 0) desc limit 1;")
+  [[ -n "$row" ]] || skip "no downloaded book on this device to open"
+  BOOK_URL="${row%%	*}"
+  BOOK_LOCAL_URI="${row#*	}"
+}
+
+# Opens a book and returns how long the reader took to become ready, in
+# milliseconds, or the string "timeout".
+#
+# The marker is books.last_opened_at, which the reader writes one line
+# before it shows the page. It is the last thing that happens on the
+# opening path, so it is the honest end of "the book opened" -- and it
+# lives in the database, so it can be read without instrumenting the
+# app or scraping a screen.
+time_book_open() {
+  local url="$1" local_uri="$2" cap_ms="${3:-60000}"
+  local before t0 elapsed now quoted
+  quoted=$(sql_quote "$url")
+
+  adb shell "am force-stop $APP_ID" >/dev/null
+  before=$(query "select coalesce(last_opened_at, 0) from books where url = $quoted;")
+  t0=$(device_now_ms)
+  adb shell "am start -n $READER_ACTIVITY \
+-e url $(shell_quote "$local_uri") -e id $(shell_quote "$url")" >/dev/null
+
+  while :; do
+    local stamp
+    stamp=$(query "select coalesce(last_opened_at, 0) from books where url = $quoted;")
+    if [[ -n "$stamp" && "$stamp" -gt "$before" ]]; then
+      elapsed=$((stamp - t0))
+      # A clock that ran backwards means the marker was not ours.
+      ((elapsed >= 0)) || elapsed=0
+      printf '%s\n' "$elapsed"
+      return 0
+    fi
+    now=$(device_now_ms)
+    if ((now - t0 > cap_ms)); then
+      printf 'timeout\n'
+      return 0
+    fi
+    sleep 1
+  done
+}
+
+# Asserts an open finished inside a budget, and says by how much it did
+# or did not.
+expect_open_under() {
+  local label="$1" measured="$2" budget_ms="$3"
+  if [[ "$measured" == "timeout" ]]; then
+    bad "$label: the book never opened (over the ${budget_ms}ms budget)"
+  elif ((measured <= budget_ms)); then
+    ok "$label: opened in ${measured}ms (budget ${budget_ms}ms)"
+  else
+    bad "$label: opened in ${measured}ms, over the ${budget_ms}ms budget"
+  fi
+}

--- a/tests/offline-open
+++ b/tests/offline-open
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# tests/offline-open -- a book must open promptly with no usable network.
+#
+# The scenario this comes from: a reader on a plane, in airplane mode,
+# waiting a very long time for a book to appear. The interesting case is
+# not a device with no network at all -- a connection that cannot be
+# made fails at once -- but a device that has a network and a book
+# server it cannot route to, which is what airplane mode with the
+# in-flight Wi-Fi joined actually looks like. There, every request waits
+# out its full connect timeout, and a sync that asks about book after
+# book holds the reader behind all of them.
+#
+# Two openings are timed:
+#
+#   1. airplane mode, so nothing resolves at all
+#   2. the network up, but the configured server pointed at an address
+#      that swallows packets rather than refusing them
+#
+# Both must finish inside the budget. Case 2 is the regression this
+# guards: before the fix it did not finish at all.
+#
+# Usage: tests/offline-open [-s SERIAL] [-t BUDGET_MS]
+#
+#   -s SERIAL     device to run against (default: the only one attached)
+#   -t BUDGET_MS  how long an open may take (default: 8000)
+#
+# The device is left as it was found: the server address is put back and
+# airplane mode turned off, on the way out however the script leaves.
+
+source "$(dirname "$(readlink -f "$0")")/lib/device.sh"
+
+# TEST-NET-1 (RFC 5737), reserved for documentation and routed nowhere:
+# packets sent here are dropped in silence, which is what a home server
+# looks like from a plane. A closed port on a reachable host would be
+# refused instantly and prove nothing.
+#
+# The app keeps its stored credentials while diverted, so before
+# anything is pointed here the device itself checks that nothing
+# answers at this address (see divert_server_to).
+readonly BLACKHOLE_URL="http://192.0.2.1:8686"
+
+budget_ms=8000
+original_url=""
+original_airplane=""
+restored=0
+
+parse_common_args "$@"
+set -- ${REMAINING_ARGS+"${REMAINING_ARGS[@]}"}
+while (($#)); do
+  case "$1" in
+    -t | --budget)
+      budget_ms="${2:-}"
+      [[ "$budget_ms" =~ ^[0-9]+$ ]] || die "-t needs a number of milliseconds"
+      shift 2
+      ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+# Puts back everything this scenario changed, however it leaves. The app
+# is stopped first: it holds the same database, and a write landing under
+# a running sync is both racy and pointless, since the address it already
+# read would stay in use.
+restore() {
+  ((restored == 0)) || return 0
+  restored=1
+  printf '\n'
+  step "Putting the device back"
+  # Both are put back to what was actually found, not to what this
+  # scenario assumed, and a failure to do so ends the run non-zero.
+  restore_device "$original_url" "$original_airplane" || exit 1
+}
+trap restore EXIT
+
+step "Checking the device"
+require_device
+
+original_url=$(query "select base_url from remote_server limit 1;")
+[[ -n "$original_url" ]] ||
+  skip "no server is connected, so there is no sync to be slow"
+note "server: $original_url"
+
+# Read before anything is touched, so the trap restores what the owner of
+# this device had rather than what this scenario assumed.
+original_airplane=$(airplane_mode_state)
+
+pick_downloaded_book
+note "book: $BOOK_URL"
+
+step "Opening in airplane mode"
+note "nothing resolves, so every connection should fail at once"
+airplane_mode on
+measured=$(time_book_open "$BOOK_URL" "$BOOK_LOCAL_URI" $((budget_ms * 4)))
+expect_open_under "airplane mode" "$measured" "$budget_ms"
+airplane_mode off
+
+step "Opening with the network up and the server unroutable"
+note "pointing the server at $BLACKHOLE_URL, which drops what it is sent"
+divert_server_to "$BLACKHOLE_URL"
+measured=$(time_book_open "$BOOK_URL" "$BOOK_LOCAL_URI" $((budget_ms * 4)))
+expect_open_under "unroutable server" "$measured" "$budget_ms"
+
+restore
+report

--- a/tests/run-all
+++ b/tests/run-all
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# tests/run-all -- runs every scenario in tests/ against one device.
+#
+# Usage: tests/run-all [-s SERIAL]
+#
+# Scenarios are the executable files in tests/ other than this one.
+# Each is run in turn. A scenario that skips itself (exit 3, from the
+# skip helper) is reported as skipped and does not fail the run, but is
+# named at the end, because a device that quietly tested nothing is not
+# the same as one that passed.
+
+set -euo pipefail
+
+here="$(dirname "$(readlink -f "$0")")"
+args=("$@")
+failed=()
+skipped=()
+passed=0
+
+for scenario in "$here"/*; do
+  [[ -f "$scenario" && -x "$scenario" ]] || continue
+  name=$(basename "$scenario")
+  [[ "$name" != "run-all" ]] || continue
+  printf '\n\033[1m### %s\033[0m\n' "$name"
+  status=0
+  "$scenario" ${args+"${args[@]}"} || status=$?
+  case $status in
+    0) passed=$((passed + 1)) ;;
+    3) skipped+=("$name") ;;
+    *) failed+=("$name") ;;
+  esac
+done
+
+printf '\n'
+((${#skipped[@]} == 0)) ||
+  printf '\033[33mskipped: %s\033[0m\n' "${skipped[*]}"
+if ((${#failed[@]} > 0)); then
+  printf '\033[31mfailed: %s\033[0m\n' "${failed[*]}"
+  exit 1
+fi
+printf '\033[32m%d scenario(s) passed\033[0m\n' "$passed"


### PR DESCRIPTION
## Summary

Opening a book on a plane could hang forever. The real culprit was not airplane mode itself but its usual companion: a network that is up while the configured book server is unroutable, so every request silently waits out its full connect timeout — and the open-time sync asks about book after book. This series makes a book always open promptly no matter what the server is doing, and fixes the fallout the investigation surfaced along the way.

Fixes #49
Fixes #50

## Changes

- **Skip server requests when the device has no network** — every remote call checks connectivity first and fails fast instead of dialing into the void.
- **Stop a sync once the server has stopped answering** — a circuit breaker: after the server goes quiet, the rest of the run is abandoned instead of paying the full timeout per book, and the run reports the network failure rather than an incidental per-book error.
- **Open a book without waiting on a sync already given up on** — the reader bounds its open-time sync (2.5 s) and no longer queues behind an abandoned run; the run itself is detached from its caller so walking away never cancels or blocks it.
- **Add device checks for how long a book takes to open** — a `tests/` harness (`tests/offline-open`, `tests/bench-open`, `tests/run-all`, `make e2e`) that reproduces the airplane and unroutable-server conditions on a real device and verifies restoration of everything it touches, refusing to divert the app anywhere that might answer.
- **Save the reading position on Android 9 and older** — the position UPSERTs needed SQLite 3.24 (Android 10); rewritten as update-then-insert with a guard test so they cannot come back. Fixes #49.
- **Leave an open book alone while a sync runs behind it** — a background sync can no longer move the saved position under a page someone is reading; the server's position stays a question for the next open. Fixes #50.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

On the emulator, `./tests/run-all` passes and page turns advance `local_revision` with no SQLite errors. Time to open a book (`tests/bench-open`, median of 3):

| condition | before | after |
|---|---|---|
| reachable | ~1.1 s | 1136 ms |
| refused (closed port) | ~1.1 s | 1134 ms |
| unroutable (blackhole) | **never opened** | 3634 ms |
| airplane mode | ~1.2 s | 1205 ms |

The series also went through three adversarial review rounds plus a final confirmation pass (approved).

## Screenshots or recordings

No screenshot: there is no UI change — the fix is that the reader reaches the page it always showed, promptly.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
