### PR TITLE
fix(reader): save where a scrolled book has got to

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -115,6 +115,7 @@ import com.chmouel.liseur.reader.chrome.PageTurner
 import com.chmouel.liseur.reader.chrome.ReaderTapZones
 import com.chmouel.liseur.reader.chrome.ReadingFooter
 import com.chmouel.liseur.reader.chrome.FooterMetrics
+import com.chmouel.liseur.reader.chrome.HeldPlace
 import com.chmouel.liseur.reader.chrome.ScrollEdgeTurner
 import com.chmouel.liseur.reader.chrome.visibleWebView
 import com.chmouel.liseur.reader.chrome.visibleWebViewCache
@@ -126,6 +127,7 @@ import com.chmouel.liseur.reader.chrome.FootnoteCard
 import com.chmouel.liseur.reader.chrome.TypographySheet
 import com.chmouel.liseur.reader.progress.ReaderProgress
 import com.chmouel.liseur.reader.progress.ExactLocatorAnchor
+import com.chmouel.liseur.reader.progress.ScrollProgression
 import com.chmouel.liseur.reader.search.SearchScreen
 import com.chmouel.liseur.ui.LocalEInk
 import com.chmouel.liseur.ui.eink.EInkDisplay
@@ -138,7 +140,10 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.flow.SharedFlow
@@ -192,6 +197,13 @@ private const val MAX_CHAPTER_DWELL_MS = 8_000L
 // loss is a line, long enough that a document round trip every so often
 // costs nothing.
 private const val AUTO_SCROLL_SAVE_NANOS = 2_000_000_000L
+
+// How often a book scrolled by hand is looked in on, and so the most a
+// place kept for the pause can be behind the reader. The same interval
+// auto-scroll writes at, for the same reason: it is a line or two of
+// loss against a document round trip, and only a page that moved since
+// the last look is worth one.
+private const val SCROLL_PLACE_POLL_MS = 2_000L
 
 /**
  * Which sheet is open over the page, if any.
@@ -322,9 +334,11 @@ fun ReaderScreen(
     // layout moving, not the reader.
     val reflow = remember { ReflowScope() }
 
-    // A fixed-layout book places everything by absolute coordinates and has no
-    // reflow to speak of; measuring what "fits" there means nothing.
-    val fitWideContent = remember(publication) {
+    // A fixed-layout book places everything by absolute coordinates: nothing
+    // reflows, so measuring what "fits" means nothing, and the document does
+    // not move under the viewport, so a fraction of its length says nothing
+    // about where the reader is either.
+    val reflowableText = remember(publication) {
         publication.metadata.layout != Layout.FIXED
     }
 
@@ -335,8 +349,67 @@ fun ReaderScreen(
     // reader actually moves, and every reflow restores to the same spot.
     var reflowAnchor by remember { mutableStateOf<Locator?>(null) }
 
+    // The place a scrolled book was last measured at, kept for the
+    // moment the reader leaves. Everything that measures one and
+    // everything that supersedes one goes through here; see [HeldPlace].
+    val heldPlace = remember { HeldPlace() }
+
     suspend fun capture(nav: EpubNavigatorFragment, locator: Locator): Locator =
         onProgressAction.prepareLocator(ExactLocatorAnchor.capture(nav, locator))
+
+    /**
+     * Where a scrolled chapter has got to, as a locator worth saving.
+     *
+     * Readium's own answer names a place — a selector and the words at
+     * the top of the screen — but no distance: `findFirstVisibleLocator`
+     * carries neither a progression nor a position, and everything
+     * downstream reads a locator without one as the start of its
+     * resource. So the distance is measured here, in the terms
+     * `ScrollProgression` explains, and a place that cannot be given one
+     * is not saved at all: a tick's delay costs the reader a line, a
+     * number that is wrong costs them the chapter.
+     *
+     * The distance and the anchor are asked for back to back, because
+     * those are the two that have to agree; the answer Readium gives
+     * first is only used for the resource it names, which is the one
+     * actually on screen and may be ahead of the one it has published.
+     * Everything the navigator last published is dropped rather than
+     * carried: its position and its words belong to wherever it last
+     * stopped, and the capture is about to supply the ones true now.
+     *
+     * Every step is a question put to the document, and the reader may
+     * have left the chapter while it was answering. A place dropped
+     * costs a tick and no more; a place kept would file the old
+     * chapter's as the reader's place in the new one. A page being
+     * rebuilt is not a page the reader has moved through at all, so the
+     * question is not put to it while a reflow is open.
+     */
+    suspend fun scrolledPlace(nav: EpubNavigatorFragment): Locator? {
+        if (!reflowableText || reflow.active) return null
+        val asking = nav.currentLocator.value.href
+        val displayed = try {
+            nav.firstVisibleElementLocator()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        } ?: return null
+        val progression = ScrollProgression
+            .of(nav, vertical = nav.settings.value.verticalText)
+            ?: return null
+        val measured = displayed.copy(
+            locations = Locator.Locations(progression = progression),
+            text = Locator.Text(),
+        )
+        val captured = capture(nav, measured)
+        if (captured.href != asking || nav.currentLocator.value.href != asking) return null
+        // The capture reaches into the document too, and swallows its
+        // own failures to do it. Cancellation is not a failure to
+        // swallow: a place written down after the loop that asked for it
+        // has gone is a place nobody is standing in.
+        currentCoroutineContext().ensureActive()
+        return captured
+    }
 
     suspend fun settleLayout() {
         withFrameNanos { }
@@ -461,7 +534,25 @@ fun ReaderScreen(
                 // Anywhere the reader actually goes ends the run of
                 // preference changes the held anchor was covering.
                 if (event != NavigatorPositionEvent.PREFERENCE_REFLOW) reflowAnchor = null
-                onLocatorChanged(capture(nav, native), event)
+                // This is fresher than anything a scroll watcher had in
+                // flight, so those answers are refused from here on. The
+                // place already held stands until this one is taken:
+                // the capture below suspends, and a reader who leaves
+                // while it is being answered would otherwise be left
+                // with neither.
+                val since = heldPlace.invalidate()
+                val captured = capture(nav, native)
+                // A reflow locator is the layout moving, not the reader,
+                // and it is not a jump anyone should be sent back to on
+                // the way out. Its arrival still retires what was held,
+                // which was measured against a page that no longer
+                // exists in that shape.
+                if (event == NavigatorPositionEvent.PREFERENCE_REFLOW) {
+                    heldPlace.retire()
+                } else {
+                    heldPlace.hold(captured, since)
+                }
+                onLocatorChanged(captured, event)
             }
         }
     }
