### PR TITLE
fix: keep reading position when typography changes

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapper.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapper.kt
@@ -66,9 +66,14 @@ fun ReaderPrefs.toEpubPreferences(
             ColumnMode.ONE -> ColumnCount.ONE
             ColumnMode.TWO -> ColumnCount.TWO
         },
-        // Readium CSS only applies font-size and advanced settings (line
-        // height, margins…) when publisher styles are turned off.
-        publisherStyles = if (fontSize != 1.0 || lineHeight != null || pageMargins != null) {
+        // Readium CSS applies the font size whatever the publisher styles
+        // say, but only applies the advanced settings (line height,
+        // margins…) when they are turned off. So they are only turned off
+        // for those: turning them off rewrites the size of every element
+        // on the page, and having that happen because a font-size slider
+        // crossed its default made the page reflow far beyond the change
+        // that was asked for — and the reading position with it.
+        publisherStyles = if (lineHeight != null || pageMargins != null) {
             false
         } else {
             null

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -143,6 +143,14 @@ import org.readium.r2.shared.publication.Publication
 /** Duration of the gentle chrome show/hide animation. */
 private const val CHROME_ANIM_MS = 300
 
+// A reflow wait is measured in settleLayout() steps of two frames each.
+// The first bound is how long a preference gets to start reflowing the
+// page before it is taken not to reflow at all (a colour change never
+// does); the second is how long a reflow gets to come to rest.
+private const val REFLOW_START_POLLS = 8
+private const val REFLOW_SETTLE_POLLS = 30
+private const val VERIFY_ATTEMPTS = 3
+
 @OptIn(
     ExperimentalMaterial3Api::class,
     ExperimentalReadiumApi::class,
@@ -240,12 +248,43 @@ fun ReaderScreen(
     val effectScope = rememberCoroutineScope()
     var pendingPositionEvent by remember { mutableStateOf<NavigatorPositionEvent?>(null) }
 
+    // The place the reader was at when a run of preference changes began.
+    // A restore that lands slightly off must not become the anchor of the
+    // next change, or each nudge of a slider walks the position a little
+    // further from the page being read; the anchor is held until the
+    // reader actually moves, and every reflow restores to the same spot.
+    var reflowAnchor by remember { mutableStateOf<Locator?>(null) }
+
     suspend fun capture(nav: EpubNavigatorFragment, locator: Locator): Locator =
         onProgressAction.prepareLocator(ExactLocatorAnchor.capture(nav, locator))
 
     suspend fun settleLayout() {
         withFrameNanos { }
         withFrameNanos { }
+    }
+
+    // Waits for the WebView to finish reflowing after a preference lands.
+    // Readium applies preferences as CSS inside the WebView on its own
+    // schedule, so counting frames of the Compose clock says nothing
+    // about it: the page keeps changing size while text is still moving.
+    // Wait first for the layout to differ from what it was — bounded,
+    // because a colour-only change never reflows at all — and then for
+    // two consecutive readings to agree.
+    suspend fun awaitReflowSettled(nav: EpubNavigatorFragment, before: String?) {
+        var last = before
+        var changed = before == null
+        repeat(REFLOW_SETTLE_POLLS) { poll ->
+            settleLayout()
+            val now = ExactLocatorAnchor.layoutSignature(nav) ?: return
+            if (!changed && now == last) {
+                if (poll >= REFLOW_START_POLLS) return
+            } else if (changed && now == last) {
+                return
+            } else {
+                changed = true
+                last = now
+            }
+        }
     }
 
     suspend fun navigate(
@@ -257,8 +296,13 @@ fun ReaderScreen(
         pendingPositionEvent = event
         nav.go(locator, animated = false)
         if (!verify || !ExactLocatorAnchor.isExact(locator)) return
-        settleLayout()
-        if (ExactLocatorAnchor.verify(nav, locator)) return
+        // The go above is carried out by a script the WebView runs when
+        // it gets to it; asking too early answers for the page it is
+        // still leaving. Look a few times before declaring it missed.
+        repeat(VERIFY_ATTEMPTS) {
+            settleLayout()
+            if (ExactLocatorAnchor.verify(nav, locator)) return
+        }
         val progression = locator.locations.totalProgression ?: return
         val fallback = onProgressAction.locatorAtOrBeforeProgression(progression) ?: return
         pendingPositionEvent = event
@@ -329,6 +373,9 @@ fun ReaderScreen(
             nav.currentLocator.drop(1).collect { native ->
                 val event = pendingPositionEvent ?: NavigatorPositionEvent.READER_MOVEMENT
                 pendingPositionEvent = null
+                // Anywhere the reader actually goes ends the run of
+                // preference changes the held anchor was covering.
+                if (event != NavigatorPositionEvent.PREFERENCE_REFLOW) reflowAnchor = null
                 onLocatorChanged(capture(nav, native), event)
             }
         }
@@ -371,11 +418,13 @@ fun ReaderScreen(
         }
             .drop(1)
             .collect {
-                val anchor = capture(nav, nav.currentLocator.value)
+                val anchor = reflowAnchor ?: capture(nav, nav.currentLocator.value)
+                reflowAnchor = anchor
                 onLocatorChanged(anchor, NavigatorPositionEvent.PREFERENCE_REFLOW)
+                val before = ExactLocatorAnchor.layoutSignature(nav)
                 pendingPositionEvent = NavigatorPositionEvent.PREFERENCE_REFLOW
                 nav.submitPreferences(it)
-                settleLayout()
+                awaitReflowSettled(nav, before)
                 navigate(
                     nav = nav,
                     locator = anchor,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/progress/ExactLocatorAnchor.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/progress/ExactLocatorAnchor.kt
@@ -113,6 +113,19 @@ object ExactLocatorAnchor {
             .takeIf(String::isNotEmpty)
     }
 
+    /**
+     * A fingerprint of the page's laid-out size.
+     *
+     * The value itself means nothing; what matters is whether two
+     * readings taken a moment apart agree. While a reflow is moving
+     * text around the document keeps changing size, so agreement is
+     * how the caller knows the layout has come to rest.
+     */
+    @OptIn(ExperimentalReadiumApi::class)
+    suspend fun layoutSignature(navigator: EpubNavigatorFragment): String? =
+        runCatching { navigator.evaluateJavascript(SIGNATURE_SCRIPT) }.getOrNull()
+            ?.takeIf { it.isNotBlank() && it != "null" }
+
     @OptIn(ExperimentalReadiumApi::class)
     suspend fun capture(navigator: EpubNavigatorFragment, native: Locator): Locator {
         val result = runCatching { navigator.evaluateJavascript(CAPTURE_SCRIPT) }.getOrNull()
@@ -188,6 +201,13 @@ object ExactLocatorAnchor {
         if (size <= count) return this
         return substring(offsetByCodePoints(0, size - count))
     }
+
+    private val SIGNATURE_SCRIPT = """
+        (() => {
+          const el = document.scrollingElement || document.documentElement;
+          return el.scrollWidth + "x" + el.scrollHeight;
+        })()
+    """.trimIndent()
 
     private val CAPTURE_SCRIPT = """
         (() => {

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapperTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapperTest.kt
@@ -114,6 +114,28 @@ class ReaderPreferencesMapperTest {
     }
 
     @Test
+    fun `a font size change leaves publisher styles alone`() {
+        // Readium CSS applies --USER__fontSize whatever the publisher
+        // styles say. Turning them off just because the slider left its
+        // default rewrites every element's size, and the page reflows far
+        // beyond the change asked for.
+        assertNull(ReaderPrefs().toEpubPreferences(theme).publisherStyles)
+        assertNull(ReaderPrefs(fontSize = 1.4).toEpubPreferences(theme).publisherStyles)
+    }
+
+    @Test
+    fun `advanced settings are what turn publisher styles off`() {
+        assertEquals(
+            false,
+            ReaderPrefs(lineHeight = 1.6).toEpubPreferences(theme).publisherStyles,
+        )
+        assertEquals(
+            false,
+            ReaderPrefs(pageMargins = 1.5).toEpubPreferences(theme).publisherStyles,
+        )
+    }
+
+    @Test
     fun `images are left exactly as the book drew them`() {
         // Readium can dim or invert them on a dark page. We deliberately
         // ask for neither: brightness(80%) leaves a white diagram nearly


### PR DESCRIPTION
## Summary

Changing the font size moved the reading position, sometimes by more than a paragraph, and every further change drifted further away. Fixes #63.

Two things caused it. The restore after a preference change waited exactly two frames while the WebView applied the CSS on its own schedule, so it navigated against a layout that was still moving. And leaving the font-size slider's default flipped publisher styles off, which restyles every element on the page and reflows it far beyond the change asked for. Line height, margins, font and column changes took the same path.

## Changes

- Wait for the page to stop changing size after `submitPreferences` before restoring the position, instead of counting two frames.
- Keep the anchor of the first change in a run of typography changes until the reader actually moves, so an imperfect restore cannot become the anchor of the next change.
- Retry the anchor visibility check a few times before falling back to the coarse progression locator.
- Stop turning publisher styles off for a font-size change; Readium CSS applies `--USER__fontSize` regardless. Line height and margins still turn them off, since they need it.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

Reproduced the jump on the emulator with the previous build (a page starting "were Ottershaw and Chertsey" came back starting "ming before my eyes"), then repeated the same font-size changes on this build: the words at the top of the page stayed on screen across two reflows in both directions.

## Screenshots or recordings

Not included: the fix changes position keeping across a reflow, which a still image cannot show, and the rendered page looks the same as before.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
