### PR TITLE
feat(reader): scroll the page for me

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ themes (Light, Sepia, Dark, and true OLED Black) let you settle into a story at
 2 a.m. without being blinded by your phone. Margins, line spacing, brightness,
 and page turns stay quietly out of your way. Prefer one long scroll to turning
 pages? Switch it on for the whole library, or for the one book that wants it,
-and keep scrolling past the end of a chapter to fall into the next one.
+and keep scrolling past the end of a chapter to fall into the next one. Set it
+scrolling by itself, at a pace you pick, and it carries on across chapters
+until you touch the page — handy over lunch, or with one hand on a strap.
 
 A discreet footer shows the time remaining in the chapter (just enough to
 convince yourself that one more chapter won't hurt), while highlights, margin

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPreferencesRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPreferencesRepository.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.chmouel.liseur.reader.chrome.AutoScrollSpeed
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -29,6 +30,7 @@ class ReaderPreferencesRepository(private val context: Context) {
         val PAGE_TURN_ANIMATION = booleanPreferencesKey("page_turn_animation")
         val FOOTER_MODE = stringPreferencesKey("footer_mode")
         val COLUMN_MODE = stringPreferencesKey("column_mode")
+        val AUTO_SCROLL_SPEED = floatPreferencesKey("auto_scroll_speed")
     }
 
     val prefs: Flow<ReaderPrefs> = context.readerPrefsStore.data.map { p ->
@@ -42,6 +44,7 @@ class ReaderPreferencesRepository(private val context: Context) {
             pageTurnAnimation = p[Keys.PAGE_TURN_ANIMATION] ?: true,
             footerMode = FooterMode.fromId(p[Keys.FOOTER_MODE]),
             columnMode = ColumnMode.fromId(p[Keys.COLUMN_MODE]),
+            autoScrollSpeed = p[Keys.AUTO_SCROLL_SPEED] ?: AutoScrollSpeed.DEFAULT_STEP,
         )
     }
 
@@ -87,5 +90,11 @@ class ReaderPreferencesRepository(private val context: Context) {
 
     suspend fun setColumnMode(mode: ColumnMode) {
         context.readerPrefsStore.edit { it[Keys.COLUMN_MODE] = mode.id }
+    }
+
+    suspend fun setAutoScrollSpeed(step: Float) {
+        context.readerPrefsStore.edit {
+            it[Keys.AUTO_SCROLL_SPEED] = AutoScrollSpeed.snap(step)
+        }
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPreferencesRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPreferencesRepository.kt
@@ -9,7 +9,6 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
-import com.chmouel.liseur.reader.chrome.AutoScrollSpeed
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -44,7 +43,9 @@ class ReaderPreferencesRepository(private val context: Context) {
             pageTurnAnimation = p[Keys.PAGE_TURN_ANIMATION] ?: true,
             footerMode = FooterMode.fromId(p[Keys.FOOTER_MODE]),
             columnMode = ColumnMode.fromId(p[Keys.COLUMN_MODE]),
-            autoScrollSpeed = p[Keys.AUTO_SCROLL_SPEED] ?: AutoScrollSpeed.DEFAULT_STEP,
+            autoScrollSpeed = AutoScrollPreference.sanitize(
+                p[Keys.AUTO_SCROLL_SPEED] ?: AutoScrollPreference.DEFAULT_STEP,
+            ),
         )
     }
 
@@ -94,7 +95,7 @@ class ReaderPreferencesRepository(private val context: Context) {
 
     suspend fun setAutoScrollSpeed(step: Float) {
         context.readerPrefsStore.edit {
-            it[Keys.AUTO_SCROLL_SPEED] = AutoScrollSpeed.snap(step)
+            it[Keys.AUTO_SCROLL_SPEED] = AutoScrollPreference.snap(step)
         }
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPrefs.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPrefs.kt
@@ -1,7 +1,7 @@
 package com.chmouel.liseur.data.settings
 
 import androidx.compose.ui.graphics.Color
-import com.chmouel.liseur.reader.chrome.AutoScrollSpeed
+import kotlin.math.roundToInt
 
 /**
  * Curated reading fonts, all OFL-licensed and bundled in assets/fonts.
@@ -163,6 +163,44 @@ enum class ColumnMode(val id: String, val displayName: String) {
 }
 
 /**
+ * Which notch the auto-scroll slider sits on, as it is stored.
+ *
+ * The bounds live here rather than beside the scrolling loop because
+ * they describe the *setting*: what the slider may show, and what the
+ * preference store may hold. The pace those notches come to is the
+ * reader's business, and is in `reader/chrome/AutoScroll.kt`.
+ *
+ * A step is stored rather than a speed so the slider means the same
+ * thing whatever else changes, and so a reader who comes back to it
+ * finds the notch they left it on.
+ */
+object AutoScrollPreference {
+
+    const val MIN_STEP = 1
+    const val MAX_STEP = 10
+    const val DEFAULT_STEP = 4f
+
+    /**
+     * A step read back from storage, made safe to use.
+     *
+     * Nothing in the app writes a step outside the range, but the store
+     * is a file on a device and this is the only door its contents come
+     * through. A value that is not a number at all falls back to the
+     * default rather than propagating: a NaN pace multiplies out to a
+     * NaN distance, which is a page that silently never moves again.
+     */
+    fun sanitize(step: Float): Float =
+        if (step.isFinite()) {
+            step.coerceIn(MIN_STEP.toFloat(), MAX_STEP.toFloat())
+        } else {
+            DEFAULT_STEP
+        }
+
+    /** The nearest whole notch, for a slider that lands on one. */
+    fun snap(step: Float): Float = sanitize(step).roundToInt().toFloat()
+}
+
+/**
  * User reading preferences.
  *
  * @param fontSize Percentage where 1.0 is the publisher's default size.
@@ -173,9 +211,9 @@ enum class ColumnMode(val id: String, val displayName: String) {
  * @param footerMode What the reading footer shows.
  * @param columnMode How many columns of text a wide page is broken into.
  * @param autoScrollSpeed Which notch the auto-scroll slider sits on, from
- *   [AutoScrollSpeed.MIN_STEP] to [AutoScrollSpeed.MAX_STEP]. Not a speed:
- *   the pace it comes to also depends on [fontSize], because larger text
- *   has further to travel to show the same words.
+ *   [AutoScrollPreference.MIN_STEP] to [AutoScrollPreference.MAX_STEP]. Not a
+ *   speed: the pace it comes to also depends on [fontSize], because larger
+ *   text has further to travel to show the same words.
  */
 data class ReaderPrefs(
     val font: ReaderFont = ReaderFont.Default,
@@ -187,7 +225,7 @@ data class ReaderPrefs(
     val pageTurnAnimation: Boolean = true,
     val footerMode: FooterMode = FooterMode.Default,
     val columnMode: ColumnMode = ColumnMode.Default,
-    val autoScrollSpeed: Float = AutoScrollSpeed.DEFAULT_STEP,
+    val autoScrollSpeed: Float = AutoScrollPreference.DEFAULT_STEP,
 ) {
     companion object {
         const val MIN_FONT_SIZE = 0.6

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPrefs.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPrefs.kt
@@ -1,6 +1,7 @@
 package com.chmouel.liseur.data.settings
 
 import androidx.compose.ui.graphics.Color
+import com.chmouel.liseur.reader.chrome.AutoScrollSpeed
 
 /**
  * Curated reading fonts, all OFL-licensed and bundled in assets/fonts.
@@ -171,6 +172,10 @@ enum class ColumnMode(val id: String, val displayName: String) {
  * @param pageTurnAnimation Slide animation when turning pages; instant jump when off.
  * @param footerMode What the reading footer shows.
  * @param columnMode How many columns of text a wide page is broken into.
+ * @param autoScrollSpeed Which notch the auto-scroll slider sits on, from
+ *   [AutoScrollSpeed.MIN_STEP] to [AutoScrollSpeed.MAX_STEP]. Not a speed:
+ *   the pace it comes to also depends on [fontSize], because larger text
+ *   has further to travel to show the same words.
  */
 data class ReaderPrefs(
     val font: ReaderFont = ReaderFont.Default,
@@ -182,6 +187,7 @@ data class ReaderPrefs(
     val pageTurnAnimation: Boolean = true,
     val footerMode: FooterMode = FooterMode.Default,
     val columnMode: ColumnMode = ColumnMode.Default,
+    val autoScrollSpeed: Float = AutoScrollSpeed.DEFAULT_STEP,
 ) {
     companion object {
         const val MIN_FONT_SIZE = 0.6

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
@@ -273,6 +273,13 @@ class ReaderActivity : FragmentActivity() {
                                     onKeepScreenOnChanged = viewModel::setKeepScreenOn,
                                     scrollModeFlow = viewModel.scrollMode,
                                     onScrollModeChanged = viewModel::setScrollMode,
+                                    // Dialogs of this activity's own,
+                                    // drawn over the reader. The page
+                                    // must not carry on scrolling under
+                                    // a question nobody has answered.
+                                    blockedByDialog = pendingExternalLink != null ||
+                                        pendingOffer != null ||
+                                        bookSync !is ReaderViewModel.BookSync.Idle,
                                     onPageTurnerChanged = { pageTurner = it },
                                     onChromeVisibleChanged = { chromeVisible = it },
                                     onPrefsAction = remember {
@@ -285,6 +292,7 @@ class ReaderActivity : FragmentActivity() {
                                             setBrightness = viewModel::setBrightness,
                                             setPageTurnAnimation = viewModel::setPageTurnAnimation,
                                             setColumnMode = viewModel::setColumnMode,
+                                            setAutoScrollSpeed = viewModel::setAutoScrollSpeed,
                                             setTypographyIsOwn = viewModel::setTypographyIsOwn,
                                         )
                                     },

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -105,6 +105,9 @@ import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.ReaderTheme
 import com.chmouel.liseur.data.settings.ReaderThemeChoice
 import com.chmouel.liseur.reader.chrome.CatchUpPill
+import com.chmouel.liseur.reader.chrome.AdvancedSheet
+import com.chmouel.liseur.reader.chrome.AutoScrollSpeed
+import com.chmouel.liseur.reader.chrome.AutoScrollTicker
 import com.chmouel.liseur.reader.chrome.JumpBackPill
 import com.chmouel.liseur.reader.chrome.PageTurnEffectState
 import com.chmouel.liseur.reader.chrome.PageTurnOverlay
@@ -131,14 +134,18 @@ import com.chmouel.liseur.ui.widthClass
 import com.chmouel.liseur.ui.windowWidth
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import org.readium.r2.navigator.Decoration
@@ -166,6 +173,34 @@ private const val VERIFY_ATTEMPTS = 3
 // mode makes on the way up, and the stream of them a handle drag sends;
 // short enough that the bar still feels like it answers the gesture.
 private const val SELECTION_SETTLE_MS = 90L
+
+// How long auto-scroll waits for the next chapter to actually arrive
+// after asking for it. Generous, because a large chapter on a slow
+// device takes a moment, and bounded, because a page that cannot be
+// stopped is worse than a page that stops early.
+private const val CHAPTER_ARRIVAL_MS = 5_000L
+
+// The look the last lines of a chapter get before the page moves on,
+// however fast or slow the reader has it set.
+private const val MIN_CHAPTER_DWELL_MS = 400L
+private const val MAX_CHAPTER_DWELL_MS = 8_000L
+
+// How often a self-scrolling page writes down where it has got to. It
+// is what stands between a reader who backgrounds the app mid-scroll
+// and a place a paragraph or two behind them; short enough that the
+// loss is a line, long enough that a document round trip every so often
+// costs nothing.
+private const val AUTO_SCROLL_SAVE_NANOS = 2_000_000_000L
+
+/**
+ * Which sheet is open over the page, if any.
+ *
+ * One value rather than a flag each, because they are not independent:
+ * Advanced is reached *from* typography and closes back to it, and two
+ * modal sheets composed at once is a state the reader can neither see
+ * nor get out of cleanly.
+ */
+private enum class ReaderSheet { NONE, TYPOGRAPHY, ADVANCED }
 
 @OptIn(
     ExperimentalMaterial3Api::class,
@@ -209,6 +244,11 @@ fun ReaderScreen(
     onKeepScreenOnChanged: (Boolean) -> Unit,
     scrollModeFlow: StateFlow<Boolean>,
     onScrollModeChanged: (Boolean) -> Unit,
+    // The activity draws dialogs of its own over this screen — a link
+    // out of the book, a sync, an offer to send the book up — and a tap
+    // on a link never reaches the tap zones, so the screen would
+    // otherwise carry on scrolling behind one.
+    blockedByDialog: Boolean = false,
     goTo: SharedFlow<Locator>,
     onBookSyncAction: ReaderBookSyncActions,
     onBack: () -> Unit,
@@ -220,12 +260,20 @@ fun ReaderScreen(
     var showToc by remember { mutableStateOf(false) }
     var searchFor by remember { mutableStateOf<String?>(null) }
     var searchHit by remember { mutableStateOf<Locator?>(null) }
-    var showTypography by remember { mutableStateOf(false) }
+    var sheet by remember { mutableStateOf(ReaderSheet.NONE) }
     val chromeVisibleNow by rememberUpdatedState(chromeVisible)
     val prefs by prefsFlow.collectAsStateWithLifecycle()
     val keepScreenOn by keepScreenOnFlow.collectAsStateWithLifecycle()
     val scrollMode by scrollModeFlow.collectAsStateWithLifecycle()
-    val scrollModeNow by rememberUpdatedState(scrollMode)
+    // Readium reads vertical text off the book rather than off the
+    // reader: it cannot paginate lines that run down the page, so such a
+    // book is scrolled whatever the setting says. Everything that asks
+    // "is this book scrolled" has to ask it this way, or a vertical book
+    // gets tap zones that turn pages it has not got.
+    var verticalText by remember { mutableStateOf(false) }
+    val effectiveScrolling = scrollMode || verticalText
+    val effectiveScrollingNow by rememberUpdatedState(effectiveScrolling)
+    var autoScrollArmed by remember { mutableStateOf(false) }
     val columnMode = prefs.columnMode.effectiveFor(widthClass())
 
     // The activity decides what a keyboard's arrows mean, and the
@@ -254,6 +302,7 @@ fun ReaderScreen(
      * and the tap zones seeing exactly what they saw before.
      */
     var lastTouchY by remember { mutableStateOf<Float?>(null) }
+    var fingerDown by remember { mutableStateOf(false) }
     // The tracker below outlives every recomposition, so it cannot read
     // `footnote` directly — it would keep seeing whatever was true when it
     // started. This gives it a window onto the current value.
@@ -366,11 +415,11 @@ fun ReaderScreen(
             // answer as whether its scrolling glides or jumps.
             isAnimated = { prefsFlow.value.pageTurnAnimation && !eInkNow },
             isEffectSuppressed = { chromeVisibleNow },
-            isScrolling = { scrollModeNow },
-            // Readium reads this off the book rather than the reader:
-            // vertical text is always scrolled, because CSS columns
-            // cannot paginate it, so a book can be scrolling here with
-            // the setting switched off.
+            // Vertical text is scrolled whatever the setting says, so
+            // this is the derived answer and not the preference: a
+            // sideways-scrolled book asked to turn a page would be asked
+            // for a page it has not got.
+            isScrolling = { effectiveScrollingNow },
             isVerticalText = { navigatorNow?.settings?.value?.verticalText == true },
             showingEnd = { showingEndNow },
             onReachedEnd = {
@@ -483,6 +532,14 @@ fun ReaderScreen(
             p.toEpubPreferences(theme, columns, scrolling)
         }
             .drop(1)
+            // What the book is rendered with, not what the reader
+            // happens to be holding. Reading preferences carry answers
+            // the page cannot see — the auto-scroll speed is one — and a
+            // slider dragged through its notches would otherwise reflow
+            // the whole book at every notch, each time capturing an
+            // anchor and restoring it, for a setting that changes not one
+            // line of the text.
+            .distinctUntilChanged()
             .collect {
                 reflow.within {
                     val anchor = reflowAnchor ?: capture(nav, nav.currentLocator.value)
@@ -606,6 +663,197 @@ fun ReaderScreen(
         nav.applyDecorations(annotations.toDecorations(), DECORATION_GROUP)
     }
 
+    // Tracked rather than read: the setting arrives with the book, and
+    // asking a nullable navigator for it from the composition would make
+    // the read itself conditional.
+    LaunchedEffect(navigator) {
+        val nav = navigator
+        if (nav == null) {
+            verticalText = false
+            return@LaunchedEffect
+        }
+        nav.settings.collect { verticalText = it.verticalText }
+    }
+
+    /*
+     * The page carrying itself.
+     *
+     * One predicate decides whether it moves, and it is written here in
+     * one place rather than scattered through the screen, because the
+     * pause ADR 6 asks for *is* the predicate: a tap raises the chrome,
+     * the chrome is in the list, the page stops. Touch it again, the
+     * chrome goes, the page carries on. A drag is a finger down, so the
+     * text goes where the reader puts it and picks up from there.
+     *
+     * Nothing else in the reader gains a control for this. An offer the
+     * reader has not answered — a pill, a dialog — holds the page still
+     * too: a decision taken about a page that has moved on is a decision
+     * about nothing.
+     */
+    val canAutoScroll = autoScrollArmed &&
+        effectiveScrolling &&
+        !chromeVisible &&
+        !fingerDown &&
+        !showingEnd &&
+        sheet == ReaderSheet.NONE &&
+        !showToc &&
+        searchFor == null &&
+        footnote == null &&
+        selection == null &&
+        noteFor == null &&
+        defineWord == null &&
+        jumpBack == null &&
+        catchUp == null &&
+        !blockedByDialog
+
+    // Arming is a decision taken in a sheet, and the page it applies to
+    // is behind the sheet. Get out of the way so the reader can see what
+    // they asked for.
+    LaunchedEffect(autoScrollArmed) {
+        if (autoScrollArmed) {
+            sheet = ReaderSheet.NONE
+            chromeVisible = false
+        }
+    }
+
+    // A book that stops being scrolled has nothing to scroll. Switching
+    // to pages while the text was moving would otherwise leave the
+    // switch on with nothing behind it.
+    LaunchedEffect(effectiveScrolling) {
+        if (!effectiveScrolling) autoScrollArmed = false
+    }
+
+    /*
+     * Saving the reader's place while the page never stops.
+     *
+     * Readium notices a scroll through the web view's own
+     * `onScrollChanged` and answers it with a *debounced* location
+     * notification — a hundred milliseconds of stillness. A finger drag
+     * always ends, so that debounce always lands. A page carrying itself
+     * never stops, so it never lands at all, and the reader's place
+     * would stay wherever they last lifted a finger.
+     *
+     * So the loop asks for the location itself, on its own clock, with
+     * the navigator's own `firstVisibleElementLocator` — the same
+     * question the debounce would have asked, just asked on time. It is
+     * asked off the frame loop so the page does not hitch waiting for a
+     * round trip into the document.
+     */
+    var autoScrollLocator by remember { mutableStateOf<Locator?>(null) }
+    val autoScrollRunning by rememberUpdatedState(canAutoScroll)
+
+    LaunchedEffect(navigator, canAutoScroll, prefs.autoScrollSpeed, prefs.fontSize, lifecycle) {
+        if (!canAutoScroll) return@LaunchedEffect
+        val nav = navigator ?: return@LaunchedEffect
+        val density = view.resources.displayMetrics.density
+        val ticker = AutoScrollTicker()
+        // RESUMED and not merely STARTED: a reader looking at something
+        // else on a split screen is not reading this, and the page they
+        // come back to should be the page they left.
+        lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            ticker.reset()
+            var savedAtNanos = 0L
+            var saving = false
+            while (true) {
+                val now = withFrameNanos { it }
+                val web = visibleWebView(nav.publicationView) ?: continue
+                val vertical = nav.settings.value.verticalText
+                val pixelsPerSecond = AutoScrollSpeed.dpPerSecond(
+                    step = prefs.autoScrollSpeed,
+                    fontSize = prefs.fontSize,
+                ) * density
+                val pixels = ticker.step(nowNanos = now, pixelsPerSecond = pixelsPerSecond)
+                if (pixels <= 0) continue
+                if (!saving && now - savedAtNanos >= AUTO_SCROLL_SAVE_NANOS) {
+                    savedAtNanos = now
+                    saving = true
+                    launch {
+                        try {
+                            // A failed round trip must not take the loop
+                            // down with it: this coroutine is the loop's
+                            // child, and an exception here would cancel
+                            // its parent and stop the page for good.
+                            val here = runCatching { nav.firstVisibleElementLocator() }
+                                .getOrNull()
+                            if (here != null) {
+                                val captured = runCatching { capture(nav, here) }
+                                    .getOrDefault(here)
+                                autoScrollLocator = captured
+                                // Auto-scroll is reading, so it teaches
+                                // the pace estimator and counts as time
+                                // spent, which READER_MOVEMENT is what
+                                // carries.
+                                onLocatorChanged(
+                                    captured,
+                                    NavigatorPositionEvent.READER_MOVEMENT,
+                                )
+                            }
+                        } finally {
+                            saving = false
+                        }
+                    }
+                }
+                // Later text lies below in a book set in lines across,
+                // and to the left in one set in lines down — the same
+                // convention ScrollEdgeTurner reads its drags by.
+                val atEnd = if (vertical) {
+                    !web.canScrollHorizontally(-1)
+                } else {
+                    !web.canScrollVertically(1)
+                }
+                if (atEnd) {
+                    // The last lines have only just arrived. Leave them
+                    // on screen for as long as they took to get there.
+                    val viewport = if (vertical) web.width else web.height
+                    val moved = carryIntoNextChapter(
+                        nav = nav,
+                        pageTurner = pageTurner,
+                        dwellMillis = dwellMillis(viewport, pixelsPerSecond),
+                    )
+                    ticker.reset()
+                    savedAtNanos = 0L
+                    autoScrollLocator = null
+                    if (!moved) {
+                        autoScrollArmed = false
+                        return@repeatOnLifecycle
+                    }
+                    continue
+                }
+                if (vertical) web.scrollBy(-pixels, 0) else web.scrollBy(0, pixels)
+            }
+        }
+    }
+
+    /*
+     * The last place before the reader leaves.
+     *
+     * `ReaderViewModel` drops a READER_MOVEMENT locator once the reader
+     * is inactive, and `ReaderActivity.onPause` clears that flag before
+     * `super.onPause()` — so nothing published from an ON_PAUSE observer
+     * can arrive as movement, and Readium's own debounce, landing a
+     * hundred milliseconds later, is dropped as well. What goes in here
+     * is the last position the loop fetched, republished as the jump it
+     * effectively was: LOCAL_JUMP persists, is not dropped by that
+     * guard, and does not count the same reading twice.
+     *
+     * Nothing is asked of the page and nothing is waited for, so this is
+     * an ordinary synchronous call inside `onPause`. `onStop` — and with
+     * it the closing of the position queue — cannot begin until
+     * `onPause` has returned, so the position is always in the queue
+     * before there is any question of the queue being shut.
+     */
+    DisposableEffect(lifecycle) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event != Lifecycle.Event.ON_PAUSE) return@LifecycleEventObserver
+            if (!autoScrollRunning) return@LifecycleEventObserver
+            autoScrollLocator?.let {
+                onLocatorChanged(it, NavigatorPositionEvent.LOCAL_JUMP)
+            }
+        }
+        lifecycle.addObserver(observer)
+        onDispose { lifecycle.removeObserver(observer) }
+    }
+
     DisposableEffect(navigator) {
         val nav = navigator
         pageTurner.navigator = nav
@@ -617,14 +865,14 @@ fun ReaderScreen(
                 ReaderTapZones(
                     navigator = it,
                     isChromeVisible = { chromeVisibleNow },
-                    isScrolling = { scrollModeNow },
+                    isScrolling = { effectiveScrollingNow },
                     onTurnPage = pageTurner::turn,
                     onShowChrome = { chromeVisible = true },
                     onHideChrome = { chromeVisible = false },
                 ),
                 ScrollEdgeTurner(
                     navigator = it,
-                    isScrolling = { scrollModeNow },
+                    isScrolling = { effectiveScrollingNow },
                     isVerticalText = { it.settings.value.verticalText },
                     onStepChapter = { forward -> pageTurner.stepChapter(forward) },
                 ),
@@ -642,7 +890,10 @@ fun ReaderScreen(
 
     ImmersiveMode(hideSystemBars = !chromeVisible)
     ScreenBrightness(brightness = prefs.brightness)
-    KeepScreenOn(enabled = keepScreenOn)
+    // Auto-scroll implies it: a page that carries itself past a screen
+    // timeout is a page nobody is reading. The reader's own switch still
+    // decides everything else, and this adds nothing once the page stops.
+    KeepScreenOn(enabled = keepScreenOn || autoScrollArmed)
 
     Box(
         Modifier
@@ -652,6 +903,11 @@ fun ReaderScreen(
                 awaitPointerEventScope {
                     while (true) {
                         val event = awaitPointerEvent(PointerEventPass.Initial)
+                        // A finger on the page is a finger on the page,
+                        // whatever it is doing there. Auto-scroll waits
+                        // for it to be lifted, so a reader nudging the
+                        // text is not fighting the page for it.
+                        fingerDown = event.changes.any { it.pressed }
                         // The card is drawn inside this box, so without this
                         // guard reading a note would move it: every touch on
                         // the card would become the new anchor and the card
@@ -909,7 +1165,7 @@ fun ReaderScreen(
                     // what it opens instead.
                     val typographyLabel = stringResource(R.string.reader_typography)
                     IconButton(
-                        onClick = { showTypography = true },
+                        onClick = { sheet = ReaderSheet.TYPOGRAPHY },
                         modifier = Modifier.semantics {
                             contentDescription = typographyLabel
                         },
@@ -1048,7 +1304,7 @@ fun ReaderScreen(
         )
     }
 
-    if (showTypography) {
+    if (sheet == ReaderSheet.TYPOGRAPHY) {
         TypographySheet(
             prefs = prefs,
             readingTheme = readingTheme,
@@ -1067,7 +1323,26 @@ fun ReaderScreen(
             onKeepScreenOnChanged = onKeepScreenOnChanged,
             scrollMode = scrollMode,
             onScrollModeChanged = onScrollModeChanged,
-            onDismiss = { showTypography = false },
+            // Nothing lives behind Advanced yet but auto-scroll, and
+            // auto-scroll is only offered to a scrolled book. A paginated
+            // one would open an empty sheet, so it is not offered the way
+            // in either.
+            advancedOffered = effectiveScrolling,
+            onOpenAdvanced = { sheet = ReaderSheet.ADVANCED },
+            onDismiss = { sheet = ReaderSheet.NONE },
+        )
+    }
+
+    if (sheet == ReaderSheet.ADVANCED) {
+        AdvancedSheet(
+            autoScrollOffered = effectiveScrolling,
+            autoScrolling = autoScrollArmed,
+            autoScrollSpeed = prefs.autoScrollSpeed,
+            onAutoScrollChanged = { autoScrollArmed = it },
+            onAutoScrollSpeedChanged = onPrefsAction.setAutoScrollSpeed,
+            // Back to typography, not back to the book: this sheet was
+            // reached from there, and that is where the reader left off.
+            onDismiss = { sheet = ReaderSheet.TYPOGRAPHY },
         )
     }
 
@@ -1203,6 +1478,61 @@ class ReaderAnnotationActions(
     val notebookMarkdown: () -> String,
 )
 
+/**
+ * Opens the next chapter and waits for it to arrive, or says it could
+ * not.
+ *
+ * Reaching the bottom of a chapter is not the moment to leave it: the
+ * last lines have only just come into view, and a reader who has been
+ * carried down to them still has to read them. So the page waits there
+ * for as long as those lines took to arrive — [dwellMillis], one
+ * viewport at the pace the reader chose — before turning.
+ *
+ * `stepChapter` answers false when it did not move: the endpaper, the
+ * end of the book, a reading order it could not place. The page has
+ * nowhere to carry itself to, and says so, rather than sitting against
+ * the edge waiting for a chapter that is not coming.
+ *
+ * The wait afterwards is for the resource to actually change, not for a
+ * fixed delay: too short and the next chapter is stepped through before
+ * it has laid out, taking the reader two chapters on; too long and a
+ * chapter shorter than a screen is read as a stall. It is bounded all
+ * the same, because a wait that can never end is a page that can never
+ * be stopped.
+ */
+private suspend fun carryIntoNextChapter(
+    nav: EpubNavigatorFragment,
+    pageTurner: PageTurner,
+    dwellMillis: Long,
+): Boolean {
+    delay(dwellMillis)
+    val leaving = nav.currentLocator.value.href
+    if (!pageTurner.stepChapter(forward = true)) return false
+    return withTimeoutOrNull(CHAPTER_ARRIVAL_MS) {
+        nav.currentLocator.first { it.href != leaving }
+        // Arriving is not the same as being laid out, and a chapter
+        // scrolled before it has settled scrolls the wrong distance.
+        withFrameNanos { }
+        withFrameNanos { }
+        true
+    } == true
+}
+
+/**
+ * How long to leave the last lines of a chapter on screen: the time it
+ * took the reader to be carried one screen, at the pace they chose, so a
+ * slow reader gets the long look and a skimming one is not held up.
+ *
+ * Bounded at both ends. A viewport the layout has not measured yet would
+ * otherwise be no wait at all, and a very slow pace would hold a reader
+ * against the edge long enough to wonder whether it had broken.
+ */
+private fun dwellMillis(viewportPixels: Int, pixelsPerSecond: Double): Long {
+    if (viewportPixels <= 0 || pixelsPerSecond <= 0.0) return MIN_CHAPTER_DWELL_MS
+    val millis = (viewportPixels / pixelsPerSecond * 1_000L).toLong()
+    return millis.coerceIn(MIN_CHAPTER_DWELL_MS, MAX_CHAPTER_DWELL_MS)
+}
+
 /** Bundle of preference setters passed down to the reader chrome. */
 class ReaderPrefsActions(
     val setFont: (ReaderFont) -> Unit,
@@ -1213,6 +1543,7 @@ class ReaderPrefsActions(
     val setBrightness: (Float?) -> Unit,
     val setPageTurnAnimation: (Boolean) -> Unit,
     val setColumnMode: (ColumnMode) -> Unit,
+    val setAutoScrollSpeed: (Float) -> Unit,
     val setTypographyIsOwn: (Boolean) -> Unit,
 )
 

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -1300,6 +1300,9 @@ class ReaderViewModel(
     fun setColumnMode(mode: ColumnMode) =
         viewModelScope.launch { prefsRepo.setColumnMode(mode) }
 
+    fun setAutoScrollSpeed(step: Float) =
+        viewModelScope.launch { prefsRepo.setAutoScrollSpeed(step) }
+
     fun cycleFooterMode() = viewModelScope.launch {
         prefsRepo.setFooterMode(prefs.value.footerMode.next())
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
@@ -1,0 +1,169 @@
+package com.chmouel.liseur.reader.chrome
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import com.chmouel.liseur.R
+import com.chmouel.liseur.ui.contentWidthCap
+import com.chmouel.liseur.ui.reading.ReadingSectionLabel
+import com.chmouel.liseur.ui.windowWidth
+
+/**
+ * The second sheet, reached from the typography sheet's last row.
+ *
+ * It exists so that the typography sheet does not have to grow: that one
+ * stays the four or five answers a reader changes often, and everything
+ * rarer lives a tap further in. Dismissing this lands back on
+ * typography, and dismissing that lands back on the page.
+ *
+ * Today it holds one row. The rest of what belongs here — finer
+ * typography, read-aloud, imported fonts, tap-zone presets — arrives with
+ * its own issue, and the shape of the sheet is the point: one row, or
+ * five, it is the same sheet and the reader learns it once.
+ *
+ * See `docs/adr/0001-advanced-reading-menu.md`.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AdvancedSheet(
+    autoScrollOffered: Boolean,
+    autoScrolling: Boolean,
+    autoScrollSpeed: Float,
+    onAutoScrollChanged: (Boolean) -> Unit,
+    onAutoScrollSpeedChanged: (Float) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            Modifier
+                .verticalScroll(rememberScrollState())
+                .align(Alignment.CenterHorizontally)
+                .widthIn(max = contentWidthCap(windowWidth()))
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            if (autoScrollOffered) {
+                AutoScrollRow(
+                    enabled = autoScrolling,
+                    speed = autoScrollSpeed,
+                    onChanged = onAutoScrollChanged,
+                    onSpeedChanged = onAutoScrollSpeedChanged,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Starts the page moving on its own, and sets how fast.
+ *
+ * Only offered to a book read by scrolling, which is what keeps this out
+ * of a paginated one: there, the tap zones and the volume keys already
+ * turn pages without the reader reaching for anything.
+ *
+ * The speed sits under the switch whether or not the page is moving.
+ * Starting closes this sheet, so a slider shown only while running would
+ * be a slider nobody could ever reach: the reader sets a pace, watches
+ * the page, and comes back to move it a notch.
+ *
+ * See `docs/adr/0006-auto-scroll.md`.
+ */
+@Composable
+private fun AutoScrollRow(
+    enabled: Boolean,
+    speed: Float,
+    onChanged: (Boolean) -> Unit,
+    onSpeedChanged: (Float) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .toggleable(
+                    value = enabled,
+                    role = Role.Switch,
+                    onValueChange = onChanged,
+                ),
+        ) {
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.reader_auto_scroll),
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+                Text(
+                    text = stringResource(R.string.reader_auto_scroll_detail),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Switch(checked = enabled, onCheckedChange = null)
+        }
+        AutoScrollSpeedSlider(value = speed, onChanged = onSpeedChanged)
+    }
+}
+
+/**
+ * The pace, in notches rather than in numbers.
+ *
+ * A figure in dp a second would be honest and useless: nobody knows what
+ * their reading speed is in dp a second, and the same figure reads
+ * differently at every text size anyway. Notches are what the reader can
+ * actually judge, by watching the page at one and then at the next.
+ *
+ * Committed when the slider is let go rather than as it moves, the way
+ * every other reading slider here works: what is written down is the
+ * answer, not the sweep of the thumb getting to it.
+ */
+@Composable
+private fun AutoScrollSpeedSlider(value: Float, onChanged: (Float) -> Unit) {
+    var sliderValue by remember(value) { mutableFloatStateOf(value) }
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        ReadingSectionLabel(stringResource(R.string.reader_auto_scroll_speed))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = stringResource(R.string.reader_auto_scroll_slower),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Slider(
+                value = sliderValue,
+                onValueChange = { sliderValue = it },
+                onValueChangeFinished = { onChanged(sliderValue) },
+                valueRange = AutoScrollSpeed.MIN_STEP.toFloat()..AutoScrollSpeed.MAX_STEP.toFloat(),
+                steps = AutoScrollSpeed.MAX_STEP - AutoScrollSpeed.MIN_STEP - 1,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(horizontal = 12.dp),
+            )
+            Text(
+                text = stringResource(R.string.reader_auto_scroll_faster),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.chmouel.liseur.R
+import com.chmouel.liseur.data.settings.AutoScrollPreference
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.reading.ReadingSectionLabel
 import com.chmouel.liseur.ui.windowWidth
@@ -153,8 +154,8 @@ private fun AutoScrollSpeedSlider(value: Float, onChanged: (Float) -> Unit) {
                 value = sliderValue,
                 onValueChange = { sliderValue = it },
                 onValueChangeFinished = { onChanged(sliderValue) },
-                valueRange = AutoScrollSpeed.MIN_STEP.toFloat()..AutoScrollSpeed.MAX_STEP.toFloat(),
-                steps = AutoScrollSpeed.MAX_STEP - AutoScrollSpeed.MIN_STEP - 1,
+                valueRange = AutoScrollPreference.MIN_STEP.toFloat()..AutoScrollPreference.MAX_STEP.toFloat(),
+                steps = AutoScrollPreference.MAX_STEP - AutoScrollPreference.MIN_STEP - 1,
                 modifier = Modifier
                     .weight(1f)
                     .padding(horizontal = 12.dp),

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AutoScroll.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AutoScroll.kt
@@ -1,0 +1,132 @@
+package com.chmouel.liseur.reader.chrome
+
+import kotlin.math.pow
+import kotlin.math.roundToInt
+
+/**
+ * The page carrying itself, for a book read by scrolling.
+ *
+ * Everything here is arithmetic, and deliberately knows nothing about
+ * web views, densities or frames: how fast the text should move, how far
+ * it has moved since the last time anyone asked. The screen owns the
+ * parts that need a device.
+ *
+ * See `docs/adr/0006-auto-scroll.md`.
+ */
+
+/**
+ * Turns elapsed time into whole pixels of movement.
+ *
+ * A view scrolls by whole pixels, and at a comfortable reading pace a
+ * frame is worth less than one. Rounding each frame on its own would
+ * either stand still forever or run at a pixel a frame whatever the
+ * setting, so the fraction left over is kept and spent later: what is
+ * asked for over a second is what is delivered over a second.
+ *
+ * The ticker is not told what a frame is. It is told when it last
+ * moved and when it is being asked again, and it counts in nanoseconds
+ * throughout, so a frame is never rounded down to a whole millisecond on
+ * its way in — sixty of those a second is a page that quietly runs slow.
+ * A dropped frame is then nothing more than a longer gap, until the gap
+ * stops being a gap at all: a reader who leaves a chapter loading, or
+ * whose device thinks about something else for half a second, must not
+ * come back to the page having jumped. Past [MAX_STEP_NANOS] the gap is
+ * taken as an interruption and only that much of it is paid out.
+ */
+class AutoScrollTicker {
+
+    private var lastNanos: Long? = null
+    private var carried = 0.0
+
+    /**
+     * Forgets the time that has passed and the fraction owed.
+     *
+     * Called whenever the page stops moving — a finger on the screen,
+     * the chrome coming up, a chapter turning — so that the first step
+     * after it is a step, and not the whole pause paid out at once.
+     */
+    fun reset() {
+        lastNanos = null
+        carried = 0.0
+    }
+
+    /**
+     * How far to move now, in whole pixels, at [pixelsPerSecond].
+     *
+     * The first call after a [reset] establishes when "now" is and
+     * returns zero: there is no elapsed time to convert yet.
+     */
+    fun step(nowNanos: Long, pixelsPerSecond: Double): Int {
+        val last = lastNanos
+        lastNanos = nowNanos
+        if (last == null) return 0
+        val elapsed = nowNanos - last
+        // A clock that went backwards is not elapsed time.
+        if (elapsed <= 0L) return 0
+        val paid = elapsed.coerceAtMost(MAX_STEP_NANOS)
+        carried += pixelsPerSecond * paid / NANOS_PER_SECOND
+        val whole = carried.toInt()
+        carried -= whole
+        return whole
+    }
+
+    private companion object {
+        const val NANOS_PER_SECOND = 1_000_000_000.0
+
+        /**
+         * The longest gap still treated as reading rather than as an
+         * interruption. Comfortably more than a dropped frame or two,
+         * and far less than the time it takes to notice the page has
+         * gone somewhere it should not have.
+         */
+        const val MAX_STEP_NANOS = 250_000_000L
+    }
+}
+
+/**
+ * The reading pace, as a step on a slider and as pixels a second.
+ *
+ * Stored as the step rather than as a speed so the slider means the same
+ * thing whatever else changes, and so a reader who comes back to it
+ * finds the notch they left it on.
+ *
+ * The pace is multiplied by the font size because the two are the same
+ * question asked twice: text set half again as large has half again as
+ * far to travel to show the same words, so scaling by it holds *lines*
+ * per minute roughly steady across sizes. Words per minute also depends
+ * on how wide the measure is and how the book is set, which nothing here
+ * pretends to model.
+ */
+object AutoScrollSpeed {
+
+    const val MIN_STEP = 1
+    const val MAX_STEP = 10
+    const val DEFAULT_STEP = 4f
+
+    /** The pace at [MIN_STEP], in dp a second, before font size. */
+    const val SLOWEST_DP_PER_SECOND = 6.0
+
+    /** The pace at [MAX_STEP], in dp a second, before font size. */
+    const val FASTEST_DP_PER_SECOND = 90.0
+
+    /**
+     * Dp a second at [step], for text set at [fontSize].
+     *
+     * The steps are spread geometrically rather than evenly. The slow
+     * end is where a reader actually chooses — the difference between 8
+     * and 12 dp a second is the difference between keeping up and not —
+     * while at the fast end, where the page is being skimmed rather than
+     * read, a few dp either way is nothing. Even steps would spend most
+     * of the slider on speeds nobody reads at.
+     */
+    fun dpPerSecond(step: Float, fontSize: Double = 1.0): Double {
+        val clamped = step.toDouble().coerceIn(MIN_STEP.toDouble(), MAX_STEP.toDouble())
+        val across = (clamped - MIN_STEP) / (MAX_STEP - MIN_STEP)
+        val ratio = FASTEST_DP_PER_SECOND / SLOWEST_DP_PER_SECOND
+        return SLOWEST_DP_PER_SECOND * ratio.pow(across) * fontSize
+    }
+
+    /** The nearest whole notch, for a slider that lands on one. */
+    fun snap(step: Float): Float =
+        step.roundToInt().coerceIn(MIN_STEP, MAX_STEP).toFloat()
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AutoScroll.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AutoScroll.kt
@@ -1,7 +1,7 @@
 package com.chmouel.liseur.reader.chrome
 
+import com.chmouel.liseur.data.settings.AutoScrollPreference
 import kotlin.math.pow
-import kotlin.math.roundToInt
 
 /**
  * The page carrying itself, for a book read by scrolling.
@@ -60,6 +60,9 @@ class AutoScrollTicker {
         val last = lastNanos
         lastNanos = nowNanos
         if (last == null) return 0
+        // A pace that is not a number would poison the carried fraction
+        // for good, and the page would never move again.
+        if (!pixelsPerSecond.isFinite()) return 0
         val elapsed = nowNanos - last
         // A clock that went backwards is not elapsed time.
         if (elapsed <= 0L) return 0
@@ -84,11 +87,12 @@ class AutoScrollTicker {
 }
 
 /**
- * The reading pace, as a step on a slider and as pixels a second.
+ * The reading pace, as pixels a second.
  *
- * Stored as the step rather than as a speed so the slider means the same
- * thing whatever else changes, and so a reader who comes back to it
- * finds the notch they left it on.
+ * The notch itself belongs to the setting, not to the movement, so its
+ * bounds live in [AutoScrollPreference] and every step that arrives here
+ * is normalised through it — a curve with its own idea of the range
+ * would drift from the slider the moment either changed.
  *
  * The pace is multiplied by the font size because the two are the same
  * question asked twice: text set half again as large has half again as
@@ -99,14 +103,10 @@ class AutoScrollTicker {
  */
 object AutoScrollSpeed {
 
-    const val MIN_STEP = 1
-    const val MAX_STEP = 10
-    const val DEFAULT_STEP = 4f
-
-    /** The pace at [MIN_STEP], in dp a second, before font size. */
+    /** The pace at [AutoScrollPreference.MIN_STEP], in dp a second, before font size. */
     const val SLOWEST_DP_PER_SECOND = 6.0
 
-    /** The pace at [MAX_STEP], in dp a second, before font size. */
+    /** The pace at [AutoScrollPreference.MAX_STEP], in dp a second, before font size. */
     const val FASTEST_DP_PER_SECOND = 90.0
 
     /**
@@ -120,13 +120,10 @@ object AutoScrollSpeed {
      * of the slider on speeds nobody reads at.
      */
     fun dpPerSecond(step: Float, fontSize: Double = 1.0): Double {
-        val clamped = step.toDouble().coerceIn(MIN_STEP.toDouble(), MAX_STEP.toDouble())
-        val across = (clamped - MIN_STEP) / (MAX_STEP - MIN_STEP)
+        val notch = AutoScrollPreference.sanitize(step).toDouble()
+        val span = (AutoScrollPreference.MAX_STEP - AutoScrollPreference.MIN_STEP).toDouble()
+        val across = (notch - AutoScrollPreference.MIN_STEP) / span
         val ratio = FASTEST_DP_PER_SECOND / SLOWEST_DP_PER_SECOND
         return SLOWEST_DP_PER_SECOND * ratio.pow(across) * fontSize
     }
-
-    /** The nearest whole notch, for a slider that lands on one. */
-    fun snap(step: Float): Float =
-        step.roundToInt().coerceIn(MIN_STEP, MAX_STEP).toFloat()
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/TypographySheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/TypographySheet.kt
@@ -10,7 +10,10 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Switch
@@ -67,6 +70,8 @@ fun TypographySheet(
     onKeepScreenOnChanged: (Boolean) -> Unit,
     scrollMode: Boolean,
     onScrollModeChanged: (Boolean) -> Unit,
+    advancedOffered: Boolean,
+    onOpenAdvanced: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     ModalBottomSheet(onDismissRequest = onDismiss) {
@@ -123,7 +128,42 @@ fun TypographySheet(
                 enabled = typographyIsOwn,
                 onChanged = onTypographyIsOwnChanged,
             )
+            // Last, and only when there is something behind it. An
+            // Advanced row that opens an empty sheet is worse than no
+            // row at all.
+            if (advancedOffered) {
+                AdvancedRow(onClick = onOpenAdvanced)
+            }
         }
+    }
+}
+
+/**
+ * The way through to the settings a reader changes once, if ever.
+ *
+ * One row, at the bottom, and the only row this sheet gains however many
+ * reading features arrive: that is the whole bargain of
+ * `docs/adr/0001-advanced-reading-menu.md`. What it opens closes back to
+ * here, and here closes back to the book.
+ */
+@Composable
+private fun AdvancedRow(onClick: () -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+    ) {
+        Text(
+            text = stringResource(R.string.reader_advanced),
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.weight(1f),
+        )
+        Icon(
+            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -430,6 +430,12 @@
     <string name="reader_typography_own">Use separate settings for this book</string>
     <string name="reader_typography_own_on">Font, size and layout stay with this book.</string>
     <string name="reader_typography_own_off">Font, size and layout are shared with every book.</string>
+    <string name="reader_advanced">Advanced</string>
+    <string name="reader_auto_scroll">Scroll the page for me</string>
+    <string name="reader_auto_scroll_detail">The page carries itself along, and the screen stays awake. Touch it to stop, touch it again to carry on.</string>
+    <string name="reader_auto_scroll_speed">Scrolling speed</string>
+    <string name="reader_auto_scroll_slower">Slower</string>
+    <string name="reader_auto_scroll_faster">Faster</string>
     <string name="footer_mode_smart">Time left, or the chapter</string>
     <string name="footer_mode_time_book">Time left in book</string>
     <string name="footer_mode_chapter">Chapter title</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/settings/AutoScrollPreferenceTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/settings/AutoScrollPreferenceTest.kt
@@ -1,0 +1,75 @@
+package com.chmouel.liseur.data.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The auto-scroll notch, as it is stored and read back.
+ *
+ * Nothing in the app writes a step outside the slider's range, so
+ * everything here is about the other door: a preference file on a
+ * device, which can hold whatever it ends up holding. A step that is not
+ * a number is the dangerous one — it survives arithmetic silently and
+ * comes out the far end as a page that never moves.
+ */
+class AutoScrollPreferenceTest {
+
+    @Test
+    fun `the default is a notch on the slider`() {
+        assertEquals(
+            AutoScrollPreference.DEFAULT_STEP,
+            AutoScrollPreference.snap(AutoScrollPreference.DEFAULT_STEP),
+        )
+        assertTrue(AutoScrollPreference.DEFAULT_STEP >= AutoScrollPreference.MIN_STEP)
+        assertTrue(AutoScrollPreference.DEFAULT_STEP <= AutoScrollPreference.MAX_STEP)
+    }
+
+    @Test
+    fun `snapping lands on a whole notch inside the slider`() {
+        assertEquals(3f, AutoScrollPreference.snap(3.4f))
+        assertEquals(4f, AutoScrollPreference.snap(3.6f))
+        assertEquals(AutoScrollPreference.MIN_STEP.toFloat(), AutoScrollPreference.snap(0f))
+        assertEquals(AutoScrollPreference.MAX_STEP.toFloat(), AutoScrollPreference.snap(42f))
+    }
+
+    @Test
+    fun `a stored step outside the slider is brought back onto it`() {
+        assertEquals(AutoScrollPreference.MIN_STEP.toFloat(), AutoScrollPreference.sanitize(-99f))
+        assertEquals(AutoScrollPreference.MAX_STEP.toFloat(), AutoScrollPreference.sanitize(1e9f))
+    }
+
+    @Test
+    fun `a stored step that is not a number falls back to the default`() {
+        assertEquals(AutoScrollPreference.DEFAULT_STEP, AutoScrollPreference.sanitize(Float.NaN))
+        assertEquals(
+            AutoScrollPreference.DEFAULT_STEP,
+            AutoScrollPreference.sanitize(Float.POSITIVE_INFINITY),
+        )
+        assertEquals(
+            AutoScrollPreference.DEFAULT_STEP,
+            AutoScrollPreference.sanitize(Float.NEGATIVE_INFINITY),
+        )
+    }
+
+    @Test
+    fun `snapping a step that is not a number does not throw`() {
+        // Float.roundToInt() throws on NaN, so snap has to go through
+        // sanitize rather than round first and ask questions later.
+        assertEquals(AutoScrollPreference.DEFAULT_STEP, AutoScrollPreference.snap(Float.NaN))
+    }
+
+    @Test
+    fun `a sanitised step is always somewhere the slider can sit`() {
+        val awkward = listOf(
+            Float.NaN, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY,
+            -1f, 0f, 0.4f, 5.5f, 10.5f, 1e30f, -1e30f,
+        )
+        awkward.forEach { step ->
+            val safe = AutoScrollPreference.sanitize(step)
+            assertTrue("$step sanitised to $safe, which is not a number", safe.isFinite())
+            assertTrue("$step sanitised below the slider", safe >= AutoScrollPreference.MIN_STEP)
+            assertTrue("$step sanitised above the slider", safe <= AutoScrollPreference.MAX_STEP)
+        }
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/AutoScrollTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/AutoScrollTest.kt
@@ -1,0 +1,157 @@
+package com.chmouel.liseur.reader.chrome
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutoScrollTickerTest {
+
+    private val ticker = AutoScrollTicker()
+
+    private fun millis(value: Long) = value * 1_000_000L
+
+    /** Sixty frames of a second, without rounding the frames themselves. */
+    private fun frameNanos(frame: Int) = frame * 1_000_000_000L / 60
+
+    @Test
+    fun `the first step only starts the clock`() {
+        assertEquals(0, ticker.step(millis(0), pixelsPerSecond = 100.0))
+    }
+
+    @Test
+    fun `a whole second at a hundred pixels a second is a hundred pixels`() {
+        ticker.step(frameNanos(0), 100.0)
+        // Paid out in frames, because that is how it will be asked.
+        var moved = 0
+        for (frame in 1..60) moved += ticker.step(frameNanos(frame), 100.0)
+        assertEquals(100.0, moved.toDouble(), 1.0)
+    }
+
+    @Test
+    fun `a pace slower than a pixel a frame still moves the page`() {
+        ticker.step(frameNanos(0), 6.0)
+        var moved = 0
+        for (frame in 1..60) moved += ticker.step(frameNanos(frame), 6.0)
+        assertEquals(6.0, moved.toDouble(), 1.0)
+    }
+
+    @Test
+    fun `the fraction is carried rather than rounded away`() {
+        ticker.step(millis(0), 10.0)
+        // Each of these is worth a third of a pixel. Rounded on its own
+        // every one would be nothing at all.
+        val first = ticker.step(millis(33), 10.0)
+        val second = ticker.step(millis(66), 10.0)
+        val third = ticker.step(millis(100), 10.0)
+        assertEquals(0, first)
+        assertEquals(0, second)
+        assertEquals(1, third)
+    }
+
+    @Test
+    fun `a frame that is not a whole millisecond is not rounded away`() {
+        // Sixty frames a second are 16 and two thirds of a millisecond
+        // each. Counting them in whole milliseconds loses that third
+        // sixty times over, and the page quietly runs four percent slow.
+        ticker.step(0L, 100.0)
+        var moved = 0
+        for (frame in 1..600) moved += ticker.step(frameNanos(frame), 100.0)
+        assertEquals(1_000.0, moved.toDouble(), 1.0)
+    }
+
+    @Test
+    fun `a long stall is clamped instead of jumping the page`() {
+        ticker.step(millis(0), 100.0)
+        // Ten seconds away would otherwise be a thousand pixels at once.
+        assertEquals(25, ticker.step(millis(10_000), 100.0))
+    }
+
+    @Test
+    fun `a reset drops the time that passed while the page was still`() {
+        ticker.step(millis(0), 100.0)
+        ticker.reset()
+        assertEquals(0, ticker.step(millis(5_000), 100.0))
+        assertEquals(1, ticker.step(millis(5_010), 100.0))
+    }
+
+    @Test
+    fun `a reset also drops the fraction owed`() {
+        ticker.step(millis(0), 10.0)
+        ticker.step(millis(90), 10.0)
+        ticker.reset()
+        ticker.step(millis(200), 10.0)
+        assertEquals(0, ticker.step(millis(210), 10.0))
+    }
+
+    @Test
+    fun `a clock that goes backwards is not elapsed time`() {
+        ticker.step(millis(1_000), 100.0)
+        assertEquals(0, ticker.step(millis(900), 100.0))
+    }
+}
+
+class AutoScrollSpeedTest {
+
+    @Test
+    fun `the ends of the slider are the documented paces`() {
+        assertEquals(
+            AutoScrollSpeed.SLOWEST_DP_PER_SECOND,
+            AutoScrollSpeed.dpPerSecond(AutoScrollSpeed.MIN_STEP.toFloat()),
+            0.001,
+        )
+        assertEquals(
+            AutoScrollSpeed.FASTEST_DP_PER_SECOND,
+            AutoScrollSpeed.dpPerSecond(AutoScrollSpeed.MAX_STEP.toFloat()),
+            0.001,
+        )
+    }
+
+    @Test
+    fun `every notch is faster than the one before it`() {
+        val paces = (AutoScrollSpeed.MIN_STEP..AutoScrollSpeed.MAX_STEP)
+            .map { AutoScrollSpeed.dpPerSecond(it.toFloat()) }
+        assertEquals(paces.sorted(), paces)
+        assertEquals(paces.distinct().size, paces.size)
+    }
+
+    @Test
+    fun `a step off the end of the slider is held at the end`() {
+        assertEquals(
+            AutoScrollSpeed.dpPerSecond(AutoScrollSpeed.MIN_STEP.toFloat()),
+            AutoScrollSpeed.dpPerSecond(-4f),
+            0.001,
+        )
+        assertEquals(
+            AutoScrollSpeed.dpPerSecond(AutoScrollSpeed.MAX_STEP.toFloat()),
+            AutoScrollSpeed.dpPerSecond(99f),
+            0.001,
+        )
+    }
+
+    @Test
+    fun `larger text travels proportionally further`() {
+        val normal = AutoScrollSpeed.dpPerSecond(5f, fontSize = 1.0)
+        assertEquals(normal * 1.5, AutoScrollSpeed.dpPerSecond(5f, fontSize = 1.5), 0.001)
+        assertEquals(normal * 0.6, AutoScrollSpeed.dpPerSecond(5f, fontSize = 0.6), 0.001)
+    }
+
+    @Test
+    fun `the slow end is spread more finely than the fast end`() {
+        val slowGap = AutoScrollSpeed.dpPerSecond(2f) - AutoScrollSpeed.dpPerSecond(1f)
+        val fastGap = AutoScrollSpeed.dpPerSecond(10f) - AutoScrollSpeed.dpPerSecond(9f)
+        assertTrue("a notch at the slow end should be a smaller change", slowGap < fastGap)
+    }
+
+    @Test
+    fun `the default is a notch on the slider`() {
+        assertEquals(AutoScrollSpeed.DEFAULT_STEP, AutoScrollSpeed.snap(AutoScrollSpeed.DEFAULT_STEP))
+    }
+
+    @Test
+    fun `snapping lands on a whole notch inside the slider`() {
+        assertEquals(3f, AutoScrollSpeed.snap(3.4f))
+        assertEquals(4f, AutoScrollSpeed.snap(3.6f))
+        assertEquals(AutoScrollSpeed.MIN_STEP.toFloat(), AutoScrollSpeed.snap(0f))
+        assertEquals(AutoScrollSpeed.MAX_STEP.toFloat(), AutoScrollSpeed.snap(42f))
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/AutoScrollTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/AutoScrollTest.kt
@@ -1,5 +1,6 @@
 package com.chmouel.liseur.reader.chrome
 
+import com.chmouel.liseur.data.settings.AutoScrollPreference
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -88,6 +89,16 @@ class AutoScrollTickerTest {
         ticker.step(millis(1_000), 100.0)
         assertEquals(0, ticker.step(millis(900), 100.0))
     }
+
+    @Test
+    fun `a pace that is not a number does not poison the carried fraction`() {
+        // NaN added to the carried remainder would stay NaN for the life
+        // of the ticker, and the page would never move again.
+        ticker.step(millis(0), 100.0)
+        assertEquals(0, ticker.step(millis(100), Double.NaN))
+        assertEquals(0, ticker.step(millis(200), Double.POSITIVE_INFINITY))
+        assertEquals(10, ticker.step(millis(300), 100.0))
+    }
 }
 
 class AutoScrollSpeedTest {
@@ -96,19 +107,19 @@ class AutoScrollSpeedTest {
     fun `the ends of the slider are the documented paces`() {
         assertEquals(
             AutoScrollSpeed.SLOWEST_DP_PER_SECOND,
-            AutoScrollSpeed.dpPerSecond(AutoScrollSpeed.MIN_STEP.toFloat()),
+            AutoScrollSpeed.dpPerSecond(AutoScrollPreference.MIN_STEP.toFloat()),
             0.001,
         )
         assertEquals(
             AutoScrollSpeed.FASTEST_DP_PER_SECOND,
-            AutoScrollSpeed.dpPerSecond(AutoScrollSpeed.MAX_STEP.toFloat()),
+            AutoScrollSpeed.dpPerSecond(AutoScrollPreference.MAX_STEP.toFloat()),
             0.001,
         )
     }
 
     @Test
     fun `every notch is faster than the one before it`() {
-        val paces = (AutoScrollSpeed.MIN_STEP..AutoScrollSpeed.MAX_STEP)
+        val paces = (AutoScrollPreference.MIN_STEP..AutoScrollPreference.MAX_STEP)
             .map { AutoScrollSpeed.dpPerSecond(it.toFloat()) }
         assertEquals(paces.sorted(), paces)
         assertEquals(paces.distinct().size, paces.size)
@@ -117,12 +128,12 @@ class AutoScrollSpeedTest {
     @Test
     fun `a step off the end of the slider is held at the end`() {
         assertEquals(
-            AutoScrollSpeed.dpPerSecond(AutoScrollSpeed.MIN_STEP.toFloat()),
+            AutoScrollSpeed.dpPerSecond(AutoScrollPreference.MIN_STEP.toFloat()),
             AutoScrollSpeed.dpPerSecond(-4f),
             0.001,
         )
         assertEquals(
-            AutoScrollSpeed.dpPerSecond(AutoScrollSpeed.MAX_STEP.toFloat()),
+            AutoScrollSpeed.dpPerSecond(AutoScrollPreference.MAX_STEP.toFloat()),
             AutoScrollSpeed.dpPerSecond(99f),
             0.001,
         )
@@ -143,15 +154,32 @@ class AutoScrollSpeedTest {
     }
 
     @Test
-    fun `the default is a notch on the slider`() {
-        assertEquals(AutoScrollSpeed.DEFAULT_STEP, AutoScrollSpeed.snap(AutoScrollSpeed.DEFAULT_STEP))
+    fun `a pace that is not a number is never handed to the page`() {
+        // The step comes from a preference file, so the curve is the
+        // last place a NaN can be stopped before it reaches the ticker.
+        assertTrue(AutoScrollSpeed.dpPerSecond(Float.NaN).isFinite())
+        assertTrue(AutoScrollSpeed.dpPerSecond(Float.POSITIVE_INFINITY).isFinite())
+        assertEquals(
+            AutoScrollSpeed.dpPerSecond(AutoScrollPreference.DEFAULT_STEP),
+            AutoScrollSpeed.dpPerSecond(Float.NaN),
+            0.001,
+        )
     }
 
     @Test
-    fun `snapping lands on a whole notch inside the slider`() {
-        assertEquals(3f, AutoScrollSpeed.snap(3.4f))
-        assertEquals(4f, AutoScrollSpeed.snap(3.6f))
-        assertEquals(AutoScrollSpeed.MIN_STEP.toFloat(), AutoScrollSpeed.snap(0f))
-        assertEquals(AutoScrollSpeed.MAX_STEP.toFloat(), AutoScrollSpeed.snap(42f))
+    fun `the curve uses the slider's own bounds`() {
+        // Were the curve to keep its own copy of the range, the two
+        // would drift the moment either moved: a step just off each end
+        // has to come out as that end's documented pace.
+        assertEquals(
+            AutoScrollSpeed.SLOWEST_DP_PER_SECOND,
+            AutoScrollSpeed.dpPerSecond(AutoScrollPreference.MIN_STEP - 1f),
+            0.001,
+        )
+        assertEquals(
+            AutoScrollSpeed.FASTEST_DP_PER_SECOND,
+            AutoScrollSpeed.dpPerSecond(AutoScrollPreference.MAX_STEP + 1f),
+            0.001,
+        )
     }
 }

--- a/docs/adr/0001-advanced-reading-menu.md
+++ b/docs/adr/0001-advanced-reading-menu.md
@@ -51,4 +51,11 @@ The Advanced sheet itself is a second bottom sheet reached from the
 first, not a navigation destination: dismissing it lands back on the
 typography sheet, and dismissing that lands back on the page.
 
-*Where:* `reader/chrome/TypographySheet.kt`.
+It exists as of auto-scroll ([ADR 6](0006-auto-scroll.md)), which was
+the first of the five to be built and so brought the sheet with it. It
+holds that one row, and the **Advanced** row that opens it is hidden
+when it would be empty — today, in a book read by turning pages. The
+other four arrive with their own issues.
+
+*Where:* `reader/chrome/TypographySheet.kt`,
+`reader/chrome/AdvancedSheet.kt`.

--- a/docs/adr/0006-auto-scroll.md
+++ b/docs/adr/0006-auto-scroll.md
@@ -1,6 +1,6 @@
 # 6. Auto-scroll
 
-Status: proposed
+Status: accepted
 GitHub issue: [#45](https://github.com/chmouel/liseur/issues/45)
 
 ## Context
@@ -23,19 +23,83 @@ control it already is — a tap shows the chrome and stops the movement.
 
 ## Design
 
-A coroutine in `ReaderViewModel`, alive only while reading, ticks a
-small `scrollBy` into the navigator's web view on a frame cadence
-derived from the speed setting. Speed is stored as a `Float` DataStore
-key; the slider maps to a range slow enough for dense prose and fast
-enough for skimming.
+**Where it lives.** Not `ReaderViewModel`, as first proposed: the view
+model has no navigator. `ReaderScreen` owns the navigator and the
+`PageTurner` that knows how to cross a chapter, so the loop lives there,
+driving a pure `reader/chrome/AutoScroll.kt` that knows nothing of web
+views, densities or frames. A `withFrameNanos` loop turns elapsed time
+into whole pixels — carrying the remainder, so a slow pace still moves —
+and calls `scrollBy` on the visible web view.
 
-Pause is the existing tap handling in `ReaderTapZones`: any tap that
-reveals the chrome also cancels the coroutine. Reaching the end of a
-resource behaves like a manual scroll reaching it — the existing
-`ScrollEdgeTurner` carries into the next one.
+**Whether it moves.** Readium's scroll mode scrolls the web view itself,
+which is why `ScrollEdgeTurner` reads `canScrollVertically` off it and
+why `R2BasicWebView` hangs its progression notification on
+`onScrollChanged`. A book set in vertical lines is scrolled sideways and
+runs right to left, so it is scrolled by a *negative* horizontal step —
+the same convention `scrollScreenfulScript` and `ScrollEdgeTurner`
+already read.
 
-Position saving needs nothing new: the navigator already reports
-locator changes as the page moves, and auto-scroll moves the page.
+**When it runs** is one predicate, `canAutoScroll`, stated once:
+
+> armed, and the book is effectively scrolled, and the chrome is hidden,
+> and no finger is down, and no overlay is up, and the endpaper is not
+> showing, and the lifecycle is `RESUMED`.
+
+That is the pause, rather than a separate mechanism for it. In a
+scrolled book every tap is a chrome tap, so a tap raises the chrome and
+the page stops; the next tap hides it and the page carries on. A drag is
+a finger down, so the text goes where the reader puts it and picks up
+from there. "Overlay" is every one of them — both sheets, contents,
+search, the footnote card, the selection popup, the note dialog, the
+definition sheet, the jump-back and catch-up pills, and the activity's
+own dialogs: an offer nobody has answered is about the page as it was.
+
+**Effectively scrolled** is `scrollMode || verticalText`, not
+`scrollMode`: Readium cannot paginate lines that run down the page, so
+it scrolls such a book whatever the preference says. The same derivation
+feeds `ReaderTapZones`, `ScrollEdgeTurner` and `PageTurner`, which read
+the preference alone before — without that, a tap on a vertical book
+turns a page instead of pausing, and this pause does not work at all.
+
+**Chapter boundaries.** Reaching the bottom is not the moment to leave;
+the last lines have only just arrived. The loop dwells there for one
+screen's worth of reading time at the reader's pace, then asks
+`PageTurner.stepChapter`, which is what a hand drag past the edge asks
+too. It *reads the answer*: false means there was nowhere to go, and the
+loop disarms rather than sitting against the edge. On true it waits for
+the resource to actually change — not a fixed delay, which would step a
+slow chapter twice and skip one shorter than a screen — and that wait,
+like every other, is bounded and cancellable.
+
+**Position saving does need something new**, contrary to the first
+draft. Readium answers a scroll with a *debounced* location notification
+— a hundred milliseconds of stillness. A finger drag always ends, so
+that debounce always lands. A page that never stops never lands it, and
+the reader's place would stay where they last lifted a finger. So the
+loop asks the navigator itself, every couple of seconds, through
+`firstVisibleElementLocator` — the same question the debounce would have
+asked, asked on time, and asked off the frame loop so the page does not
+hitch. Those go in as `READER_MOVEMENT`: auto-scroll is reading, so it
+should teach the pace estimator and count as time spent.
+
+Leaving the book is the one case that needs its own note.
+`ReaderViewModel` drops a `READER_MOVEMENT` locator once the reader is
+inactive, and `ReaderActivity.onPause` clears that flag before
+`super.onPause()`, so neither Readium's late debounce nor anything the
+loop publishes on `ON_PAUSE` can arrive as movement. The last position
+the loop fetched is therefore republished from an `ON_PAUSE` observer as
+`LOCAL_JUMP`, which persists, is not dropped by that guard, and does not
+count the same reading twice. It asks the page nothing and waits for
+nothing, so it is a synchronous call that has returned before `onStop`
+can begin to close the position queue.
+
+**Speed** is one shared `Float` in the reader DataStore, a step from 1
+to 10 mapped to dp per second and multiplied by the font size, so
+*lines* per minute stay roughly constant across text sizes. It lives in
+`ReaderPrefs` alongside the typography, which means the flow that maps
+those to `EpubPreferences` gains a `distinctUntilChanged()` — without
+it, dragging the slider would reflow the whole book once per notch for a
+setting the book cannot see.
 
 ## Consequences
 
@@ -44,5 +108,9 @@ genuine reading and needs no special-casing. The screen must not sleep
 mid-scroll, so starting auto-scroll implies keep-screen-on for the
 session regardless of the toggle.
 
-*Where:* `reader/ReaderViewModel.kt`, `reader/chrome/ReaderTapZones.kt`,
-`reader/chrome/TypographySheet.kt`.
+The reader gains no new chrome: the page moving is the state, and the
+switch that started it is where it stops.
+
+*Where:* `reader/chrome/AutoScroll.kt`, `reader/ReaderScreen.kt`,
+`reader/chrome/AdvancedSheet.kt`, `reader/chrome/TypographySheet.kt`,
+`reader/chrome/ReaderTapZones.kt`.

--- a/docs/adr/0006-auto-scroll.md
+++ b/docs/adr/0006-auto-scroll.md
@@ -31,6 +31,27 @@ views, densities or frames. A `withFrameNanos` loop turns elapsed time
 into whole pixels — carrying the remainder, so a slow pace still moves —
 and calls `scrollBy` on the visible web view.
 
+The notch and the pace are split, and the seam is the direction the
+dependency has to run. `AutoScrollPreference` — the range, the default,
+`snap` and `sanitize` — is in `data/settings/ReaderPrefs.kt` beside
+`ReaderFont`, `FooterMode` and `ColumnMode`, because those bounds
+describe the stored setting: what the slider may show and what the
+preference store may hold. `AutoScrollSpeed` and `AutoScrollTicker` stay
+in the reader, because how fast a page moves is the reader's business.
+The reader then reads the setting, which is the way round every other
+reading preference already goes. Having the DataStore repository import
+the reader instead would have been the layering backwards, and no
+tidier for being pointed at a pure file.
+
+The curve normalises every step through `AutoScrollPreference.sanitize`
+rather than keeping its own copy of the range, so the slider and the
+pace cannot drift apart. `sanitize` is also the only door the stored
+value comes through, and it is where a step that is not a number is
+stopped: `Float.roundToInt` throws on NaN, and a NaN pace otherwise
+multiplies out to a NaN distance, which the ticker would carry forever
+as a page that silently never moves again. The ticker refuses a
+non-finite pace too, so that invariant does not rest on one caller.
+
 **Whether it moves.** Readium's scroll mode scrolls the web view itself,
 which is why `ScrollEdgeTurner` reads `canScrollVertically` off it and
 why `R2BasicWebView` hangs its progression notification on
@@ -111,6 +132,6 @@ session regardless of the toggle.
 The reader gains no new chrome: the page moving is the state, and the
 switch that started it is where it stops.
 
-*Where:* `reader/chrome/AutoScroll.kt`, `reader/ReaderScreen.kt`,
-`reader/chrome/AdvancedSheet.kt`, `reader/chrome/TypographySheet.kt`,
-`reader/chrome/ReaderTapZones.kt`.
+*Where:* `reader/chrome/AutoScroll.kt`, `data/settings/ReaderPrefs.kt`,
+`reader/ReaderScreen.kt`, `reader/chrome/AdvancedSheet.kt`,
+`reader/chrome/TypographySheet.kt`, `reader/chrome/ReaderTapZones.kt`.


### PR DESCRIPTION
## Summary

Scroll mode still needed a thumb on the page. A switch in a new **Advanced**
sheet now hands that job over: the page carries itself at a chosen pace,
crosses a chapter boundary unattended, keeps the screen awake, and stops the
moment a finger lands on it.

ADR 6 puts that control in the Advanced sheet, and ADR 1 says the Advanced
sheet is a second bottom sheet reached from a single new **Advanced** row at
the bottom of the typography sheet. That sheet did not exist, so this brings
its shell along — the shell only, holding the one row auto-scroll needs. The
other four rows ADR 1 lists stay for their own issues, so **#40 stays open**.

Fixes #45

## Changes

- **`reader/chrome/AutoScroll.kt`** — the pure core, no Android types.
  `AutoScrollTicker` turns a frame delta and a pixels-per-second figure into
  whole pixels with the remainder carried, so a slow speed still moves and a
  stalled frame is clamped rather than jumping the page. `AutoScrollSpeed`
  maps a step 1–10 geometrically to 6–90 dp/s and multiplies by the font size,
  which keeps *lines* per minute roughly constant across text sizes.
- **`reader/chrome/AdvancedSheet.kt`** — the #40 shell: the auto-scroll switch
  and its speed slider, nothing else. Dismissing lands back on the typography
  sheet, per ADR 1.
- **`ReaderScreen.kt`** — a `withFrameNanos` loop driving `WebView.scrollBy`,
  living here because this is what owns the navigator and the `PageTurner`
  that already knows how to cross a chapter. `showTypography` and a second
  boolean would have raced, so the two sheets became one `ReaderSheet` enum.
- **Effectively scrolled** — `scrollMode || verticalText`, because Readium
  scrolls a vertical-text book whatever the preference says. The tap zones,
  the edge turner and the page turner all read that same derivation now.
- **`distinctUntilChanged()`** on the mapped `EpubPreferences` flow, so
  dragging the speed slider does not reflow the book ten times for a setting
  the book cannot see.
- ADR 6 to accepted with its Design section corrected, a line in ADR 1, and
  the scrolling sentence in `README.md` extended.

### Two things worth a reviewer's attention

**ADR 6 was wrong about position saving.** It assumed locators would follow for
free. They do not: `R2BasicWebView.onScrollChanged` reaches
`EpubNavigatorFragment.notifyCurrentLocation()`, which is debounced by 100 ms —
and a page that never stops cancels that debounce every frame, so nothing would
ever be written. A finger drag always ends, which is why this never bit before.
The loop therefore fetches `firstVisibleElementLocator()` itself every couple of
seconds, off the frame loop, and publishes it as `READER_MOVEMENT`; an
`ON_PAUSE` observer republishes the last one as `LOCAL_JUMP`, which the
inactive-reader guard does not drop. Verified: a force-stop mid-scroll loses
about two lines.

**When it may run is one predicate**, `canAutoScroll`: armed, effectively
scrolled, chrome hidden, no finger down, no overlay or dialog up, not on the
endpaper, and `RESUMED`. That gives ADR 6's pause for free — in a scrolled book
every tap is a chrome tap already — and it is what keeps the page still behind a
footnote card or a catch-up pill.

## Testing

- [x] `./gradlew testDebugUnitTest` — 24 new tests for the ticker and the speed curve
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on `emulator-5554` (API 36)

On device, all confirmed:

- the **Advanced** row is absent in paginated mode and appears the instant
  scroll mode is turned on;
- arming closes both sheets, hides the chrome and sets `KEEP_SCREEN_ON`
  (checked in `dumpsys window`);
- a tap stops the page and a tap restarts it; a drag pauses and hands the page
  back;
- a selection popup holds the page still **with the chrome hidden** — real
  non-chrome overlay gating, not the chrome check in disguise;
- a chapter shorter than one screen is dwelled on rather than skipped, and the
  crossing into the next chapter happens unattended;
- the last chapter stops on the endpaper and **disarms** rather than spinning;
- the position survives a force-stop mid-scroll, restored about two lines back;
- max speed is roughly 5.5 lines/sec against 1 line/sec at the default, and the
  slider commits without the book reflowing.

A hand-written vertical-text EPUB (the Standard Ebooks demo set is all
horizontal) confirms the `effectiveScrolling` payoff: with **"Read by
scrolling" off**, the Advanced row is still offered, the page scrolls sideways
right-to-left, and a tap **pauses it instead of turning a page**.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

## Screenshots

**The Advanced row is earned, not always there.** Paginated on the left, the
same sheet with "Read by scrolling" on at the right — the row appears with it.

| Paginated: no Advanced row | Scrolled: Advanced appears |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/699b8b39-0512-417e-ab57-21a492bfe4eb" width="330"> | <img src="https://github.com/user-attachments/assets/42e78dc9-d48c-4f87-99bf-3933ad4a599b" width="330"> |

**The sheet itself**, and the vertical-text book paused by a tap — note the
chrome came back and the page stopped rather than turning.

| The Advanced sheet | Vertical text, paused by a tap |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/c68bdb37-e1ca-40e7-9241-9273a2ae94ed" width="330"> | <img src="https://github.com/user-attachments/assets/a4c645fd-e4a4-4dea-8db1-73474a8da39b" width="330"> |
