### PR TITLE
perf(reader): ask the auto-scroll frame less

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -1565,14 +1565,23 @@ class ReaderAnnotationActions(
  * chapter shorter than a screen is read as a stall. It is bounded all
  * the same, because a wait that can never end is a page that can never
  * be stopped.
+ *
+ * The dwell is the one window in which someone else can turn the page
+ * first. A volume or page key goes straight to the turner without the
+ * chrome coming up, so auto-scroll stays armed and this call stays
+ * alive; stepping again afterwards would carry the reader a chapter
+ * further than they asked for. If the chapter changed while we waited,
+ * the page moved — which is what the wait was there to allow — and the
+ * loop carries on wherever the reader now is.
  */
 private suspend fun carryIntoNextChapter(
     nav: EpubNavigatorFragment,
     pageTurner: PageTurner,
     dwellMillis: Long,
 ): Boolean {
-    delay(dwellMillis)
     val leaving = nav.currentLocator.value.href
+    delay(dwellMillis)
+    if (nav.currentLocator.value.href != leaving) return true
     if (!pageTurner.stepChapter(forward = true)) return false
     return withTimeoutOrNull(CHAPTER_ARRIVAL_MS) {
         nav.currentLocator.first { it.href != leaving }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -117,6 +117,7 @@ import com.chmouel.liseur.reader.chrome.ReadingFooter
 import com.chmouel.liseur.reader.chrome.FooterMetrics
 import com.chmouel.liseur.reader.chrome.ScrollEdgeTurner
 import com.chmouel.liseur.reader.chrome.visibleWebView
+import com.chmouel.liseur.reader.chrome.visibleWebViewCache
 import com.chmouel.liseur.reader.chrome.layoutPasses
 import com.chmouel.liseur.reader.chrome.ReadingScrubber
 import com.chmouel.liseur.reader.chrome.ContentsScreen
@@ -741,12 +742,30 @@ fun ReaderScreen(
      */
     var autoScrollLocator by remember { mutableStateOf<Locator?>(null) }
     val autoScrollRunning by rememberUpdatedState(canAutoScroll)
+    val density = LocalDensity.current.density
 
-    LaunchedEffect(navigator, canAutoScroll, prefs.autoScrollSpeed, prefs.fontSize, lifecycle) {
+    LaunchedEffect(
+        navigator,
+        canAutoScroll,
+        prefs.autoScrollSpeed,
+        prefs.fontSize,
+        density,
+        lifecycle,
+    ) {
         if (!canAutoScroll) return@LaunchedEffect
         val nav = navigator ?: return@LaunchedEffect
-        val density = view.resources.displayMetrics.density
+        val root = nav.publicationView
         val ticker = AutoScrollTicker()
+        val webViews = visibleWebViewCache(root)
+        // The pace cannot change under the loop: every term of it is a
+        // key of this effect, so a reader who moves the slider gets a
+        // new loop rather than a new number in the old one. Working it
+        // out sixty times a second to arrive at the same answer is the
+        // sort of arithmetic a frame should not be spending itself on.
+        val pixelsPerSecond = AutoScrollSpeed.dpPerSecond(
+            step = prefs.autoScrollSpeed,
+            fontSize = prefs.fontSize,
+        ) * density
         // RESUMED and not merely STARTED: a reader looking at something
         // else on a split screen is not reading this, and the page they
         // come back to should be the page they left.
@@ -754,14 +773,48 @@ fun ReaderScreen(
             ticker.reset()
             var savedAtNanos = 0L
             var saving = false
+            // The place kept for the pause outlives this loop, and a
+            // book moved to another chapter while the reader was away
+            // moved without anyone here to see it: the flow below only
+            // starts watching now, and its first value is the state of
+            // things rather than news. A locator from a chapter that is
+            // no longer open is not the reader's place in this one.
+            if (autoScrollLocator?.href != nav.currentLocator.value.href) {
+                autoScrollLocator = null
+            }
+            // Two events, told apart because they are not the same news.
+            // Invalidating costs nothing and can be said too often —
+            // the next frame simply looks the view up again — so it
+            // rides both a new position and a layout pass, the pair
+            // this screen already trusts elsewhere: Readium reports
+            // arriving at a resource before laying it out, and a view
+            // that does not exist yet cannot be found.
+            launch {
+                merge(nav.currentLocator.map { }, layoutPasses(root)).collect {
+                    webViews.invalidate()
+                }
+            }
+            // A chapter change, on the other hand, is rare and means
+            // something: the carried fraction belongs to the page that
+            // has gone, and so does the place kept for the pause.
+            // Hanging that off every position — they arrive as the
+            // reader moves within a chapter — would reset the pace
+            // constantly and throw the pause position away for nothing.
+            launch {
+                nav.currentLocator
+                    .map { it.href }
+                    .distinctUntilChanged()
+                    .drop(1)
+                    .collect {
+                        ticker.reset()
+                        savedAtNanos = 0L
+                        autoScrollLocator = null
+                    }
+            }
             while (true) {
                 val now = withFrameNanos { it }
-                val web = visibleWebView(nav.publicationView) ?: continue
+                val web = webViews.current() ?: continue
                 val vertical = nav.settings.value.verticalText
-                val pixelsPerSecond = AutoScrollSpeed.dpPerSecond(
-                    step = prefs.autoScrollSpeed,
-                    fontSize = prefs.fontSize,
-                ) * density
                 val pixels = ticker.step(nowNanos = now, pixelsPerSecond = pixelsPerSecond)
                 if (pixels <= 0) continue
                 if (!saving && now - savedAtNanos >= AUTO_SCROLL_SAVE_NANOS) {
@@ -773,20 +826,32 @@ fun ReaderScreen(
                             // down with it: this coroutine is the loop's
                             // child, and an exception here would cancel
                             // its parent and stop the page for good.
+                            val asking = nav.currentLocator.value.href
                             val here = runCatching { nav.firstVisibleElementLocator() }
                                 .getOrNull()
                             if (here != null) {
                                 val captured = runCatching { capture(nav, here) }
                                     .getOrDefault(here)
-                                autoScrollLocator = captured
-                                // Auto-scroll is reading, so it teaches
-                                // the pace estimator and counts as time
-                                // spent, which READER_MOVEMENT is what
-                                // carries.
-                                onLocatorChanged(
-                                    captured,
-                                    NavigatorPositionEvent.READER_MOVEMENT,
-                                )
+                                // Both halves of this are questions put
+                                // to the document, and the reader may
+                                // have left the chapter while it was
+                                // answering. A save dropped costs a tick
+                                // and no more; a save kept would file
+                                // the old chapter's place as the
+                                // reader's place in the new one.
+                                if (captured.href == asking &&
+                                    nav.currentLocator.value.href == asking
+                                ) {
+                                    autoScrollLocator = captured
+                                    // Auto-scroll is reading, so it
+                                    // teaches the pace estimator and
+                                    // counts as time spent, which
+                                    // READER_MOVEMENT is what carries.
+                                    onLocatorChanged(
+                                        captured,
+                                        NavigatorPositionEvent.READER_MOVEMENT,
+                                    )
+                                }
                             }
                         } finally {
                             saving = false
@@ -813,6 +878,7 @@ fun ReaderScreen(
                     ticker.reset()
                     savedAtNanos = 0L
                     autoScrollLocator = null
+                    webViews.invalidate()
                     if (!moved) {
                         autoScrollArmed = false
                         return@repeatOnLifecycle

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/CachedLookup.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/CachedLookup.kt
@@ -1,0 +1,50 @@
+package com.chmouel.liseur.reader.chrome
+
+/**
+ * A value that is expensive to find and cheap to check.
+ *
+ * The reader's frame loop needs the web view it is scrolling sixty
+ * times a second, and finding it means walking the view tree. Holding
+ * on to the answer only works if there is a way to notice it has gone
+ * stale, so a holder is given both halves: how to find the value, and
+ * how to tell whether the one it has is still the answer. The check is
+ * expected to be the cheap half — a comparison rather than a search —
+ * and it is only ever asked of a value already held.
+ *
+ * Nothing here is synchronised, and nothing here should be: this is a
+ * plain field read on whichever thread calls it, meant to be confined
+ * to a single dispatcher — for the reader, the main one, where both the
+ * frame loop and the events that invalidate it already live. A holder
+ * shared across threads would need a different design, not a lock
+ * bolted onto this one.
+ */
+internal class CachedLookup<T : Any>(
+    private val stillGood: (T) -> Boolean,
+    private val lookup: () -> T?,
+) {
+
+    private var held: T? = null
+
+    /**
+     * The value, found again only if the one held will no longer do.
+     *
+     * A lookup that comes back empty is not remembered as an answer:
+     * the next call asks again, because "not there yet" is a state
+     * things come out of.
+     */
+    fun current(): T? {
+        val known = held
+        if (known != null && stillGood(known)) return known
+        return lookup().also { held = it }
+    }
+
+    /**
+     * Forgets what is held, so the next [current] goes and looks.
+     *
+     * For the moments a caller knows about and the predicate cannot see
+     * yet — a page turn that has been asked for but not laid out.
+     */
+    fun invalidate() {
+        held = null
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReaderWebViews.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReaderWebViews.kt
@@ -30,6 +30,49 @@ internal fun visibleWebView(root: View): WebView? {
         ?: visible.maxByOrNull { (_, rect) -> rect.width() * rect.height() }?.first
 }
 
+/**
+ * The same web view, held on to between frames.
+ *
+ * A reader carrying itself down the page asks this question sixty times
+ * a second, and [visibleWebView] answers it by walking the whole view
+ * tree. So the answer is kept, and what is asked each frame instead is
+ * the cheap half of the same question: is the view still attached, and
+ * does it still cover the middle of the reader — one rect against one
+ * point, no traversal and no allocation.
+ *
+ * The check has to be that question and not a weaker one. Readium keeps
+ * the neighbouring chapters attached to its pager, so a chapter the
+ * reader has left goes on being attached and, as far as `isShown` is
+ * concerned, shown. Only covering the centre means *current*, because
+ * that is what [visibleWebView] means by it.
+ *
+ * When nothing covers the centre — mid-transition — [visibleWebView]
+ * falls back to the largest visible view, which by construction fails
+ * the check, so the cache spends those frames looking the answer up
+ * again. That is the cost paid on every frame before this existed, and
+ * it stops as soon as the new chapter settles under the centre.
+ *
+ * Not thread-safe, by [CachedLookup]: views belong to the main thread
+ * anyway.
+ */
+internal fun visibleWebViewCache(root: View): CachedLookup<WebView> {
+    val origin = IntArray(2)
+    val bounds = Rect()
+    return CachedLookup(
+        stillGood = { web ->
+            if (!web.isAttachedToWindow) {
+                false
+            } else {
+                root.getLocationOnScreen(origin)
+                val x = origin[0] + root.width / 2
+                val y = origin[1] + root.height / 2
+                web.getGlobalVisibleRect(bounds) && bounds.contains(x, y)
+            }
+        },
+        lookup = { visibleWebView(root) },
+    )
+}
+
 private fun collectVisibleWebViews(view: View, into: MutableList<Pair<WebView, Rect>>) {
     when {
         view is WebView -> {

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/CachedLookupTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/CachedLookupTest.kt
@@ -1,0 +1,86 @@
+package com.chmouel.liseur.reader.chrome
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class CachedLookupTest {
+
+    private class Answer(val name: String)
+
+    private var found: Answer? = Answer("first")
+    private var lookups = 0
+    private var checks = 0
+    private var good = true
+
+    private val cache = CachedLookup<Answer>(
+        stillGood = {
+            checks++
+            good
+        },
+        lookup = {
+            lookups++
+            found
+        },
+    )
+
+    @Test
+    fun `the first call has to go and look`() {
+        val first = found
+        assertSame(first, cache.current())
+        assertEquals(1, lookups)
+    }
+
+    @Test
+    fun `nothing is checked when nothing is held`() {
+        cache.current()
+        assertEquals(0, checks)
+    }
+
+    @Test
+    fun `a value that still does is handed back without looking again`() {
+        val first = cache.current()
+        repeat(60) { assertSame(first, cache.current()) }
+        assertEquals(1, lookups)
+    }
+
+    @Test
+    fun `a value that no longer does is replaced`() {
+        val first = cache.current()
+        good = false
+        found = Answer("second")
+        val second = cache.current()
+        assertEquals("second", second?.name)
+        assertEquals(2, lookups)
+        assertEquals("first", first?.name)
+    }
+
+    @Test
+    fun `invalidating sends the next call back to the lookup`() {
+        cache.current()
+        cache.invalidate()
+        found = Answer("second")
+        assertEquals("second", cache.current()?.name)
+        assertEquals(2, lookups)
+    }
+
+    @Test
+    fun `a value invalidated is not asked whether it still does`() {
+        cache.current()
+        cache.invalidate()
+        cache.current()
+        assertEquals(0, checks)
+    }
+
+    @Test
+    fun `finding nothing is not an answer worth keeping`() {
+        found = null
+        assertNull(cache.current())
+        found = Answer("arrived")
+        assertEquals("arrived", cache.current()?.name)
+        assertEquals(2, lookups)
+        // The empty result was never held, so it was never checked.
+        assertEquals(0, checks)
+    }
+}

--- a/docs/adr/0006-auto-scroll.md
+++ b/docs/adr/0006-auto-scroll.md
@@ -122,6 +122,53 @@ those to `EpubPreferences` gains a `distinctUntilChanged()` — without
 it, dragging the slider would reflow the whole book once per notch for a
 setting the book cannot see.
 
+**What a frame costs.** A frame here does arithmetic on elapsed time and
+one `scrollBy`, and nothing else, because everything else it used to do
+had the same answer as the frame before. The pace is a curve over the
+speed notch, the font size and the display density; all three are keys
+of the effect that runs the loop, so it is computed on the way in and
+cannot go stale without the loop being rebuilt around it. The web view
+was found by walking the view tree and taking a global visible rect off
+every web view in it, sixty times a second, so it is held between frames
+by a `CachedLookup`.
+
+Holding it is only safe if "current" keeps the meaning `visibleWebView`
+gives it: the view covering the middle of the reader. Attachment will
+not do — Readium keeps the neighbouring chapters attached to its pager,
+so a chapter the reader has left stays attached and, to `isShown`,
+shown. The check is therefore the cheap half of the same question, one
+rect against one point. Mid-transition, when nothing covers the centre,
+the search falls back to the largest visible view, which fails that
+check, so the cache spends those frames looking again — the cost paid on
+every frame before, now paid only while a chapter is arriving.
+
+The held view is also dropped on a new position or a layout pass, the
+pair this screen already watches for exactly this reason: Readium
+reports arriving at a resource before laying it out, and a view that
+does not exist yet cannot be found. Invalidating is free and idempotent,
+so it can be said too often. A chapter *changing* is different news and
+rides its own event — positions arrive as the reader moves within a
+chapter, and the ticker's carried fraction and the place kept for the
+pause may only be thrown away when the page they belong to has actually
+gone.
+
+**Someone else turning the page first.** The dwell at a chapter's end is
+the one window where the loop is alive and waiting rather than moving,
+and `ReaderActivity` sends volume and page keys straight to the turner
+without raising the chrome — so auto-scroll stays armed and the dwell
+stays alive. The dwell therefore notes which chapter it is waiting in
+and does not step if it is somewhere else when the wait ends: the page
+moved, which is what the wait was there to allow.
+
+Two round trips into the document have the same shape of problem. The
+position the loop saves is fetched and captured while the reader may be
+leaving, so it is discarded unless the chapter it was asked of is still
+open — a save dropped costs one tick, a save kept would file the old
+chapter's place as the reader's place in the new one. The place kept for
+the pause outlives the loop, so it is dropped on the way back in unless
+it still points into the open chapter: a book moved elsewhere while the
+reader was away moved with nobody watching.
+
 ## Consequences
 
 The reading-speed estimator will see unusually steady progress; that is
@@ -132,6 +179,7 @@ session regardless of the toggle.
 The reader gains no new chrome: the page moving is the state, and the
 switch that started it is where it stops.
 
-*Where:* `reader/chrome/AutoScroll.kt`, `data/settings/ReaderPrefs.kt`,
+*Where:* `reader/chrome/AutoScroll.kt`, `reader/chrome/CachedLookup.kt`,
+`reader/chrome/ReaderWebViews.kt`, `data/settings/ReaderPrefs.kt`,
 `reader/ReaderScreen.kt`, `reader/chrome/AdvancedSheet.kt`,
 `reader/chrome/TypographySheet.kt`, `reader/chrome/ReaderTapZones.kt`.


### PR DESCRIPTION
## Summary

Follow-up to #75, which merged with one review comment unaddressed:
https://github.com/chmouel/liseur/pull/75#discussion_r3846807158

The auto-scroll loop asked two questions sixty times a second that it already
knew the answers to. The pace is a `pow` curve over the speed notch and the font
size, both already keys of the effect that runs the loop, so it cannot change
while the loop lives. And the web view being scrolled was found by walking the
whole view tree and taking a global visible rect off every web view in it —
every frame, to arrive at the view it had the frame before.

Chasing what would make caching that view *safe* turned up a second bug, which
is the middle commit: a page turn during the end-of-chapter dwell was answered
by turning again on top of it.

## Changes

- **`reader/chrome/CachedLookup.kt`** (new, pure, no Android types) — a value
  that is expensive to find and cheap to check: it is given how to look, and how
  to tell whether what it holds still answers. Not synchronised, and its KDoc
  says so; it is confined to the main thread, where both the frame loop and the
  events that invalidate it already live.
- **`reader/chrome/ReaderWebViews.kt`** — `visibleWebViewCache(root)`, whose
  check is the cheap half of the question `visibleWebView` asks: attached, and
  still covering the middle of the reader, one rect against one point over a
  reused `Rect`. It cannot be a weaker question — Readium keeps the neighbouring
  chapters attached to its pager, so a chapter the reader has left stays
  attached and, to `isShown`, shown.
- **`ReaderScreen.kt`** — `pixelsPerSecond` computed once on the way in, with
  the density lifted into composition and keyed alongside the notch and the font
  size so that stays true. The held view is dropped on a new position or a layout
  pass — the pair this screen already watches, because Readium reports arriving
  at a resource before laying it out — and explicitly at the loop's own chapter
  turn.
- **`ReaderScreen.kt`** — a chapter actually *changing* is different news from a
  position arriving, and now rides its own event: positions arrive as the reader
  moves within a chapter, so resetting the ticker and the pause position on every
  one of them would have thrown that position away constantly.
- **`carryIntoNextChapter`** — notes the chapter before the dwell rather than
  after it, and does not step if it is somewhere else when the wait ends.
- ADR 6 gains what a frame costs and why "current" means covering the centre.

### Worth a reviewer's attention

**The dwell was a real bug, not a theoretical one.** `ReaderActivity.onKeyDown`
sends `FORWARD_KEYS`/`BACK_KEYS` — volume, page up/down, space, D-pad — straight
to `turner.turn()`, and only `FOCUS_KEYS` are gated on the chrome. So a volume
press during the end-of-chapter dwell turned the page with auto-scroll still
armed and the dwell still alive, and the loop then advanced *again*: the reader
lost a chapter. I had first talked myself out of this on the grounds that
navigation drops `canAutoScroll` and cancels the delay; the key handler is the
path that does not.

**Two round trips, two dropped saves.** `firstVisibleElementLocator()` and
`capture()` are both questions put to the document, and the reader can leave the
chapter while it is answering — the result is now discarded unless the resource
it was asked of is still open. Separately, the position kept for `onPause`
outlives the loop, so a book moved elsewhere while the reader was away would
have been republished as their place; it is dropped on the way back in unless it
still points into the open chapter.

**Where the cache stops helping, on purpose.** Mid-transition nothing covers the
centre, `visibleWebView` falls back to the largest visible view, and that fails
the check — so those frames go back to searching. That is the cost paid on every
frame before this change, now paid only while a chapter is arriving.

## Testing

- [x] `./gradlew testDebugUnitTest` — including 7 new `CachedLookupTest` cases
- [x] `./gradlew lintDebug` — 0 errors
- [x] `./gradlew assembleDebug`
- [ ] Manually tested on a device or emulator — **not done**: installing on the
      emulator was not authorised for this change. The cases worth a human are
      the first chapter after opening a book (locator before layout), an
      auto-scroll chapter turn, a volume-key turn during the dwell, and
      background/resume after the book was moved elsewhere.

## Screenshots or recordings

None: nothing here is visible. Same pace, same pixels, same saved positions —
fewer of them computed twice.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.