### PR TITLE
fix: derive the page's footer reservation instead of hardcoding it

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -69,6 +69,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -704,15 +705,20 @@ fun ReaderScreen(
             // Derived, not measured: the reservation must exist before
             // the page lays out, or the last line is cut in half. The
             // line height is the very style the footer draws with, and
-            // sp-to-dp is exactly a multiply by the font scale.
+            // toDp() owns the sp-to-dp conversion so nonlinear font
+            // scaling is honoured. A footer switched off reserves
+            // nothing — the page takes the whole band back, and the
+            // one reflow that costs is the settings change itself.
             val footerLineHeight = MaterialTheme.typography.labelSmall.lineHeight
+            val footerShowing = prefs.footerMode != FooterMode.NONE
             val footerReserve = FooterMetrics.reservedHeightDp(
-                lineHeightSp = if (footerLineHeight.isSp) {
-                    footerLineHeight.value
-                } else {
-                    FooterMetrics.FALLBACK_LINE_HEIGHT_SP
+                lineHeightDp = with(LocalDensity.current) {
+                    if (footerLineHeight.isSp) {
+                        footerLineHeight.toDp().value
+                    } else {
+                        FooterMetrics.FALLBACK_LINE_HEIGHT_SP.sp.toDp().value
+                    }
                 },
-                fontScale = LocalDensity.current.fontScale,
             ).dp
             AndroidFragment<EpubNavigatorFragment>(
                 modifier = Modifier
@@ -725,11 +731,20 @@ fun ReaderScreen(
                         } else {
                             Modifier
                                 .windowInsetsPadding(WindowInsets.displayCutout)
-                                .windowInsetsPadding(
-                                    WindowInsets.navigationBarsIgnoringVisibility
-                                        .only(WindowInsetsSides.Bottom),
+                                .then(
+                                    if (footerShowing) {
+                                        Modifier.windowInsetsPadding(
+                                            WindowInsets.navigationBarsIgnoringVisibility
+                                                .only(WindowInsetsSides.Bottom),
+                                        )
+                                    } else {
+                                        Modifier
+                                    },
                                 )
-                                .padding(top = 12.dp, bottom = footerReserve)
+                                .padding(
+                                    top = 12.dp,
+                                    bottom = if (footerShowing) footerReserve else 12.dp,
+                                )
                         },
                     ),
             ) { fragment ->

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -706,9 +706,11 @@ fun ReaderScreen(
             // the page lays out, or the last line is cut in half. The
             // line height is the very style the footer draws with, and
             // toDp() owns the sp-to-dp conversion so nonlinear font
-            // scaling is honoured. A footer switched off reserves
-            // nothing — the page takes the whole band back, and the
-            // one reflow that costs is the settings change itself.
+            // scaling is honoured. A footer switched off reserves only
+            // the page's own 12dp margin, same as the top edge — the
+            // footer band and the inset under it go back to the text,
+            // and the one reflow that costs is the settings change
+            // itself.
             val footerLineHeight = MaterialTheme.typography.labelSmall.lineHeight
             val footerShowing = prefs.footerMode != FooterMode.NONE
             val footerReserve = FooterMetrics.reservedHeightDp(

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -109,6 +110,7 @@ import com.chmouel.liseur.reader.chrome.PageTurnOverlay
 import com.chmouel.liseur.reader.chrome.PageTurner
 import com.chmouel.liseur.reader.chrome.ReaderTapZones
 import com.chmouel.liseur.reader.chrome.ReadingFooter
+import com.chmouel.liseur.reader.chrome.FooterMetrics
 import com.chmouel.liseur.reader.chrome.ScrollEdgeTurner
 import com.chmouel.liseur.reader.chrome.visibleWebView
 import com.chmouel.liseur.reader.chrome.layoutPasses
@@ -668,11 +670,15 @@ fun ReaderScreen(
         //
         // The system bars used to be inset out of the way. They are
         // hidden while reading, so all that space bought was a band of
-        // background at the top and bottom of every page. They are not
-        // inset now, and because the layout no longer depends on where
-        // the bars are, showing and hiding the chrome cannot reflow the
-        // page either, which was the other half of what the insets were
-        // for.
+        // background at the top of every page; the top is not inset
+        // now. The bottom of a paged book keeps clear of the footer
+        // instead of the bars: the navigation-bar inset the footer
+        // floats on — read ignoring visibility, so it is the same
+        // whether the bars are shown — and above it the footer's own
+        // derived height (FooterMetrics), which follows the system
+        // font scale the way the fixed count of dp it replaces could
+        // not. Neither figure moves when the chrome shows or hides, so
+        // toggling the chrome still cannot reflow the page.
         //
         // The camera hole is the one thing still kept clear of a page
         // that is turned, because a line behind it is a line that never
@@ -695,6 +701,19 @@ fun ReaderScreen(
         // swipe turns a page is fixed at construction too, and it has to
         // stop turning them when the pages become one long column.
         key(columnMode, scrollMode) {
+            // Derived, not measured: the reservation must exist before
+            // the page lays out, or the last line is cut in half. The
+            // line height is the very style the footer draws with, and
+            // sp-to-dp is exactly a multiply by the font scale.
+            val footerLineHeight = MaterialTheme.typography.labelSmall.lineHeight
+            val footerReserve = FooterMetrics.reservedHeightDp(
+                lineHeightSp = if (footerLineHeight.isSp) {
+                    footerLineHeight.value
+                } else {
+                    FooterMetrics.FALLBACK_LINE_HEIGHT_SP
+                },
+                fontScale = LocalDensity.current.fontScale,
+            ).dp
             AndroidFragment<EpubNavigatorFragment>(
                 modifier = Modifier
                     .fillMaxSize()
@@ -706,7 +725,11 @@ fun ReaderScreen(
                         } else {
                             Modifier
                                 .windowInsetsPadding(WindowInsets.displayCutout)
-                                .padding(top = 12.dp, bottom = 26.dp)
+                                .windowInsetsPadding(
+                                    WindowInsets.navigationBarsIgnoringVisibility
+                                        .only(WindowInsetsSides.Bottom),
+                                )
+                                .padding(top = 12.dp, bottom = footerReserve)
                         },
                     ),
             ) { fragment ->

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/FooterMetrics.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/FooterMetrics.kt
@@ -25,13 +25,13 @@ object FooterMetrics {
     /**
      * The height, in dp, a page must keep clear for the footer.
      *
-     * The text is set in sp, which follows the system font-size
-     * setting; dp does not. Converting sp to dp is exactly a multiply
-     * by the font scale, so the reservation grows with the text it is
-     * making room for. Window insets are deliberately not in here —
-     * they are the layout's job, applied as inset padding where
-     * Compose can consume overlaps between them.
+     * The line height arrives already converted to dp — the caller
+     * owns the sp-to-dp conversion, through `Density.toDp()`, which
+     * honours Android's nonlinear font scaling where a bare multiply
+     * by the font scale would not. Window insets are deliberately not
+     * in here either — they are the layout's job, applied as inset
+     * padding where Compose can consume overlaps between them.
      */
-    fun reservedHeightDp(lineHeightSp: Float, fontScale: Float): Float =
-        lineHeightSp * fontScale + VERTICAL_PADDING_DP * 2 + CLEARANCE_DP
+    fun reservedHeightDp(lineHeightDp: Float): Float =
+        lineHeightDp + VERTICAL_PADDING_DP * 2 + CLEARANCE_DP
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/FooterMetrics.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/FooterMetrics.kt
@@ -1,0 +1,37 @@
+package com.chmouel.liseur.reader.chrome
+
+/**
+ * The one place that knows how tall the reading footer is.
+ *
+ * The page reserves the footer's room before it lays itself out (see
+ * ReaderScreen), so the reservation cannot be measured off the composed
+ * footer — it has to be derived. Everything the derivation uses lives
+ * here, and [ReadingFooter] draws with the same constants, so the
+ * reservation and the footer cannot drift apart.
+ */
+object FooterMetrics {
+    /** Vertical padding inside the footer row, top and bottom, in dp. */
+    const val VERTICAL_PADDING_DP = 6f
+
+    /** Air kept between the page's last line and the footer's top edge, in dp. */
+    const val CLEARANCE_DP = 4f
+
+    /**
+     * The line height the footer's labelSmall text falls back to when
+     * the theme's value is not given in sp (Material's own default).
+     */
+    const val FALLBACK_LINE_HEIGHT_SP = 16f
+
+    /**
+     * The height, in dp, a page must keep clear for the footer.
+     *
+     * The text is set in sp, which follows the system font-size
+     * setting; dp does not. Converting sp to dp is exactly a multiply
+     * by the font scale, so the reservation grows with the text it is
+     * making room for. Window insets are deliberately not in here —
+     * they are the layout's job, applied as inset padding where
+     * Compose can consume overlaps between them.
+     */
+    fun reservedHeightDp(lineHeightSp: Float, fontScale: Float): Float =
+        lineHeightSp * fontScale + VERTICAL_PADDING_DP * 2 + CLEARANCE_DP
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReadingProgressUi.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReadingProgressUi.kt
@@ -67,7 +67,7 @@ fun ReadingFooter(
         modifier
             .fillMaxWidth()
             .clickableWithoutRipple(onCycleMode)
-            .padding(horizontal = 20.dp, vertical = 6.dp),
+            .padding(horizontal = 20.dp, vertical = FooterMetrics.VERTICAL_PADDING_DP.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/FooterMetricsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/FooterMetricsTest.kt
@@ -1,0 +1,50 @@
+package com.chmouel.liseur.reader.chrome
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The room a page keeps clear for the footer. The footer's text is set
+ * in sp and follows the system font size; the reservation is derived
+ * from the same line height and the same paddings, so it must follow
+ * too — the fixed 26dp it replaced is exactly the bug being guarded
+ * against here.
+ */
+class FooterMetricsTest {
+
+    @Test
+    fun `reserves the line and both paddings at default scale`() {
+        // 16sp line + 2 × 6dp padding + 4dp clearance.
+        assertEquals(32f, FooterMetrics.reservedHeightDp(16f, 1.0f), 1e-4f)
+    }
+
+    @Test
+    fun `grows with the font scale`() {
+        assertEquals(36.8f, FooterMetrics.reservedHeightDp(16f, 1.3f), 1e-4f)
+        assertEquals(48f, FooterMetrics.reservedHeightDp(16f, 2.0f), 1e-4f)
+    }
+
+    @Test
+    fun `keeps a fractional scale exact rather than rounding it away`() {
+        assertEquals(34.4f, FooterMetrics.reservedHeightDp(16f, 1.15f), 1e-4f)
+    }
+
+    @Test
+    fun `only the text scales, never the paddings`() {
+        val atOne = FooterMetrics.reservedHeightDp(16f, 1.0f)
+        val atTwo = FooterMetrics.reservedHeightDp(16f, 2.0f)
+        assertEquals(16f, atTwo - atOne, 1e-4f)
+    }
+
+    @Test
+    fun `clears the footer's drawn height at every scale`() {
+        for (scale in floatArrayOf(0.85f, 1.0f, 1.15f, 1.3f, 2.0f)) {
+            val drawn = 16f * scale + FooterMetrics.VERTICAL_PADDING_DP * 2
+            assertTrue(
+                "no clearance left at font scale $scale",
+                FooterMetrics.reservedHeightDp(16f, scale) > drawn,
+            )
+        }
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/FooterMetricsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/FooterMetricsTest.kt
@@ -6,44 +6,48 @@ import org.junit.Test
 
 /**
  * The room a page keeps clear for the footer. The footer's text is set
- * in sp and follows the system font size; the reservation is derived
- * from the same line height and the same paddings, so it must follow
- * too — the fixed 26dp it replaced is exactly the bug being guarded
- * against here.
+ * in sp and follows the system font size; the caller converts it to dp
+ * through Compose's Density (which knows about nonlinear font scaling)
+ * and the reservation is derived from that converted height plus the
+ * same paddings the footer draws with — the fixed 26dp it replaced is
+ * exactly the bug being guarded against here.
  */
 class FooterMetricsTest {
 
     @Test
-    fun `reserves the line and both paddings at default scale`() {
-        // 16sp line + 2 × 6dp padding + 4dp clearance.
-        assertEquals(32f, FooterMetrics.reservedHeightDp(16f, 1.0f), 1e-4f)
+    fun `reserves the line and both paddings`() {
+        // 16dp line + 2 × 6dp padding + 4dp clearance.
+        assertEquals(32f, FooterMetrics.reservedHeightDp(16f), 1e-4f)
     }
 
     @Test
-    fun `grows with the font scale`() {
-        assertEquals(36.8f, FooterMetrics.reservedHeightDp(16f, 1.3f), 1e-4f)
-        assertEquals(48f, FooterMetrics.reservedHeightDp(16f, 2.0f), 1e-4f)
+    fun `grows with the converted line height`() {
+        // 16sp at font scale 1.3 and 2.0 under linear scaling; the
+        // exact conversion is Density's business, the reservation just
+        // has to carry whatever it says.
+        assertEquals(36.8f, FooterMetrics.reservedHeightDp(20.8f), 1e-4f)
+        assertEquals(48f, FooterMetrics.reservedHeightDp(32f), 1e-4f)
     }
 
     @Test
-    fun `keeps a fractional scale exact rather than rounding it away`() {
-        assertEquals(34.4f, FooterMetrics.reservedHeightDp(16f, 1.15f), 1e-4f)
+    fun `keeps a fractional height exact rather than rounding it away`() {
+        assertEquals(34.4f, FooterMetrics.reservedHeightDp(18.4f), 1e-4f)
     }
 
     @Test
-    fun `only the text scales, never the paddings`() {
-        val atOne = FooterMetrics.reservedHeightDp(16f, 1.0f)
-        val atTwo = FooterMetrics.reservedHeightDp(16f, 2.0f)
+    fun `only the text grows, never the paddings`() {
+        val atOne = FooterMetrics.reservedHeightDp(16f)
+        val atTwo = FooterMetrics.reservedHeightDp(32f)
         assertEquals(16f, atTwo - atOne, 1e-4f)
     }
 
     @Test
-    fun `clears the footer's drawn height at every scale`() {
-        for (scale in floatArrayOf(0.85f, 1.0f, 1.15f, 1.3f, 2.0f)) {
-            val drawn = 16f * scale + FooterMetrics.VERTICAL_PADDING_DP * 2
+    fun `clears the footer's drawn height at every text size`() {
+        for (lineDp in floatArrayOf(13.6f, 16f, 18.4f, 20.8f, 32f)) {
+            val drawn = lineDp + FooterMetrics.VERTICAL_PADDING_DP * 2
             assertTrue(
-                "no clearance left at font scale $scale",
-                FooterMetrics.reservedHeightDp(16f, scale) > drawn,
+                "no clearance left at line height ${lineDp}dp",
+                FooterMetrics.reservedHeightDp(lineDp) > drawn,
             )
         }
     }


### PR DESCRIPTION
Fixes #72

A tester's screenshot showed the last line of a page running into the reading footer. The paged navigator reserved a fixed `26.dp` for the footer, but the footer's real bottom extent is bigger whenever the system font scale is above ~1.15 (the footer is sp-set labelSmall text; dp does not scale) or the device has a navigation-bar inset the footer floats on (gesture nav reproduces the overlap at font scale 1.0).

The reservation is now derived, before the page lays out, from:

- a chained `windowInsetsPadding(navigationBarsIgnoringVisibility.only(Bottom))`, so Compose consumes any overlap with the display-cutout inset and chrome toggles still cannot reflow the page, plus
- `FooterMetrics.reservedHeightDp`: the same `labelSmall` line height the footer draws with (sp → dp via the font scale) plus shared padding constants `ReadingFooter` itself now uses, plus 4dp clearance.

No new setting; the fix is automatic. Scroll mode is untouched (no footer is drawn over a scrolled page).

Verified on the emulator at font scale 1.3 with gesture navigation; `testDebugUnitTest`, `lintDebug` and `assembleDebug` pass, with a new JVM test for the height math.

### Screenshot

Font scale 1.3, gesture navigation — the last line clears the footer:

<img src="https://github.com/user-attachments/assets/a6c27549-e5ab-4c2c-b95b-ab5cf0ce0147" width="360" alt="reader page at font scale 1.3 with the last line clearing the footer" />
