### PR TITLE
fix: put the release on the Play track testers are recruited into

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,9 @@ jobs:
       # Everything below is Google Play, and only Google Play. It runs
       # after the release above on purpose: the GitHub artefact and the
       # F-Droid submission are the primary channels, so a rejected upload
-      # here must never be what makes a release fail.
+      # here must never be what makes a release fail. The lane puts the
+      # build on the internal track and then on the closed one testers
+      # are recruited into; see DEVELOPER.md for why both.
       - name: Check for the Play credential
         id: play
         env:
@@ -177,7 +179,7 @@ jobs:
         with:
           ruby-version: "3.3"
 
-      - name: Upload to the Play internal track
+      - name: Upload to the Play testing tracks
         if: steps.play.outputs.enabled == 'true'
         continue-on-error: true
         env:

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -262,11 +262,24 @@ To install one, download the APK from the release page and
 Play is the third channel, after the GitHub release and F-Droid, and it
 is deliberately the least load-bearing of the three. The same tag that
 publishes the release also builds an app bundle and pushes it to the
-**internal testing** track:
+**internal testing** track, then promotes that same build to the
+**closed** track named `Testing`:
 
 ```bash
 make bundle     # ./gradlew bundleRelease, for Play only
 ```
+
+The second track is not decoration. Internal testing holds a hundred
+hand-listed addresses and hands out its own opt-in link; the closed
+track is the one testers are recruited into (issue #62), the one
+`https://play.google.com/apps/testing/com.chmouel.liseur` leads to, and
+the only one whose opted-in testers count towards the twelve Play wants
+for fourteen days before a personal developer account may publish.
+Uploading to internal alone, which is what happened up to 0.10.0, leaves
+everyone who followed the instructions on whichever build the closed
+track was last given by hand — 0.9.3, as it turned out, four releases
+back. `hack/store-status` now says so in a line when the closed track
+falls behind internal, because nothing else did.
 
 Nothing about the APK path changes. F-Droid's recipe builds
 `assembleRelease` and never sees `fastlane/Fastfile`, no Gradle
@@ -285,6 +298,34 @@ The upload runs `fastlane android internal` with
 other apps on the account; it needs *Release to testing tracks* on Liseur
 under Users and permissions.
 
+A build that is already on internal — a release whose Play step was
+skipped, or one that predates the promotion — can be pushed across
+without rebuilding:
+
+```bash
+fastlane android promote version_code:19
+```
+
+The version code defaults to whatever `app/build.gradle.kts` currently
+says, so the argument is only needed for an older build.
+
+**Who can actually install it.** Everything above puts a build on a
+track; none of it lets anyone in. The tester list is console state, and
+these are the things that quietly turn a correct opt-in link into "this
+app isn't available":
+
+- The closed `Testing` track needs an **email list** attached, holding
+  the Google account each tester uses *on their phone*. A Google Group
+  works too, but adds an approval step that nobody sees fail: an
+  unapproved join request and a missing address look identical from the
+  tester's side.
+- Country availability for the track has to include the countries
+  testers are writing from.
+- The track's release must be `completed`, not draft. `hack/store-status`
+  prints the status of each one.
+- Adding an address is not instant. Play takes a few hours to
+  propagate, so a tester told to try again should be told to wait.
+
 Only the changelog is pushed from the repository. The store listing is
 edited in the console, because Play holds declarations that no file here
 describes — data safety, content rating, target audience, app access, ads
@@ -294,9 +335,9 @@ Play links to is `docs/PRIVACY.md`, served by GitHub Pages from `main`
 `/docs`; it is a published legal document, so change it in a commit and
 not in the console.
 
-Promotion out of internal testing is a manual action in the console, on
-purpose. Nothing in this repository can put a build in front of the
-public.
+Promotion out of testing and in front of the public is a manual action
+in the console, on purpose. Nothing in this repository can put a build
+on the production track.
 
 **The signing key.** Play App Signing holds the same key as the GitHub
 release, enrolled from `pass` through Google's PEPK tool rather than

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,11 +8,60 @@
 # the console, because Play holds the declarations (data safety, content
 # rating, target audience) that no file in this repository describes, and
 # an accidental metadata push is a listing change under review.
+#
+# A build goes to two tracks, not one. Internal testing is the fast lane
+# and holds a hundred hand-listed addresses at most; the closed track is
+# where testers are actually recruited — it is the one the opt-in link in
+# issue #62 points at, and the only one whose opted-in testers count
+# towards the twelve Play wants for fourteen days before a personal
+# account may publish. Uploading to internal alone, which this did until
+# 0.10.0, leaves everyone who followed the instructions on whatever build
+# the closed track was last given by hand.
 
 default_platform(:android)
 
+# The track the bundle is uploaded to, and the track that upload is then
+# promoted to. The second name is the closed track's id in the Play API,
+# which is the display name it was created with rather than one of the
+# four standard ids.
+INTERNAL_TRACK = "internal".freeze
+CLOSED_TRACK = "Testing".freeze
+
+# The version code being released, read from the one file that decides
+# it. Promotion has to name a build, and naming it from the source is
+# what keeps the promotion pointed at the bundle just uploaded.
+def liseur_version_code
+  gradle = File.expand_path("../app/build.gradle.kts", __dir__)
+  code = File.read(gradle)[/^\s*versionCode\s*=\s*(\d+)/, 1]
+  UI.user_error!("no versionCode in #{gradle}") if code.nil?
+  code.to_i
+end
+
+# Moving a build already on the internal track across to the closed one.
+# The bundle is not sent again: Play refuses a version code it has seen,
+# so the only way to put one build on two tracks is to promote it.
+def liseur_promote(version_code)
+  upload_to_play_store(
+    track: INTERNAL_TRACK,
+    track_promote_to: CLOSED_TRACK,
+    track_promote_release_status: "completed",
+    version_code: version_code,
+    # Promoting takes the build off the track it came from unless it is
+    # told not to, and a build that leaves internal is a build the fast
+    # lane no longer has. It belongs on both.
+    deactivate_on_promote: false,
+    skip_upload_aab: true,
+    skip_upload_apk: true,
+    skip_upload_metadata: true,
+    skip_upload_images: true,
+    skip_upload_screenshots: true,
+    skip_upload_changelogs: false,
+    validate_only: ENV["PLAY_VALIDATE_ONLY"] == "true"
+  )
+end
+
 platform :android do
-  desc "Upload the release bundle to the Play internal testing track"
+  desc "Upload the release bundle to the Play internal track, then promote it to the closed track"
   lane :internal do
     # Anchored to this file rather than the working directory: fastlane
     # runs lanes from inside fastlane/, so a bare relative path would
@@ -20,8 +69,10 @@ platform :android do
     bundle = File.expand_path("../app/build/outputs/bundle/release/app-release.aab", __dir__)
     UI.user_error!("no bundle at #{bundle} — run ./gradlew bundleRelease") unless File.exist?(bundle)
 
+    version_code = liseur_version_code
+
     upload_to_play_store(
-      track: "internal",
+      track: INTERNAL_TRACK,
       aab: bundle,
       # A track upload is a release; the APK path belongs to GitHub.
       skip_upload_apk: true,
@@ -35,5 +86,18 @@ platform :android do
       release_status: "completed",
       validate_only: ENV["PLAY_VALIDATE_ONLY"] == "true"
     )
+
+    liseur_promote(version_code)
+    UI.success("#{version_code} is on #{INTERNAL_TRACK} and #{CLOSED_TRACK}")
+  end
+
+  desc "Promote a build already on the internal track to the closed track, without rebuilding"
+  lane :promote do |options|
+    # For a release whose bundle is already up: the version code can be
+    # named outright (fastlane android promote version_code:19), and
+    # falls back to whatever the source says is current.
+    version_code = (options[:version_code] || ENV["PLAY_VERSION_CODE"] || liseur_version_code).to_i
+    liseur_promote(version_code)
+    UI.success("#{version_code} is on #{CLOSED_TRACK}")
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -96,7 +96,14 @@ platform :android do
     # For a release whose bundle is already up: the version code can be
     # named outright (fastlane android promote version_code:19), and
     # falls back to whatever the source says is current.
-    version_code = (options[:version_code] || ENV["PLAY_VERSION_CODE"] || liseur_version_code).to_i
+    requested = (options[:version_code] || ENV["PLAY_VERSION_CODE"] || liseur_version_code).to_s
+    # to_i turns anything unparseable into 0, which Play would take as a
+    # promotion of nothing at all: refuse it here instead.
+    unless requested.match?(/\A[1-9][0-9]*\z/)
+      UI.user_error!("version_code must be a positive integer, got #{requested.inspect}")
+    end
+
+    version_code = requested.to_i
     liseur_promote(version_code)
     UI.success("#{version_code} is on #{CLOSED_TRACK}")
   end

--- a/hack/README.md
+++ b/hack/README.md
@@ -57,9 +57,11 @@ target wrapping them — run `make help` for the short list. See
   three channels at once: the last GitHub releases, what F-Droid has
   published and how old its index is, what its last build run did with
   the app, the fdroiddata metadata, any open merge request with its
-  pipeline state, and what sits on each Google Play track. Everything
+  pipeline state, and what sits on each Google Play track. It also says
+  when the closed track testers are recruited into has fallen behind
+  internal, and prints the opt-in link they are handed. Everything
   but the Play section reads public sources; Play has no public answer
-  while the app is in internal testing, so that one signs a token with
+  while the app is in testing, so that one signs a token with
   the service account from `pass` and is skipped with a line when it
   cannot. Backs `make store-status`.
 - **`verify-reproducible`** — Builds the release APK twice from two

--- a/hack/README.md
+++ b/hack/README.md
@@ -58,7 +58,7 @@ target wrapping them — run `make help` for the short list. See
   published and how old its index is, what its last build run did with
   the app, the fdroiddata metadata, any open merge request with its
   pipeline state, and what sits on each Google Play track. It also says
-  when the closed track testers are recruited into has fallen behind
+  when the closed track that testers are recruited into falls behind
   internal, and prints the opt-in link they are handed. Everything
   but the Play section reads public sources; Play has no public answer
   while the app is in testing, so that one signs a token with

--- a/hack/store-status
+++ b/hack/store-status
@@ -159,8 +159,12 @@ report_play() {
              | .releases[]? | .versionCodes[]? | tonumber] | max // 0;
         (codes("internal")) as $internal
         | (codes($closed)) as $recruiting
-        | if $recruiting == 0 then
+        | if $recruiting == 0 and $internal == 0 then
+              "  warning: nothing on either the \($closed) or internal track"
+          elif $recruiting == 0 then
               "  warning: nothing on the \($closed) track; the opt-in link leads nowhere"
+          elif $internal == 0 then
+              "  \($closed) has versionCode \($recruiting); nothing on internal"
           elif $recruiting < $internal then
               "  warning: \($closed) has versionCode \($recruiting), internal has \($internal);"
               + " testers who used the opt-in link are on the older build"

--- a/hack/store-status
+++ b/hack/store-status
@@ -20,6 +20,12 @@ readonly FDROID_PROJECT="fdroid%2Ffdroiddata"
 readonly PASS_PLAY_SERVICE_ACCOUNT="android/google.play.service.serviceaccount"
 readonly PLAY_API="https://androidpublisher.googleapis.com/androidpublisher/v3"
 readonly PLAY_SCOPE="https://www.googleapis.com/auth/androidpublisher"
+# The closed track testers are actually recruited into, and the link
+# they are handed. Internal testing has its own link and its own
+# hundred-address limit, and none of its testers count towards the
+# twelve Play wants before a personal account may publish.
+readonly PLAY_CLOSED_TRACK="Testing"
+readonly PLAY_OPT_IN_URL="https://play.google.com/apps/testing/$APP_ID"
 
 die() {
     printf 'error: %s\n' "$*" >&2
@@ -140,6 +146,28 @@ report_play() {
                     + "] versionCode \((.versionCodes // ["none"]) | join(", "))"
               end
         end'
+
+    # A build on internal and nowhere else is the state that went
+    # unnoticed for four releases: everyone who followed the opt-in link
+    # is on the closed track, so a closed track left behind is a room
+    # full of testers reading an old build and a fourteen-day clock that
+    # is not running. Said outright rather than left to be spotted in the
+    # version codes above.
+    printf '%s' "$tracks" | jq -r --arg closed "$PLAY_CLOSED_TRACK" '
+        def codes($name):
+            [.tracks[]? | select(.track == $name)
+             | .releases[]? | .versionCodes[]? | tonumber] | max // 0;
+        (codes("internal")) as $internal
+        | (codes($closed)) as $recruiting
+        | if $recruiting == 0 then
+              "  warning: nothing on the \($closed) track; the opt-in link leads nowhere"
+          elif $recruiting < $internal then
+              "  warning: \($closed) has versionCode \($recruiting), internal has \($internal);"
+              + " testers who used the opt-in link are on the older build"
+          else
+              "  \($closed) is level with internal at versionCode \($recruiting)"
+          end'
+    printf '  tester opt-in: %s\n' "$PLAY_OPT_IN_URL"
 }
 
 require_command curl


### PR DESCRIPTION
## Why

Testers reported they could not join the Play test. The Play API explains it:

| Track | Was | Now |
| --- | --- | --- |
| `internal` | 0.10.0 (vc 19) | 0.10.0 (vc 19) |
| `Testing` (closed) | **0.9.3 (vc 17)** | 0.10.0 (vc 19) |

`fastlane/Fastfile` uploaded to `internal` only, but the opt-in link in #62 (`play.google.com/apps/testing/…`) leads to the **closed** track. Internal testing has its own separate link and a 100-address limit, so everyone who followed the instructions correctly landed on a track four releases behind. Worse, internal testers do not count towards Google's 12-testers-for-14-days requirement, so the clock was never running.

## What changed

- `fastlane/Fastfile`: the `internal` lane now promotes the build it just uploaded to the closed track (a second plain upload of the same AAB is rejected — `versionCode has already been used` — so promotion is the only shape that works). Version code is read from `app/build.gradle.kts`. A new `promote` lane moves an older build across without rebuilding.
- `hack/store-status`: warns when the closed track falls behind internal, and prints the opt-in link testers are handed.
- `DEVELOPER.md`: documents both tracks, the `promote` lane, and the console-side reasons an opt-in silently fails (email list, country availability, draft status, propagation delay).

## Already done outside this PR

- 0.10.0 backfilled onto the closed track (`fastlane android promote version_code:19`); `store-status` confirms both tracks at vc 19.
- #62 rewritten: the Google Group step is gone — an unapproved join request is indistinguishable from being refused — replaced by an email list, with a troubleshooting section for the real failure modes.

## Validation

`fastlane android promote` was run against the real Play API with `PLAY_VALIDATE_ONLY=true` first, then for real; `hack/store-status` shows both tracks level. Shellcheck and a YAML parse pass on the changed files.