### PR TITLE
fix(reader): keep a wide table on its own page

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -142,6 +142,7 @@ import org.readium.r2.navigator.Decoration
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.navigator.preferences.ReadingProgression
 import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Layout
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
@@ -262,6 +263,17 @@ fun ReaderScreen(
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     val effectScope = rememberCoroutineScope()
     var pendingPositionEvent by remember { mutableStateOf<NavigatorPositionEvent?>(null) }
+
+    // Open for as long as the page is being rebuilt underneath the reader.
+    // See ReflowScope: a locator nobody has claimed while this is open is the
+    // layout moving, not the reader.
+    val reflow = remember { ReflowScope() }
+
+    // A fixed-layout book places everything by absolute coordinates and has no
+    // reflow to speak of; measuring what "fits" there means nothing.
+    val fitWideContent = remember(publication) {
+        publication.metadata.layout != Layout.FIXED
+    }
 
     // The place the reader was at when a run of preference changes began.
     // A restore that lands slightly off must not become the anchor of the
@@ -386,7 +398,12 @@ fun ReaderScreen(
             // must not look like this device turned a page and turn a
             // one-sided remote update into a conflict.
             nav.currentLocator.drop(1).collect { native ->
-                val event = pendingPositionEvent ?: NavigatorPositionEvent.READER_MOVEMENT
+                val event = pendingPositionEvent
+                    ?: if (reflow.active) {
+                        NavigatorPositionEvent.PREFERENCE_REFLOW
+                    } else {
+                        NavigatorPositionEvent.READER_MOVEMENT
+                    }
                 pendingPositionEvent = null
                 // Anywhere the reader actually goes ends the run of
                 // preference changes the held anchor was covering.
@@ -464,20 +481,70 @@ fun ReaderScreen(
         }
             .drop(1)
             .collect {
-                val anchor = reflowAnchor ?: capture(nav, nav.currentLocator.value)
-                reflowAnchor = anchor
-                onLocatorChanged(anchor, NavigatorPositionEvent.PREFERENCE_REFLOW)
-                val before = ExactLocatorAnchor.layoutSignature(nav)
-                pendingPositionEvent = NavigatorPositionEvent.PREFERENCE_REFLOW
-                nav.submitPreferences(it)
-                awaitReflowSettled(nav, before)
-                navigate(
-                    nav = nav,
-                    locator = anchor,
-                    event = NavigatorPositionEvent.PREFERENCE_REFLOW,
-                    verify = true,
-                )
+                reflow.within {
+                    val anchor = reflowAnchor ?: capture(nav, nav.currentLocator.value)
+                    reflowAnchor = anchor
+                    onLocatorChanged(anchor, NavigatorPositionEvent.PREFERENCE_REFLOW)
+                    val before = ExactLocatorAnchor.layoutSignature(nav)
+                    nav.submitPreferences(it)
+                    awaitReflowSettled(nav, before)
+                    // A table can be comfortable at 100% and too wide at 175%,
+                    // so what fits has to be asked again once the new size has
+                    // landed — and before the anchor is restored, since fitting
+                    // it moves the text once more.
+                    if (fitWideContent &&
+                        WideContentFit.apply(nav) == WideContentFit.Result.CHANGED
+                    ) {
+                        awaitReflowSettled(nav, before)
+                    }
+                    navigate(
+                        nav = nav,
+                        locator = anchor,
+                        event = NavigatorPositionEvent.PREFERENCE_REFLOW,
+                        verify = true,
+                    )
+                }
             }
+    }
+
+    // Content wider than the page paints over the page after it rather than
+    // being clipped, because in paginated mode the columns Readium sets
+    // `overflow: visible` on are the pages themselves. Measure and constrain
+    // what actually overflows, once per resource that gets laid out.
+    //
+    // Positions and layout passes are both only prompts to go and look, for
+    // the same reasons the e-ink block above gives: a position alone misses
+    // the page the book opens at, a layout pass alone can miss a resource
+    // swapped in without one, and finding the same web view again costs a
+    // reference comparison.
+    LaunchedEffect(navigator, fitWideContent) {
+        val nav = navigator ?: return@LaunchedEffect
+        if (!fitWideContent) return@LaunchedEffect
+        val root = nav.publicationView
+        var fitted: WebView? = null
+        merge(nav.currentLocator.map { }, layoutPasses(root)).collect {
+            val web = visibleWebView(root) ?: return@collect
+            if (web === fitted) return@collect
+            fitted = web
+            reflow.within {
+                // The anchor is captured here rather than taken from
+                // reflowAnchor: that one belongs to a run of preference
+                // changes in the resource being left, and restoring to it
+                // would carry the reader back out of the one they just
+                // turned into.
+                val anchor = capture(nav, nav.currentLocator.value)
+                val before = ExactLocatorAnchor.layoutSignature(nav)
+                if (WideContentFit.apply(nav) == WideContentFit.Result.CHANGED) {
+                    awaitReflowSettled(nav, before)
+                    navigate(
+                        nav = nav,
+                        locator = anchor,
+                        event = NavigatorPositionEvent.PREFERENCE_REFLOW,
+                        verify = true,
+                    )
+                }
+            }
+        }
     }
 
     // Picking the selection up from the navigator when it tells us the

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReflowScope.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReflowScope.kt
@@ -1,0 +1,44 @@
+package com.chmouel.liseur.reader
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * The window during which the rendered page is being rebuilt underneath the
+ * reader.
+ *
+ * Readium announces a locator whenever the page it is showing changes, and it
+ * cannot tell a page the reader turned to from one that arrived because the
+ * text was re-laid out. Arming a single pending event before a reflow only
+ * covers the first announcement; a reflow that settles in two steps announces
+ * twice, and the second reads as a page turn. Worse, an armed event that is
+ * never spent stays armed, and the reader's *next* real page turn is then
+ * discarded as a reflow and their place is not saved.
+ *
+ * So the reflow is a scope rather than a token: while it is open, every
+ * announcement nobody has claimed is a reflow, however many there are, and
+ * `finally` closes it even if the work inside throws or is cancelled.
+ *
+ * The mutex is not about the flag. Two reflows overlapping would each capture
+ * the place to return to from a layout the other is still moving, and then
+ * navigate against it; taking them in turn is what keeps the anchor meaningful.
+ *
+ * Both the flag and its readers live on the main dispatcher, where the
+ * navigator's locators are collected, so it needs no synchronisation of its own.
+ */
+class ReflowScope {
+    private val mutex = Mutex()
+
+    var active: Boolean = false
+        private set
+
+    suspend fun <T> within(block: suspend () -> T): T =
+        mutex.withLock {
+            active = true
+            try {
+                block()
+            } finally {
+                active = false
+            }
+        }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/WideContentFit.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/WideContentFit.kt
@@ -1,0 +1,132 @@
+package com.chmouel.liseur.reader
+
+import org.readium.r2.navigator.epub.EpubNavigatorFragment
+import org.readium.r2.shared.ExperimentalReadiumApi
+
+/**
+ * Keeps content that is wider than the page from painting over the next one.
+ *
+ * A table is never narrower than the sum of its columns' smallest possible
+ * widths, whatever a stylesheet asks for, so Readium's `max-width: 100%` on
+ * tables quietly fails on a four-column table at a large font size. Readium
+ * then sets `overflow: visible` on the root to stop the same overflow being
+ * clipped, but in paginated mode the root is the multi-column box whose
+ * columns *are* the pages — so the overflow is not clipped, it is painted on
+ * top of the page after it. That is the ghosting the reader sees.
+ *
+ * The fix is to measure and only then constrain: a table that genuinely does
+ * not fit is given `table-layout: fixed`, which lets the columns be squeezed;
+ * a long index that merely *looks* wide because it is spread over four pages
+ * is left exactly as its author wrote it.
+ *
+ * Injected at runtime rather than into the resource, because Readium decides
+ * whether to link its default stylesheet by looking for `<style` in the
+ * resource: shipping one ahead of it would make an unstyled book look styled
+ * and cost it Readium's typography entirely.
+ */
+internal object WideContentFit {
+    internal enum class Result {
+        /** Something was constrained, or the stylesheet was installed: the page may have moved. */
+        CHANGED,
+
+        /** Nothing to do; the layout is untouched. */
+        STABLE,
+
+        /** The book's Content-Security-Policy refused the stylesheet. */
+        BLOCKED,
+
+        /** No reflowable page to talk to, or the script did not answer. */
+        FAILED,
+    }
+
+    /**
+     * Runs in the book's own document, repeatedly, so it must end where it
+     * started when there is nothing to do.
+     *
+     * Ownership is a token minted per document rather than a fixed class or
+     * id: a publisher is free to ship `class="liseur-wide"`, and stripping it
+     * from their table — or letting it suppress our own work — would be our
+     * bug, not theirs. Only attributes carrying this document's token are ever
+     * read or removed.
+     *
+     * Width is measured from `getClientRects()`, never `getBoundingClientRect()`:
+     * across columns the latter returns the union of every fragment, so a
+     * perfectly well-behaved 60-row index reports 1382px against a 372px page
+     * and would be constrained for no reason. Only the widest single fragment
+     * says anything about fitting.
+     *
+     * The marker is cleared before measuring, or a second run would measure the
+     * width we imposed on the first and keep it forever.
+     */
+    const val SCRIPT: String = """
+        (function () {
+          var ATTR = "data-liseur-fit";
+          var state = window.__liseurFit || (window.__liseurFit = {});
+          var installed = false;
+          var tok = state.token ||
+                    (state.token = "f" + Math.random().toString(36).slice(2, 10));
+          var SEL = 'table[' + ATTR + '="' + tok + '"]';
+
+          if (!state.styleEl || !state.styleEl.isConnected) {
+            var css = document.createElement("style");
+            css.textContent =
+              "p,li,dd,dt,td,th,blockquote,figcaption{overflow-wrap:break-word}" +
+              SEL + "{table-layout:fixed !important;width:100% !important}" +
+              SEL + " td," + SEL + " th{overflow-wrap:anywhere}" +
+              'pre[' + ATTR + '="' + tok + '"]{white-space:pre-wrap !important}';
+            document.head.appendChild(css);
+            state.styleEl = css;
+            installed = true;
+            if (!css.sheet) return "blocked";
+          }
+
+          function contentWidth(el) {
+            var s = getComputedStyle(el);
+            return el.clientWidth - parseFloat(s.paddingLeft) - parseFloat(s.paddingRight);
+          }
+
+          var changed = installed;
+          for (var pass = 0; pass < 3; pass++) {
+            var els = document.querySelectorAll("table,pre");
+            var had = [], i;
+            for (i = 0; i < els.length; i++) {
+              had.push(els[i].getAttribute(ATTR) === tok);
+              if (had[i]) els[i].removeAttribute(ATTR);
+            }
+            var passChanged = false;
+            for (i = 0; i < els.length; i++) {
+              var el = els[i], parent = el.parentElement;
+              var avail = parent ? contentWidth(parent) : 0;
+              var rects = el.getClientRects(), widest = 0;
+              for (var j = 0; j < rects.length; j++) {
+                if (rects[j].width > widest) widest = rects[j].width;
+              }
+              var want = avail > 0 && widest > avail + 1;
+              if (want) el.setAttribute(ATTR, tok);
+              if (want !== had[i]) passChanged = true;
+            }
+            if (!passChanged) break;
+            changed = true;
+          }
+          return changed ? "changed" : "stable";
+        })();
+    """
+
+    /**
+     * `evaluateJavascript` hands back the JSON encoding of the value, so a
+     * plain string arrives wearing quotes.
+     */
+    internal fun parse(result: String?): Result {
+        val value = result?.trim()?.removeSurrounding("\"")?.trim()
+        return when (value) {
+            "changed" -> Result.CHANGED
+            "stable" -> Result.STABLE
+            "blocked" -> Result.BLOCKED
+            else -> Result.FAILED
+        }
+    }
+
+    @OptIn(ExperimentalReadiumApi::class)
+    internal suspend fun apply(navigator: EpubNavigatorFragment): Result =
+        parse(runCatching { navigator.evaluateJavascript(SCRIPT) }.getOrNull())
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/ReflowScopeTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/ReflowScopeTest.kt
@@ -1,0 +1,75 @@
+package com.chmouel.liseur.reader
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReflowScopeTest {
+
+    @Test
+    fun `the scope is open only for the duration of the block`() = runTest {
+        val scope = ReflowScope()
+        assertFalse(scope.active)
+        val seen = scope.within { scope.active }
+        assertTrue(seen)
+        assertFalse(scope.active)
+    }
+
+    @Test
+    fun `a throwing block still closes the scope`() = runTest {
+        val scope = ReflowScope()
+        var thrown = false
+        try {
+            scope.within { throw IllegalStateException("boom") }
+        } catch (e: IllegalStateException) {
+            thrown = true
+        }
+        assertTrue(thrown)
+        assertFalse(scope.active)
+    }
+
+    @Test
+    fun `cancelling the caller closes the scope`() = runTest {
+        val scope = ReflowScope()
+        val entered = CompletableDeferred<Unit>()
+        val job = launch {
+            scope.within {
+                entered.complete(Unit)
+                CompletableDeferred<Unit>().await()
+            }
+        }
+        entered.await()
+        assertTrue(scope.active)
+        job.cancelAndJoin()
+        assertFalse(scope.active)
+    }
+
+    @Test
+    fun `two reflows never overlap`() = runTest {
+        val scope = ReflowScope()
+        var inFlight = 0
+        var peak = 0
+        val work: suspend () -> Unit = {
+            scope.within {
+                inFlight++
+                peak = maxOf(peak, inFlight)
+                repeat(4) { yield() }
+                inFlight--
+            }
+        }
+        val a = async { work() }
+        val b = async { work() }
+        a.await()
+        b.await()
+        assertEquals(1, peak)
+        assertFalse(scope.active)
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/ReflowScopeTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/ReflowScopeTest.kt
@@ -1,7 +1,6 @@
 package com.chmouel.liseur.reader
 
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/WideContentFitTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/WideContentFitTest.kt
@@ -1,0 +1,76 @@
+package com.chmouel.liseur.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WideContentFitTest {
+
+    @Test
+    fun `the javascript answer is read through its json quoting`() {
+        assertEquals(WideContentFit.Result.CHANGED, WideContentFit.parse("\"changed\""))
+        assertEquals(WideContentFit.Result.STABLE, WideContentFit.parse("\"stable\""))
+        assertEquals(WideContentFit.Result.BLOCKED, WideContentFit.parse("\"blocked\""))
+    }
+
+    @Test
+    fun `an unquoted answer is read too`() {
+        assertEquals(WideContentFit.Result.CHANGED, WideContentFit.parse("changed"))
+        assertEquals(WideContentFit.Result.STABLE, WideContentFit.parse(" stable "))
+    }
+
+    @Test
+    fun `no answer is a failure, never a silent success`() {
+        assertEquals(WideContentFit.Result.FAILED, WideContentFit.parse(null))
+        assertEquals(WideContentFit.Result.FAILED, WideContentFit.parse(""))
+        assertEquals(WideContentFit.Result.FAILED, WideContentFit.parse("null"))
+        assertEquals(WideContentFit.Result.FAILED, WideContentFit.parse("undefined"))
+        assertEquals(WideContentFit.Result.FAILED, WideContentFit.parse("\"whatever\""))
+    }
+
+    @Test
+    fun `the script is one expression, so evaluateJavascript returns its value`() {
+        val script = WideContentFit.SCRIPT.trim()
+        assertTrue(script.startsWith("(function"))
+        assertTrue(script.endsWith("})();"))
+    }
+
+    @Test
+    fun `width is measured per fragment, not from the union of them`() {
+        // getBoundingClientRect() spans every column a table is spread over, so
+        // a long index that fits reports several times the page width.
+        assertTrue(WideContentFit.SCRIPT.contains("getClientRects"))
+        assertFalse(WideContentFit.SCRIPT.contains("getBoundingClientRect"))
+    }
+
+    @Test
+    fun `breaking words anywhere is confined to what was measured as too wide`() {
+        WideContentFit.SCRIPT.lineSequence()
+            .filter { it.contains("overflow-wrap:anywhere") }
+            .forEach { assertTrue(it, it.contains("SEL")) }
+        assertTrue(WideContentFit.SCRIPT.contains("overflow-wrap:anywhere"))
+    }
+
+    @Test
+    fun `the marker is owned by a per-document token, not a guessable name`() {
+        assertTrue(WideContentFit.SCRIPT.contains("state.token"))
+        assertFalse(WideContentFit.SCRIPT.contains("liseur-wide"))
+        assertFalse(WideContentFit.SCRIPT.contains("getElementById"))
+    }
+
+    @Test
+    fun `the author's own markup is never rewritten`() {
+        // Only our attribute is ever removed; a class the publisher shipped
+        // stays exactly where they put it.
+        assertTrue(WideContentFit.SCRIPT.contains("removeAttribute(ATTR)"))
+        assertFalse(WideContentFit.SCRIPT.contains("className"))
+        assertFalse(WideContentFit.SCRIPT.contains("classList"))
+        assertFalse(WideContentFit.SCRIPT.contains("innerHTML"))
+    }
+
+    @Test
+    fun `a stylesheet the book's policy refused is reported rather than assumed`() {
+        assertTrue(WideContentFit.SCRIPT.contains("if (!css.sheet) return \"blocked\""))
+    }
+}

--- a/hack/README.md
+++ b/hack/README.md
@@ -56,6 +56,16 @@ target wrapping them — run `make help` for the short list. See
 - **`verify-reproducible`** — Builds the release APK twice from two
   independent clean checkouts and diffs them byte for byte, the check
   F-Droid's reproducible-builds requirement demands before submission.
+- **`verify-wide-content`** — Checks that content wider than the page is
+  measured and constrained rather than painted over the page after it
+  (issue #67). The fix is JavaScript that runs inside the book's own
+  document, and none of what it has to get right is visible from the
+  JVM, so the script is lifted straight out of `WideContentFit.kt` —
+  never a copy — and run against Readium's own stylesheets in headless
+  Chrome, in a frame the size of a phone. Needs Chrome or Chromium and a
+  prior `./gradlew assembleDebug` (Readium's CSS is unpacked from the
+  AAR by the build), so it is a check to run by hand when that script
+  changes, not part of `make check`. `PORT=` picks another port.
 - **`icon`** — Renders the adaptive launcher icon (two vector drawables)
   to a flat PNG for the F-Droid listing and the README.
 - **`feature-graphic`** — Renders the 1024x500 store feature graphic

--- a/hack/verify-wide-content
+++ b/hack/verify-wide-content
@@ -1,0 +1,363 @@
+#!/usr/bin/env bash
+#
+# Checks that content wider than the page is measured and constrained
+# instead of painting over the page after it (issue #67).
+#
+# The fix is a few lines of JavaScript run inside the book's own document,
+# and none of what it has to get right can be seen from the JVM: whether a
+# table really overflows its column, whether an index that merely looks wide
+# is left alone, whether a second run changes anything. So the script is
+# lifted out of WideContentFit.kt — the same text the app ships, never a
+# copy — and run against Readium's own stylesheets in headless Chrome, in a
+# frame the size of a phone.
+#
+# There is no Chrome on the CI runners, so this is a check to run by hand
+# when the script changes, not part of `make check`.
+
+set -euo pipefail
+
+readonly SOURCE="app/src/main/kotlin/com/chmouel/liseur/reader/WideContentFit.kt"
+readonly ASSETS="app/build/intermediates/assets/debug/mergeDebugAssets/readium/readium-css"
+readonly PORT="${PORT:-8791}"
+
+die() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+cd "$(git rev-parse --show-toplevel)"
+
+browser=""
+for candidate in google-chrome-stable google-chrome chromium chromium-browser; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+        browser=$candidate
+        break
+    fi
+done
+[[ -n $browser ]] || die "no chrome or chromium on PATH"
+
+command -v python3 >/dev/null 2>&1 || die "python3 is needed to serve the harness"
+
+# Readium's stylesheets arrive from the navigator AAR and are only unpacked
+# once something has been built.
+[[ -d $ASSETS ]] || die "$ASSETS is missing — run ./gradlew assembleDebug first"
+
+work=$(mktemp -d)
+server=""
+cleanup() {
+    # Under `set -e` a kill that loses the race would abort the trap and
+    # leave the temporary tree behind.
+    if [[ -n $server ]]; then
+        kill "$server" 2>/dev/null || true
+        wait "$server" 2>/dev/null || true
+    fi
+    rm -rf "$work"
+}
+trap cleanup EXIT
+
+cp -r "$ASSETS" "$work/readium-css"
+mkdir -p "$work/cases"
+
+python3 - "$SOURCE" "$work/fit.js" <<'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+match = re.search(r'const val SCRIPT: String = """(.*?)"""', src, re.S)
+if not match:
+    sys.exit("could not find SCRIPT in " + sys.argv[1])
+open(sys.argv[2], "w").write(match.group(1))
+PY
+
+# The reporter's table: four columns, comfortable at a default font size and
+# wider than the page well before the largest one.
+cat >"$work/cases/wide-table.xhtml" <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><title>t</title></head><body>
+<p>Before the table there is a paragraph of ordinary prose.</p>
+<table id="probe" border="1">
+<tr><th>Symbol</th><th>Marks</th><th>Description</th><th>Reference</th></tr>
+<tr><td>ABCDEFG</td><td>1234567</td><td>Something reasonably long</td><td>p. 214</td></tr>
+<tr><td>HIJKLMN</td><td>8901234</td><td>Another descriptive phrase</td><td>p. 388</td></tr>
+</table>
+<p>After the table, more prose follows for several lines so pagination has something to do.</p>
+</body></html>
+EOF
+
+# A long index: narrow, but spread over several pages, so the rectangle that
+# spans all of them is several times the page width. Nothing here needs fixing.
+cat >"$work/cases/narrow-index.xhtml" <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><title>t</title></head><body>
+<table id="probe"><tbody id="rows"></tbody></table>
+<script>
+var b=document.getElementById("rows");
+for(var i=0;i<60;i++){var r=document.createElement("tr");
+r.innerHTML="<td>Item "+i+"</td><td>"+(i*7)+"</td>";b.appendChild(r);}
+</script>
+</body></html>
+EOF
+
+cat >"$work/cases/long-url.xhtml" <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><title>t</title></head><body>
+<p id="probe">See https://example.org/a/very/long/path/that/never/breaks/anywhere/at/all/because/it/has/no/hyphens/or/spaces/in/it/whatsoever/ok</p>
+</body></html>
+EOF
+
+cat >"$work/cases/nested-tables.xhtml" <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><title>t</title></head><body>
+<table id="outer" border="1"><tr><td>
+  <table id="probe" border="1">
+  <tr><td>Alphabetical</td><td>Numerical</td><td>Chronological</td><td>Categorical</td></tr>
+  <tr><td>AAAAAAAAAA</td><td>BBBBBBBBBB</td><td>CCCCCCCCCC</td><td>DDDDDDDDDD</td></tr>
+  </table>
+</td><td>Sidebar column with its own text</td></tr></table>
+</body></html>
+EOF
+
+# A publisher who happens to have picked our names for their own markup.
+cat >"$work/cases/publisher-markers.xhtml" <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><title>t</title>
+<style id="liseur-fix-css">.publisher-note{color:#333}</style></head><body>
+<table id="probe" class="liseur-wide publisher-note" data-liseur-fit="wide"><tr><td>a</td><td>b</td></tr></table>
+</body></html>
+EOF
+
+cat >"$work/index.html" <<'EOF'
+<!DOCTYPE html><html><head><meta charset="utf-8"><title>running</title>
+<style>body{margin:0;font:12px monospace}#f{border:0;width:412px;height:820px}</style>
+</head><body>
+<iframe id="f"></iframe><pre id="out"></pre>
+<script>
+var FIT = null;
+var results = [];
+function log(ok, name, detail) {
+  results.push((ok ? "PASS " : "FAIL ") + name + (detail ? "  [" + detail + "]" : ""));
+}
+function frame(caseName, fontSize, colCount, dir) {
+  return fetch("cases/" + caseName).then(function (r) { return r.text(); }).then(function (src) {
+    var base = dir === "rtl" ? "../readium-css/rtl/" : "../readium-css/";
+    // column-width acts as a minimum, so readium's 45em default would
+    // collapse a two-column request back to one at any tablet width.
+    var vars = "--USER__fontSize:" + fontSize + "%;--RS__colCount:" + colCount + ";" +
+               (colCount > 1 ? "--RS__colWidth:auto;" : "") +
+               "--USER__view:readium-paged-on;";
+    // The overflow rule is readium's own, injected into every resource; it
+    // is why the excess is painted rather than clipped.
+    var head =
+      '<link rel="stylesheet" href="' + base + 'ReadiumCSS-before.css"/>' +
+      '<style>:root,:root > body{overflow:visible !important}html,body{height:100%}</style>';
+    var tail = '<link rel="stylesheet" href="' + base + 'ReadiumCSS-after.css"/>';
+    src = src.replace("</head>", head + tail + "</head>")
+             .replace("<body>", '<body style="' + vars + '">');
+    src = src.replace(/<html([^>]*)>/, '<html$1 style="' + vars + '" dir="' + (dir || "ltr") + '">');
+    var f = document.getElementById("f");
+    f.style.width = (colCount > 1 ? 800 : 412) + "px";
+    return new Promise(function (res) {
+      f.onload = function () { setTimeout(function () { res(f.contentWindow); }, 60); };
+      f.srcdoc = src;
+    });
+  });
+}
+function measure(win, sel) {
+  var el = win.document.querySelector(sel || "#probe");
+  if (!el) return null;
+  var p = el.parentElement, s = win.getComputedStyle(p);
+  var avail = p.clientWidth - parseFloat(s.paddingLeft) - parseFloat(s.paddingRight);
+  var rects = el.getClientRects(), widest = 0;
+  for (var i = 0; i < rects.length; i++) if (rects[i].width > widest) widest = rects[i].width;
+  return { avail: Math.round(avail), widest: Math.round(widest), frags: rects.length,
+           bleed: Math.round(widest - avail),
+           marked: el.hasAttribute("data-liseur-fit"),
+           attr: el.getAttribute("data-liseur-fit"),
+           cls: el.className,
+           scrollW: el.scrollWidth, clientW: el.clientWidth };
+}
+function run(win) { return win.eval(FIT); }
+function dom(win) { return win.document.body.innerHTML; }
+
+var TESTS = [];
+
+[100, 137.5, 150, 175].forEach(function (fs) {
+  TESTS.push(function () {
+    return frame("wide-table.xhtml", fs, 1).then(function (w) {
+      var before = measure(w);
+      run(w);
+      var after = measure(w);
+      log(after.bleed <= 0, "wide table fits at " + fs + "%",
+          "before bleed " + before.bleed + " -> after " + after.bleed);
+    });
+  });
+});
+
+TESTS.push(function () {
+  return frame("narrow-index.xhtml", 100, 1).then(function (w) {
+    var el = w.document.querySelector("#probe");
+    var union = Math.round(el.getBoundingClientRect().width);
+    run(w);
+    var m = measure(w);
+    log(!m.marked, "narrow index left alone",
+        "bounding rect said " + union + ", widest fragment " + m.widest + ", avail " + m.avail + ", marked " + m.marked);
+    log(m.frags > 1, "narrow index still paginates", m.frags + " fragments");
+  });
+});
+
+TESTS.push(function () {
+  return frame("long-url.xhtml", 100, 1).then(function (w) {
+    var before = measure(w);
+    run(w);
+    var after = measure(w);
+    log(after.scrollW <= after.clientW, "long url wraps",
+        "scrollWidth " + before.scrollW + " -> " + after.scrollW +
+        " (client " + after.clientW + ")");
+  });
+});
+
+TESTS.push(function () {
+  return frame("wide-table.xhtml", 200, 2).then(function (w) {
+    var before = measure(w);
+    run(w);
+    var after = measure(w);
+    log(before.bleed > 0, "two-column mode actually bleeds to begin with",
+        "avail " + before.avail + ", bleed " + before.bleed);
+    log(after.bleed <= 0, "wide table fits in two-column mode",
+        "avail " + after.avail + ", before bleed " + before.bleed +
+        " -> after " + after.bleed);
+  });
+});
+
+TESTS.push(function () {
+  return frame("wide-table.xhtml", 150, 1, "rtl").then(function (w) {
+    var before = measure(w);
+    run(w);
+    var after = measure(w);
+    log(before.bleed > 0, "rtl actually bleeds to begin with", "bleed " + before.bleed);
+    log(after.bleed <= 0, "wide table fits in rtl",
+        "before bleed " + before.bleed + " -> after " + after.bleed);
+  });
+});
+
+TESTS.push(function () {
+  return frame("nested-tables.xhtml", 150, 1).then(function (w) {
+    var b1 = measure(w, "#probe"), b2 = measure(w, "#outer");
+    run(w);
+    var inner = measure(w, "#probe"), outer = measure(w, "#outer");
+    log(b1.bleed > 0 || b2.bleed > 0, "nested actually bleeds to begin with",
+        "outer " + b2.bleed + ", inner " + b1.bleed);
+    log(outer.bleed <= 0, "nested: outer fits", b2.bleed + " -> " + outer.bleed);
+    log(inner.bleed <= 0, "nested: inner fits", b1.bleed + " -> " + inner.bleed);
+  });
+});
+
+TESTS.push(function () {
+  return frame("wide-table.xhtml", 175, 1).then(function (w) {
+    var r1 = run(w);
+    var afterRun1 = dom(w);
+    var installed = !!w.__liseurFit && !!w.__liseurFit.styleEl;
+    var r2 = run(w);
+    log(r1 === "changed", "run 1 reports changed", "got " + r1);
+    log(installed, "run 1 installs the stylesheet");
+    log(r2 === "stable", "run 2 reports stable", "got " + r2);
+    log(dom(w) === afterRun1, "run 2 leaves the dom as run 1 left it");
+  });
+});
+
+TESTS.push(function () {
+  return frame("narrow-index.xhtml", 100, 1).then(function (w) {
+    run(w);
+    log(run(w) === "stable", "untouched page settles to stable");
+  });
+});
+
+TESTS.push(function () {
+  return frame("wide-table.xhtml", 100, 1).then(function (w) {
+    run(w);
+    var small = measure(w).marked;
+    w.document.documentElement.style.setProperty("--USER__fontSize", "175%");
+    w.document.body.style.setProperty("--USER__fontSize", "175%");
+    var r = run(w);
+    var big = measure(w);
+    log(!small, "not marked at 100%");
+    log(big.marked && r === "changed", "marked after growing to 175%",
+        "result " + r + ", bleed " + big.bleed);
+  });
+});
+
+TESTS.push(function () {
+  return frame("publisher-markers.xhtml", 100, 1).then(function (w) {
+    var r = run(w);
+    var m = measure(w);
+    log(!!w.__liseurFit.styleEl, "installs despite an author id=liseur-fix-css");
+    log(m.cls.indexOf("liseur-wide") >= 0 && m.cls.indexOf("publisher-note") >= 0,
+        "author classes untouched", m.cls);
+    log(m.attr === "wide", "author's own data-liseur-fit value left alone",
+        "attr " + m.attr + ", result " + r);
+  });
+});
+
+fetch("fit.js").then(function (r) { return r.text(); }).then(function (t) {
+  FIT = t;
+  return TESTS.reduce(function (p, t) { return p.then(t); }, Promise.resolve());
+}).then(function () {
+  var failed = results.filter(function (r) { return r.indexOf("FAIL") === 0; }).length;
+  document.getElementById("out").textContent = results.join("\n");
+  document.title = failed === 0 ? "ALL PASS" : failed + " FAILED";
+}).catch(function (e) {
+  document.getElementById("out").textContent = "harness error: " + (e && e.stack || e);
+  document.title = "HARNESS ERROR";
+});
+</script></body></html>
+EOF
+
+(cd "$work" && exec python3 -m http.server "$PORT" >/dev/null 2>&1) &
+server=$!
+
+# Wait for the server rather than guessing at it, and make it prove the tree
+# it is serving is this one: a stale server left on the port would answer
+# every request with someone else's script, and every assertion below would
+# then be about the wrong thing.
+ready=false
+for _ in $(seq 1 50); do
+    status=0
+    python3 - "$PORT" "$work/fit.js" <<'PY' || status=$?
+import sys, urllib.request
+port, path = sys.argv[1], sys.argv[2]
+try:
+    served = urllib.request.urlopen("http://127.0.0.1:%s/fit.js" % port, timeout=1).read()
+except Exception:
+    sys.exit(1)
+sys.exit(0 if served == open(path, "rb").read() else 2)
+PY
+    case $status in
+        0)
+            ready=true
+            break
+            ;;
+        2)
+            die "port $PORT is serving another tree; try PORT=… "
+            ;;
+    esac
+    kill -0 "$server" 2>/dev/null ||
+        die "could not serve the harness on port $PORT; something else is using it (try PORT=…)"
+    sleep 0.2
+done
+$ready || die "the harness server never came up on port $PORT"
+
+"$browser" --headless=new --disable-gpu --no-sandbox \
+    --virtual-time-budget=20000 \
+    --user-data-dir="$work/chrome" \
+    --dump-dom "http://127.0.0.1:$PORT/index.html" \
+    >"$work/dump.html" 2>/dev/null
+
+python3 - "$work/dump.html" <<'PY'
+import html, re, sys
+page = open(sys.argv[1]).read()
+title = re.search(r"<title>(.*?)</title>", page, re.S)
+out = re.search(r'<pre id="out">(.*?)</pre>', page, re.S)
+title = title.group(1) if title else "?"
+print(html.unescape(out.group(1)) if out else "(the harness produced no output)")
+print()
+print(title)
+sys.exit(0 if title == "ALL PASS" else 1)
+PY


### PR DESCRIPTION
## Summary

A four-column chart in a local EPUB paints its right-hand columns on top of the
*next* page's prose. Two things have to go wrong together for that, and both are
by design:

1. Readium asks tables to behave with `table { max-width: var(--RS__maxMediaWidth) }`,
   but per CSS 2.1 §17.5.2 a table's used width is never below the sum of its
   columns' min-content widths. With `table-layout: auto` those minimums are
   whatever the longest word in each cell needs, so the clamp is silently ignored
   the moment the reader sets a comfortable type size.
2. Readium then sets `:root, :root > body { overflow: visible !important }` to
   stop that overflow from being clipped (its fix for readium/kotlin-toolkit#292).
   In paginated mode `:root` is the multi-column box whose *columns are the pages*,
   so the excess is not clipped — it is painted over the page that follows.

Measured at a 412px viewport (372px of page): 0px of bleed at 137.5% type, 53px at
137.5%, 88px at 150%, 157px at 175%. The same mechanism catches a bare URL in a
paragraph, because Readium only applies `word-wrap: break-word` to `a` and `h1..h6`.

Fixes #67.

### Why not horizontal scrolling, which the issue asks for

Tried and rejected, on two independent grounds:

- `R2WebView.onTouchEvent` turns any horizontal drag past `mTouchSlop` into a page
  turn without ever consulting an inner scroller, so the gesture is not available
  to give away.
- A scroll container is monolithic and cannot fragment across multicol columns.
  On a 60-row index the baseline lays out as 4 page fragments; wrapped in a
  scroller it becomes 1 fragment 2810px tall inside an 820px page — **1990px of it
  simply unreachable**. The issue title says "Indexes".

### What this does instead

`WideContentFit` measures after Readium's own stylesheets have applied, and only
constrains what genuinely overflows. A table that does not fit is given
`table-layout: fixed` so its columns *can* be squeezed; a long index that merely
looks wide is left exactly as its author wrote it.

Two details worth review:

- **Width comes from the widest single `getClientRects()` fragment, never
  `getBoundingClientRect()`.** Across columns the bounding rect is the *union* of
  all fragments: a well-behaved 60-row index reports 480px against a 357px page,
  while its widest actual fragment is 83px. Using the bounding rect squeezes
  innocent content.
- **The script is injected at runtime, not folded into the resource.**
  `ReadiumCss.hasStyles()` decides whether to link `ReadiumCSS-default.css` by
  looking for `<style`/`style=`/`<link ` in the document, so shipping a `<style>`
  ahead of Readium would make an unstyled book look styled and cost it Readium's
  default typography entirely.

### Position safety

Fitting moves text, and moving text is how a reader loses their place, so the
locator a fit provokes must not be recorded as a page they turned. The existing
`pendingPositionEvent` latch could not carry that — it is one-shot, the preference
path spends it on `submitPreferences()`, and a reflow that settles in two steps was
*already* announcing twice with only the first suppressed. That is a pre-existing
hole, not one this change introduces.

`ReflowScope` replaces the latch: while a reflow is open, every unclaimed locator is
a reflow however many arrive, and `finally` closes the window even on throw or
cancellation. Its mutex keeps a resource swap and a preference change from capturing
anchors out of each other's half-settled layout.

## Changes

- `reader/WideContentFit.kt` — the measure-then-fit script, a `Result` enum, and a
  pure `parse()`. The script mints a per-document random token, writes it as the
  value of its `data-liseur-fit` marker, and only ever clears attributes carrying
  that token, so a publisher's own markup is never touched. Bounded 3-pass loop for
  nested tables; returns `blocked` when `css.sheet` is null (CSP).
- `reader/ReflowScope.kt` — the mutex-serialized reflow window.
- `reader/ReaderScreen.kt` — scope-aware locator classification; fit inserted into
  the preference path and into a new resource-swap trigger.
- `hack/verify-wide-content` — headless-Chrome harness, 24 assertions, run against
  the app's *own* built `readium-css` assets. It extracts `SCRIPT` straight out of
  `WideContentFit.kt` so it cannot drift from the shipped code, and every fix case
  asserts the bleed existed *before*. Not wired into CI — CI has no Chrome.
- Unit tests for `parse()`, for structural properties of the script (the
  `getClientRects` choice, marker ownership, the JSON-quoting trap in
  `evaluateJavascript`'s return), and for the scope's lifecycle.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug` — 0 errors
- [x] `./gradlew assembleDebug`
- [x] `hack/verify-wide-content` — 24/24. Deliberately regressed (`getClientRects` →
      `getBoundingClientRect`) to confirm the harness actually fails; it does.
- [x] Manually tested on an emulator, with a purpose-built EPUB carrying the
      reporter's four-column chart *and* a 60-row narrow index.

Emulator runs covered: the chart at several type sizes, the narrow index (must stay
untouched), both directions across a chapter boundary, and a page turn after a fit
still saving the reader's place across a force-stop.

That last one earned its place — a first cut had the resource-swap trigger reuse the
preference path's `reflowAnchor`, which belongs to the resource being *left*, so
turning into the next chapter threw the reader back to 0% of the previous one. Only
the device caught it; it is fixed by giving that trigger its own anchor.

## Screenshots or recordings

**Before** — the Description and Reference columns of the chart printed on top of the
next page's prose. This is the reporter's screenshot, reproduced:

![before](https://github.com/user-attachments/assets/91a5b433-c7e9-491f-bfe5-ff277b61db97)

**After** — all four columns inside the page:

![after](https://github.com/user-attachments/assets/508c9775-048f-4773-a137-eba5b538f2d0)

**After** — the page that follows is clean prose again:

![after page 2](https://github.com/user-attachments/assets/c6cf5f88-6c28-4c0c-a1b7-54850a1cc786)

**After** — and the narrow 60-row index in the same book is left alone, still
paginating over four pages rather than being squeezed or trapped in a scroller:

![after index](https://github.com/user-attachments/assets/ef73dc82-c060-4954-890e-707470ba3c7e)

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
