### PR TITLE
fix: Make the release APK byte-identical on every machine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,11 @@ push. Skip with `git push --no-verify`.
   Maven Central or Google's Maven repo. No proprietary blobs, trackers,
   analytics, or Google Play services. In particular, never add
   `readium-lcp` (depends on the proprietary liblcp).
+- **The release build must stay reproducible** (`hack/verify-reproducible`
+  must pass): F-Droid rebuilds every tag from source. Do not remove the
+  `dependenciesInfo` or `packaging.jniLibs.keepDebugSymbols` settings in
+  `app/build.gradle.kts` — both exist only for this. `DEVELOPER.md`
+  explains why.
 - Network access is limited to the user-configured book server
   (calibre-web, Komga or liseur-sync) and opt-in dictionary lookups.
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -693,6 +693,31 @@ what lets it sync a book that came off an SD card.
   timestamp baked into a resource or an absolute build path that leaked
   in. Run it before every release. Move `keystore.properties` aside
   first if you have one: the check compares the unsigned APK.
+
+  Two build-file settings exist purely to keep this true and must not
+  be removed: `dependenciesInfo` is switched off (AGP would otherwise
+  embed a dependency manifest encrypted for Google Play, which nobody
+  else can reproduce), and `packaging.jniLibs.keepDebugSymbols` covers
+  every `.so` (the only native code arrives prebuilt in AndroidX AARs;
+  re-stripping it ties the bytes to the build machine's NDK — this was
+  the one thing that made the CI APK differ from a local rebuild).
+- **Publishing our own signature (not yet enabled).** Because the build
+  is reproducible, F-Droid can be asked to publish the developer-signed
+  APK instead of signing with its own key: the recipe gains
+
+  ```yaml
+  Binaries: https://github.com/chmouel/liseur/releases/download/v%v/liseur-v%v.apk
+  ```
+
+  and per-build `AllowedAPKSigningKeys` with the SHA-256 of our signing
+  certificate (`keytool -list` on the keystore, lowercase without
+  colons). F-Droid then rebuilds the tag, strips both signatures,
+  compares byte for byte, and ships the GitHub artefact on success —
+  giving F-Droid, the GitHub release, and Play the same signature, so a
+  reader can switch channels without uninstalling. The switch is
+  breaking once: existing F-Droid installs carry F-Droid's signature
+  and must uninstall/reinstall (losing local data) to cross over. It
+  applies per version, so old versions stay as they are.
 - **Submitted.** The metadata merge request is
   [fdroiddata!44292](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/44292),
   and `hack/release` keeps it up to date with each version. See *What

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,6 +77,14 @@ android {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
+        jniLibs {
+            // The only native code in the app arrives prebuilt inside
+            // library AARs. Left alone it is already stripped; letting
+            // AGP strip it again ties the bytes to whichever NDK the
+            // build machine happens to have, which is exactly the kind
+            // of environment leak that breaks reproducible builds.
+            keepDebugSymbols += "**/*.so"
+        }
     }
 
     dependenciesInfo {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,15 @@ android {
         }
     }
 
+    dependenciesInfo {
+        // AGP's dependency manifest is encrypted with a Google key, so
+        // nobody but Play can read it and F-Droid cannot reproduce it.
+        // Dropping it keeps the APK byte-identical across rebuilds,
+        // which is what lets F-Droid publish our own signed binary.
+        includeInApk = false
+        includeInBundle = false
+    }
+
     testOptions {
         unitTests {
             // The calibre-web clients log with android.util.Log, which is a


### PR DESCRIPTION
## What

Two packaging changes plus documentation, in aid of F-Droid reproducible builds (the road to all three channels sharing the same signature):

- `dependenciesInfo { includeInApk/includeInBundle = false }` — drops the Play-only dependency manifest, which is encrypted with a Google key and therefore unreproducible by anyone else.
- `packaging.jniLibs.keepDebugSymbols += "**/*.so"` — the app's only native code (`libdatastore_shared_counter.so`, prebuilt in the AndroidX datastore AAR) was being re-stripped with the build machine's NDK, producing different bytes per machine.
- DEVELOPER.md/AGENTS.md: why those settings exist and must stay, and the (not yet enabled) `Binaries:` + `AllowedAPKSigningKeys:` publish flow.

## Why

Cross-checking the CI-built v0.9.2 APK against a local rebuild of the same tag showed exactly four differing entries — the datastore `.so` for each ABI. Everything else already matched. Fixing that and the Play blob makes the release APK machine-independent, which is the precondition for F-Droid publishing our own signed artefact.

## Testing

- `hack/verify-reproducible` passes before and after each change (double clean-checkout builds, identical SHA-256).
- All four `.so` files in the new APK are byte-identical (`cmp`) to the ones inside the upstream `datastore-core.aar` from Maven Central — no NDK touches them, so no machine dependence by construction.
- CI runs tests/lint/assembleDebug on this PR.

No screenshot: no UI change.