### PR TITLE
fix(dictionary): make non-English Wiktionary editions work

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/domain/DictionaryUrl.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/DictionaryUrl.kt
@@ -58,6 +58,14 @@ object DictionaryUrl {
     fun definitionApi(baseUrl: String, term: String): String =
         orDefault(baseUrl) + "/api/rest_v1/page/definition/" + encode(term)
 
+    /**
+     * The entry as Parsoid HTML. The tidy [definitionApi] only exists on
+     * the English edition — every other edition answers it with a 501 —
+     * so this is where their definitions are read from.
+     */
+    fun pageHtmlApi(baseUrl: String, term: String): String =
+        orDefault(baseUrl) + "/api/rest_v1/page/html/" + encode(term)
+
     /** The full entry, for reading in a browser. */
     fun entryPage(baseUrl: String, term: String): String =
         orDefault(baseUrl) + "/wiki/" + encode(term)

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/WiktionaryEditions.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/WiktionaryEditions.kt
@@ -1,0 +1,80 @@
+package com.chmouel.liseur.domain
+
+/**
+ * A Wiktionary language edition the settings picker can offer.
+ *
+ * @param code The subdomain, which is also the wiki's language code.
+ * @param nativeName The edition's name in its own language, because a
+ *   reader picking the French dictionary looks for «Français», not for
+ *   the English word for it.
+ */
+data class WiktionaryEdition(val code: String, val nativeName: String) {
+    val baseUrl: String get() = "https://$code.wiktionary.org"
+}
+
+/**
+ * The Wiktionary editions the settings screen offers by name.
+ *
+ * A reader used to type the edition's URL by hand, and a single typo'd
+ * letter became a stored setting that failed later, in the reader, as a
+ * bare HTTP error (fr.wiktionary misspelled was the bug report that
+ * bought this list). Picking a name cannot be misspelled. The list is
+ * the larger editions; anything else still fits through the custom URL
+ * field.
+ */
+object WiktionaryEditions {
+
+    val all: List<WiktionaryEdition> = listOf(
+        WiktionaryEdition("en", "English"),
+        WiktionaryEdition("fr", "Français"),
+        WiktionaryEdition("de", "Deutsch"),
+        WiktionaryEdition("es", "Español"),
+        WiktionaryEdition("it", "Italiano"),
+        WiktionaryEdition("pt", "Português"),
+        WiktionaryEdition("nl", "Nederlands"),
+        WiktionaryEdition("pl", "Polski"),
+        WiktionaryEdition("sv", "Svenska"),
+        WiktionaryEdition("da", "Dansk"),
+        WiktionaryEdition("no", "Norsk"),
+        WiktionaryEdition("fi", "Suomi"),
+        WiktionaryEdition("cs", "Čeština"),
+        WiktionaryEdition("hu", "Magyar"),
+        WiktionaryEdition("ro", "Română"),
+        WiktionaryEdition("ca", "Català"),
+        WiktionaryEdition("el", "Ελληνικά"),
+        WiktionaryEdition("ru", "Русский"),
+        WiktionaryEdition("uk", "Українська"),
+        WiktionaryEdition("tr", "Türkçe"),
+        WiktionaryEdition("ar", "العربية"),
+        WiktionaryEdition("fa", "فارسی"),
+        WiktionaryEdition("hi", "हिन्दी"),
+        WiktionaryEdition("ja", "日本語"),
+        WiktionaryEdition("ko", "한국어"),
+        WiktionaryEdition("zh", "中文"),
+    )
+
+    /**
+     * The edition a stored URL points at, or null when it is something
+     * else — a mirror, a proxy, a hand-typed address. The picker uses
+     * this to show the right name for what is stored, and to know when
+     * to fall back to the custom field instead.
+     */
+    fun editionOf(baseUrl: String?): WiktionaryEdition? {
+        val host = baseUrl?.let(DictionaryUrl::hostOf) ?: return null
+        val code = host.removeSuffix(".wiktionary.org")
+        if (code == host || code.contains('.')) return null
+        return all.firstOrNull { it.code.equals(code, ignoreCase = true) }
+    }
+
+    /**
+     * Whether a URL points at a real Wikimedia-hosted Wiktionary — any
+     * edition, not just the listed ones. Those are the hosts where the
+     * REST API's shape is known: `page/definition` on the English one,
+     * `page/html` everywhere.
+     */
+    fun isWiktionaryHost(baseUrl: String): Boolean {
+        val host = DictionaryUrl.hostOf(baseUrl)
+        val code = host.removeSuffix(".wiktionary.org")
+        return code != host && code.isNotEmpty() && !code.contains('.')
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/dictionary/DefinitionSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/dictionary/DefinitionSheet.kt
@@ -126,9 +126,17 @@ fun DefinitionSheet(
                 )
 
                 is DictionaryState.Failed -> Text(
-                    text = current.message
-                        ?.let { stringResource(R.string.dictionary_failed_reason, it) }
-                        ?: stringResource(R.string.dictionary_failed),
+                    text = when {
+                        current.host != null && current.message != null ->
+                            stringResource(
+                                R.string.dictionary_failed_host,
+                                current.host,
+                                current.message,
+                            )
+                        current.message != null ->
+                            stringResource(R.string.dictionary_failed_reason, current.message)
+                        else -> stringResource(R.string.dictionary_failed)
+                    },
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.error,
                 )

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/dictionary/WiktionaryClient.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/dictionary/WiktionaryClient.kt
@@ -106,7 +106,11 @@ class WiktionaryClient(
         languages: List<String>,
         baseUrl: String,
     ): DictionaryState =
-        fetch(DictionaryUrl.definitionApi(baseUrl, term), baseUrl) { body ->
+        fetch(
+            url = DictionaryUrl.definitionApi(baseUrl, term),
+            baseUrl = baseUrl,
+            accept = "application/json",
+        ) { body ->
             parseWiktionaryDefinitions(body, languages)
         }
 
@@ -115,19 +119,24 @@ class WiktionaryClient(
         languages: List<String>,
         baseUrl: String,
     ): DictionaryState =
-        fetch(DictionaryUrl.pageHtmlApi(baseUrl, term), baseUrl) { body ->
+        fetch(
+            url = DictionaryUrl.pageHtmlApi(baseUrl, term),
+            baseUrl = baseUrl,
+            accept = "text/html",
+        ) { body ->
             parseWiktionaryEntryHtml(body, languages)
         }
 
     private fun fetch(
         url: String,
         baseUrl: String,
+        accept: String,
         parse: (String) -> List<DictionarySense>,
     ): DictionaryState {
         val host = DictionaryUrl.hostOf(baseUrl)
         val request = Request.Builder()
             .url(url)
-            .header("Accept", "application/json")
+            .header("Accept", accept)
             // Wikimedia answers 403 to requests without a descriptive
             // agent, so say who we are and where to complain.
             .header("User-Agent", USER_AGENT)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/dictionary/WiktionaryClient.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/dictionary/WiktionaryClient.kt
@@ -2,6 +2,7 @@ package com.chmouel.liseur.reader.dictionary
 
 import com.chmouel.liseur.BuildConfig
 import com.chmouel.liseur.domain.DictionaryUrl
+import com.chmouel.liseur.domain.WiktionaryEditions
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -23,7 +24,12 @@ sealed interface DictionaryState {
     /** The word is not in Wiktionary — a normal outcome, not an error. */
     data object NotFound : DictionaryState
 
-    data class Failed(val message: String?) : DictionaryState
+    /**
+     * The lookup failed, and [host] is who did not answer, so the card
+     * can point at the dictionary setting rather than leave the reader
+     * staring at a bare HTTP code.
+     */
+    data class Failed(val message: String?, val host: String? = null) : DictionaryState
 }
 
 /**
@@ -32,7 +38,13 @@ sealed interface DictionaryState {
  * This is the only request the app makes that is not to the reader's own
  * book server, and it happens only after the reader has turned definitions
  * on, and only when they tap Define on a word. The site is theirs to
- * choose: any Wiktionary edition or mirror answers the same endpoint.
+ * choose — any Wiktionary edition, or a mirror.
+ *
+ * The tidy JSON endpoint (`page/definition`) is implemented only on
+ * en.wiktionary.org; every other edition answers it with a 501. So the
+ * English edition is asked for JSON, the others for their entry page as
+ * Parsoid HTML, and an unknown host gets the JSON endpoint first with the
+ * page as the fallback.
  */
 class WiktionaryClient(
     private val client: OkHttpClient = default(),
@@ -53,13 +65,68 @@ class WiktionaryClient(
             lookup(lowercaseTerm, languages, baseUrl)
         }
 
+    /**
+     * Whether [baseUrl] answers as a dictionary at all, checked with a
+     * word every edition has an entry for. Null when it does; what went
+     * wrong when it does not — so a typo in the settings field fails
+     * right there, under the field, not later in the reader as a bare
+     * HTTP code (a misspelling of fr.wiktionary.org earned this check).
+     */
+    suspend fun probe(baseUrl: String): String? =
+        withContext(Dispatchers.IO) {
+            when (val state = lookup(PROBE_WORD, emptyList(), baseUrl)) {
+                is DictionaryState.Failed -> state.message ?: "error"
+                // Even NotFound means a dictionary answered the endpoint.
+                else -> null
+            }
+        }
+
     private fun lookup(
         term: String,
         languages: List<String>,
         baseUrl: String,
     ): DictionaryState {
+        val edition = WiktionaryEditions.editionOf(baseUrl)
+        val nonEnglishEdition = WiktionaryEditions.isWiktionaryHost(baseUrl) &&
+            (edition == null || edition.code != "en")
+        if (nonEnglishEdition) return lookupEntryPage(term, languages, baseUrl)
+
+        val definitions = lookupDefinitions(term, languages, baseUrl)
+        // A mirror may only serve pages: on the 501 that marks a wiki
+        // without the definition endpoint, try the page instead.
+        return if (definitions is DictionaryState.Failed && definitions.message == "HTTP 501") {
+            lookupEntryPage(term, languages, baseUrl)
+        } else {
+            definitions
+        }
+    }
+
+    private fun lookupDefinitions(
+        term: String,
+        languages: List<String>,
+        baseUrl: String,
+    ): DictionaryState =
+        fetch(DictionaryUrl.definitionApi(baseUrl, term), baseUrl) { body ->
+            parseWiktionaryDefinitions(body, languages)
+        }
+
+    private fun lookupEntryPage(
+        term: String,
+        languages: List<String>,
+        baseUrl: String,
+    ): DictionaryState =
+        fetch(DictionaryUrl.pageHtmlApi(baseUrl, term), baseUrl) { body ->
+            parseWiktionaryEntryHtml(body, languages)
+        }
+
+    private fun fetch(
+        url: String,
+        baseUrl: String,
+        parse: (String) -> List<DictionarySense>,
+    ): DictionaryState {
+        val host = DictionaryUrl.hostOf(baseUrl)
         val request = Request.Builder()
-            .url(DictionaryUrl.definitionApi(baseUrl, term))
+            .url(url)
             .header("Accept", "application/json")
             // Wikimedia answers 403 to requests without a descriptive
             // agent, so say who we are and where to complain.
@@ -69,12 +136,10 @@ class WiktionaryClient(
             client.newCall(request).execute().use { response ->
                 when {
                     response.code == 404 -> DictionaryState.NotFound
-                    !response.isSuccessful -> DictionaryState.Failed("HTTP ${response.code}")
+                    !response.isSuccessful ->
+                        DictionaryState.Failed("HTTP ${response.code}", host)
                     else -> {
-                        val senses = parseWiktionaryDefinitions(
-                            response.body?.string().orEmpty(),
-                            languages,
-                        )
+                        val senses = parse(response.body?.string().orEmpty())
                         if (senses.isEmpty()) {
                             DictionaryState.NotFound
                         } else {
@@ -83,13 +148,16 @@ class WiktionaryClient(
                     }
                 }
             }
-        }.getOrElse { DictionaryState.Failed(it.message) }
+        }.getOrElse { DictionaryState.Failed(it.message, host) }
     }
 
     companion object {
         private val USER_AGENT =
             "Liseur/${BuildConfig.VERSION_NAME} " +
                 "(https://github.com/chmouel/liseur; ebook reader)"
+
+        /** In every edition, and short: what [probe] asks for. */
+        private const val PROBE_WORD = "book"
 
         fun default(): OkHttpClient = OkHttpClient.Builder()
             .connectTimeout(10, TimeUnit.SECONDS)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/dictionary/WiktionaryHtml.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/dictionary/WiktionaryHtml.kt
@@ -1,0 +1,120 @@
+package com.chmouel.liseur.reader.dictionary
+
+import java.util.Locale
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+
+/**
+ * Reads definitions out of a Wiktionary page as Parsoid HTML
+ * (`/api/rest_v1/page/html/{term}`).
+ *
+ * The tidy JSON endpoint (`page/definition`) only exists on
+ * en.wiktionary.org — every other edition answers it with a 501 — so the
+ * other editions get their entry page parsed instead. The page is one
+ * `<section>` per language with an `<h2>` naming it, part-of-speech
+ * subsections under `<h3>`, and the senses in an `<ol>` (most editions),
+ * a `<dl>` of `[1]`-numbered `<dd>`s (German style) or a `<dl>` of
+ * numbered `<dt>`s (Spanish style).
+ *
+ * Pure function on a string, like [parseWiktionaryDefinitions], so the
+ * awkward pages become fixtures rather than field reports.
+ */
+fun parseWiktionaryEntryHtml(
+    html: String,
+    languages: List<String> = emptyList(),
+): List<DictionarySense> {
+    val document = runCatching { Jsoup.parse(html) }.getOrNull() ?: return emptyList()
+    val sections = document.select("section:has(> h2)")
+    if (sections.isEmpty()) return emptyList()
+
+    val wantedNames = languages.flatMap(::displayNamesOf).toSet()
+    val ordered = sections.sortedByDescending { section ->
+        val heading = section.selectFirst("> h2")?.text().orEmpty().lowercase()
+        wantedNames.count { heading.contains(it) }
+    }
+
+    for (section in ordered) {
+        val senses = sensesOf(section)
+        if (senses.isNotEmpty()) return senses
+    }
+    return emptyList()
+}
+
+/**
+ * A language's name as each Wiktionary edition would write it in a
+ * section heading: «Français» at home, "French" in English, «Francés»
+ * in Spanish. The page does not say which edition it came from, so the
+ * heading is matched against all the spellings at once.
+ */
+private fun displayNamesOf(languageCode: String): List<String> {
+    val language = Locale.forLanguageTag(languageCode)
+    if (language.language.isEmpty()) return emptyList()
+    return HEADING_LOCALES
+        .map { language.getDisplayLanguage(Locale.forLanguageTag(it)).lowercase() }
+        .filter { it.isNotBlank() && it != language.language }
+        .distinct()
+}
+
+private val HEADING_LOCALES = listOf(
+    "en", "fr", "de", "es", "it", "pt", "nl", "pl", "sv", "da", "no", "fi",
+    "cs", "hu", "ro", "ca", "el", "ru", "uk", "tr", "ar", "fa", "hi", "ja",
+    "ko", "zh",
+)
+
+private fun sensesOf(languageSection: Element): List<DictionarySense> {
+    val senses = mutableListOf<DictionarySense>()
+    val subsections = languageSection.select("section:has(> h3), section:has(> h4)")
+    for (subsection in subsections) {
+        val definitions = definitionsOf(subsection)
+        if (definitions.isEmpty()) continue
+        val heading = subsection.selectFirst("> h3, > h4")?.text().orEmpty()
+        senses += DictionarySense(
+            partOfSpeech = heading.replace(Regex("\\s*\\d+$"), "").trim(),
+            definitions = definitions,
+        )
+    }
+    return senses
+}
+
+private fun definitionsOf(subsection: Element): List<String> {
+    val fromLists = subsection.select("> ol, > p ~ ol")
+        .asSequence()
+        .filterNot { it.hasClass("references") || it.attr("typeof").contains("mw:Extension/references") }
+        .flatMap { it.select("> li") }
+        .filterNot { it.id().startsWith("cite_note") }
+        .map(::definitionText)
+        .filter { it.isNotBlank() }
+        .toList()
+    if (fromLists.isNotEmpty()) return fromLists
+
+    // German-style <dd>[1] …</dd> and Spanish-style <dt>1 …</dt><dd>…</dd>.
+    val fromGlossaries = mutableListOf<String>()
+    for (glossary in subsection.select("dl")) {
+        for (item in glossary.select("> dd")) {
+            val text = definitionText(item)
+            if (text.matches(NUMBERED_DEFINITION)) fromGlossaries += text
+        }
+        if (fromGlossaries.isNotEmpty()) continue
+        for (term in glossary.select("> dt")) {
+            if (!term.text().trim().matches(NUMBERED_TERM)) continue
+            val text = definitionText(term.nextElementSibling()?.takeIf { it.tagName() == "dd" } ?: continue)
+            if (text.isNotBlank()) fromGlossaries += text
+        }
+    }
+    return fromGlossaries.map { it.replace(LEADING_NUMBER, "") }
+}
+
+/**
+ * The item's own words: quotations, sub-senses and usage examples nest
+ * inside the item as further lists, and belong to the full entry, not
+ * to a card.
+ */
+private fun definitionText(item: Element): String {
+    val copy = item.clone()
+    copy.select("ul, ol, dl, style, .references").forEach(Element::remove)
+    return copy.text().trim()
+}
+
+private val NUMBERED_DEFINITION = Regex("^\\[\\d+[a-z]?].*", RegexOption.DOT_MATCHES_ALL)
+private val NUMBERED_TERM = Regex("^\\d+[a-z]?\\b.*", RegexOption.DOT_MATCHES_ALL)
+private val LEADING_NUMBER = Regex("^\\[\\d+[a-z]?]\\s*")

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
@@ -25,6 +25,9 @@ import androidx.compose.material.icons.outlined.HelpOutline
 import androidx.compose.material.icons.outlined.TextFormat
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -33,6 +36,7 @@ import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
@@ -42,6 +46,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -69,6 +74,8 @@ import com.chmouel.liseur.data.settings.EInkMode
 import com.chmouel.liseur.data.settings.ReaderThemeChoice
 import com.chmouel.liseur.data.settings.ThemeMode
 import com.chmouel.liseur.domain.DictionaryUrl
+import com.chmouel.liseur.domain.WiktionaryEditions
+import com.chmouel.liseur.reader.dictionary.WiktionaryClient
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.reading.label
 import com.chmouel.liseur.ui.windowWidth
@@ -353,14 +360,45 @@ private val DefinitionTarget.label: Int
  * Where definitions come from.
  *
  * Shown only once online lookups are on, because until then there is no
- * site to pick. The field keeps what is typed and only commits it once it
- * parses, so a half-typed address never becomes the stored one.
+ * site to pick. A dropdown of editions by name replaced the bare URL
+ * field after a reader misspelled fr.wiktionary.org and got nothing but
+ * an HTTP 501 out of it — a name cannot be typo'd. Mirrors still fit
+ * through the custom entry, which keeps what is typed and only commits
+ * it once it parses, so a half-typed address never becomes the stored
+ * one. Every committed choice is then tried against the site once,
+ * right here, so a dead address fails under the field and not later in
+ * the reader.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DictionarySiteRow(baseUrl: String, onBaseUrl: (String) -> Unit) {
-    var typed by remember(baseUrl) { mutableStateOf(baseUrl) }
+    val storedEdition = remember(baseUrl) { WiktionaryEditions.editionOf(baseUrl) }
+    var customChosen by remember(baseUrl) { mutableStateOf(storedEdition == null) }
+    var expanded by remember { mutableStateOf(false) }
+    var typed by remember(baseUrl) { mutableStateOf(if (storedEdition == null) baseUrl else "") }
     val normalised = remember(typed) { DictionaryUrl.normalise(typed) }
     val invalid = typed.isNotBlank() && normalised == null
+
+    // Probed only when the reader commits a choice here — never on
+    // merely opening the screen, because a request nobody asked for
+    // has no place in this app.
+    var probeTarget by remember { mutableStateOf<String?>(null) }
+    var probeResult by remember { mutableStateOf<ProbeUi>(ProbeUi.Idle) }
+    val client = remember { WiktionaryClient() }
+    LaunchedEffect(probeTarget) {
+        val target = probeTarget ?: return@LaunchedEffect
+        probeResult = ProbeUi.Checking
+        val error = client.probe(target)
+        probeResult = if (error == null) {
+            ProbeUi.Ok(DictionaryUrl.hostOf(target))
+        } else {
+            ProbeUi.Unreachable(DictionaryUrl.hostOf(target), error)
+        }
+    }
+    val commit = { url: String ->
+        onBaseUrl(url)
+        probeTarget = url
+    }
 
     Column(Modifier.padding(horizontal = 16.dp, vertical = 10.dp)) {
         Text(
@@ -372,34 +410,109 @@ private fun DictionarySiteRow(baseUrl: String, onBaseUrl: (String) -> Unit) {
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        OutlinedTextField(
-            value = typed,
-            onValueChange = {
-                typed = it
-                DictionaryUrl.normalise(it)?.let(onBaseUrl)
-            },
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = it },
             modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
-            singleLine = true,
-            isError = invalid,
-            placeholder = { Text(stringResource(R.string.settings_dictionary_site_hint)) },
-            supportingText = if (invalid) {
-                { Text(stringResource(R.string.settings_dictionary_site_invalid)) }
-            } else {
-                null
-            },
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-        )
-        if (normalised != DictionaryUrl.DEFAULT_BASE_URL) {
+        ) {
+            OutlinedTextField(
+                value = if (customChosen) {
+                    stringResource(R.string.settings_dictionary_site_custom)
+                } else {
+                    storedEdition?.nativeName.orEmpty()
+                },
+                onValueChange = {},
+                readOnly = true,
+                singleLine = true,
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+            )
+            ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                WiktionaryEditions.all.forEach { edition ->
+                    DropdownMenuItem(
+                        text = { Text(edition.nativeName) },
+                        onClick = {
+                            expanded = false
+                            customChosen = false
+                            commit(edition.baseUrl)
+                        },
+                    )
+                }
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.settings_dictionary_site_custom)) },
+                    onClick = {
+                        expanded = false
+                        customChosen = true
+                    },
+                )
+            }
+        }
+        if (customChosen) {
+            OutlinedTextField(
+                value = typed,
+                onValueChange = {
+                    typed = it
+                    DictionaryUrl.normalise(it)?.let(commit)
+                },
+                modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
+                singleLine = true,
+                isError = invalid,
+                placeholder = { Text(stringResource(R.string.settings_dictionary_site_hint)) },
+                supportingText = if (invalid) {
+                    { Text(stringResource(R.string.settings_dictionary_site_invalid)) }
+                } else {
+                    null
+                },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+            )
+        }
+        when (val probe = probeResult) {
+            ProbeUi.Idle -> Unit
+            ProbeUi.Checking -> Text(
+                text = stringResource(R.string.settings_dictionary_site_checking),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+            is ProbeUi.Ok -> Text(
+                text = stringResource(R.string.settings_dictionary_site_ok, probe.host),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+            is ProbeUi.Unreachable -> Text(
+                text = stringResource(
+                    R.string.settings_dictionary_site_unreachable,
+                    probe.host,
+                    probe.error,
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+        }
+        if (baseUrl != DictionaryUrl.DEFAULT_BASE_URL) {
             TextButton(
                 onClick = {
-                    typed = DictionaryUrl.DEFAULT_BASE_URL
-                    onBaseUrl(DictionaryUrl.DEFAULT_BASE_URL)
+                    typed = ""
+                    customChosen = false
+                    commit(DictionaryUrl.DEFAULT_BASE_URL)
                 },
             ) {
                 Text(stringResource(R.string.settings_dictionary_site_reset))
             }
         }
     }
+}
+
+/** The one-shot check of a committed dictionary site, as the row shows it. */
+private sealed interface ProbeUi {
+    data object Idle : ProbeUi
+    data object Checking : ProbeUi
+    data class Ok(val host: String) : ProbeUi
+    data class Unreachable(val host: String, val error: String) : ProbeUi
 }
 
 /**

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -62,6 +63,7 @@ import androidx.compose.foundation.text.ClickableText
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.chmouel.liseur.R
@@ -364,10 +366,10 @@ private val DefinitionTarget.label: Int
  * field after a reader misspelled fr.wiktionary.org and got nothing but
  * an HTTP 501 out of it — a name cannot be typo'd. Mirrors still fit
  * through the custom entry, which keeps what is typed and only commits
- * it once it parses, so a half-typed address never becomes the stored
- * one. Every committed choice is then tried against the site once,
- * right here, so a dead address fails under the field and not later in
- * the reader.
+ * it on Done, once it parses — so a half-typed address never becomes
+ * the stored one. Every committed choice is then tried against the site
+ * once, right here, so a dead address fails under the field and not
+ * later in the reader.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -385,6 +387,14 @@ private fun DictionarySiteRow(baseUrl: String, onBaseUrl: (String) -> Unit) {
     var probeTarget by remember { mutableStateOf<String?>(null) }
     var probeResult by remember { mutableStateOf<ProbeUi>(ProbeUi.Idle) }
     val client = remember { WiktionaryClient() }
+    LaunchedEffect(baseUrl) {
+        // The stored site moved under us (a restore, another writer):
+        // whatever the probe said, it said it about somewhere else.
+        if (probeTarget != null && probeTarget != baseUrl) {
+            probeTarget = null
+            probeResult = ProbeUi.Idle
+        }
+    }
     LaunchedEffect(probeTarget) {
         val target = probeTarget ?: return@LaunchedEffect
         probeResult = ProbeUi.Checking
@@ -452,10 +462,7 @@ private fun DictionarySiteRow(baseUrl: String, onBaseUrl: (String) -> Unit) {
         if (customChosen) {
             OutlinedTextField(
                 value = typed,
-                onValueChange = {
-                    typed = it
-                    DictionaryUrl.normalise(it)?.let(commit)
-                },
+                onValueChange = { typed = it },
                 modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
                 singleLine = true,
                 isError = invalid,
@@ -465,7 +472,14 @@ private fun DictionarySiteRow(baseUrl: String, onBaseUrl: (String) -> Unit) {
                 } else {
                     null
                 },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Uri,
+                    imeAction = ImeAction.Done,
+                ),
+                // Committed on Done, not per keystroke: a commit stores
+                // the setting and probes the site, and a half-typed host
+                // deserves neither.
+                keyboardActions = KeyboardActions(onDone = { normalised?.let(commit) }),
             )
         }
         when (val probe = probeResult) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -326,6 +326,7 @@
     <string name="dictionary_not_found">No entry for “%1$s”.</string>
     <string name="dictionary_failed">Could not reach the dictionary.</string>
     <string name="dictionary_failed_reason">Could not reach the dictionary: %1$s</string>
+    <string name="dictionary_failed_host">Could not reach %1$s (%2$s). Check the dictionary site in Settings.</string>
     <string name="dictionary_other_app">Open in app</string>
     <string name="dictionary_open_full_entry">Full entry</string>
     <string name="dictionary_disabled_explanation">Definitions are off. Turning them on lets Liseur send the word you tapped, and nothing else, to %1$s. A dictionary app on your phone works without any of that.</string>
@@ -444,10 +445,14 @@
     <string name="settings_dictionary_lookup">Look up definitions online</string>
     <string name="settings_dictionary_lookup_detail">Off by default. When on, defining a word sends that word to the site below — the only place Liseur talks to besides your own book server.</string>
     <string name="settings_dictionary_site">Dictionary site</string>
-    <string name="settings_dictionary_site_detail">Any Wiktionary edition or mirror. Use your own language\'s edition to get its definitions first.</string>
+    <string name="settings_dictionary_site_detail">Pick your language\'s Wiktionary to get its definitions, in its words.</string>
+    <string name="settings_dictionary_site_custom">Custom site…</string>
     <string name="settings_dictionary_site_hint">https://en.wiktionary.org</string>
     <string name="settings_dictionary_site_invalid">Needs to be an https address, like https://fr.wiktionary.org</string>
     <string name="settings_dictionary_site_reset">Use the default</string>
+    <string name="settings_dictionary_site_checking">Checking…</string>
+    <string name="settings_dictionary_site_ok">%1$s answers.</string>
+    <string name="settings_dictionary_site_unreachable">%1$s did not answer: %2$s</string>
     <string name="settings_library">Library</string>
     <string name="settings_group_series">Group series</string>
     <string name="settings_group_series_detail">Show the books of a series as one pile on the shelf, alongside your other books.</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/DictionaryUrlTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/DictionaryUrlTest.kt
@@ -56,6 +56,10 @@ class DictionaryUrlTest {
             DictionaryUrl.definitionApi("https://fr.wiktionary.org", "chat"),
         )
         assertEquals(
+            "https://fr.wiktionary.org/api/rest_v1/page/html/chat",
+            DictionaryUrl.pageHtmlApi("https://fr.wiktionary.org", "chat"),
+        )
+        assertEquals(
             "https://fr.wiktionary.org/wiki/chat",
             DictionaryUrl.entryPage("https://fr.wiktionary.org", "chat"),
         )

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/WiktionaryEditionsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/WiktionaryEditionsTest.kt
@@ -1,0 +1,49 @@
+package com.chmouel.liseur.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WiktionaryEditionsTest {
+
+    @Test
+    fun `an edition's base url is its subdomain`() {
+        val french = WiktionaryEditions.all.first { it.code == "fr" }
+        assertEquals("https://fr.wiktionary.org", french.baseUrl)
+    }
+
+    @Test
+    fun `a stored url maps back to its edition`() {
+        assertEquals("fr", WiktionaryEditions.editionOf("https://fr.wiktionary.org")?.code)
+        assertEquals("en", WiktionaryEditions.editionOf("https://en.wiktionary.org")?.code)
+    }
+
+    @Test
+    fun `anything else is custom`() {
+        assertNull(WiktionaryEditions.editionOf("https://mirror.example/wiktionary"))
+        assertNull(WiktionaryEditions.editionOf("https://fr.wikictionnary.org"))
+        assertNull(WiktionaryEditions.editionOf(null))
+        // A real edition, just not one the picker lists.
+        assertNull(WiktionaryEditions.editionOf("https://eo.wiktionary.org"))
+    }
+
+    @Test
+    fun `recognises any wikimedia-hosted edition, listed or not`() {
+        assertTrue(WiktionaryEditions.isWiktionaryHost("https://fr.wiktionary.org"))
+        assertTrue(WiktionaryEditions.isWiktionaryHost("https://eo.wiktionary.org"))
+        assertFalse(WiktionaryEditions.isWiktionaryHost("https://mirror.example"))
+        // The misspelling that earned this file is not a Wiktionary.
+        assertFalse(WiktionaryEditions.isWiktionaryHost("https://fr.wikictionnary.org"))
+        assertFalse(WiktionaryEditions.isWiktionaryHost("https://a.b.wiktionary.org"))
+    }
+
+    @Test
+    fun `every listed edition is picked out of its own url`() {
+        for (edition in WiktionaryEditions.all) {
+            assertEquals(edition, WiktionaryEditions.editionOf(edition.baseUrl))
+            assertTrue(WiktionaryEditions.isWiktionaryHost(edition.baseUrl))
+        }
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/dictionary/WiktionaryClientTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/dictionary/WiktionaryClientTest.kt
@@ -6,6 +6,7 @@ import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -111,7 +112,48 @@ class WiktionaryClientTest {
 
         val state = WiktionaryClient().define("chat", listOf("en"), baseUrl())
 
-        assertEquals(DictionaryState.Failed("HTTP 503"), state)
+        assertEquals(DictionaryState.Failed("HTTP 503", "127.0.0.1:${server.port}"), state)
+    }
+
+    /**
+     * Only en.wiktionary.org implements the definition endpoint; other
+     * wikis and bare mirrors answer it with a 501. The entry page is the
+     * fallback, so those hosts still define words.
+     */
+    @Test
+    fun `falls back to the entry page when the definition endpoint is a 501`() = runBlocking {
+        server.enqueue(MockResponse(code = 501, body = """{"status":501}"""))
+        server.enqueue(
+            MockResponse(
+                code = 200,
+                body = """
+                    <html><body><section><h2>Français</h2>
+                    <section><h3>Nom commun</h3><ol><li>Un félin.</li></ol></section>
+                    </section></body></html>
+                """.trimIndent(),
+            ),
+        )
+
+        val state = WiktionaryClient().define("chat", listOf("fr"), baseUrl())
+
+        assertEquals("/api/rest_v1/page/definition/chat", server.takeRequest().target)
+        assertEquals("/api/rest_v1/page/html/chat", server.takeRequest().target)
+        assertTrue(state is DictionaryState.Found)
+        assertEquals("Un félin.", (state as DictionaryState.Found).senses.single().definitions.single())
+    }
+
+    @Test
+    fun `a probe passes when the site answers, even with nothing found`() = runBlocking {
+        server.enqueue(MockResponse(code = 404))
+
+        assertNull(WiktionaryClient().probe(baseUrl()))
+    }
+
+    @Test
+    fun `a probe fails with the reason when the site does not answer`() = runBlocking {
+        server.enqueue(MockResponse(code = 503))
+
+        assertEquals("HTTP 503", WiktionaryClient().probe(baseUrl()))
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/dictionary/WiktionaryHtmlTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/dictionary/WiktionaryHtmlTest.kt
@@ -1,0 +1,136 @@
+package com.chmouel.liseur.reader.dictionary
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The Parsoid entry-page parser, against the three shapes the editions
+ * actually use: an `<ol>` of senses (French and most others), a `<dl>`
+ * of `[1]`-numbered `<dd>`s (German), and a `<dl>` of numbered `<dt>`s
+ * (Spanish). The fixtures are trimmed from real pages.
+ */
+class WiktionaryHtmlTest {
+
+    private val french = """
+        <html><body>
+        <section data-mw-section-id="1"><h2 id="Français">Français</h2>
+          <section><h3 id="Étymologie">Étymologie</h3><p>Du latin liber.</p></section>
+          <section><h3 id="Nom_commun_1">Nom commun 1</h3>
+            <p>livre masculin</p>
+            <ol>
+              <li>Assemblage de <a href="./feuille">feuilles</a> imprimées.
+                <ul><li><span class="example">C’est le livre des Destinées.</span></li></ul>
+              </li>
+              <li>Registre de comptes.</li>
+            </ol>
+          </section>
+          <section><h3 id="Références">Références</h3>
+            <ol class="references" typeof="mw:Extension/references">
+              <li id="cite_note-1">Un renvoi.</li>
+            </ol>
+          </section>
+        </section>
+        <section data-mw-section-id="2"><h2 id="Portugais">Portugais</h2>
+          <section><h3 id="Adjectif">Adjectif</h3><ol><li>Libre.</li></ol></section>
+        </section>
+        </body></html>
+    """.trimIndent()
+
+    private val german = """
+        <html><body>
+        <section><h2 id="Buch_(Deutsch)">Buch (Deutsch)</h2>
+          <section><h3 id="Substantiv,_n">Substantiv, n</h3>
+            <p>Worttrennung:</p>
+            <dl><dd>Buch, Plural: Bü·cher</dd></dl>
+            <p>Bedeutungen:</p>
+            <dl>
+              <dd>[1] fest gebundenes <a href="./Schriftwerk">Schriftwerk</a></dd>
+              <dd>[2] literarische Publikation in Buchform</dd>
+            </dl>
+          </section>
+        </section>
+        </body></html>
+    """.trimIndent()
+
+    private val spanish = """
+        <html><body>
+        <section><h2 id="Alemán">Alemán</h2>
+          <section><h3 id="Sustantivo_neutro">Sustantivo neutro</h3>
+            <dl><dt>1 Cultura</dt><dd><a href="./libro">libro</a>.</dd></dl>
+          </section>
+        </section>
+        </body></html>
+    """.trimIndent()
+
+    @Test
+    fun `reads senses out of a French-style entry`() {
+        val senses = parseWiktionaryEntryHtml(french, listOf("fr"))
+
+        assertEquals(listOf("Nom commun"), senses.map { it.partOfSpeech })
+        assertEquals(
+            listOf("Assemblage de feuilles imprimées.", "Registre de comptes."),
+            senses.single().definitions,
+        )
+    }
+
+    @Test
+    fun `prefers the section of the book's language`() {
+        val senses = parseWiktionaryEntryHtml(french, listOf("pt"))
+
+        assertEquals(listOf("Adjectif"), senses.map { it.partOfSpeech })
+        assertEquals(listOf("Libre."), senses.single().definitions)
+    }
+
+    @Test
+    fun `falls back to the first section with senses`() {
+        val senses = parseWiktionaryEntryHtml(french, listOf("ja"))
+
+        assertEquals("Nom commun", senses.first().partOfSpeech)
+    }
+
+    @Test
+    fun `usage examples stay in the full entry, not on the card`() {
+        val senses = parseWiktionaryEntryHtml(french, listOf("fr"))
+
+        assertTrue(senses.single().definitions.none { it.contains("Destinées") })
+    }
+
+    @Test
+    fun `footnotes are not definitions`() {
+        val senses = parseWiktionaryEntryHtml(french, listOf("fr"))
+
+        assertTrue(senses.none { it.partOfSpeech == "Références" })
+    }
+
+    @Test
+    fun `reads senses out of a German-style entry`() {
+        val senses = parseWiktionaryEntryHtml(german, listOf("de"))
+
+        assertEquals(listOf("Substantiv, n"), senses.map { it.partOfSpeech })
+        assertEquals(
+            listOf(
+                "fest gebundenes Schriftwerk",
+                "literarische Publikation in Buchform",
+            ),
+            senses.single().definitions,
+        )
+    }
+
+    @Test
+    fun `reads senses out of a Spanish-style entry`() {
+        val senses = parseWiktionaryEntryHtml(spanish, listOf("de"))
+
+        assertEquals(listOf("Sustantivo neutro"), senses.map { it.partOfSpeech })
+        assertEquals(listOf("libro."), senses.single().definitions)
+    }
+
+    @Test
+    fun `an empty or unparseable page has no senses`() {
+        assertEquals(emptyList<DictionarySense>(), parseWiktionaryEntryHtml(""))
+        assertEquals(
+            emptyList<DictionarySense>(),
+            parseWiktionaryEntryHtml("<html><body><p>Rien.</p></body></html>"),
+        )
+    }
+}

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -59,7 +59,10 @@ to the dictionary site configured in Settings — by default the public
 Wiktionary API — over HTTPS. No identifier, no book title and no account
 accompanies it. You may point this at any Wiktionary edition or mirror,
 or leave the feature off and hand words to an offline dictionary app
-installed on your device instead.
+installed on your device instead. When you pick or type a dictionary
+site in Settings, Liseur checks it once with a fixed word ("book") so a
+dead address fails there and then; no request is made just for opening
+the screen.
 
 Liseur never contacts any other host. It requests the `INTERNET` and
 `ACCESS_NETWORK_STATE` permissions for the two purposes above and for


### PR DESCRIPTION
## Summary

Fixes #57 — reported by @fredo333@framapiaf.org on Mastodon: replacing the default English dictionary with `https://fr.wikictionnary.org` fails with an HTTP 501.

Two bugs behind the report:

1. Wikimedia's REST `page/definition` endpoint is implemented **only on en.wiktionary.org** — every other edition answers it with a 501. Even the correctly spelled `fr.wiktionary.org` never worked, despite the settings copy promising any edition does.
2. The dictionary site was a free-text URL field, so a misspelled domain was syntactically valid, got stored silently, and failed later in the reader as a bare `HTTP 501`.

## Changes

- **Non-English editions now work**: their entry page is fetched as Parsoid HTML (`api/rest_v1/page/html`, served by every edition) and definitions are parsed out with jsoup, covering the three shapes editions use — `<ol>` of senses (French and most others), `<dl>` of `[1]`-numbered `<dd>`s (German), `<dl>` of numbered `<dt>`s (Spanish).
- **Unknown hosts (mirrors)** still get the JSON endpoint first and fall back to the page on a 501.
- **Settings: edition picker by name** (Français, Deutsch, Español, … 26 editions) replaces the free-text field; a name cannot be typo'd. A "Custom site…" entry keeps mirrors possible, with the same https-only validation.
- **Probe on commit**: every committed choice is tried once against the site with a fixed word, so a dead address fails right under the field ("fr.wiktionary.org answers." / "… did not answer: HTTP 501") instead of later in the reader. No request is made just for opening the screen; the row only exists once online lookups are opted into.
- **Reader failure message** now names the host and points at the setting: "Could not reach fr.wiktionary.org (HTTP 501). Check the dictionary site in Settings."
- `docs/PRIVACY.md` documents the one-shot probe.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [ ] Manually tested on a device or emulator, if applicable

New unit tests: Parsoid parser (fr/de/es shapes, example/footnote exclusion, language-section selection), edition↔URL mapping, 501→page fallback, probe semantics. Parser additionally exercised against the real downloaded fr/de/es pages during development.

## Screenshots or recordings

_To be added if an emulator run is authorized._

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories (no new dependencies; jsoup was already in the catalog).
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.