### PR TITLE
perf(eink): stop drawing the animations no composable could decline

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -48,6 +48,8 @@ import com.chmouel.liseur.sync.PositionSyncCoordinator
 import com.chmouel.liseur.sync.LatestPositionSync
 import com.chmouel.liseur.sync.PositionSyncWorker
 import com.chmouel.liseur.sync.ReadingPositionPublisher
+import com.chmouel.liseur.ui.eink.EInkDisplay
+import com.chmouel.liseur.ui.eink.OnyxEInkDisplay
 import com.chmouel.liseur.sync.SyncScope
 import android.util.Log
 import org.readium.r2.shared.util.asset.AssetRetriever
@@ -64,6 +66,14 @@ import kotlinx.coroutines.SupervisorJob
  */
 class AppContainer(context: Context) {
     val networkAvailability = AndroidNetworkAvailability(context.applicationContext)
+
+    /**
+     * The maker's screen controller, if this device turns out to have
+     * one. Bound once, lazily, because the answer cannot change while
+     * the process lives and looking is a handful of failed class loads
+     * on every device that is not an e-reader.
+     */
+    val eInkDisplay: EInkDisplay by lazy { OnyxEInkDisplay.bind() }
 
     private val httpClient = DefaultHttpClient()
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)

--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -256,6 +256,8 @@ private fun LiseurApp(settings: AppSettings) {
                 onDynamicColor = { scope.launch { repository.setDynamicColor(it) } },
                 onVolumeKeys = { scope.launch { repository.setVolumeKeysTurnPages(it) } },
                 onEInkMode = { scope.launch { repository.setEInkMode(it) } },
+                onVendorRefresh = { scope.launch { repository.setVendorRefresh(it) } },
+                vendorName = context.container.eInkDisplay.vendor,
                 onResumeLastBook = { scope.launch { repository.setResumeLastBook(it) } },
                 onKeepScreenOn = { scope.launch { repository.setKeepScreenOn(it) } },
                 onGroupSeries = { grouped ->

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
@@ -107,6 +107,11 @@ enum class DefinitionTarget(val id: String) {
  * @param librarySortReversed The library order read back to front.
  * @param libraryFilters What the library grid is narrowed to.
  * @param eInkMode Whether to drop animation for an electronic paper screen.
+ * @param vendorRefresh Whether to drive the panel through the maker's own
+ *   screen controller where the device has one. Off until asked for: it
+ *   is reached by reflection into firmware that differs between devices
+ *   sold under the same name, so it is a thing the reader turns on and
+ *   sees the result of, not a thing done to them.
  * @param definitionTarget Whether Define opens Liseur's definition card or
  *   sends the text to another app.
  * @param dictionaryLookupEnabled Whether Define may ask a dictionary server
@@ -127,6 +132,7 @@ data class AppSettings(
     val librarySortReversed: Boolean = false,
     val libraryFilters: LibraryFilters = LibraryFilters.None,
     val eInkMode: EInkMode = EInkMode.Default,
+    val vendorRefresh: Boolean = false,
     val definitionTarget: DefinitionTarget = DefinitionTarget.Default,
     val dictionaryLookupEnabled: Boolean = false,
     val dictionaryBaseUrl: String = DictionaryUrl.DEFAULT_BASE_URL,
@@ -173,6 +179,7 @@ class AppSettingsRepository(private val context: Context) {
         val LIBRARY_FILTERS = stringPreferencesKey("library_filters")
         val LIBRARY_GROUP_BY_SERIES = booleanPreferencesKey("library_group_by_series")
         val EINK_MODE = stringPreferencesKey("eink_mode")
+        val VENDOR_REFRESH = booleanPreferencesKey("vendor_refresh")
         val DEFINITION_TARGET = stringPreferencesKey("definition_target")
         val DICTIONARY_ENABLED = booleanPreferencesKey("dictionary_lookup_enabled")
         val DICTIONARY_BASE_URL = stringPreferencesKey("dictionary_base_url")
@@ -210,6 +217,7 @@ class AppSettingsRepository(private val context: Context) {
                 groupBySeries = p[Keys.LIBRARY_GROUP_BY_SERIES] ?: true,
             ),
             eInkMode = EInkMode.fromId(p[Keys.EINK_MODE]),
+            vendorRefresh = p[Keys.VENDOR_REFRESH] ?: false,
             definitionTarget = DefinitionTarget.fromId(p[Keys.DEFINITION_TARGET]),
             dictionaryLookupEnabled = p[Keys.DICTIONARY_ENABLED] ?: false,
             dictionaryBaseUrl = p[Keys.DICTIONARY_BASE_URL]?.let(DictionaryUrl::normalise)
@@ -285,6 +293,10 @@ class AppSettingsRepository(private val context: Context) {
 
     suspend fun setEInkMode(mode: EInkMode) {
         context.appSettingsStore.edit { it[Keys.EINK_MODE] = mode.id }
+    }
+
+    suspend fun setVendorRefresh(enabled: Boolean) {
+        context.appSettingsStore.edit { it[Keys.VENDOR_REFRESH] = enabled }
     }
 
     suspend fun setDefinitionTarget(target: DefinitionTarget) {

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
@@ -458,12 +458,6 @@ class ReaderActivity : FragmentActivity() {
         // Leaving the book is the moment the position is worth sending:
         // it is settled, and the reader is likely to pick up elsewhere.
         if (target != null) viewModel.onReaderStopped()
-        // Anything asked of the panel is given back the moment the book
-        // is no longer the thing on screen. Some of these controls are
-        // applied per application but take effect on the hardware, so one
-        // left set is this app's ghosting inflicted on whatever the reader
-        // opens next.
-        container.eInkDisplay.release()
     }
 
     /**

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
@@ -312,6 +312,8 @@ class ReaderActivity : FragmentActivity() {
                                     bookmarkedFlow = viewModel.bookmarked,
                                     selectionEvents = viewModel.selectionEvents,
                                     onSelectionDismissed = viewModel::onSelectionCleared,
+                                    eInkDisplay = container.eInkDisplay,
+                                    vendorRefresh = settings.vendorRefresh,
                                     onAnnotationAction = remember {
                                         ReaderAnnotationActions(
                                             highlight = viewModel::highlight,
@@ -456,6 +458,12 @@ class ReaderActivity : FragmentActivity() {
         // Leaving the book is the moment the position is worth sending:
         // it is settled, and the reader is likely to pick up elsewhere.
         if (target != null) viewModel.onReaderStopped()
+        // Anything asked of the panel is given back the moment the book
+        // is no longer the thing on screen. Some of these controls are
+        // applied per application but take effect on the hardware, so one
+        // left set is this app's ghosting inflicted on whatever the reader
+        // opens next.
+        container.eInkDisplay.release()
     }
 
     /**

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -109,6 +109,7 @@ import com.chmouel.liseur.reader.chrome.PageTurner
 import com.chmouel.liseur.reader.chrome.ReaderTapZones
 import com.chmouel.liseur.reader.chrome.ReadingFooter
 import com.chmouel.liseur.reader.chrome.ScrollEdgeTurner
+import com.chmouel.liseur.reader.chrome.visibleWebView
 import com.chmouel.liseur.reader.chrome.ReadingScrubber
 import com.chmouel.liseur.reader.chrome.ContentsScreen
 import com.chmouel.liseur.reader.chrome.Endpaper
@@ -118,6 +119,7 @@ import com.chmouel.liseur.reader.progress.ReaderProgress
 import com.chmouel.liseur.reader.progress.ExactLocatorAnchor
 import com.chmouel.liseur.reader.search.SearchScreen
 import com.chmouel.liseur.ui.LocalEInk
+import com.chmouel.liseur.ui.eink.EInkDisplay
 import com.chmouel.liseur.ui.BusyIndicator
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.widthClass
@@ -186,6 +188,8 @@ fun ReaderScreen(
     bookmarkedFlow: StateFlow<Boolean>,
     selectionEvents: SharedFlow<SelectionEvent>,
     onSelectionDismissed: () -> Unit,
+    eInkDisplay: EInkDisplay,
+    vendorRefresh: Boolean,
     onAnnotationAction: ReaderAnnotationActions,
     onSearchAction: ReaderSearchActions,
     syncableFlow: StateFlow<Boolean>,
@@ -385,6 +389,25 @@ fun ReaderScreen(
                 if (event != NavigatorPositionEvent.PREFERENCE_REFLOW) reflowAnchor = null
                 onLocatorChanged(capture(nav, native), event)
             }
+        }
+    }
+
+    // Asking the maker's screen controller to repaint the page the way it
+    // repaints text.
+    //
+    // Readium builds a fresh web view for each resource and swaps it in,
+    // so this cannot be said once at the start: it is said again for each
+    // one, keyed on the page on screen. The calls are cheap, and the
+    // controller retires itself for good at the first sign it is not the
+    // one we guessed at, so a device this was wrong about pays for the
+    // guess once.
+    LaunchedEffect(navigator, eInkDisplay, vendorRefresh) {
+        val nav = navigator ?: return@LaunchedEffect
+        if (!vendorRefresh || eInkDisplay.vendor == null) return@LaunchedEffect
+        nav.currentLocator.collect {
+            val root = nav.publicationView
+            eInkDisplay.readingMode(root)
+            visibleWebView(root)?.let(eInkDisplay::optimizeWebView)
         }
     }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -76,6 +76,7 @@ import androidx.fragment.compose.AndroidFragment
 import android.graphics.RectF
 import android.view.HapticFeedbackConstants
 import android.view.View
+import android.webkit.WebView
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.IntOffset
@@ -109,7 +110,7 @@ import com.chmouel.liseur.reader.chrome.PageTurner
 import com.chmouel.liseur.reader.chrome.ReaderTapZones
 import com.chmouel.liseur.reader.chrome.ReadingFooter
 import com.chmouel.liseur.reader.chrome.ScrollEdgeTurner
-import com.chmouel.liseur.reader.chrome.visibleWebView
+import com.chmouel.liseur.reader.chrome.awaitWebView
 import com.chmouel.liseur.reader.chrome.ReadingScrubber
 import com.chmouel.liseur.reader.chrome.ContentsScreen
 import com.chmouel.liseur.reader.chrome.Endpaper
@@ -392,22 +393,34 @@ fun ReaderScreen(
         }
     }
 
-    // Asking the maker's screen controller to repaint the page the way it
-    // repaints text.
+    // Asking the maker's screen controller to repaint the page the way
+    // it repaints text.
     //
-    // Readium builds a fresh web view for each resource and swaps it in,
-    // so this cannot be said once at the start: it is said again for each
-    // one, keyed on the page on screen. The calls are cheap, and the
-    // controller retires itself for good at the first sign it is not the
-    // one we guessed at, so a device this was wrong about pays for the
-    // guess once.
+    //
+    // Both calls are made against the web view the book is actually
+    // drawn in, because Onyx's are per view and the fragment root is not
+    // the view that holds the prose. Readium builds a fresh web view for
+    // each resource and swaps it in, so this cannot be said once at the
+    // start; it is said again whenever the view on screen is not the one
+    // spoken to last. Locator emissions are only the prompt to look —
+    // most of them are the same view a page further on, and cost a
+    // comparison rather than two calls into the firmware.
     LaunchedEffect(navigator, eInkDisplay, vendorRefresh) {
         val nav = navigator ?: return@LaunchedEffect
         if (!vendorRefresh || eInkDisplay.vendor == null) return@LaunchedEffect
+        var spokenTo: WebView? = null
         nav.currentLocator.collect {
-            val root = nav.publicationView
-            eInkDisplay.readingMode(root)
-            visibleWebView(root)?.let(eInkDisplay::optimizeWebView)
+            // The opening emission can arrive before the first resource
+            // has been laid out, and if the reader then simply reads that
+            // page there is no second emission to try again on. So the
+            // first one waits — for frames, briefly, not forever, since a
+            // book that never produces a web view is a book this has
+            // nothing to say about anyway.
+            val web = awaitWebView(nav.publicationView) ?: return@collect
+            if (web === spokenTo) return@collect
+            spokenTo = web
+            eInkDisplay.readingMode(web)
+            eInkDisplay.optimizeWebView(web)
         }
     }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -110,7 +110,8 @@ import com.chmouel.liseur.reader.chrome.PageTurner
 import com.chmouel.liseur.reader.chrome.ReaderTapZones
 import com.chmouel.liseur.reader.chrome.ReadingFooter
 import com.chmouel.liseur.reader.chrome.ScrollEdgeTurner
-import com.chmouel.liseur.reader.chrome.awaitWebView
+import com.chmouel.liseur.reader.chrome.visibleWebView
+import com.chmouel.liseur.reader.chrome.layoutPasses
 import com.chmouel.liseur.reader.chrome.ReadingScrubber
 import com.chmouel.liseur.reader.chrome.ContentsScreen
 import com.chmouel.liseur.reader.chrome.Endpaper
@@ -135,6 +136,8 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import org.readium.r2.navigator.Decoration
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.navigator.preferences.ReadingProgression
@@ -396,27 +399,27 @@ fun ReaderScreen(
     // Asking the maker's screen controller to repaint the page the way
     // it repaints text.
     //
-    //
     // Both calls are made against the web view the book is actually
     // drawn in, because Onyx's are per view and the fragment root is not
     // the view that holds the prose. Readium builds a fresh web view for
     // each resource and swaps it in, so this cannot be said once at the
     // start; it is said again whenever the view on screen is not the one
-    // spoken to last. Locator emissions are only the prompt to look —
-    // most of them are the same view a page further on, and cost a
-    // comparison rather than two calls into the firmware.
+    // spoken to last.
+    //
+    // Positions and layout passes are both only prompts to go and look.
+    // Positions alone would miss the page the book opens at, which is
+    // laid out after the position announcing it and may be the only page
+    // a reader visits; layout alone would be at the mercy of a resource
+    // swapped in without one. Neither costs anything it should not: the
+    // common case is finding the same view again and stopping at a
+    // reference comparison.
     LaunchedEffect(navigator, eInkDisplay, vendorRefresh) {
         val nav = navigator ?: return@LaunchedEffect
         if (!vendorRefresh || eInkDisplay.vendor == null) return@LaunchedEffect
+        val root = nav.publicationView
         var spokenTo: WebView? = null
-        nav.currentLocator.collect {
-            // The opening emission can arrive before the first resource
-            // has been laid out, and if the reader then simply reads that
-            // page there is no second emission to try again on. So the
-            // first one waits — for frames, briefly, not forever, since a
-            // book that never produces a web view is a book this has
-            // nothing to say about anyway.
-            val web = awaitWebView(nav.publicationView) ?: return@collect
+        merge(nav.currentLocator.map { }, layoutPasses(root)).collect {
+            val web = visibleWebView(root) ?: return@collect
             if (web === spokenTo) return@collect
             spokenTo = web
             eInkDisplay.readingMode(web)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReaderWebViews.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReaderWebViews.kt
@@ -1,10 +1,14 @@
 package com.chmouel.liseur.reader.chrome
 
 import android.view.View
-import androidx.compose.runtime.withFrameNanos
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
 import android.webkit.WebView
 import android.graphics.Rect
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.conflate
 
 /**
  * The web view showing the chapter being read.
@@ -39,22 +43,26 @@ private fun collectVisibleWebViews(view: View, into: MutableList<Pair<WebView, R
 }
 
 /**
- * The visible web view, waiting a bounded number of frames for one.
+ * Every time the reader's views are laid out.
  *
- * Readium lays a resource out after it reports having moved there, so
- * asking the instant the position arrives can be a frame or two early —
- * and on the opening page there is no later position to ask again on.
- * Waiting on frames rather than a clock means this costs nothing on a
- * screen that is not drawing, and gives up rather than holding a
- * coroutine open against a book that will never produce one.
+ * Readium reports having moved to a resource before it has laid that
+ * resource out, so anything that needs the web view rather than the
+ * position cannot be driven by positions alone — and on the page a book
+ * opens at there is no second position coming to try again on. Layout is
+ * the signal that actually says a view now exists, and unlike a bounded
+ * wait it cannot run out on a device that took longer than expected.
+ *
+ * It fires often and says nothing about what changed, so it is a prompt
+ * to go and look, not news.
  */
-internal suspend fun awaitWebView(root: View, frames: Int = WEB_VIEW_WAIT_FRAMES): WebView? {
-    repeat(frames) {
-        visibleWebView(root)?.let { return it }
-        withFrameNanos { }
+internal fun layoutPasses(root: View): Flow<Unit> = callbackFlow {
+    val observer = root.viewTreeObserver
+    val listener = ViewTreeObserver.OnGlobalLayoutListener { trySend(Unit) }
+    observer.addOnGlobalLayoutListener(listener)
+    awaitClose {
+        // The observer a view hands out is replaced when it is moved
+        // between windows, and the dead one throws if written to.
+        val current = root.viewTreeObserver
+        if (current.isAlive) current.removeOnGlobalLayoutListener(listener)
     }
-    return visibleWebView(root)
-}
-
-/** About a second of frames on an ordinary screen. */
-private const val WEB_VIEW_WAIT_FRAMES = 60
+}.conflate()

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReaderWebViews.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReaderWebViews.kt
@@ -1,6 +1,7 @@
 package com.chmouel.liseur.reader.chrome
 
 import android.view.View
+import androidx.compose.runtime.withFrameNanos
 import android.view.ViewGroup
 import android.webkit.WebView
 import android.graphics.Rect
@@ -36,3 +37,24 @@ private fun collectVisibleWebViews(view: View, into: MutableList<Pair<WebView, R
             for (i in 0 until view.childCount) collectVisibleWebViews(view.getChildAt(i), into)
     }
 }
+
+/**
+ * The visible web view, waiting a bounded number of frames for one.
+ *
+ * Readium lays a resource out after it reports having moved there, so
+ * asking the instant the position arrives can be a frame or two early —
+ * and on the opening page there is no later position to ask again on.
+ * Waiting on frames rather than a clock means this costs nothing on a
+ * screen that is not drawing, and gives up rather than holding a
+ * coroutine open against a book that will never produce one.
+ */
+internal suspend fun awaitWebView(root: View, frames: Int = WEB_VIEW_WAIT_FRAMES): WebView? {
+    repeat(frames) {
+        visibleWebView(root)?.let { return it }
+        withFrameNanos { }
+    }
+    return visibleWebView(root)
+}
+
+/** About a second of frames on an ordinary screen. */
+private const val WEB_VIEW_WAIT_FRAMES = 60

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReadingProgressUi.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReadingProgressUi.kt
@@ -44,6 +44,7 @@ import com.chmouel.liseur.data.settings.ReaderTheme
 import com.chmouel.liseur.reader.progress.FooterMiddle
 import com.chmouel.liseur.reader.progress.ReaderProgress
 import com.chmouel.liseur.reader.progress.footerMiddle
+import com.chmouel.liseur.ui.LocalEInk
 
 /**
  * The quiet line of text at the bottom of the page, Kindle-style. The
@@ -213,6 +214,35 @@ private fun Modifier.clickableWithoutRipple(onClick: () -> Unit): Modifier =
         onClick = onClick,
     )
 
+/**
+ * The rounded bar the reader chrome speaks from: the page's own ink,
+ * with the page's own paper written on it.
+ *
+ * The lift is drawn two different ways. On a backlit screen a shadow
+ * and a hair of translucency place it above the text. Electronic paper
+ * has neither to give: a shadow is dithered into a halo of grey specks
+ * that then ghosts, and 92% of an ink-coloured bar over a page of text
+ * is that text, faintly, showing through the words on top of it. There
+ * the bar is simply solid, which separates it from the page more
+ * plainly than either.
+ */
+@Composable
+private fun ChromePill(
+    theme: ReaderTheme,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    val eInk = LocalEInk.current
+    Surface(
+        shape = RoundedCornerShape(50),
+        color = if (eInk) theme.foreground else theme.foreground.copy(alpha = 0.92f),
+        contentColor = theme.background,
+        shadowElevation = if (eInk) 0.dp else 6.dp,
+        modifier = modifier.padding(16.dp),
+        content = content,
+    )
+}
+
 /** Small marks along the scrubber showing where chapters begin. */
 private fun Modifier.chapterTicks(ticks: List<Float>, color: Color): Modifier =
     drawWithContent {
@@ -251,13 +281,7 @@ fun JumpBackPill(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Surface(
-        shape = RoundedCornerShape(50),
-        color = theme.foreground.copy(alpha = 0.92f),
-        contentColor = theme.background,
-        shadowElevation = 6.dp,
-        modifier = modifier.padding(16.dp),
-    ) {
+    ChromePill(theme = theme, modifier = modifier) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -345,13 +369,7 @@ fun NextInSeriesPill(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Surface(
-        shape = RoundedCornerShape(50),
-        color = theme.foreground.copy(alpha = 0.92f),
-        contentColor = theme.background,
-        shadowElevation = 6.dp,
-        modifier = modifier.padding(16.dp),
-    ) {
+    ChromePill(theme = theme, modifier = modifier) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -398,13 +416,7 @@ fun CatchUpPill(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Surface(
-        shape = RoundedCornerShape(50),
-        color = theme.foreground.copy(alpha = 0.92f),
-        contentColor = theme.background,
-        shadowElevation = 6.dp,
-        modifier = modifier.padding(16.dp),
-    ) {
+    ChromePill(theme = theme, modifier = modifier) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/EInk.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/EInk.kt
@@ -2,6 +2,11 @@ package com.chmouel.liseur.ui
 
 import android.content.pm.PackageManager
 import android.os.Build
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.LocalOverscrollFactory
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LocalRippleConfiguration
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
@@ -82,10 +87,36 @@ fun isEInkDevice(packageManager: PackageManager): Boolean = isEInkDevice(
     hasFeature = packageManager::hasSystemFeature,
 )
 
-/** Settles [mode] against the device and puts the answer in [LocalEInk]. */
+/**
+ * Settles [mode] against the device and draws [content] for that screen.
+ *
+ * Beyond [LocalEInk], which each screen reads for itself, this is where
+ * the three animations the app never asked for are declined. They come
+ * from Compose, Material and the platform rather than from any of our
+ * own code, so there is no composable to guard: a ripple spreading from
+ * the finger, and a list stretching away from its own end, are drawn by
+ * defaults that can only be turned off from above.
+ *
+ * Material 3 controls pass their ripple explicitly and so never read
+ * [LocalIndication]; for them the choice the API offers is a ripple or
+ * nothing, and nothing is right here. A state layer that finishes
+ * arriving after the finger has lifted, over a screen that has usually
+ * already changed to whatever the tap did, is not feedback.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun ProvideEInk(mode: EInkMode, content: @Composable () -> Unit) {
     val context = LocalContext.current
     val detected = remember(context) { isEInkDevice(context.packageManager) }
-    CompositionLocalProvider(LocalEInk provides mode.resolve(detected), content = content)
+    if (!mode.resolve(detected)) {
+        CompositionLocalProvider(LocalEInk provides false, content = content)
+        return
+    }
+    CompositionLocalProvider(
+        LocalEInk provides true,
+        LocalIndication provides EInkPressIndication,
+        LocalRippleConfiguration provides null,
+        LocalOverscrollFactory provides null,
+        content = content,
+    )
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/EInkInteraction.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/EInkInteraction.kt
@@ -46,26 +46,31 @@ private class EInkPressNode(
     private val interactionSource: InteractionSource,
 ) : Modifier.Node(), DrawModifierNode, CompositionLocalConsumerModifierNode {
 
-    private var presses = 0
-    private var focuses = 0
-    private var hovers = 0
+    private val active = mutableSetOf<Any>()
     private var marked = false
 
     override fun onAttach() {
         coroutineScope.launch {
             interactionSource.interactions.collect { interaction ->
+                // Each ending carries the beginning it ends, and that
+                // object is what is tracked. Counting instead would go
+                // wrong the moment this node attached in the middle of a
+                // gesture and saw a release whose press it never got: the
+                // count would fall below zero and the control would stop
+                // showing anything for the rest of its life.
                 when (interaction) {
-                    is PressInteraction.Press -> presses++
-                    is PressInteraction.Release, is PressInteraction.Cancel -> presses--
-                    is FocusInteraction.Focus -> focuses++
-                    is FocusInteraction.Unfocus -> focuses--
-                    is HoverInteraction.Enter -> hovers++
-                    is HoverInteraction.Exit -> hovers--
+                    is PressInteraction.Press -> active.add(interaction)
+                    is PressInteraction.Release -> active.remove(interaction.press)
+                    is PressInteraction.Cancel -> active.remove(interaction.press)
+                    is FocusInteraction.Focus -> active.add(interaction)
+                    is FocusInteraction.Unfocus -> active.remove(interaction.focus)
+                    is HoverInteraction.Enter -> active.add(interaction)
+                    is HoverInteraction.Exit -> active.remove(interaction.enter)
                 }
                 // Only a change of state is worth a repaint here, which is
                 // the whole point: a press and its release are two frames,
                 // not however many the interaction stream happens to send.
-                val nowMarked = presses > 0 || focuses > 0 || hovers > 0
+                val nowMarked = active.isNotEmpty()
                 if (marked != nowMarked) {
                     marked = nowMarked
                     invalidateDraw()

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/EInkInteraction.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/EInkInteraction.kt
@@ -1,0 +1,83 @@
+package com.chmouel.liseur.ui
+
+import androidx.compose.foundation.IndicationNodeFactory
+import androidx.compose.foundation.interaction.FocusInteraction
+import androidx.compose.foundation.interaction.HoverInteraction
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.DelegatableNode
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.currentValueOf
+import androidx.compose.ui.node.invalidateDraw
+import kotlinx.coroutines.launch
+
+/**
+ * Touch feedback for electronic paper: there, or not there.
+ *
+ * Material's ripple spreads from the finger and fades, which is a
+ * sequence of frames. A panel that takes about a fifth of a second to
+ * repaint cannot show a sequence of frames; it shows some arbitrary
+ * subset of them, late, as a smear over the control. This draws a flat
+ * overlay instead, on when the control is held and off when it is not,
+ * which is one repaint each way and the most any of this hardware was
+ * ever going to manage.
+ *
+ * Focus and hover are drawn the same way, so that moving through the app
+ * with a D-pad or a keyboard still shows where you are.
+ */
+object EInkPressIndication : IndicationNodeFactory {
+
+    override fun create(interactionSource: InteractionSource): DelegatableNode =
+        EInkPressNode(interactionSource)
+
+    override fun equals(other: Any?): Boolean = other === this
+
+    override fun hashCode(): Int = javaClass.hashCode()
+}
+
+/** How much of the content colour a held control is washed with. */
+private const val PRESS_ALPHA = 0.16f
+
+private class EInkPressNode(
+    private val interactionSource: InteractionSource,
+) : Modifier.Node(), DrawModifierNode, CompositionLocalConsumerModifierNode {
+
+    private var presses = 0
+    private var focuses = 0
+    private var hovers = 0
+    private var marked = false
+
+    override fun onAttach() {
+        coroutineScope.launch {
+            interactionSource.interactions.collect { interaction ->
+                when (interaction) {
+                    is PressInteraction.Press -> presses++
+                    is PressInteraction.Release, is PressInteraction.Cancel -> presses--
+                    is FocusInteraction.Focus -> focuses++
+                    is FocusInteraction.Unfocus -> focuses--
+                    is HoverInteraction.Enter -> hovers++
+                    is HoverInteraction.Exit -> hovers--
+                }
+                // Only a change of state is worth a repaint here, which is
+                // the whole point: a press and its release are two frames,
+                // not however many the interaction stream happens to send.
+                val nowMarked = presses > 0 || focuses > 0 || hovers > 0
+                if (marked != nowMarked) {
+                    marked = nowMarked
+                    invalidateDraw()
+                }
+            }
+        }
+    }
+
+    override fun ContentDrawScope.draw() {
+        drawContent()
+        if (marked) {
+            drawRect(color = currentValueOf(LocalContentColor).copy(alpha = PRESS_ALPHA))
+        }
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/EInkInteraction.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/EInkInteraction.kt
@@ -79,6 +79,28 @@ private class EInkPressNode(
         }
     }
 
+    override fun onDetach() {
+        forget()
+    }
+
+    override fun onReset() {
+        forget()
+    }
+
+    /**
+     * Drops what was being tracked, because it can no longer be finished.
+     *
+     * Detaching cancels the collector, so a gesture that was under way
+     * when it happened will never have its ending delivered here. Left
+     * alone, that control comes back attached — or reused by an entirely
+     * different one — still holding a press nobody is making, and stays
+     * tinted for good.
+     */
+    private fun forget() {
+        active.clear()
+        marked = false
+    }
+
     override fun ContentDrawScope.draw() {
         drawContent()
         if (marked) {

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/eink/EInkDisplay.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/eink/EInkDisplay.kt
@@ -1,0 +1,134 @@
+package com.chmouel.liseur.ui.eink
+
+import android.view.View
+import android.webkit.WebView
+
+/**
+ * How the app asks a vendor's screen controller to do something.
+ *
+ * Ordinary Android has nothing to say about electronic paper. It draws
+ * frames and assumes a panel that can show them; whether the panel then
+ * ghosts, flashes, or takes a fifth of a second about it is not
+ * expressible. Makers therefore ship their own controls, and Onyx's are
+ * the ones this reaches for.
+ *
+ * [Absent] is the ordinary answer. Almost every device that runs Liseur
+ * has no such controller, and some that do will spell it in a way this
+ * does not recognise, so nothing here may be load-bearing: everything it
+ * offers is an improvement to a screen that already works without it.
+ */
+interface EInkDisplay {
+
+    /**
+     * What was bound, for the settings screen to show.
+     *
+     * None of this can be tested from a build — the classes exist only
+     * on the devices themselves — so the app says out loud what it
+     * found, and the reader holding the device can see at a glance
+     * whether the guess landed.
+     */
+    val vendor: String?
+
+    /**
+     * Asks that [view] be repainted in the mode meant for pages of text.
+     *
+     * Onyx calls it REGAL: a partial update tuned to leave as little of
+     * the previous page behind as it can, at the cost of some flicker
+     * over dark backgrounds. It is the right mode for a book and the
+     * wrong one for a photograph.
+     */
+    fun readingMode(view: View)
+
+    /**
+     * Asks that a web view not be dropped into the crude two-tone mode
+     * the firmware uses for scrolling web pages.
+     *
+     * A book is rendered in a web view, and prose flattened to pure
+     * black and white loses every antialiased edge on every glyph.
+     */
+    fun optimizeWebView(view: WebView)
+
+    /**
+     * Puts back whatever was changed.
+     *
+     * Called when the reader is no longer in front, and on any failure.
+     * Some of these settings are not the app's to keep: they are applied
+     * per-application by name but take effect on the panel, and one left
+     * switched on is this app's ghosting inflicted on whatever the
+     * reader opens next.
+     */
+    fun release()
+
+    /** The controller nobody has, which is nearly everybody. */
+    object Absent : EInkDisplay {
+        override val vendor: String? = null
+        override fun readingMode(view: View) = Unit
+        override fun optimizeWebView(view: WebView) = Unit
+        override fun release() = Unit
+    }
+}
+
+/**
+ * A shape a vendor's controller might have on a given device.
+ *
+ * Onyx publishes `com.onyx.android.sdk.api.device.epd.EpdController`,
+ * but publishes it as a library apps are expected to bundle — and a
+ * proprietary jar would end Liseur's F-Droid eligibility, so that is not
+ * a door this app can walk through. What is reachable is whatever the
+ * firmware itself put on the classpath, and that is spelled differently
+ * across generations of device and versions of their Android.
+ *
+ * So rather than one name and a hope, this is a list of guesses tried in
+ * order. [updateModeClass] is named separately because the mode is an
+ * enum, and an enum constant has to be resolved by name before it can be
+ * passed to anything.
+ */
+data class EInkVendorShape(
+    val vendor: String,
+    val controllerClass: String,
+    val updateModeClass: String,
+)
+
+/**
+ * The shapes to try, best-known first.
+ *
+ * The first is the SDK's own spelling, which is present on devices that
+ * happen to expose the SDK system-wide. The rest are framework classes
+ * on Onyx's modified Android, which is what an app that bundles nothing
+ * can actually reach.
+ */
+val ONYX_SHAPES: List<EInkVendorShape> = listOf(
+    EInkVendorShape(
+        vendor = "Onyx",
+        controllerClass = "com.onyx.android.sdk.api.device.epd.EpdController",
+        updateModeClass = "com.onyx.android.sdk.api.device.epd.UpdateMode",
+    ),
+    EInkVendorShape(
+        vendor = "Onyx",
+        controllerClass = "android.onyx.EpdController",
+        updateModeClass = "android.onyx.UpdateMode",
+    ),
+    EInkVendorShape(
+        vendor = "Onyx",
+        controllerClass = "android.onyx.epd.EpdController",
+        updateModeClass = "android.onyx.epd.UpdateMode",
+    ),
+)
+
+/**
+ * The first shape whose classes [isPresent] says are on this device.
+ *
+ * Kept apart from the reflection that uses it so that the choosing — the
+ * part with an order, a fallback and an answer — can be tested, while
+ * the part that can only be exercised on the hardware itself stays as
+ * small as it can be made.
+ *
+ * Both classes must be there. A controller without the enum its methods
+ * take is a controller nothing can be asked of.
+ */
+fun firstAvailableShape(
+    shapes: List<EInkVendorShape>,
+    isPresent: (String) -> Boolean,
+): EInkVendorShape? = shapes.firstOrNull {
+    isPresent(it.controllerClass) && isPresent(it.updateModeClass)
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/eink/EInkDisplay.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/eink/EInkDisplay.kt
@@ -48,23 +48,11 @@ interface EInkDisplay {
      */
     fun optimizeWebView(view: WebView)
 
-    /**
-     * Puts back whatever was changed.
-     *
-     * Called when the reader is no longer in front, and on any failure.
-     * Some of these settings are not the app's to keep: they are applied
-     * per-application by name but take effect on the panel, and one left
-     * switched on is this app's ghosting inflicted on whatever the
-     * reader opens next.
-     */
-    fun release()
-
     /** The controller nobody has, which is nearly everybody. */
     object Absent : EInkDisplay {
         override val vendor: String? = null
         override fun readingMode(view: View) = Unit
         override fun optimizeWebView(view: WebView) = Unit
-        override fun release() = Unit
     }
 }
 
@@ -114,21 +102,3 @@ val ONYX_SHAPES: List<EInkVendorShape> = listOf(
         updateModeClass = "android.onyx.epd.UpdateMode",
     ),
 )
-
-/**
- * The first shape whose classes [isPresent] says are on this device.
- *
- * Kept apart from the reflection that uses it so that the choosing — the
- * part with an order, a fallback and an answer — can be tested, while
- * the part that can only be exercised on the hardware itself stays as
- * small as it can be made.
- *
- * Both classes must be there. A controller without the enum its methods
- * take is a controller nothing can be asked of.
- */
-fun firstAvailableShape(
-    shapes: List<EInkVendorShape>,
-    isPresent: (String) -> Boolean,
-): EInkVendorShape? = shapes.firstOrNull {
-    isPresent(it.controllerClass) && isPresent(it.updateModeClass)
-}

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/eink/OnyxEInkDisplay.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/eink/OnyxEInkDisplay.kt
@@ -1,0 +1,128 @@
+package com.chmouel.liseur.ui.eink
+
+import android.util.Log
+import android.view.View
+import android.webkit.WebView
+import java.lang.reflect.Method
+
+/**
+ * Onyx's screen controller, reached without depending on it.
+ *
+ * Every call here is a guess that is allowed to be wrong. The class may
+ * not exist, may exist under another name, may exist with these methods
+ * missing or taking other arguments, or may exist and throw. All of
+ * those are the same outcome — the app goes on drawing exactly as it
+ * did before — and the first of them permanently retires this object,
+ * because a controller that failed once will fail every time and there
+ * is nothing to gain by asking it again on every page turn.
+ *
+ * Nothing is bundled and nothing is linked. This compiles and runs on a
+ * device that has never heard of Onyx, which is the only reason it can
+ * exist in an app that must stay free software from source.
+ */
+class OnyxEInkDisplay private constructor(
+    override val vendor: String,
+    private val controller: Class<*>,
+    private val updateMode: Class<*>,
+    private val regal: Any,
+) : EInkDisplay {
+
+    private var retired = false
+    private var touched = false
+
+    override fun readingMode(view: View) {
+        attempt("readingMode") {
+            controller
+                .getMethod(SET_UPDATE_MODE, View::class.java, updateMode)
+                .invoke(null, view, regal)
+            touched = true
+        }
+    }
+
+    override fun optimizeWebView(view: WebView) {
+        attempt("optimizeWebView") {
+            controller
+                .getMethod(SET_CONTRAST, WebView::class.java, Boolean::class.javaPrimitiveType)
+                .invoke(null, view, true)
+            touched = true
+        }
+    }
+
+    override fun release() {
+        if (!touched || retired) return
+        touched = false
+        // There is deliberately nothing to undo for the two calls above:
+        // both are set per view, and the view goes away with the reader.
+        // This exists so that the moment anything is added here that is
+        // *not* per view — a fast mode applied by application name, say —
+        // there is already a place it must be given back, called from
+        // every path that leaves the reader.
+    }
+
+    /**
+     * Runs [block], and on any failure gives up on this device for good.
+     *
+     * The catch is deliberately everything. This is reflection against a
+     * class nobody here has ever seen, on firmware that varies between
+     * devices sold under the same name, and the correct response to any
+     * surprise is the behaviour the app had before it tried.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private inline fun attempt(what: String, block: () -> Unit) {
+        if (retired) return
+        try {
+            block()
+        } catch (e: Throwable) {
+            retired = true
+            Log.i(TAG, "$vendor screen controller withdrawn after $what: $e")
+        }
+    }
+
+    companion object {
+        private const val TAG = "OnyxEInkDisplay"
+        private const val SET_UPDATE_MODE = "setViewDefaultUpdateMode"
+        private const val SET_CONTRAST = "setWebViewContrastOptimize"
+
+        /** The update mode Onyx documents as being for pages of text. */
+        private const val REGAL = "REGAL"
+
+        /**
+         * Binds to whichever controller this device has, or to nothing.
+         *
+         * The enum constant is resolved here rather than at each call
+         * because failing to find it is the same as not having the
+         * controller at all: every method worth calling takes one. The
+         * enum *class* is kept alongside the constant, because a constant
+         * that carries a body is an instance of an anonymous subclass and
+         * would never match the parameter type the method declares.
+         */
+        @Suppress("TooGenericExceptionCaught")
+        fun bind(
+            shapes: List<EInkVendorShape> = ONYX_SHAPES,
+            loader: ClassLoader? = OnyxEInkDisplay::class.java.classLoader,
+        ): EInkDisplay {
+            val shape = firstAvailableShape(shapes) { name -> loadClass(name, loader) != null }
+                ?: return EInkDisplay.Absent
+            return try {
+                val controller = loadClass(shape.controllerClass, loader)
+                    ?: return EInkDisplay.Absent
+                val modes = loadClass(shape.updateModeClass, loader)
+                    ?: return EInkDisplay.Absent
+                val regal = modes.enumConstants
+                    ?.firstOrNull { (it as? Enum<*>)?.name == REGAL }
+                    ?: return EInkDisplay.Absent
+                OnyxEInkDisplay(shape.vendor, controller, modes, regal)
+            } catch (e: Throwable) {
+                Log.i(TAG, "no usable ${shape.vendor} screen controller: $e")
+                EInkDisplay.Absent
+            }
+        }
+
+        @Suppress("TooGenericExceptionCaught")
+        private fun loadClass(name: String, loader: ClassLoader?): Class<*>? = try {
+            Class.forName(name, false, loader)
+        } catch (e: Throwable) {
+            null
+        }
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/eink/OnyxEInkDisplay.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/eink/OnyxEInkDisplay.kt
@@ -3,7 +3,9 @@ package com.chmouel.liseur.ui.eink
 import android.util.Log
 import android.view.View
 import android.webkit.WebView
+import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
+import java.lang.reflect.Modifier
 
 /**
  * Onyx's screen controller, reached without depending on it.
@@ -11,10 +13,10 @@ import java.lang.reflect.Method
  * Every call here is a guess that is allowed to be wrong. The class may
  * not exist, may exist under another name, may exist with these methods
  * missing or taking other arguments, or may exist and throw. All of
- * those are the same outcome — the app goes on drawing exactly as it
- * did before — and the first of them permanently retires this object,
- * because a controller that failed once will fail every time and there
- * is nothing to gain by asking it again on every page turn.
+ * those are the same outcome — the app goes on drawing exactly as it did
+ * before — and the last of them permanently retires this object, because
+ * a controller that threw once will throw every time and there is
+ * nothing to gain by asking it again on every page turn.
  *
  * Nothing is bundled and nothing is linked. This compiles and runs on a
  * device that has never heard of Onyx, which is the only reason it can
@@ -22,60 +24,35 @@ import java.lang.reflect.Method
  */
 class OnyxEInkDisplay private constructor(
     override val vendor: String,
-    private val controller: Class<*>,
-    private val updateMode: Class<*>,
+    private val setUpdateMode: Method,
+    private val setContrast: Method,
     private val regal: Any,
 ) : EInkDisplay {
 
     private var retired = false
-    private var touched = false
 
     override fun readingMode(view: View) {
-        attempt("readingMode") {
-            controller
-                .getMethod(SET_UPDATE_MODE, View::class.java, updateMode)
-                .invoke(null, view, regal)
-            touched = true
-        }
+        attempt("readingMode") { setUpdateMode.invoke(null, view, regal) }
     }
 
     override fun optimizeWebView(view: WebView) {
-        attempt("optimizeWebView") {
-            controller
-                .getMethod(SET_CONTRAST, WebView::class.java, Boolean::class.javaPrimitiveType)
-                .invoke(null, view, true)
-            touched = true
-        }
-    }
-
-    override fun release() {
-        if (!touched || retired) return
-        touched = false
-        // There is deliberately nothing to undo for the two calls above:
-        // both are set per view, and the view goes away with the reader.
-        // This exists so that the moment anything is added here that is
-        // *not* per view — a fast mode applied by application name, say —
-        // there is already a place it must be given back, called from
-        // every path that leaves the reader.
+        attempt("optimizeWebView") { setContrast.invoke(null, view, true) }
     }
 
     /**
      * Runs [block], and on any failure gives up on this device for good.
      *
-     * The catch is deliberately everything. This is reflection against a
-     * class nobody here has ever seen, on firmware that varies between
-     * devices sold under the same name, and the correct response to any
-     * surprise is the behaviour the app had before it tried.
+     * Everything reflection can raise is caught, and nothing else is: a
+     * method that has gone missing or a controller that throws is exactly
+     * the surprise this was written to expect, whereas an
+     * `OutOfMemoryError` coming back through a vendor call is not this
+     * code's to swallow.
      */
-    @Suppress("TooGenericExceptionCaught")
     private inline fun attempt(what: String, block: () -> Unit) {
         if (retired) return
-        try {
-            block()
-        } catch (e: Throwable) {
-            retired = true
-            Log.i(TAG, "$vendor screen controller withdrawn after $what: $e")
-        }
+        val failure = guard(block) ?: return
+        retired = true
+        Log.i(TAG, "$vendor screen controller withdrawn after $what: $failure")
     }
 
     companion object {
@@ -87,42 +64,87 @@ class OnyxEInkDisplay private constructor(
         private const val REGAL = "REGAL"
 
         /**
-         * Binds to whichever controller this device has, or to nothing.
+         * Binds to whichever shape this device has, or to nothing.
          *
-         * The enum constant is resolved here rather than at each call
-         * because failing to find it is the same as not having the
-         * controller at all: every method worth calling takes one. The
-         * enum *class* is kept alongside the constant, because a constant
-         * that carries a body is an instance of an anonymous subclass and
-         * would never match the parameter type the method declares.
+         * A shape is only taken once everything it needs has actually
+         * been found: both classes, the enum constant, and both methods,
+         * with the arguments they are called with and static. A shape
+         * that falls short is passed over for the next rather than
+         * accepted and left to fail later — partly because a later
+         * spelling may be the right one, and mostly because [vendor] is
+         * shown to the reader as the answer to "did this work", and it
+         * must not say Onyx on a device where nothing will ever be
+         * called.
          */
-        @Suppress("TooGenericExceptionCaught")
         fun bind(
             shapes: List<EInkVendorShape> = ONYX_SHAPES,
             loader: ClassLoader? = OnyxEInkDisplay::class.java.classLoader,
-        ): EInkDisplay {
-            val shape = firstAvailableShape(shapes) { name -> loadClass(name, loader) != null }
-                ?: return EInkDisplay.Absent
-            return try {
-                val controller = loadClass(shape.controllerClass, loader)
-                    ?: return EInkDisplay.Absent
-                val modes = loadClass(shape.updateModeClass, loader)
-                    ?: return EInkDisplay.Absent
+        ): EInkDisplay = shapes.firstNotNullOfOrNull { resolve(it, loader) } ?: EInkDisplay.Absent
+
+        /** One shape, fully resolved, or null because something was missing. */
+        private fun resolve(shape: EInkVendorShape, loader: ClassLoader?): OnyxEInkDisplay? {
+            var bound: OnyxEInkDisplay? = null
+            val failure = guard {
+                val controller = loadClass(shape.controllerClass, loader) ?: return@guard
+                val modes = loadClass(shape.updateModeClass, loader) ?: return@guard
                 val regal = modes.enumConstants
                     ?.firstOrNull { (it as? Enum<*>)?.name == REGAL }
-                    ?: return EInkDisplay.Absent
-                OnyxEInkDisplay(shape.vendor, controller, modes, regal)
-            } catch (e: Throwable) {
-                Log.i(TAG, "no usable ${shape.vendor} screen controller: $e")
-                EInkDisplay.Absent
+                    ?: return@guard
+                // The enum *class* is what the method declares, not the
+                // constant's own class: a constant carrying a body is an
+                // instance of an anonymous subclass, and looking the
+                // method up by that would never match.
+                val setUpdateMode = controller
+                    .getMethod(SET_UPDATE_MODE, View::class.java, modes)
+                    .takeIf { Modifier.isStatic(it.modifiers) } ?: return@guard
+                val setContrast = controller
+                    .getMethod(SET_CONTRAST, WebView::class.java, Boolean::class.javaPrimitiveType)
+                    .takeIf { Modifier.isStatic(it.modifiers) } ?: return@guard
+                bound = OnyxEInkDisplay(shape.vendor, setUpdateMode, setContrast, regal)
             }
+            failure?.let { Log.i(TAG, "no controller at ${shape.controllerClass}: $it") }
+            return bound
         }
 
-        @Suppress("TooGenericExceptionCaught")
-        private fun loadClass(name: String, loader: ClassLoader?): Class<*>? = try {
-            Class.forName(name, false, loader)
-        } catch (e: Throwable) {
-            null
-        }
+        private fun loadClass(name: String, loader: ClassLoader?): Class<*>? =
+            try {
+                Class.forName(name, false, loader)
+            } catch (e: ClassNotFoundException) {
+                null
+            }
     }
 }
+
+/**
+ * Runs [block] and returns what went wrong, or null if nothing did.
+ *
+ * These are what reflection against a class this code has never seen can
+ * raise: the lookups themselves, the linkage of a class the firmware may
+ * have built differently, and whatever the vendor's own method throws
+ * once it is running. Anything outside that set is left alone rather
+ * than swallowed.
+ *
+ * The vendor's own throw needs unwrapping before that promise is worth
+ * anything. Everything a called method raises comes back wrapped in an
+ * [InvocationTargetException], which is itself a
+ * [ReflectiveOperationException] — so catching that alone would quietly
+ * swallow a [VirtualMachineError] raised inside the firmware, which is
+ * the exact thing the narrow catch was written to stop doing.
+ */
+private inline fun guard(block: () -> Unit): Throwable? =
+    try {
+        block()
+        null
+    } catch (e: InvocationTargetException) {
+        e.cause?.let { if (it.isFatal()) throw it }
+        e
+    } catch (e: ReflectiveOperationException) {
+        e
+    } catch (e: LinkageError) {
+        e
+    } catch (e: RuntimeException) {
+        e
+    }
+
+/** Not this code's to catch, wherever it was raised. */
+private fun Throwable.isFatal(): Boolean = this is VirtualMachineError || this is ThreadDeath

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
@@ -114,6 +114,7 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
@@ -129,6 +130,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import coil3.compose.SubcomposeAsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import com.chmouel.liseur.R
 import com.chmouel.liseur.data.remote.CatalogStatus
 import com.chmouel.liseur.data.remote.SyncFailure
@@ -1215,7 +1218,14 @@ private fun ContinueReadingCard(
                 modifier = Modifier
                     .width(72.dp)
                     .height(108.dp)
-                    .shadow(6.dp, RoundedCornerShape(10.dp)),
+                    // A drop shadow is a soft gradient, and electronic paper
+                    // has no soft: it dithers one into a halo of grey specks
+                    // around the cover, which then ghosts. The cover already
+                    // draws its own outline, which is all the lift it needs.
+                    .then(
+                        if (LocalEInk.current) Modifier
+                        else Modifier.shadow(6.dp, RoundedCornerShape(10.dp)),
+                    ),
             )
             Column(
                 Modifier
@@ -1561,8 +1571,22 @@ fun BookCover(book: Book, modifier: Modifier = Modifier) {
             shape,
         )
     if (artwork != null) {
+        // Covers fade in by default, which on a shelf means every cover on
+        // screen fading at once. Electronic paper draws a fade as a short
+        // run of whole-screen repaints, so the request says so here rather
+        // than the loader saying it for the whole app: the reader can force
+        // e-ink on or off by hand, and the loader is built before anyone
+        // has asked what they chose.
+        val context = LocalContext.current
+        val eInk = LocalEInk.current
+        val request = remember(artwork, eInk, context) {
+            ImageRequest.Builder(context)
+                .data(artwork)
+                .crossfade(!eInk)
+                .build()
+        }
         SubcomposeAsyncImage(
-            model = artwork,
+            model = request,
             contentDescription = null,
             contentScale = ContentScale.Crop,
             modifier = borderModifier,

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/AboutScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.chmouel.liseur.BuildConfig
 import com.chmouel.liseur.R
+import com.chmouel.liseur.ui.LocalEInk
 
 private data class LiteraryQuote(val text: String, val author: String)
 
@@ -136,7 +137,13 @@ fun AboutScreen(
                 AnimatedVisibility(
                     visibleState = remember { MutableTransitionState(false) }
                         .apply { targetState = true },
-                    enter = fadeIn(animationSpec = tween(durationMillis = 300)),
+                    // A fade is a run of whole-screen repaints on electronic
+                    // paper, so the quote is simply there when the screen is.
+                    enter = fadeIn(
+                        animationSpec = tween(
+                            durationMillis = if (LocalEInk.current) 0 else 300,
+                        ),
+                    ),
                     modifier = Modifier.padding(top = 48.dp),
                 ) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
@@ -95,6 +95,8 @@ fun SettingsScreen(
     onDynamicColor: (Boolean) -> Unit,
     onVolumeKeys: (Boolean) -> Unit,
     onEInkMode: (EInkMode) -> Unit,
+    onVendorRefresh: (Boolean) -> Unit,
+    vendorName: String?,
     onResumeLastBook: (Boolean) -> Unit,
     onKeepScreenOn: (Boolean) -> Unit,
     onGroupSeries: (Boolean) -> Unit,
@@ -297,6 +299,20 @@ fun SettingsScreen(
                         selected = settings.eInkMode,
                         label = { stringResource(it.label) },
                         onSelected = onEInkMode,
+                    )
+                    RowDivider()
+                    // The subtitle carries the finding, not just the offer.
+                    // None of this can be checked from a build — the classes
+                    // live on the devices — so the one place it can be
+                    // checked is the device, and this is where it says so.
+                    SwitchRow(
+                        title = stringResource(R.string.settings_vendor_refresh),
+                        subtitle = vendorName?.let {
+                            stringResource(R.string.settings_vendor_refresh_found, it)
+                        } ?: stringResource(R.string.settings_vendor_refresh_absent),
+                        checked = settings.vendorRefresh && vendorName != null,
+                        enabled = vendorName != null,
+                        onCheckedChange = onVendorRefresh,
                     )
                 }
 
@@ -582,11 +598,14 @@ private fun SwitchRow(
     subtitle: String,
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
+    enabled: Boolean = true,
 ) {
     ListItem(
         headlineContent = { Text(title) },
         supportingContent = { Text(subtitle) },
-        trailingContent = { Switch(checked = checked, onCheckedChange = null) },
+        trailingContent = {
+            Switch(checked = checked, onCheckedChange = null, enabled = enabled)
+        },
         colors = ListItemDefaults.colors(containerColor = Color.Transparent),
         modifier = Modifier
             // One tap target for the whole row, so the switch is not the
@@ -595,6 +614,7 @@ private fun SwitchRow(
             // and a screen reader can say which it is.
             .toggleable(
                 value = checked,
+                enabled = enabled,
                 role = Role.Switch,
                 onValueChange = onCheckedChange,
             ),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -450,6 +450,9 @@
     <string name="eink_auto">Auto</string>
     <string name="eink_on">On</string>
     <string name="eink_off">Off</string>
+    <string name="settings_vendor_refresh">Use the screen controller</string>
+    <string name="settings_vendor_refresh_found">Asks %1$s\'s own controller to repaint the page in the mode meant for text. Experimental: it is reached by reflection into firmware that differs between devices sold under the same name.</string>
+    <string name="settings_vendor_refresh_absent">No maker\'s screen controller was found on this device, so this would do nothing.</string>
     <string name="settings_dictionary">Dictionary</string>
     <string name="settings_define_with">Define with</string>
     <string name="definition_target_builtin">Built-in</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/EInkTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/EInkTest.kt
@@ -1,0 +1,101 @@
+package com.chmouel.liseur.ui
+
+import com.chmouel.liseur.data.settings.EInkMode
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * What the app decides a screen is made of.
+ *
+ * The maker list this walks is a guess by construction — Android has no
+ * flag for "this panel ghosts" — so the value of these cases is less in
+ * proving it right than in pinning what it currently answers, using
+ * build strings that real devices actually report. When someone widens
+ * the list, the phones below are what stops it swallowing them.
+ */
+class EInkTest {
+
+    private fun noFeatures(name: String) = false
+
+    private fun looksLikeEInk(
+        manufacturer: String,
+        brand: String,
+        model: String,
+        device: String,
+    ) = isEInkDevice(manufacturer, brand, model, device, ::noFeatures)
+
+    @Test
+    fun `an ordinary phone is not e-ink`() {
+        assertFalse(looksLikeEInk("Google", "google", "Pixel 8", "shiba"))
+        assertFalse(looksLikeEInk("samsung", "samsung", "SM-S918B", "dm3q"))
+        assertFalse(looksLikeEInk("OnePlus", "OnePlus", "CPH2449", "OP595DL1"))
+    }
+
+    @Test
+    fun `an Onyx Boox is e-ink by name`() {
+        assertTrue(looksLikeEInk("ONYX", "Onyx", "Go 7", "GO7"))
+        assertTrue(looksLikeEInk("ONYX", "Onyx", "GoColor7", "GoColor7"))
+        assertTrue(looksLikeEInk("ONYX", "Onyx", "Page", "Page"))
+        assertTrue(looksLikeEInk("ONYX", "Onyx", "Note Air4 C", "NoteAir4C"))
+        assertTrue(looksLikeEInk("ONYX", "Onyx", "Tab Ultra C", "TabUltraC"))
+    }
+
+    @Test
+    fun `the other makers are recognised too`() {
+        assertTrue(looksLikeEInk("Rakuten Kobo", "kobo", "Kobo Elipsa", "elipsa"))
+        assertTrue(looksLikeEInk("Tolino", "tolino", "tolino epos 3", "epos3"))
+        assertTrue(looksLikeEInk("Obreey", "pocketbook", "PocketBook 740", "pb740"))
+        assertTrue(looksLikeEInk("reMarkable", "remarkable", "reMarkable 2", "rm2"))
+        assertTrue(looksLikeEInk("Meebook", "meebook", "M6", "m6"))
+        assertTrue(looksLikeEInk("BIGME", "bigme", "HiBreak Pro", "hibreakpro"))
+        assertTrue(looksLikeEInk("Boyue", "boyue", "Likebook P78", "p78"))
+        assertTrue(looksLikeEInk("Ratta", "supernote", "A5X", "a5x"))
+        assertTrue(looksLikeEInk("Dasung", "dasung", "Paperlike", "paperlike"))
+    }
+
+    @Test
+    fun `a name is matched wherever the maker chose to put it`() {
+        // Some devices carry the maker only in the model or the codename;
+        // an empty manufacturer must not be the end of the question.
+        assertTrue(looksLikeEInk("", "", "Boox Poke 5", ""))
+        assertTrue(looksLikeEInk("", "", "", "tolino_shine"))
+    }
+
+    @Test
+    fun `a device that declares the feature is taken at its word`() {
+        for (feature in listOf("android.hardware.type.eink", "eink", "com.onyx.eink")) {
+            assertTrue(
+                isEInkDevice(
+                    manufacturer = "Nobody",
+                    brand = "nobody",
+                    model = "Unknown",
+                    device = "unknown",
+                    hasFeature = { it == feature },
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `auto follows the device`() {
+        assertTrue(EInkMode.AUTO.resolve(deviceLooksLikeEInk = true))
+        assertFalse(EInkMode.AUTO.resolve(deviceLooksLikeEInk = false))
+    }
+
+    @Test
+    fun `the manual settings overrule the guess`() {
+        assertTrue(EInkMode.ON.resolve(deviceLooksLikeEInk = false))
+        assertTrue(EInkMode.ON.resolve(deviceLooksLikeEInk = true))
+        assertFalse(EInkMode.OFF.resolve(deviceLooksLikeEInk = true))
+        assertFalse(EInkMode.OFF.resolve(deviceLooksLikeEInk = false))
+    }
+
+    @Test
+    fun `an unknown id falls back to asking the device`() {
+        assertTrue(EInkMode.fromId(null) == EInkMode.AUTO)
+        assertTrue(EInkMode.fromId("nonsense") == EInkMode.AUTO)
+        assertTrue(EInkMode.fromId("on") == EInkMode.ON)
+        assertTrue(EInkMode.fromId("off") == EInkMode.OFF)
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/WindowSizeTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/WindowSizeTest.kt
@@ -1,9 +1,7 @@
 package com.chmouel.liseur.ui
 
 import androidx.compose.ui.unit.dp
-import com.chmouel.liseur.data.settings.EInkMode
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -84,61 +82,5 @@ class WindowSizeTest {
     @Test
     fun `wider screens cap sheet content`() {
         assertEquals(560.dp, contentWidthCap(1280.dp))
-    }
-}
-
-class EInkTest {
-
-    private fun noFeatures(name: String) = false
-
-    @Test
-    fun `an ordinary phone is not e-ink`() {
-        assertFalse(
-            isEInkDevice(
-                manufacturer = "Google",
-                brand = "google",
-                model = "Pixel 8",
-                device = "shiba",
-                hasFeature = ::noFeatures,
-            ),
-        )
-    }
-
-    @Test
-    fun `an Onyx Boox is e-ink by name`() {
-        assertTrue(
-            isEInkDevice(
-                manufacturer = "ONYX",
-                brand = "Onyx",
-                model = "Go 7",
-                device = "GO7",
-                hasFeature = ::noFeatures,
-            ),
-        )
-    }
-
-    @Test
-    fun `a device that declares the feature is taken at its word`() {
-        assertTrue(
-            isEInkDevice(
-                manufacturer = "Nobody",
-                brand = "nobody",
-                model = "Unknown",
-                device = "unknown",
-                hasFeature = { it == "android.hardware.type.eink" },
-            ),
-        )
-    }
-
-    @Test
-    fun `auto follows the device`() {
-        assertTrue(EInkMode.AUTO.resolve(deviceLooksLikeEInk = true))
-        assertFalse(EInkMode.AUTO.resolve(deviceLooksLikeEInk = false))
-    }
-
-    @Test
-    fun `the manual settings overrule the guess`() {
-        assertTrue(EInkMode.ON.resolve(deviceLooksLikeEInk = false))
-        assertFalse(EInkMode.OFF.resolve(deviceLooksLikeEInk = true))
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/eink/EInkDisplayTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/eink/EInkDisplayTest.kt
@@ -1,0 +1,94 @@
+package com.chmouel.liseur.ui.eink
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Choosing which vendor controller to talk to.
+ *
+ * The reflection itself cannot be exercised anywhere but on the devices,
+ * which is exactly why the deciding is kept out of it: the order, the
+ * requirement that both classes be present, and the answer when none of
+ * them are, are all questions about a list, and a list can be asked them
+ * here.
+ */
+class EInkDisplayTest {
+
+    private fun present(vararg names: String): (String) -> Boolean {
+        val set = names.toSet()
+        return { it in set }
+    }
+
+    @Test
+    fun `a device with none of the classes gets no controller`() {
+        assertNull(firstAvailableShape(ONYX_SHAPES, present()))
+    }
+
+    @Test
+    fun `the framework spelling is found when the SDK one is absent`() {
+        val shape = firstAvailableShape(
+            ONYX_SHAPES,
+            present("android.onyx.EpdController", "android.onyx.UpdateMode"),
+        )
+        assertEquals("android.onyx.EpdController", shape?.controllerClass)
+        assertEquals("Onyx", shape?.vendor)
+    }
+
+    @Test
+    fun `the best known shape wins when more than one is present`() {
+        val shape = firstAvailableShape(ONYX_SHAPES) { true }
+        assertEquals(ONYX_SHAPES.first().controllerClass, shape?.controllerClass)
+    }
+
+    @Test
+    fun `a controller without its update mode enum is not usable`() {
+        // Half a shape is no shape: every method worth calling takes the
+        // enum, so a controller found without it can be asked nothing.
+        assertNull(
+            firstAvailableShape(
+                ONYX_SHAPES,
+                present("com.onyx.android.sdk.api.device.epd.EpdController"),
+            ),
+        )
+    }
+
+    @Test
+    fun `an update mode enum without its controller is not usable`() {
+        assertNull(
+            firstAvailableShape(
+                ONYX_SHAPES,
+                present("com.onyx.android.sdk.api.device.epd.UpdateMode"),
+            ),
+        )
+    }
+
+    @Test
+    fun `every shape names both classes`() {
+        // A blank name would be asked of the class loader and fail the
+        // same way a real absence does, so a shape carrying one would be
+        // a guess that can never match and never say so.
+        ONYX_SHAPES.forEach {
+            assertTrue(it.controllerClass.isNotBlank())
+            assertTrue(it.updateModeClass.isNotBlank())
+            assertTrue(it.vendor.isNotBlank())
+        }
+    }
+
+    @Test
+    fun `binding where no vendor classes exist yields the absent display`() {
+        // The JVM running these tests is the best available stand-in for
+        // every device that is not a Boox, which is nearly all of them.
+        val display = OnyxEInkDisplay.bind()
+        assertNull(display.vendor)
+        assertEquals(EInkDisplay.Absent, display)
+    }
+
+    @Test
+    fun `the absent display answers every call and does nothing`() {
+        val absent = EInkDisplay.Absent
+        absent.release()
+        assertNull(absent.vendor)
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/eink/EInkDisplayTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/eink/EInkDisplayTest.kt
@@ -1,71 +1,174 @@
 package com.chmouel.liseur.ui.eink
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
+import android.view.View
+import android.webkit.WebView
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 /**
- * Choosing which vendor controller to talk to.
+ * Binding to a vendor controller that is not there, or is there wrong.
  *
- * The reflection itself cannot be exercised anywhere but on the devices,
- * which is exactly why the deciding is kept out of it: the order, the
- * requirement that both classes be present, and the answer when none of
- * them are, are all questions about a list, and a list can be asked them
- * here.
+ * No real Onyx class can be reached from a build, so these point the
+ * binder at [FakeController] and its variously broken siblings instead.
+ * That covers everything the binder decides — the order it tries shapes
+ * in, what it insists on finding before it claims a vendor, and what it
+ * does when a call fails — and leaves exactly one thing untested, which
+ * is whether Onyx's real classes are spelled the way [ONYX_SHAPES]
+ * guesses. Only a device can answer that, which is why the setting says
+ * out loud what it bound.
  */
+@Config(sdk = [35], application = android.app.Application::class)
+@RunWith(RobolectricTestRunner::class)
 class EInkDisplayTest {
 
-    private fun present(vararg names: String): (String) -> Boolean {
-        val set = names.toSet()
-        return { it in set }
-    }
+    // Real views, because the calls under test take them. They are handed
+    // straight to a fake that ignores them; Robolectric is here only so
+    // that "a view" is something this JVM can produce at all.
+    private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+    private val view by lazy { View(context) }
+    private val webView by lazy { WebView(context) }
 
-    @Test
-    fun `a device with none of the classes gets no controller`() {
-        assertNull(firstAvailableShape(ONYX_SHAPES, present()))
-    }
+    private val pkg = "com.chmouel.liseur.ui.eink"
 
-    @Test
-    fun `the framework spelling is found when the SDK one is absent`() {
-        val shape = firstAvailableShape(
-            ONYX_SHAPES,
-            present("android.onyx.EpdController", "android.onyx.UpdateMode"),
+    private fun shape(controller: String, mode: String = "FakeUpdateMode") =
+        EInkVendorShape(
+            vendor = "Fake",
+            controllerClass = "$pkg.$controller",
+            updateModeClass = "$pkg.$mode",
         )
-        assertEquals("android.onyx.EpdController", shape?.controllerClass)
-        assertEquals("Onyx", shape?.vendor)
+
+    private fun bind(vararg shapes: EInkVendorShape) =
+        OnyxEInkDisplay.bind(shapes.toList(), javaClass.classLoader)
+
+    @Before
+    fun clearCounters() {
+        FakeController.reset()
+        FakeThrowingController.reset()
     }
 
     @Test
-    fun `the best known shape wins when more than one is present`() {
-        val shape = firstAvailableShape(ONYX_SHAPES) { true }
-        assertEquals(ONYX_SHAPES.first().controllerClass, shape?.controllerClass)
+    fun `a whole controller binds and is named`() {
+        val display = bind(shape("FakeController"))
+        assertEquals("Fake", display.vendor)
+        assertTrue(display is OnyxEInkDisplay)
     }
 
     @Test
-    fun `a controller without its update mode enum is not usable`() {
-        // Half a shape is no shape: every method worth calling takes the
+    fun `a bound controller is actually called`() {
+        val display = bind(shape("FakeController"))
+        display.readingMode(view)
+        display.optimizeWebView(webView)
+        assertEquals(1, FakeController.updateModeCalls)
+        assertEquals(1, FakeController.contrastCalls)
+    }
+
+    @Test
+    fun `a device with none of the classes gets nothing`() {
+        assertSame(EInkDisplay.Absent, bind(shape("NotAClassAnywhere")))
+    }
+
+    @Test
+    fun `a controller found without its update mode enum is refused`() {
+        // Half a shape is no shape: the method worth calling takes the
         // enum, so a controller found without it can be asked nothing.
-        assertNull(
-            firstAvailableShape(
-                ONYX_SHAPES,
-                present("com.onyx.android.sdk.api.device.epd.EpdController"),
-            ),
+        assertSame(EInkDisplay.Absent, bind(shape("FakeController", "NoSuchMode")))
+    }
+
+    @Test
+    fun `an enum without REGAL is refused`() {
+        // The one mode this asks for. An enum that has everything else is
+        // an enum this has nothing to say to.
+        assertSame(
+            EInkDisplay.Absent,
+            bind(shape("FakeController", "FakeModeWithoutRegal")),
         )
     }
 
     @Test
-    fun `an update mode enum without its controller is not usable`() {
-        assertNull(
-            firstAvailableShape(
-                ONYX_SHAPES,
-                present("com.onyx.android.sdk.api.device.epd.UpdateMode"),
-            ),
-        )
+    fun `a controller whose methods are not static is refused`() {
+        // They would be invoked with no receiver, so binding to them
+        // would be claiming a vendor that fails on its first call.
+        assertSame(EInkDisplay.Absent, bind(shape("FakeInstanceController")))
     }
 
     @Test
-    fun `every shape names both classes`() {
+    fun `a controller missing one of the two methods is refused`() {
+        assertSame(EInkDisplay.Absent, bind(shape("FakeHalfController")))
+    }
+
+    @Test
+    fun `an unusable shape is passed over for a later one`() {
+        // The point of a list: the first spelling being wrong on this
+        // firmware must not cost the device the spelling that is right.
+        val display = bind(
+            shape("NotAClassAnywhere"),
+            shape("FakeInstanceController"),
+            shape("FakeHalfController"),
+            shape("FakeController"),
+        )
+        assertEquals("Fake", display.vendor)
+    }
+
+    @Test
+    fun `the first usable shape wins`() {
+        val display = bind(
+            shape("FakeController").copy(vendor = "First"),
+            shape("FakeController").copy(vendor = "Second"),
+        )
+        assertEquals("First", display.vendor)
+    }
+
+    @Test
+    fun `a controller that throws is retired and never asked again`() {
+        val display = bind(shape("FakeThrowingController"))
+        assertEquals("Fake", display.vendor)
+        // It binds — everything was found — and gives up the moment it is
+        // shown that finding is not the same as working. Ten attempts,
+        // one call: the retirement is what is being asserted, not merely
+        // that the throw does not escape.
+        repeat(5) {
+            display.readingMode(view)
+            display.optimizeWebView(webView)
+        }
+        assertEquals(1, FakeThrowingController.calls)
+    }
+
+    @Test
+    fun `a fatal error from the vendor is not swallowed`() {
+        // It arrives wrapped in an InvocationTargetException, which is a
+        // ReflectiveOperationException, so it would otherwise be filed as
+        // an ordinary miss and the process left running on a dead heap.
+        val display = bind(shape("FakeFatalController"))
+        assertThrows(OutOfMemoryError::class.java) { display.readingMode(view) }
+    }
+
+    @Test
+    fun `binding on this JVM finds no real vendor`() {
+        // The JVM running these tests is the best available stand-in for
+        // every device that is not a Boox, which is nearly all of them.
+        assertSame(EInkDisplay.Absent, OnyxEInkDisplay.bind())
+    }
+
+    @Test
+    fun `the absent display answers every call and does nothing`() {
+        val absent = EInkDisplay.Absent
+        absent.readingMode(view)
+        absent.optimizeWebView(webView)
+        assertNull(absent.vendor)
+    }
+
+    @Test
+    fun `every real shape names a vendor and both classes`() {
         // A blank name would be asked of the class loader and fail the
         // same way a real absence does, so a shape carrying one would be
         // a guess that can never match and never say so.
@@ -74,21 +177,6 @@ class EInkDisplayTest {
             assertTrue(it.updateModeClass.isNotBlank())
             assertTrue(it.vendor.isNotBlank())
         }
-    }
-
-    @Test
-    fun `binding where no vendor classes exist yields the absent display`() {
-        // The JVM running these tests is the best available stand-in for
-        // every device that is not a Boox, which is nearly all of them.
-        val display = OnyxEInkDisplay.bind()
-        assertNull(display.vendor)
-        assertEquals(EInkDisplay.Absent, display)
-    }
-
-    @Test
-    fun `the absent display answers every call and does nothing`() {
-        val absent = EInkDisplay.Absent
-        absent.release()
-        assertNull(absent.vendor)
+        assertNotNull(ONYX_SHAPES.firstOrNull())
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/eink/FakeVendorClasses.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/eink/FakeVendorClasses.kt
@@ -1,0 +1,91 @@
+package com.chmouel.liseur.ui.eink
+
+import android.view.View
+import android.webkit.WebView
+
+/**
+ * Stand-ins for the vendor classes, so that the reflection can be tested.
+ *
+ * The real controller exists only on the devices, and there is no device
+ * here. What there is, is a set of classes shaped the several ways a
+ * device's controller might be shaped — right, absent, non-static, one
+ * method short, and throwing — which is enough to ask the binder every
+ * question that matters except whether Onyx spells it the way this
+ * guesses.
+ *
+ * Arguments are nullable because these are called with nulls: what is
+ * under test is whether the call is made and what happens when it fails,
+ * not what a real panel would do with a real view.
+ */
+enum class FakeUpdateMode { DU, GC, REGAL }
+
+enum class FakeModeWithoutRegal { DU, GC }
+
+object FakeController {
+    var updateModeCalls = 0
+    var contrastCalls = 0
+
+    fun reset() {
+        updateModeCalls = 0
+        contrastCalls = 0
+    }
+
+    @JvmStatic
+    fun setViewDefaultUpdateMode(view: View?, mode: FakeUpdateMode?) {
+        updateModeCalls++
+    }
+
+    @JvmStatic
+    fun setWebViewContrastOptimize(view: WebView?, enable: Boolean) {
+        contrastCalls++
+    }
+}
+
+/** The methods are there, but on instances, so nothing can be invoked. */
+object FakeInstanceController {
+    fun setViewDefaultUpdateMode(view: View?, mode: FakeUpdateMode?) = Unit
+    fun setWebViewContrastOptimize(view: WebView?, enable: Boolean) = Unit
+}
+
+/** Names the controller, but never learned about web views. */
+object FakeHalfController {
+    @JvmStatic
+    fun setViewDefaultUpdateMode(view: View?, mode: FakeUpdateMode?) = Unit
+}
+
+/** Everything in the right place, and it throws anyway. */
+object FakeThrowingController {
+    var calls = 0
+
+    fun reset() {
+        calls = 0
+    }
+
+    @JvmStatic
+    fun setViewDefaultUpdateMode(view: View?, mode: FakeUpdateMode?): Unit {
+        calls++
+        throw UnsupportedOperationException("no panel here")
+    }
+
+    @JvmStatic
+    fun setWebViewContrastOptimize(view: WebView?, enable: Boolean): Unit {
+        calls++
+        throw UnsupportedOperationException("no panel here")
+    }
+}
+
+/**
+ * Fails in a way that is nobody's to swallow.
+ *
+ * Reflection hands back everything a called method threw wrapped in an
+ * `InvocationTargetException`, so without unwrapping, this would be
+ * caught and logged as an ordinary reflective mishap.
+ */
+object FakeFatalController {
+    @JvmStatic
+    fun setViewDefaultUpdateMode(view: View?, mode: FakeUpdateMode?): Unit =
+        throw OutOfMemoryError("not a vendor problem")
+
+    @JvmStatic
+    fun setWebViewContrastOptimize(view: WebView?, enable: Boolean): Unit = Unit
+}


### PR DESCRIPTION
## Summary

Liseur already holds still on e-ink wherever its own code draws. What was
left came from underneath — Compose, Material and Coil defaults that arrive
whether or not the app asks, and that therefore cannot be turned off one
composable at a time. This turns them off in the one place that already
knows the screen is e-paper, and then goes one layer lower and asks the
panel itself how to refresh.

Closes #66.

## Changes

**Platform defaults, switched off in `ProvideEInk`**

- **Overscroll stretch** dropped. Until now every list and grid was dragged
  over the whole viewport for several frames each time it hit an end.
  Probably the largest needless repaint the library had.
- **Ripple** dropped. On a ~200 ms panel the state layer lands after the
  finger has lifted and the screen has already changed to whatever the tap
  did. A new `EInkPressIndication` puts a flat, instant pressed tint in its
  place.
- **Cover crossfade** dropped — in a grid that was one fade per cover, all
  at once, on the screen with the most images in the app. Decided per
  `ImageRequest` rather than on the shared `ImageLoader`, so the manual
  `EInkMode.ON/OFF` override still applies.
- **Three missed shadows** go flat with a border, the way the footnote card
  and selection bar already do: under every cover in the list view, and
  under the three reader chrome pills (which also collapse into one
  `ChromePill` instead of three copies of the same `Surface`).
- The About screen's quote fade is zeroed.

**Vendor refresh (Onyx)**

The panel was being driven as if it were an LCD. Onyx exposes how it
refreshes; the app has never said anything. It now asks for `REGAL` — the
mode Onyx documents as being for pages of text — and asks the web view not
to drop into A2.

It asks **by reflection**: the Onyx SDK is proprietary, so bundling it
would end F-Droid eligibility. The class may be absent, renamed by
firmware, or throw; all three are the same outcome (the drawing the app did
before), and the first of them retires the controller for the life of the
process. A shape is only adopted once both classes, the `REGAL` constant
and both methods have actually been resolved and checked static, so the
settings screen cannot name a vendor on a device where nothing will ever
be called. The binder is unit-tested against fake controller classes
built deliberately wrong — non-static, one method short, throwing, and
throwing fatally — leaving only the question of whether Onyx spells it
the way `ONYX_SHAPES` guesses, which only a device can answer.

It ships **behind a setting that is off by default**, whose subtitle
reports what was actually bound — whether it does anything at all is a
question only the hardware can answer.

## Testing

- [x] `./gradlew testDebugUnitTest` — 16 new tests (`EInkTest`,
      `EInkDisplayTest`)
- [x] `./gradlew lintDebug` — 0 errors
- [x] `./gradlew assembleDebug`
- [ ] Manually tested on a device or emulator — **not done.** I'm
      travelling without the Boox. Everything here is either off by default
      (vendor refresh) or fails safe to the drawing the app did before, but
      the visual results are unverified on real e-paper.

## Screenshots or recordings

None — no emulator available, and the changes are e-ink-conditional, so an
LCD emulator would show the unchanged path anyway.

## Known limitation

Removing the ripple reaches ~112 Material 3 components, but the flat
replacement only reaches the 8 `Modifier.clickable` sites: Material passes
`indication = ripple()` explicitly and never consults `LocalIndication`,
and `LocalRippleConfiguration` offers no interception point. So most
tappable controls end up with *no* press feedback rather than instant
feedback. Acceptable on a panel this slow, but worth naming.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS — **no dependency was
      added**; the Onyx binding is reflective precisely to avoid one.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

