### PR TITLE
Hide unavailable screen controller

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
@@ -300,20 +300,18 @@ fun SettingsScreen(
                         label = { stringResource(it.label) },
                         onSelected = onEInkMode,
                     )
-                    RowDivider()
-                    // The subtitle carries the finding, not just the offer.
-                    // None of this can be checked from a build — the classes
-                    // live on the devices — so the one place it can be
-                    // checked is the device, and this is where it says so.
-                    SwitchRow(
-                        title = stringResource(R.string.settings_vendor_refresh),
-                        subtitle = vendorName?.let {
-                            stringResource(R.string.settings_vendor_refresh_found, it)
-                        } ?: stringResource(R.string.settings_vendor_refresh_absent),
-                        checked = settings.vendorRefresh && vendorName != null,
-                        enabled = vendorName != null,
-                        onCheckedChange = onVendorRefresh,
-                    )
+                    vendorName?.let { vendor ->
+                        RowDivider()
+                        SwitchRow(
+                            title = stringResource(R.string.settings_vendor_refresh),
+                            subtitle = stringResource(
+                                R.string.settings_vendor_refresh_found,
+                                vendor,
+                            ),
+                            checked = settings.vendorRefresh,
+                            onCheckedChange = onVendorRefresh,
+                        )
+                    }
                 }
 
                 SettingsGroup(stringResource(R.string.settings_dictionary)) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -452,7 +452,6 @@
     <string name="eink_off">Off</string>
     <string name="settings_vendor_refresh">Use the screen controller</string>
     <string name="settings_vendor_refresh_found">Asks %1$s\'s own controller to repaint the page in the mode meant for text. Experimental: it is reached by reflection into firmware that differs between devices sold under the same name.</string>
-    <string name="settings_vendor_refresh_absent">No maker\'s screen controller was found on this device, so this would do nothing.</string>
     <string name="settings_dictionary">Dictionary</string>
     <string name="settings_define_with">Define with</string>
     <string name="definition_target_builtin">Built-in</string>


### PR DESCRIPTION
## Summary

Hide the screen controller setting when the device has no compatible controller.

## Tests

- ./gradlew testDebugUnitTest
- ./gradlew lintDebug