@@ -553,7 +644,7 @@ fun ReaderScreen(
                     // so what fits has to be asked again once the new size has
                     // landed — and before the anchor is restored, since fitting
                     // it moves the text once more.
-                    if (fitWideContent &&
+                    if (reflowableText &&
                         WideContentFit.apply(nav) == WideContentFit.Result.CHANGED
                     ) {
                         awaitReflowSettled(nav, before)
@@ -578,9 +669,9 @@ fun ReaderScreen(
     // the page the book opens at, a layout pass alone can miss a resource
     // swapped in without one, and finding the same web view again costs a
     // reference comparison.
-    LaunchedEffect(navigator, fitWideContent) {
+    LaunchedEffect(navigator, reflowableText) {
         val nav = navigator ?: return@LaunchedEffect
-        if (!fitWideContent) return@LaunchedEffect
+        if (!reflowableText) return@LaunchedEffect
         val root = nav.publicationView
         var fitted: WebView? = null
         merge(nav.currentLocator.map { }, layoutPasses(root)).collect {
@@ -735,12 +826,11 @@ fun ReaderScreen(
      * would stay wherever they last lifted a finger.
      *
      * So the loop asks for the location itself, on its own clock, with
-     * the navigator's own `firstVisibleElementLocator` — the same
-     * question the debounce would have asked, just asked on time. It is
-     * asked off the frame loop so the page does not hitch waiting for a
-     * round trip into the document.
+     * `scrolledPlace` — the same question the debounce would have asked,
+     * just asked on time, and answered with a distance the navigator's
+     * own answer does not carry. It is asked off the frame loop so the
+     * page does not hitch waiting for a round trip into the document.
      */
-    var autoScrollLocator by remember { mutableStateOf<Locator?>(null) }
     val autoScrollRunning by rememberUpdatedState(canAutoScroll)
     val density = LocalDensity.current.density
 
@@ -779,8 +869,8 @@ fun ReaderScreen(
             // starts watching now, and its first value is the state of
             // things rather than news. A locator from a chapter that is
             // no longer open is not the reader's place in this one.
-            if (autoScrollLocator?.href != nav.currentLocator.value.href) {
-                autoScrollLocator = null
+            if (heldPlace.current()?.href != nav.currentLocator.value.href) {
+                heldPlace.retire()
             }
             // Two events, told apart because they are not the same news.
             // Invalidating costs nothing and can be said too often —
@@ -808,7 +898,7 @@ fun ReaderScreen(
                     .collect {
                         ticker.reset()
                         savedAtNanos = 0L
-                        autoScrollLocator = null
+                        heldPlace.retire()
                     }
             }
             while (true) {
@@ -822,37 +912,31 @@ fun ReaderScreen(
                     saving = true
                     launch {
                         try {
+                            val since = heldPlace.mark()
+                            val captured = scrolledPlace(nav)
+                            // One question decides both: a measurement
+                            // the reader has already moved past is not
+                            // worth keeping, and publishing it would
+                            // carry them back to it.
+                            if (captured != null && heldPlace.hold(captured, since)) {
+                                // Auto-scroll is reading, so it teaches
+                                // the pace estimator and counts as time
+                                // spent, which READER_MOVEMENT is what
+                                // carries.
+                                onLocatorChanged(
+                                    captured,
+                                    NavigatorPositionEvent.READER_MOVEMENT,
+                                )
+                            }
+                        } catch (e: CancellationException) {
+                            // The loop is going down anyway, and a
+                            // cancelled measurement is not an answer.
+                            throw e
+                        } catch (_: Exception) {
                             // A failed round trip must not take the loop
                             // down with it: this coroutine is the loop's
                             // child, and an exception here would cancel
                             // its parent and stop the page for good.
-                            val asking = nav.currentLocator.value.href
-                            val here = runCatching { nav.firstVisibleElementLocator() }
-                                .getOrNull()
-                            if (here != null) {
-                                val captured = runCatching { capture(nav, here) }
-                                    .getOrDefault(here)
-                                // Both halves of this are questions put
-                                // to the document, and the reader may
-                                // have left the chapter while it was
-                                // answering. A save dropped costs a tick
-                                // and no more; a save kept would file
-                                // the old chapter's place as the
-                                // reader's place in the new one.
-                                if (captured.href == asking &&
-                                    nav.currentLocator.value.href == asking
-                                ) {
-                                    autoScrollLocator = captured
-                                    // Auto-scroll is reading, so it
-                                    // teaches the pace estimator and
-                                    // counts as time spent, which
-                                    // READER_MOVEMENT is what carries.
-                                    onLocatorChanged(
-                                        captured,
-                                        NavigatorPositionEvent.READER_MOVEMENT,
-                                    )
-                                }
-                            }
                         } finally {
                             saving = false
                         }
@@ -877,7 +961,7 @@ fun ReaderScreen(
                     )
                     ticker.reset()
                     savedAtNanos = 0L
-                    autoScrollLocator = null
+                    heldPlace.retire()
                     webViews.invalidate()
                     if (!moved) {
                         autoScrollArmed = false
@@ -891,6 +975,90 @@ fun ReaderScreen(
     }
 
     /*
+     * The place a manually scrolled book has got to, kept for the pause.
+     *
+     * A page carried by a finger does stop, so Readium's debounce does
+     * land — but `ReaderActivity` marks the reader inactive before the
+     * fragment pauses, and a debounce still in the air when the reader
+     * leaves is then dropped as movement nobody made. The last drag
+     * would go with it.
+     *
+     * So the offset is watched as the reader scrolls and a place is kept
+     * against it, ready to be published on the way out without asking
+     * the document anything. Watching is the view's own scroll offset,
+     * which costs a field read; the document is only asked once that
+     * offset has moved, and no more often than auto-scroll asks it.
+     *
+     * An offset that is the same as it was a moment ago is a page at
+     * rest, and a page at rest has already been answered for. So the
+     * round trip is spent only on a page that moved within the window,
+     * which is the only page whose place can still be in the air.
+     *
+     * It watches for as long as the book is scrolled, whether or not
+     * auto-scroll is armed, because arming is not running: a finger on
+     * the page, the chrome up, a dialog open — all of them stop the
+     * carrying loop and leave the reader free to scroll by hand. One
+     * place is held between the two, so whichever of them last measured
+     * it is the one the pause publishes.
+     */
+    // A place belongs to the navigator that was asked for it and to the
+    // book being scrolled when it was. A fragment recreated underneath
+    // the reader, or a book switched to pages, leaves one behind that
+    // names a document nobody is looking at — and the holder outlives
+    // both, so it has to be told. `onDispose` runs as the keys change,
+    // before anything new can hold against the old generation.
+    DisposableEffect(navigator, effectiveScrolling) {
+        onDispose { heldPlace.retire() }
+    }
+
+    LaunchedEffect(navigator, effectiveScrolling, lifecycle) {
+        val nav = navigator ?: return@LaunchedEffect
+        if (!effectiveScrolling) return@LaunchedEffect
+        val root = nav.publicationView
+        val webViews = visibleWebViewCache(root)
+        lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            launch {
+                merge(nav.currentLocator.map { }, layoutPasses(root)).collect {
+                    webViews.invalidate()
+                }
+            }
+            var lastOffset: Int? = null
+            while (true) {
+                val web = webViews.current()
+                val offset = web?.let {
+                    if (nav.settings.value.verticalText) it.scrollX else it.scrollY
+                }
+                val moved = offset != null && lastOffset != null && offset != lastOffset
+                // The baseline is taken before the first wait, not after
+                // it, or the first window of a chapter is one nobody was
+                // watching — and the window a reader opens a book in is
+                // exactly the one they scroll in.
+                if (offset != null) lastOffset = offset
+                // Auto-scroll keeps the same place on its own clock, and
+                // it is the one moving the page: asking twice would be
+                // two round trips for one answer. The offset is still
+                // read, so that whatever it has reached while the loop
+                // ran is the baseline the moment it stops.
+                if (moved && !autoScrollRunning) {
+                    // A place that cannot be had leaves the last one
+                    // standing: it is behind the reader by a tick, where
+                    // the alternative is nothing at all.
+                    val since = heldPlace.mark()
+                    val captured = try {
+                        scrolledPlace(nav)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (_: Exception) {
+                        null
+                    }
+                    if (captured != null) heldPlace.hold(captured, since)
+                }
+                delay(SCROLL_PLACE_POLL_MS)
+            }
+        }
+    }
+
+    /*
      * The last place before the reader leaves.
      *
      * `ReaderViewModel` drops a READER_MOVEMENT locator once the reader
@@ -898,7 +1066,8 @@ fun ReaderScreen(
      * `super.onPause()` — so nothing published from an ON_PAUSE observer
      * can arrive as movement, and Readium's own debounce, landing a
      * hundred milliseconds later, is dropped as well. What goes in here
-     * is the last position the loop fetched, republished as the jump it
+     * is the place a scrolled book was last measured at — carried by the
+     * loop or by the reader's own finger — republished as the jump it
      * effectively was: LOCAL_JUMP persists, is not dropped by that
      * guard, and does not count the same reading twice.
      *
@@ -911,8 +1080,7 @@ fun ReaderScreen(
     DisposableEffect(lifecycle) {
         val observer = LifecycleEventObserver { _, event ->
             if (event != Lifecycle.Event.ON_PAUSE) return@LifecycleEventObserver
-            if (!autoScrollRunning) return@LifecycleEventObserver
-            autoScrollLocator?.let {
+            heldPlace.current()?.let {
                 onLocatorChanged(it, NavigatorPositionEvent.LOCAL_JUMP)
             }
         }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -542,6 +542,13 @@ fun ReaderScreen(
                 // with neither.
                 val since = heldPlace.invalidate()
                 val captured = capture(nav, native)
+                // The capture reaches into the document and swallows its
+                // own failures, cancellation included, so an answer can
+                // arrive after this collector has been stood down — a
+                // navigator replaced underneath it, or the reader gone.
+                // Neither a place held nor a position saved from that is
+                // anyone's.
+                currentCoroutineContext().ensureActive()
                 // A reflow locator is the layout moving, not the reader,
                 // and it is not a jump anyone should be sent back to on
                 // the way out. Its arrival still retires what was held,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/HeldPlace.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/HeldPlace.kt
@@ -1,0 +1,96 @@
+package com.chmouel.liseur.reader.chrome
+
+import org.readium.r2.shared.publication.Locator
+
+/**
+ * The place a scrolled book was last measured at, kept for the pause.
+ *
+ * Readium answers a scroll with a debounced location, and the reader is
+ * marked inactive before the fragment pauses — so a debounce still in
+ * the air when the reader leaves is dropped as movement nobody made,
+ * and a page that never stops never lands one at all. Both cases need a
+ * place already measured, ready to be published on the way out without
+ * asking the document anything.
+ *
+ * Measuring one takes several round trips into the document, and the
+ * reader can move while it is being answered. What comes back is
+ * therefore held against the state of things when the asking began: a
+ * fresher place [invalidate]s everything that was in flight, and such a
+ * measurement is refused rather than allowed to overwrite it. Without
+ * that, a reader who jumps *back* within the same chapter can be
+ * carried forward again on the way out, by a measurement that was
+ * already in the air when they jumped.
+ *
+ * Refusing an old measurement and throwing away the place already held
+ * are two different acts, and the difference is the whole point of
+ * [invalidate] existing beside [retire]. A location Readium publishes
+ * is not saved as it arrives: it is captured first, and that capture
+ * suspends. Clearing the held place the moment the location was
+ * announced would leave nothing to publish if the reader left while the
+ * capture was still being answered — which is exactly the case this
+ * class exists for. So the old place stands until the new one has been
+ * taken, and only a place that is genuinely no longer the reader's — a
+ * chapter they have left, a navigator that has gone — is retired.
+ *
+ * Nothing here is synchronised, and nothing here should be: the loops
+ * that measure, the collector that publishes and the observer that
+ * reads all live on the main thread, the same as [CachedLookup].
+ */
+internal class HeldPlace {
+
+    private var held: Locator? = null
+    private var generation = 0
+
+    /** The state to hold a later measurement against. See [hold]. */
+    fun mark(): Int = generation
+
+    /**
+     * Refuses every measurement now in flight, keeping the held place.
+     *
+     * Answers with the mark to hold the measurement being taken *now*
+     * against, so a caller that invalidates in order to replace can do
+     * both without a second call racing its own.
+     */
+    fun invalidate(): Int {
+        generation++
+        return generation
+    }
+
+    /**
+     * Keeps [place], unless something fresher arrived since [since].
+     *
+     * Answers whether it was kept, so a caller that also publishes the
+     * measurement can decide both from the one question.
+     *
+     * Keeping is itself something fresher arriving, so it moves the mark
+     * on as well: two measurements begun in the same generation are
+     * racing, and the one that lands first is the one that stands. The
+     * loser is refused rather than merged, because nothing here can tell
+     * which of them the reader is nearer to — they were asked for at
+     * different moments and answered out of order. Being a poll behind
+     * costs a line; being overwritten by an older answer walks the
+     * reader backwards, which is the thing this class exists to stop.
+     */
+    fun hold(place: Locator, since: Int): Boolean {
+        if (since != generation) return false
+        held = place
+        generation++
+        return true
+    }
+
+    /** Whatever is still worth publishing when the reader leaves. */
+    fun current(): Locator? = held
+
+    /**
+     * Forgets the place, and refuses any measurement already in flight.
+     *
+     * For a place that has stopped being the reader's at all: a chapter
+     * they have left, a navigator that has been replaced, a book that
+     * has stopped being scrolled. Not for a place merely superseded —
+     * see [invalidate].
+     */
+    fun retire() {
+        held = null
+        generation++
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/progress/ScrollProgression.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/progress/ScrollProgression.kt
@@ -1,0 +1,73 @@
+package com.chmouel.liseur.reader.progress
+
+import org.readium.r2.navigator.epub.EpubNavigatorFragment
+import org.readium.r2.shared.ExperimentalReadiumApi
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * How far into the open chapter a scrolled page has got.
+ *
+ * Readium's own answer to "where is the reader" is a debounced one — a
+ * hundred milliseconds of stillness — so a page that never stops is
+ * never answered for, and the loops that carry or watch such a page ask
+ * the document themselves. What they can ask it for is a *place*: the
+ * words at the top of the screen and a selector that finds them again.
+ * What they cannot ask it for is a *distance*, and a locator without one
+ * reads as the start of its resource everywhere downstream — in
+ * `BookPositions`, in the footer, and in the percentage every server
+ * syncs.
+ *
+ * The distance is the document's own scroll offset over its own length,
+ * which is not an approximation of Readium's convention but the inverse
+ * of it: `readium.scrollToPosition(p)` restores a fraction by setting
+ * `scrollingElement.scrollTop = scrollHeight * p`, and for a book set in
+ * vertical lines `scrollLeft = -scrollWidth * p`.
+ */
+object ScrollProgression {
+
+    /** The fraction of the open resource above the top of the screen, or null. */
+    @OptIn(ExperimentalReadiumApi::class)
+    suspend fun of(navigator: EpubNavigatorFragment, vertical: Boolean): Double? {
+        val answer = try {
+            navigator.evaluateJavascript(script(vertical))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }
+        return parse(answer)
+    }
+
+    /**
+     * [vertical] is a book set in vertical lines, which Readium scrolls
+     * sideways: the text runs right to left, so the offset it reads is
+     * negative and grows more negative further into the chapter. Only
+     * the axis changes, the same way it does in `scrollScreenfulScript`.
+     */
+    internal fun script(vertical: Boolean): String {
+        val span = if (vertical) "e.scrollWidth" else "e.scrollHeight"
+        val at = if (vertical) "Math.abs(e.scrollLeft)" else "e.scrollTop"
+        return """
+            (function() {
+              var e = document.scrollingElement || document.documentElement;
+              var span = $span;
+              if (!(span > 0)) { return null; }
+              return $at / span;
+            })();
+        """.trimIndent()
+    }
+
+    /**
+     * A fraction, or null for every way the document can decline to give
+     * one. A page mid-layout has no length to divide by, and a book
+     * whose chapter is shorter than the screen never scrolls at all;
+     * neither is a reason to file the reader at the top of the chapter.
+     */
+    internal fun parse(result: String?): Double? {
+        val text = result?.trim()?.removeSurrounding("\"")?.trim() ?: return null
+        if (text.isEmpty() || text == "null") return null
+        val value = text.toDoubleOrNull() ?: return null
+        if (!value.isFinite()) return null
+        return value.coerceIn(0.0, 1.0)
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/HeldPlaceTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/HeldPlaceTest.kt
@@ -1,0 +1,146 @@
+package com.chmouel.liseur.reader.chrome
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.json.JSONObject
+import org.readium.r2.shared.publication.Locator
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(sdk = [35], application = android.app.Application::class)
+@RunWith(RobolectricTestRunner::class)
+class HeldPlaceTest {
+
+    private fun place(progression: Double) = requireNotNull(
+        Locator.fromJSON(
+            JSONObject()
+                .put("href", "https://example.com/chapter.xhtml")
+                .put("type", "application/xhtml+xml")
+                .put("locations", JSONObject().put("progression", progression)),
+        ),
+    )
+
+    @Test
+    fun `a place measured with nothing in between is kept`() {
+        val held = HeldPlace()
+        val since = held.mark()
+
+        assertTrue(held.hold(place(0.4), since))
+        assertEquals(0.4, held.current()?.locations?.progression)
+    }
+
+    @Test
+    fun `retiring forgets the place`() {
+        val held = HeldPlace()
+        held.hold(place(0.4), held.mark())
+
+        held.retire()
+
+        assertNull(held.current())
+    }
+
+    @Test
+    fun `a measurement started before a retire is refused`() {
+        val held = HeldPlace()
+        val since = held.mark()
+
+        held.retire()
+
+        assertFalse(held.hold(place(0.4), since))
+        assertNull(held.current())
+    }
+
+    @Test
+    fun `a measurement started after a retire is kept`() {
+        val held = HeldPlace()
+        held.hold(place(0.4), held.mark())
+        held.retire()
+
+        val since = held.mark()
+
+        assertTrue(held.hold(place(0.7), since))
+        assertEquals(0.7, held.current()?.locations?.progression)
+    }
+
+    @Test
+    fun `only the measurement in flight across a retire is refused`() {
+        val held = HeldPlace()
+        val stale = held.mark()
+        held.retire()
+        val fresh = held.mark()
+        held.hold(place(0.7), fresh)
+
+        assertFalse(held.hold(place(0.4), stale))
+        assertEquals(0.7, held.current()?.locations?.progression)
+    }
+
+    @Test
+    fun `invalidating keeps the place standing`() {
+        val held = HeldPlace()
+        held.hold(place(0.4), held.mark())
+
+        held.invalidate()
+
+        assertEquals(0.4, held.current()?.locations?.progression)
+    }
+
+    @Test
+    fun `a measurement in flight across an invalidate is refused`() {
+        val held = HeldPlace()
+        held.hold(place(0.4), held.mark())
+        val stale = held.mark()
+
+        held.invalidate()
+
+        assertFalse(held.hold(place(0.2), stale))
+        assertEquals(0.4, held.current()?.locations?.progression)
+    }
+
+    @Test
+    fun `the mark an invalidate answers with still holds`() {
+        val held = HeldPlace()
+        held.hold(place(0.4), held.mark())
+
+        val since = held.invalidate()
+
+        assertTrue(held.hold(place(0.7), since))
+        assertEquals(0.7, held.current()?.locations?.progression)
+    }
+
+    @Test
+    fun `a place taken against an invalidate survives a later measurement it raced`() {
+        val held = HeldPlace()
+        val racing = held.mark()
+        val since = held.invalidate()
+        held.hold(place(0.7), since)
+
+        assertFalse(held.hold(place(0.4), racing))
+        assertEquals(0.7, held.current()?.locations?.progression)
+    }
+
+    @Test
+    fun `of two measurements in the same generation the first to land stands`() {
+        val held = HeldPlace()
+        val newer = held.mark()
+        val older = held.mark()
+
+        assertTrue(held.hold(place(0.7), newer))
+        assertFalse(held.hold(place(0.4), older))
+        assertEquals(0.7, held.current()?.locations?.progression)
+    }
+
+    @Test
+    fun `a place taken after a hold still lands`() {
+        val held = HeldPlace()
+        held.hold(place(0.4), held.mark())
+
+        val since = held.mark()
+
+        assertTrue(held.hold(place(0.7), since))
+        assertEquals(0.7, held.current()?.locations?.progression)
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/progress/BookPositionsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/progress/BookPositionsTest.kt
@@ -159,4 +159,28 @@ class BookPositionsTest {
         assertEquals(3, book.locatorAtOrBeforeProgression(0.50)?.locations?.position)
         assertEquals(5, book.locatorAtOrBeforeProgression(1.0)?.locations?.position)
     }
+
+    /**
+     * The reason a scrolled book has to measure its own distance before
+     * saving a place. Readium's `findFirstVisibleLocator` names a place
+     * and nothing else, and a place with no distance is the top of its
+     * chapter to everything downstream — the footer, the pace estimator
+     * and the percentage every server syncs.
+     */
+    @Test
+    fun `a locator with no distance resolves to the start of its resource`() {
+        val first = (1..4).map { position ->
+            locator("chapter-1.xhtml", (position - 1) / 3.0, position)
+        }
+        val second = (5..8).map { position ->
+            locator("chapter-2.xhtml", (position - 5) / 3.0, position)
+        }
+        val book = positions(listOf(first, second))
+
+        val placeOnly = book.resolve(locator("chapter-2.xhtml", null, null))!!
+        assertEquals(5.0, placeOnly.coordinate, 0.0)
+
+        val measured = book.resolve(locator("chapter-2.xhtml", 2.0 / 3.0, null))!!
+        assertEquals(7.0, measured.coordinate, 0.0)
+    }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/progress/ScrollProgressionTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/progress/ScrollProgressionTest.kt
@@ -1,0 +1,55 @@
+package com.chmouel.liseur.reader.progress
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ScrollProgressionTest {
+
+    @Test
+    fun `reads the fraction the document gives back`() {
+        assertEquals(0.25, ScrollProgression.parse("0.25")!!, 0.0)
+        assertEquals(0.25, ScrollProgression.parse("\"0.25\"")!!, 0.0)
+        assertEquals(0.0, ScrollProgression.parse(" 0 ")!!, 0.0)
+    }
+
+    @Test
+    fun `clamps an offset that overshoots its own length`() {
+        assertEquals(1.0, ScrollProgression.parse("1.4")!!, 0.0)
+        assertEquals(0.0, ScrollProgression.parse("-0.2")!!, 0.0)
+    }
+
+    /**
+     * Every one of these is a page that cannot say where it is, and the
+     * caller must save nothing rather than file the reader at the top of
+     * the chapter.
+     */
+    @Test
+    fun `declines every answer that is not a fraction`() {
+        assertNull(ScrollProgression.parse(null))
+        assertNull(ScrollProgression.parse(""))
+        assertNull(ScrollProgression.parse("   "))
+        assertNull(ScrollProgression.parse("null"))
+        assertNull(ScrollProgression.parse("\"null\""))
+        assertNull(ScrollProgression.parse("undefined"))
+        assertNull(ScrollProgression.parse("NaN"))
+        assertNull(ScrollProgression.parse("Infinity"))
+    }
+
+    @Test
+    fun `measures the axis the book is scrolled along`() {
+        val across = ScrollProgression.script(vertical = false)
+        assertTrue(across.contains("e.scrollTop"))
+        assertTrue(across.contains("e.scrollHeight"))
+
+        val down = ScrollProgression.script(vertical = true)
+        assertTrue(down.contains("Math.abs(e.scrollLeft)"))
+        assertTrue(down.contains("e.scrollWidth"))
+    }
+
+    @Test
+    fun `refuses to divide by a page that has no length yet`() {
+        assertTrue(ScrollProgression.script(vertical = false).contains("if (!(span > 0))"))
+    }
+}

--- a/docs/adr/0006-auto-scroll.md
+++ b/docs/adr/0006-auto-scroll.md
@@ -103,6 +103,24 @@ asked, asked on time, and asked off the frame loop so the page does not
 hitch. Those go in as `READER_MOVEMENT`: auto-scroll is reading, so it
 should teach the pace estimator and count as time spent.
 
+**A place is not a distance**, and that was a bug for as long as this
+existed. `firstVisibleElementLocator` answers with a selector and the
+words at the top of the screen and nothing else: no progression, no
+position. `BookPositions.resolve` reads a locator with neither as the
+start of its resource, so every save auto-scroll made filed the reader
+at the top of the chapter they were half way down — and that number is
+the one the footer shows, the one the pace estimator learns from, and
+the one calibre-web syncs outright and Komga and liseur-sync compare
+when they disagree. Only local resume escaped it, because the anchor
+saved beside the number was still exact.
+
+So the distance is measured too, by `ScrollProgression`: the document's
+own scroll offset over its own length. That is not an approximation of
+Readium's convention but the inverse of it — `readium.scrollToPosition`
+restores a fraction by multiplying it back out against the same span. A
+page that cannot give one saves nothing that tick, because a place a
+line behind is worth having and a place a chapter behind is not.
+
 Leaving the book is the one case that needs its own note.
 `ReaderViewModel` drops a `READER_MOVEMENT` locator once the reader is
 inactive, and `ReaderActivity.onPause` clears that flag before
@@ -113,6 +131,70 @@ the loop fetched is therefore republished from an `ON_PAUSE` observer as
 count the same reading twice. It asks the page nothing and waits for
 nothing, so it is a synchronous call that has returned before `onStop`
 can begin to close the position queue.
+
+**A book scrolled by hand keeps a place the same way.** Its debounce
+does land — a finger drag ends — but it lands after the reader was
+marked inactive if they leave the moment they stop scrolling, and it is
+then dropped as movement nobody made. So the same round trip runs for a
+manually scrolled book, driven not by a frame loop but by the web view's
+own scroll offset: a field read every couple of seconds, and the
+document asked only when that offset has moved since the last look. An
+offset that has not moved is a page at rest, and a page at rest has
+already been answered for. The offset is sampled before the first wait
+rather than after it, because the window a reader opens a book in is
+exactly the window they scroll in.
+
+That watcher runs for as long as the book is scrolled, armed or not,
+because arming is not running: a finger on the page, the chrome up, a
+dialog open — every one of those stops the carrying loop while leaving
+the reader free to scroll by hand, and a gap between the two would be a
+pause with nothing held. It only skips the round trip while the loop is
+actually carrying the page, which is measuring the same thing anyway; it
+keeps sampling the offset throughout, so the moment the loop stops there
+is already a baseline to compare against.
+
+One `HeldPlace` is shared between them, and both go through it: the
+question of whether a measurement is still current is the same question
+as whether it is worth publishing, so `hold` answers both and the two
+cannot drift apart. A measurement takes several round trips into a
+document the reader is still moving through, so it is held against a
+mark taken before the asking began, and a mark that has moved on refuses
+it. Without that, a reader who jumps *backwards* within the same chapter
+can be carried forward again on the way out by a round trip that was
+already in the air when they jumped; the href guard alone cannot see
+that, because it is the same chapter.
+
+Keeping a place moves the mark on too, so of two measurements begun in
+the same generation the one that lands first is the one that stands. The
+loser is refused rather than merged: they were asked for at different
+moments and answered out of order, and nothing here can tell which the
+reader is nearer to. A poll behind costs a line, and an older answer
+landing last would walk the reader back.
+
+What supersedes a held place is not the *announcement* of a location but
+the capture of one, which is why the holder distinguishes invalidating
+from retiring, and why that bookkeeping lives in the collector that
+publishes rather than in a second one watching the same flow. A locator
+Readium announces is captured before it is saved, and a capture
+suspends: clear the held place when the announcement arrives and a
+reader who leaves mid-capture has neither the new place — dropped as
+movement by an inactive reader — nor the old one. So the announcement
+only invalidates: measurements in flight are refused, the place already
+held stands, and it is replaced once the new capture has actually been
+taken. A reflow locator is the exception that retires outright, being
+the layout moving rather than the reader, and not a place anyone should
+be sent back to.
+
+A place is retired for real when it stops being anyone's: a chapter the
+reader has left, a navigator replaced underneath them, a book that has
+stopped being scrolled. The holder is remembered across all three, so
+each is told explicitly.
+
+Two things are never asked at all. A fixed-layout book has no scroll
+fraction that means anything — nothing reflows, and the document does
+not move under the viewport — and a page being rebuilt by a preference
+change is not a page the reader moved through, so an open reflow skips
+the tick the way `ReflowScope` gates everything else.
 
 **Speed** is one shared `Float` in the reader DataStore, a step from 1
 to 10 mapped to dp per second and multiplied by the font size, so
@@ -180,6 +262,8 @@ The reader gains no new chrome: the page moving is the state, and the
 switch that started it is where it stops.
 
 *Where:* `reader/chrome/AutoScroll.kt`, `reader/chrome/CachedLookup.kt`,
-`reader/chrome/ReaderWebViews.kt`, `data/settings/ReaderPrefs.kt`,
+`reader/chrome/HeldPlace.kt`,
+`reader/chrome/ReaderWebViews.kt`, `reader/progress/ScrollProgression.kt`,
+`data/settings/ReaderPrefs.kt`,
 `reader/ReaderScreen.kt`, `reader/chrome/AdvancedSheet.kt`,
 `reader/chrome/TypographySheet.kt`, `reader/chrome/ReaderTapZones.kt`.


### PR DESCRIPTION
## Summary

Position sync is wrong in scrolling mode, and has been for as long as auto-scroll existed.

A locator names a place; it does not carry a distance. Readium's `firstVisibleElementLocator` answers with a CSS selector and the words at the top of the screen and nothing else — no `progression`, no `position` — and `BookPositions.resolve` reads a locator with neither as **the start of its resource**.

Auto-scroll is the one path that asks that question directly, because Readium's own 100 ms debounce never lands on a page that never stops. So every save it made, every two seconds, filed the reader at the top of the chapter they were half way down. That number is the footer, the pace estimator, the reading session — and the one calibre-web syncs outright and Komga and liseur-sync compare when they disagree, so a device that auto-scrolled looks behind and can drag another device back with it. Only local resume escaped, the exact anchor saved beside the number still being right.

There is a second, smaller hole: a manually scrolled book. Its debounce *does* land, but `ReaderActivity` marks the reader inactive before the fragment pauses, so a debounce still in the air when the reader leaves is dropped as movement nobody made. Drag, then background the app, and the drag is gone.

## Changes

- **`reader/progress/ScrollProgression.kt` (new)** — the missing distance: the document's own scroll offset over its own length. Not an approximation of Readium's convention but the inverse of it — `readium.scrollToPosition(p)` restores a fraction by multiplying it back out against the same span. Reads the horizontal axis for a vertical-text book, the way `PageTurnEffect` already does. A page that cannot give a fraction saves nothing that tick: a place a line behind is worth having, a place a chapter behind is not.
- **`ReaderScreen.scrolledPlace()`** — one door for "where has this chapter got to": ask which resource is on screen, measure the fraction, capture the exact anchor, and drop the answer if the reader left the chapter while it was being given. Skipped for a fixed-layout book (no fraction means anything) and while a preference reflow is open (that is the layout moving, not the reader).
- **Auto-scroll** uses it for its existing two-second tick, now producing a complete locator.
- **A manually scrolled book keeps a place too**, driven by the web view's own scroll offset — a field read every couple of seconds, with the document asked only once that offset has moved. It watches whether or not auto-scroll is armed, because arming is not running: a finger on the page, the chrome up, a dialog open all stop the carrying loop while leaving the reader free to scroll by hand.
- **`reader/chrome/HeldPlace.kt` (new)** — one place held between the two loops, published on `ON_PAUSE` as `LOCAL_JUMP`. A measurement takes several round trips into a document the reader is still moving through, so it is held against a mark taken before the asking began; the first answer to land stands and a later one is refused rather than allowed to walk the reader backwards. A locator Readium announces *invalidates* what is in flight but does not clear what is held until its own capture has been taken — that capture suspends, and clearing early would leave a reader who left mid-capture with neither.
- **`docs/adr/0006-auto-scroll.md`** — why a place is not a distance, why invalidating and retiring are different acts, and what is never asked at all.

Nothing in `data/remote/`, `sync/` or `domain/ReadingStateMerge.kt` is mode-aware, and nothing there needed to change: the bad number was minted in one place.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [ ] Manually tested on a device or emulator, if applicable

New tests: `ScrollProgressionTest` (parsing, clamping, junk rejection, axis selection, zero-span guard), `HeldPlaceTest` (11 cases over the hold/invalidate/retire orderings), and a `BookPositionsTest` case pinning the behaviour that motivates all of this — a locator with neither progression nor position resolves to its resource's first position.

## Screenshots or recordings

No UI surface changes: the reading chrome, the sheets and the footer are untouched. What changes is the number behind the footer and the position that leaves the device, neither of which a screenshot would show — the footer looks identical, it just stops lying.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
