### PR TITLE
fix(reader): mark where the reader is, not where they were

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -1284,7 +1284,37 @@ fun ReaderScreen(
                 theme = readingTheme,
                 onToggle = {
                     view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
-                    onAnnotationAction.toggleBookmark()
+                    // A scrolled page moves under the reader's thumb
+                    // without Readium saying so: its current locator is
+                    // debounced, and between two of those the view
+                    // model's idea of the place can be a screen or more
+                    // behind what is on the page. A bookmark is taken at
+                    // the moment the ribbon is tapped and has to mean
+                    // that moment, so the document is asked where it is
+                    // now — the same question the reader leaving the
+                    // book already asks — and only then is the mark
+                    // made. It also decides which mark is being toggled,
+                    // so asking first is what stops a tap meant as a new
+                    // bookmark deleting the one behind it.
+                    //
+                    // Only a scrolled page is asked. A book set in pages
+                    // publishes its place on the turn, long before a
+                    // finger can reach the ribbon, and it does not
+                    // scroll: `scrolledPlace` would read an offset of
+                    // nothing over a screenful and file the reader at
+                    // the top of the chapter — the very thing this is
+                    // here to prevent. Every other caller guards on the
+                    // same flag.
+                    effectScope.launch {
+                        if (effectiveScrollingNow) {
+                            navigatorNow?.let { nav ->
+                                scrolledPlace(nav)?.let {
+                                    onLocatorChanged(it, NavigatorPositionEvent.LOCAL_JUMP)
+                                }
+                            }
+                        }
+                        onAnnotationAction.toggleBookmark()
+                    }
                 },
                 modifier = Modifier
                     .align(Alignment.TopEnd)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/progress/ExactLocatorAnchor.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/progress/ExactLocatorAnchor.kt
@@ -209,13 +209,24 @@ object ExactLocatorAnchor {
         })()
     """.trimIndent()
 
-    private val CAPTURE_SCRIPT = """
+    // Visible to the tests, which are the only place the case question
+    // this script settles can be asked without a WebView.
+    internal val CAPTURE_SCRIPT = """
         (() => {
-          const blocked = new Set(["SCRIPT", "STYLE", "NOSCRIPT", "TEMPLATE"]);
+          const blocked = new Set(["script", "style", "noscript", "template"]);
           const blockTags = new Set([
-            "P", "LI", "BLOCKQUOTE", "PRE", "TD", "TH", "FIGCAPTION",
-            "H1", "H2", "H3", "H4", "H5", "H6", "DIV"
+            "p", "li", "blockquote", "pre", "td", "th", "figcaption",
+            "h1", "h2", "h3", "h4", "h5", "h6", "div"
           ]);
+          // An EPUB resource is served as application/xhtml+xml, and an
+          // XML document reports tagName as it was written rather than
+          // upper-cased the way an HTML one does. Comparing against
+          // either spelling alone matched nothing here, which quietly
+          // sent every anchor's block up to <body>: the quote's context
+          // was then taken across the whole chapter instead of the
+          // paragraph, and Readium searched all of it to find the quote
+          // again. localName is the name without the case question.
+          const tag = element => (element && element.localName || "").toLowerCase();
           const visible = rect => rect.width > 0 && rect.height > 0 &&
             rect.right > 0 && rect.bottom > 0 &&
             rect.left < window.innerWidth && rect.top < window.innerHeight;
@@ -266,7 +277,7 @@ object ExactLocatorAnchor {
           const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
             acceptNode: node => {
               const parent = node.parentElement;
-              if (!parent || blocked.has(parent.tagName) || !node.data.trim()) {
+              if (!parent || blocked.has(tag(parent)) || !node.data.trim()) {
                 return NodeFilter.FILTER_REJECT;
               }
               return NodeFilter.FILTER_ACCEPT;
@@ -280,7 +291,7 @@ object ExactLocatorAnchor {
               range.setEnd(node, word.index + word.text.length);
               if (!Array.from(range.getClientRects()).some(visible)) continue;
               let block = node.parentElement;
-              while (block && block !== document.body && !blockTags.has(block.tagName)) {
+              while (block && block !== document.body && !blockTags.has(tag(block))) {
                 block = block.parentElement;
               }
               block = block || document.body;

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/progress/ExactLocatorAnchorTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/progress/ExactLocatorAnchorTest.kt
@@ -99,6 +99,25 @@ class ExactLocatorAnchorTest {
         assertEquals(null, ExactLocatorAnchor.excerpt(locator().toJSON().toString()))
     }
 
+    @Test
+    fun `capture script names elements without asking about case`() {
+        val script = ExactLocatorAnchor.CAPTURE_SCRIPT
+
+        // An EPUB resource is XHTML, where tagName keeps the spelling it
+        // was written with rather than upper-casing it the way an HTML
+        // document does. Reading it directly matched neither set, so
+        // every anchor's block fell through to <body> and the quote's
+        // context came from the whole chapter. There is no DOM here to
+        // catch that again, so the invariant is asserted on the script:
+        // element names are read through localName, lower-cased once.
+        assertFalse(script.contains(".tagName"))
+        assertTrue(script.contains("localName"))
+        for (tag in listOf("p", "li", "blockquote", "div", "h1", "script", "style")) {
+            assertTrue(tag, script.contains("\"$tag\""))
+            assertFalse(tag, script.contains("\"${tag.uppercase()}\""))
+        }
+    }
+
     private fun locator(): Locator = requireNotNull(
         Locator.fromJSON(
             JSONObject()


### PR DESCRIPTION
## Summary

Fixes #81.

A bookmark saved `ReaderViewModel.lastLocator`, which is fed by Readium's
*debounced* current locator. In a scrolled book the reader's thumb carries the
page well past the last locator published. The scroll watcher does keep a fresher
place in `heldPlace`, but it is only drained to `onLocatorChanged` by the
`ON_PAUSE` observer — nothing publishes it on the way to the bookmark ribbon.

So a mark taken shortly after scrolling recorded wherever the reader last came to
rest. On a book whose chapter is one long resource, that reads exactly as the
issue describes: the bookmark lands near the start of the chapter.

Pages were never affected, because a paginated book publishes its locator on the
turn, before a finger can reach the ribbon.

## Reproduction

With the reporter's book (a French SF novel; one chapter = 864 `<p>` directly
under `<body>`, ~175,000 characters in a single resource):

1. Scroll mode, scroll four screens.
2. Tap the bookmark ribbon immediately.

| | position | progression | anchor |
|---|---|---|---|
| bookmark taken *before* the four screens | 230 | 0.8388 | `p:nth-of-type(700)` |
| bookmark taken *after* the four screens | 230 | 0.8388 | `p:nth-of-type(700)` |

Byte-identical. The scroll was not recorded at all — the screen was showing
paragraph ~826 at the time.

## Changes

**`fix(reader): anchor a mark to its paragraph, not to the chapter`**

An EPUB resource is served as `application/xhtml+xml`, and an XML document
reports `tagName` as authored rather than upper-cased. `CAPTURE_SCRIPT` compared
it against uppercase sets, so nothing matched: every anchor's block fell through
to `<body>`, `cssSelector` was always `"body"`, and the quote's `before`/`after`
context was sampled across the whole resource instead of the paragraph. Now reads
`localName`.

This is an **anchor-quality fix, not the fix for #81** — see "What this is not"
below. It matters most on books shaped like this one, where `"body"` as a
text-quote root means re-searching 175,000 characters; the captured quote in one
test was the two-letter word `"au"`, which occurs 723 times in that resource.

**`fix(reader): mark where the reader is, not where they were`**

The ribbon asks the document where it is before marking, via the same
`scrolledPlace()` + `LOCAL_JUMP` path the reader leaving the book already uses.
Guarded by `effectiveScrollingNow`, as every other `scrolledPlace()` caller is:
a paginated book does not scroll, so the offset would divide to nothing and file
the reader at the top of the chapter — the very bug being fixed.

Asking first also fixes a quieter bug: the create-vs-delete decision
(`isHere()`) is made against the same position, so a tap meant as a new bookmark
could remove the one behind it.

## What this is not

My first attempt at this PR added `verify = true` to the annotation jump and
claimed the `tagName` fix resolved #81. Both were wrong, and review caught it:

- I tested a `"body"`-rooted bookmark directly by rewriting only that field on a
  stored mark. It landed on page 231 against a saved 230 — **correct**. So an
  ambiguous `"body"` root does not drag the jump to the chapter start.
- `verify` therefore had nothing to catch: a wrong-but-visible resolution
  verifies fine. It was a placebo, and it has been dropped.

`isExact()` deliberately still accepts legacy `"body"` anchors. Downgrading them
to approximate would trade a working exact restore for a worse one on every
existing bookmark, to avoid a transient mixed-version disagreement that
`sameReadingPositionAs()` does not actually treat as movement.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

On `liseur_phone_api36`, with the reporter's book:

| scenario | saved | on screen | |
|---|---|---|---|
| scroll mode, scroll then bookmark (before fix) | p700 | p826 | ✗ |
| scroll mode, scroll then bookmark (after fix) | `p:nth-of-type(838)` | p838 | ✓ exact |
| paginated, bookmark after page turns | page 240, progression 0.9715 | — | ✓ not chapter start |
| paginated, ribbon on an already-bookmarked page | removed it | — | ✓ correct toggle |

The anchor fix was additionally proved with a jsdom harness running the extracted
script against both content types: correct under `text/html` (which is why it was
never caught) and wrong under `application/xhtml+xml`.

## Screenshots or recordings

No UI change. The book used for verification is a commercial ebook supplied by
the maintainer for testing and is deliberately not attached.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
