### PR TITLE
fix(reader): stop reserving a hidden navigation bar under the footer

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.navigationBarsIgnoringVisibility
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -1170,13 +1169,15 @@ fun ReaderScreen(
         // hidden while reading, so all that space bought was a band of
         // background at the top of every page; the top is not inset
         // now. The bottom of a paged book keeps clear of the footer
-        // instead of the bars: the navigation-bar inset the footer
-        // floats on — read ignoring visibility, so it is the same
-        // whether the bars are shown — and above it the footer's own
-        // derived height (FooterMetrics), which follows the system
-        // font scale the way the fixed count of dp it replaces could
-        // not. Neither figure moves when the chrome shows or hides, so
-        // toggling the chrome still cannot reflow the page.
+        // instead of the bars: the footer's own derived height
+        // (FooterMetrics), which follows the system font scale the way
+        // the fixed count of dp it replaces could not. The navigation
+        // bar is not in that figure — the footer is only drawn while
+        // the chrome is hidden, which is the very thing that hides the
+        // bars, so reserving the bar's inset only left a blank band
+        // under the footer, a finger deep on three-button navigation.
+        // The reservation does not move when the chrome shows or hides,
+        // so toggling the chrome still cannot reflow the page.
         //
         // The camera hole is the one thing still kept clear of a page
         // that is turned, because a line behind it is a line that never
@@ -1205,9 +1206,14 @@ fun ReaderScreen(
             // toDp() owns the sp-to-dp conversion so nonlinear font
             // scaling is honoured. A footer switched off reserves only
             // the page's own 12dp margin, same as the top edge — the
-            // footer band and the inset under it go back to the text,
-            // and the one reflow that costs is the settings change
-            // itself.
+            // footer band goes back to the text, and the one reflow
+            // that costs is the settings change itself.
+            //
+            // A vertical-text book draws no footer either, but it keeps
+            // the band: whether the text is vertical is only known once
+            // the navigator has read the publication, and taking the
+            // band back then would reflow the book under the reader on
+            // open. An unused 38dp is the cheaper of the two.
             val footerLineHeight = MaterialTheme.typography.labelSmall.lineHeight
             val footerShowing = prefs.footerMode != FooterMode.NONE
             val footerReserve = FooterMetrics.reservedHeightDp(
@@ -1230,16 +1236,6 @@ fun ReaderScreen(
                         } else {
                             Modifier
                                 .windowInsetsPadding(WindowInsets.displayCutout)
-                                .then(
-                                    if (footerShowing) {
-                                        Modifier.windowInsetsPadding(
-                                            WindowInsets.navigationBarsIgnoringVisibility
-                                                .only(WindowInsetsSides.Bottom),
-                                        )
-                                    } else {
-                                        Modifier
-                                    },
-                                )
                                 .padding(
                                     top = 12.dp,
                                     bottom = if (footerShowing) footerReserve else 12.dp,
@@ -1296,11 +1292,16 @@ fun ReaderScreen(
             )
         }
 
+        // The bars come and go with the chrome, so this corner takes the
+        // live navigation-bar inset: it lifts the scrubber and the pills
+        // clear of a bar that is actually there, and asks for nothing
+        // when there is none. Reading it ignoring visibility parked
+        // everything a bar's height up an empty screen.
         Column(
             Modifier
                 .align(Alignment.BottomCenter)
                 .fillMaxWidth()
-                .windowInsetsPadding(WindowInsets.navigationBarsIgnoringVisibility),
+                .navigationBarsPadding(),
         ) {
             if (!showingEnd) {
                 jumpBack?.let { target ->
@@ -1350,18 +1351,44 @@ fun ReaderScreen(
                             }
                         },
                     )
-                } else if (!scrollMode && jumpBack == null && catchUp == null) {
-                    // A scrolled page runs under this corner, so a footer
-                    // left drawn there prints itself over the text. The
-                    // figures are one tap away with the rest of the chrome.
-                    ReadingFooter(
-                        progress = progress,
-                        mode = prefs.footerMode,
-                        theme = readingTheme,
-                        onCycleMode = onProgressAction.cycleFooterMode,
-                    )
                 }
             }
+        }
+
+        // The footer sits outside that column, on the screen's edge and
+        // no inset at all, because it is the one piece of chrome drawn
+        // while the bars are hidden. Riding the inset would have it
+        // slide down as the bars animate away — a slide the page cannot
+        // follow, since the page's reservation is a constant, and one
+        // e-paper repaints as a smear. It never shares the corner: the
+        // pills displace it rather than stack on it.
+        //
+        // Two states put a bar back over it, and both are accepted. A
+        // bar swiped out transiently is drawn over the page without
+        // changing an inset, so nothing could dodge it anyway, and it
+        // takes itself away again. A window that is not allowed to hide
+        // its bars at all — split screen — covers the footer for good;
+        // the figures are lost, which is the graceful half of that
+        // trade, where floating the footer up a bar it cannot predict
+        // would print it through the page's last line instead.
+        //
+        // The guard is effectiveScrolling, not the reader's scrolling
+        // preference: a vertical-text book scrolls whatever the setting
+        // says, and a scrolled page runs under this corner, so a footer
+        // left drawn there prints itself over the text. The figures are
+        // one tap away with the rest of the chrome.
+        if (!showingEnd && !chromeVisible && !effectiveScrolling &&
+            jumpBack == null && catchUp == null
+        ) {
+            ReadingFooter(
+                progress = progress,
+                mode = prefs.footerMode,
+                theme = readingTheme,
+                onCycleMode = onProgressAction.cycleFooterMode,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = FooterMetrics.BOTTOM_MARGIN_DP.dp),
+            )
         }
 
         // Electronic paper cannot slide: it repaints in whole frames and

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/FooterMetrics.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/FooterMetrics.kt
@@ -17,6 +17,18 @@ object FooterMetrics {
     const val CLEARANCE_DP = 4f
 
     /**
+     * Air kept under the footer, between it and the screen's edge, in dp.
+     *
+     * The footer is only ever drawn while the chrome is hidden, and the
+     * chrome being hidden is what hides the system bars, so there is no
+     * navigation bar down there to sit on — reserving its inset left a
+     * finger-deep band of blank paper on three-button navigation. With
+     * the footer's own [VERTICAL_PADDING_DP] this comes to the same
+     * 12dp margin the page keeps at the top.
+     */
+    const val BOTTOM_MARGIN_DP = 6f
+
+    /**
      * The line height the footer's labelSmall text falls back to when
      * the theme's value is not given in sp (Material's own default).
      */
@@ -29,9 +41,9 @@ object FooterMetrics {
      * owns the sp-to-dp conversion, through `Density.toDp()`, which
      * honours Android's nonlinear font scaling where a bare multiply
      * by the font scale would not. Window insets are deliberately not
-     * in here either — they are the layout's job, applied as inset
-     * padding where Compose can consume overlaps between them.
+     * in here: the footer is drawn with the system bars hidden, so the
+     * only thing under it is the screen's edge and [BOTTOM_MARGIN_DP].
      */
     fun reservedHeightDp(lineHeightDp: Float): Float =
-        lineHeightDp + VERTICAL_PADDING_DP * 2 + CLEARANCE_DP
+        lineHeightDp + VERTICAL_PADDING_DP * 2 + CLEARANCE_DP + BOTTOM_MARGIN_DP
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/FooterMetricsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/FooterMetricsTest.kt
@@ -10,14 +10,22 @@ import org.junit.Test
  * through Compose's Density (which knows about nonlinear font scaling)
  * and the reservation is derived from that converted height plus the
  * same paddings the footer draws with — the fixed 26dp it replaced is
- * exactly the bug being guarded against here.
+ * exactly the bug being guarded against here. No navigation-bar inset
+ * belongs in the figure: the footer is drawn with the bars hidden.
  */
 class FooterMetricsTest {
 
     @Test
-    fun `reserves the line and both paddings`() {
-        // 16dp line + 2 × 6dp padding + 4dp clearance.
-        assertEquals(32f, FooterMetrics.reservedHeightDp(16f), 1e-4f)
+    fun `reserves the line, both paddings and the margin under it`() {
+        // 16dp line + 2 × 6dp padding + 4dp clearance + 6dp margin.
+        assertEquals(38f, FooterMetrics.reservedHeightDp(16f), 1e-4f)
+    }
+
+    @Test
+    fun `keeps the footer off the screen's edge`() {
+        // The bars are hidden whenever the footer is drawn, so nothing
+        // but this margin stands between it and the bottom of the glass.
+        assertTrue(FooterMetrics.BOTTOM_MARGIN_DP > 0f)
     }
 
     @Test
@@ -25,13 +33,13 @@ class FooterMetricsTest {
         // 16sp at font scale 1.3 and 2.0 under linear scaling; the
         // exact conversion is Density's business, the reservation just
         // has to carry whatever it says.
-        assertEquals(36.8f, FooterMetrics.reservedHeightDp(20.8f), 1e-4f)
-        assertEquals(48f, FooterMetrics.reservedHeightDp(32f), 1e-4f)
+        assertEquals(42.8f, FooterMetrics.reservedHeightDp(20.8f), 1e-4f)
+        assertEquals(54f, FooterMetrics.reservedHeightDp(32f), 1e-4f)
     }
 
     @Test
     fun `keeps a fractional height exact rather than rounding it away`() {
-        assertEquals(34.4f, FooterMetrics.reservedHeightDp(18.4f), 1e-4f)
+        assertEquals(40.4f, FooterMetrics.reservedHeightDp(18.4f), 1e-4f)
     }
 
     @Test
@@ -44,7 +52,8 @@ class FooterMetricsTest {
     @Test
     fun `clears the footer's drawn height at every text size`() {
         for (lineDp in floatArrayOf(13.6f, 16f, 18.4f, 20.8f, 32f)) {
-            val drawn = lineDp + FooterMetrics.VERTICAL_PADDING_DP * 2
+            val drawn = lineDp + FooterMetrics.VERTICAL_PADDING_DP * 2 +
+                FooterMetrics.BOTTOM_MARGIN_DP
             assertTrue(
                 "no clearance left at line height ${lineDp}dp",
                 FooterMetrics.reservedHeightDp(lineDp) > drawn,


### PR DESCRIPTION
## Summary

Fixes the over-large band under the reading footer that turned up while testing 0.11.

#73 replaced the hardcoded 26dp footer reservation with a derived one, and added the
navigation-bar inset on top of it, read ignoring visibility so the figure stayed constant
and the page could not reflow when the chrome toggled.

The inset half of that was wrong. The footer is only drawn while the chrome is hidden,
and hiding the chrome is what hides the system bars, so whenever the footer exists there
is no navigation bar under it. The page was giving up 48dp on three-button navigation and
24dp on gesture navigation to clear a bar that is never on screen at that moment. On a
1080x2400 phone that cost two lines of text on every page.

## Changes

- The reservation is the footer's derived height plus a 6dp margin, which with the
  footer's own padding matches the 12dp the page keeps at the top. Still derived, still
  constant with respect to bar visibility, so toggling the chrome still cannot reflow the
  page.
- The bottom chrome splits. The scrubber and the jump-back and catch-up pills appear
  alongside a bar that is really there, so they take the live navigation-bar inset, which
  also covers a bar that moves to the side in landscape. The footer moves out of that
  column onto the screen's edge with no inset, so it cannot slide while the bars animate
  away, a slide the page's constant reservation could not follow and one e-paper repaints
  as a smear.
- The footer's guard becomes `effectiveScrolling` rather than the reader's scrolling
  preference. A vertical-text book scrolls whichever way the preference is set, and a
  footer left drawn over a scrolled page prints itself through the text, which is the
  reason the guard exists.
- `FooterMetricsTest` updated for the new figures, plus a case for the new margin.

Two states still put a bar over the footer and both are accepted, documented at the call
site. A transient bar swiped out by the reader is drawn over the window without changing
an inset, so no layout could dodge it, and it retracts on its own. A window not allowed
to hide its bars at all covers the footer for as long as that lasts, which loses the
figures rather than printing them through the page's last line, as floating the footer up
an unpredictable bar would.

The page reservation stays keyed on the scrolling preference rather than
`effectiveScrolling`: whether a book is vertical-text is only known once the navigator has
read the publication, so feeding it in would reflow the book on open, which is what #73
exists to prevent. A vertical-text book keeps an unused 38dp band instead.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

Checked on an emulator at 1080x2400, density 420:

| State | Result |
| --- | --- |
| Three-button, portrait | 56dp gap before, 14dp after, two lines of text recovered |
| Three-button, portrait, chrome shown | scrubber sits above the real bottom bar |
| Gesture nav, portrait, font scale 1.3 | footer scales up, reservation grows with it, no overlap |
| Landscape, gesture nav | two-column page, footer full width at the bottom edge |
| Landscape, three-button | bar moves to the right edge, footer unaffected |
| Landscape, three-button, chrome shown | scrubber stops short of the right-edge bar |

Not covered: vertical-text books, e-ink hardware, and multi-window, none of which I have
here. The `effectiveScrolling` change is reasoned from the code rather than observed.

## Screenshots or recordings

Same book, same page 106, three-button navigation. Before, the page stops at "It is not,
indeed." with a finger-deep band of blank paper below the footer. After, the band is gone
and the two lines it was costing are back.

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/6a3fcd24-c21f-4547-bf5e-ff224754af5a) | ![after](https://github.com/user-attachments/assets/f9ad1405-f298-4db6-929b-8b8c7be7ac1e) |

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
