### PR TITLE
docs: Note that the app is not on Google Play yet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,11 @@ jobs:
       # after the release above on purpose: the GitHub artefact and the
       # F-Droid submission are the primary channels, so a rejected upload
       # here must never be what makes a release fail.
+      #
+      # The app is not on Play yet: until someone does the first upload
+      # by hand in the Play Console (see DEVELOPER.md, Google Play), the
+      # upload step below fails with "Package not found" and that is
+      # expected. Remove this notice once the app exists on Play.
       - name: Check for the Play credential
         id: play
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,12 @@ has finished, because the long `fdroid build` is not waited for. Check
 the pipeline it links before calling a release done. `DEVELOPER.md`
 explains what those checks are.
 
+The app is **not on Google Play yet**: the release workflow's Play
+upload step fails with `Package not found: com.chmouel.liseur` and that
+is expected, not a release blocker. The first upload must be done by
+hand in the Play Console (see the Google Play section of
+`DEVELOPER.md`); do not try to automate around it.
+
 Toolchain: JDK 17, AGP 9.x (built-in Kotlin support — **do not** add the
 `org.jetbrains.kotlin.android` plugin, only `org.jetbrains.kotlin.plugin.compose`
 is applied), compileSdk/targetSdk 37, minSdk 26. Dependencies are managed in

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -216,6 +216,15 @@ Signing a build on your own machine is a separate matter, covered under
 
 ### Google Play
 
+> **Not live yet.** The app has not been created in the Play Console, so
+> every upload — CI or manual — fails with `Package not found:
+> com.chmouel.liseur`. That failure is expected and must not hold up a
+> release; the GitHub release and F-Droid are the channels that count
+> today. The very first upload has to go through the console's release
+> wizard by hand (that is where the upload key gets enrolled, see **The
+> signing key** below), and only a human with console access can do it.
+> Delete this notice once that first upload has happened.
+
 Play is the third channel, after the GitHub release and F-Droid, and it
 is deliberately the least load-bearing of the three. The same tag that
 publishes the release also builds an app bundle and pushes it to the


### PR DESCRIPTION
The release workflow's Play upload fails with "Package not found"
because the app has never been created in the Play Console, and the
first upload has to be done by hand in the console's release wizard.
Wrote that down in DEVELOPER.md, AGENTS.md and the workflow itself so
nobody treats the failure as a release blocker or tries to automate
around it.
