### PR TITLE
fix: Look for the release bundle where Gradle actually puts it

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,7 +14,10 @@ default_platform(:android)
 platform :android do
   desc "Upload the release bundle to the Play internal testing track"
   lane :internal do
-    bundle = "app/build/outputs/bundle/release/app-release.aab"
+    # Anchored to this file rather than the working directory: fastlane
+    # runs lanes from inside fastlane/, so a bare relative path would
+    # look for the bundle one directory too deep and never find it.
+    bundle = File.expand_path("../app/build/outputs/bundle/release/app-release.aab", __dir__)
     UI.user_error!("no bundle at #{bundle} — run ./gradlew bundleRelease") unless File.exist?(bundle)
 
     upload_to_play_store(


### PR DESCRIPTION
## What

Anchor the Play upload lane's bundle path to the project root instead of the current directory.

## Why

The v0.9.2 release run was the first ever to reach the "Upload to the Play internal track" step, and it failed with `no bundle at app/build/outputs/bundle/release/app-release.aab` even though the bundle had just been built and signed one step earlier. fastlane executes lanes from inside `fastlane/`, so the bare relative path resolved to `fastlane/app/build/...` — a directory that never exists.

## Testing

Ran `fastlane android internal` against a locally built signed bundle (in a `ruby:3` container, fastlane 2.238.0 as in CI): with the fix the lane finds the bundle and proceeds to the Play API call. The upload itself then fails with `Package not found: com.chmouel.liseur` — expected, since the app hasn't had its first manual console upload yet, exactly as the Fastfile comment describes.

No screenshot: no UI change.