### PR TITLE
fix(reader): stop a reopened book sending every device back to page one

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
@@ -663,11 +663,11 @@ class LiseurSyncPositionSync(
                 return
             }
 
-            val ops = ops(page.optJSONArray("ops"))
+            val items = feed(page.optJSONArray("ops"))
             val highWater = page.optLong("high_water", cursor)
-            val next = ops.maxOfOrNull { it.seq }?.coerceAtLeast(cursor) ?: highWater
+            val next = items.maxOfOrNull { it.seq }?.coerceAtLeast(cursor) ?: highWater
 
-            apply(account, ops, next)
+            apply(account, items.mapNotNull(SyncFeedItem::op), next)
             cursor = next
 
             if (!page.optBoolean("has_more", false)) return
@@ -695,7 +695,11 @@ class LiseurSyncPositionSync(
             trouble.failed(e, reasonFor(e))
             return
         }
-        apply(account, ops(snapshot.optJSONArray("ops")), snapshot.optLong("snapshot_seq"))
+        apply(
+            account,
+            feed(snapshot.optJSONArray("ops")).mapNotNull(SyncFeedItem::op),
+            snapshot.optLong("snapshot_seq"),
+        )
     }
 
     /** Lands a page and moves the cursor, together or not at all. */
@@ -1308,19 +1312,33 @@ class LiseurSyncPositionSync(
 
     // -- Odds and ends ----------------------------------------------------
 
-    /** The newest thing anybody said about one book. */
+    /**
+     * The newest thing anybody said about one book, that this device
+     * could actually read.
+     *
+     * A window rather than the single newest record, because the newest
+     * record is exactly the one a misbehaving client is most likely to
+     * have spoiled: an account has been seen with four unusable ops on
+     * top of a perfectly good one. Answering `null` there would hide a
+     * real position behind the corruption — telling the reader there is
+     * nothing to catch up to, and leaving a newly named book unseeded —
+     * which is the same harm as the phantom zero, only quieter.
+     *
+     * Null means the whole window was unreadable, never that the reader
+     * is at the start of the book.
+     */
     private suspend fun latestOp(
         baseUrl: String,
         credentials: RemoteCredentials,
         workId: String,
-    ): SyncOp? = ops(
-        http.get(LiseurSyncApi.positions(baseUrl, workId, limit = 1), credentials)
+    ): SyncOp? = feed(
+        http.get(LiseurSyncApi.positions(baseUrl, workId, limit = LATEST_WINDOW), credentials)
             .optJSONArray("ops"),
-    ).firstOrNull()
+    ).mapNotNull(SyncFeedItem::op).maxByOrNull(SyncOp::seq)
 
-    private fun ops(array: JSONArray?): List<SyncOp> =
+    private fun feed(array: JSONArray?): List<SyncFeedItem> =
         (0 until (array?.length() ?: 0)).mapNotNull { index ->
-            array?.optJSONObject(index)?.let(SyncOps::fromJson)
+            array?.optJSONObject(index)?.let(SyncOps::feedItemFrom)
         }
 
     /**
@@ -1391,6 +1409,14 @@ class LiseurSyncPositionSync(
         const val TAG = "liseur-sync-positions"
         const val PAGE = 500
         const val MAX_PAGES = 200
+
+        /**
+         * How far back to look for a book's newest readable position.
+         *
+         * Small: this is a defence against a short run of spoiled ops on
+         * top of a good one, not an attempt to reconstruct history.
+         */
+        const val LATEST_WINDOW = 20
         const val MAX_RESOLVES_PER_RUN = 25
         val ACCEPTED = setOf("applied", "duplicate")
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/SyncOps.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/SyncOps.kt
@@ -22,6 +22,28 @@ data class SyncOp(
 )
 
 /**
+ * One record from the server's feed: a sequence number, and a position
+ * only if the record made sense.
+ *
+ * The two are separate because they are owed to different people. The
+ * cursor is owed the `seq` of every record the server sent, whether or
+ * not this device could read it — dropping one either strands the feed
+ * on a page it re-fetches forever, or hands the cursor to `high_water`,
+ * which is the account's global maximum and would skip every real
+ * position after it.
+ *
+ * Reading state, on the other hand, is owed nothing by a record that
+ * could not be read. A position that arrives unreadable must not be
+ * landed as a position of zero, and must not be landed as no position
+ * either: `readingStatusFor(null)` is `ReadyToRead`, so letting one
+ * through would mark a book the reader is part-way through as unread.
+ */
+data class SyncFeedItem(
+    val seq: Long,
+    val op: SyncOp?,
+)
+
+/**
  * Turning a reading position into an op, and back.
  *
  * The interesting part is [opIdFor]. The server treats `op_id` as an
@@ -87,17 +109,82 @@ object SyncOps {
     fun fromJson(json: JSONObject): SyncOp? {
         val workId = json.optString("work_id").takeIf { it.isNotEmpty() } ?: return null
         val opId = json.optString("op_id").takeIf { it.isNotEmpty() } ?: return null
-        if (!json.has("progression")) return null
+        val progression = (fractionAt(json, "progression") as? Fraction.Present)?.value
+            ?: return null
+        val locator = json.optJSONObject("locator")
+        if (locator != null && !locatorReadable(locator)) return null
         return SyncOp(
             opId = opId,
             workId = workId,
             editionSha = json.optString("edition_sha").takeIf { it.isNotEmpty() },
             clientTs = parseTime(json.optString("client_ts")) ?: 0,
-            progression = json.optDouble("progression", 0.0),
-            locatorJson = json.optJSONObject("locator")?.toString(),
+            progression = progression,
+            locatorJson = locator?.toString(),
             deviceId = json.optString("device_id").takeIf { it.isNotEmpty() },
             seq = json.optLong("seq"),
         )
+    }
+
+    /**
+     * A record from the feed, kept for its sequence number even when its
+     * position is unusable.
+     *
+     * Null only when there is nothing to keep at all: no readable
+     * position *and* no sequence number to advance the cursor with.
+     */
+    fun feedItemFrom(json: JSONObject): SyncFeedItem? {
+        val op = fromJson(json)
+        val seq = op?.seq ?: json.optLong("seq")
+        if (op == null && seq <= 0) return null
+        return SyncFeedItem(seq = seq, op = op)
+    }
+
+    /**
+     * A number that was really there, told apart from one that was not.
+     *
+     * `optDouble(key, 0.0)` is the mistake this exists to avoid: it
+     * turns a null, a string and a missing key alike into a
+     * legitimate-looking start of the book. An unpatched or third-party
+     * server that writes `"progression": null` — which is what
+     * `JSON.stringify` does with a `NaN` — must not be able to send this
+     * reader back to page one.
+     */
+    private fun fractionAt(json: JSONObject, key: String): Fraction {
+        if (!json.has(key)) return Fraction.Absent
+        if (json.isNull(key)) return Fraction.Unusable
+        val fraction = when (val value = json.opt(key)) {
+            is Number -> value.toDouble()
+            // A server that quotes its numbers is out of contract but
+            // not ambiguous, and the value is checked either way. This
+            // is also the one door a non-finite can still come through:
+            // org.json refuses a bare `NaN` while parsing, but "NaN" is
+            // just a string until something asks it for a double.
+            is String -> value.toDoubleOrNull() ?: return Fraction.Unusable
+            else -> return Fraction.Unusable
+        }
+        // Written this way round so a NaN is refused: it answers false
+        // to both comparisons, and so would also answer false to the
+        // `< 0 || > 1` phrasing that reads more naturally.
+        if (!(fraction >= 0.0 && fraction <= 1.0)) return Fraction.Unusable
+        return Fraction.Present(fraction)
+    }
+
+    /**
+     * Whether a locator's own idea of the position is usable.
+     *
+     * Only explicit malformedness is refused. A locator with no
+     * `locations`, or a partner that syncs a percentage and sends no
+     * locator at all, are both legitimate shapes and are left alone.
+     */
+    private fun locatorReadable(locator: JSONObject): Boolean {
+        val locations = locator.optJSONObject("locations") ?: return true
+        return fractionAt(locations, "totalProgression") !is Fraction.Unusable
+    }
+
+    private sealed interface Fraction {
+        data class Present(val value: Double) : Fraction
+        data object Absent : Fraction
+        data object Unusable : Fraction
     }
 
     /**

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/NavigatorPositionEvent.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/NavigatorPositionEvent.kt
@@ -19,3 +19,53 @@ enum class NavigatorPositionEvent(
      */
     OPENING_RESTORATION(persists = false, teachesPace = false, recordsReadingTime = false),
 }
+
+/**
+ * What an emission means, and whether it spends the marker that labels it.
+ *
+ * @param event how the emission should be treated.
+ * @param markerSurvives whether the pending marker is still owed to a
+ *   later emission. A marker is single use, so this is what stops
+ *   opening noise from spending one that belongs to the arrival.
+ */
+data class NavigatorEmission(
+    val event: NavigatorPositionEvent,
+    val markerSurvives: Boolean,
+)
+
+/**
+ * Decide what the navigator just told us.
+ *
+ * Pure so the interaction between the four inputs can be tested without
+ * a navigator: it is subtle enough to have been wrong once. A
+ * navigation's marker must outlive an emission the opening gate
+ * suppressed as noise, because `go` is asynchronous and the position
+ * being left behind can be reported first. Spending the marker there
+ * leaves the real arrival looking like the reader turning a page — a
+ * jump would teach the pace estimator a distance nobody read, and an
+ * adopted remote position would be published straight back as local
+ * movement, which is the loop the gate exists to break.
+ *
+ * The emission that ends the restoration does spend it, so the page turn
+ * after it is not labelled a jump.
+ *
+ * @param requested the marker set alongside a navigation, if any.
+ * @param suppressed whether the opening gate refused this emission.
+ * @param landed whether this emission is the one that ended the
+ *   restoration rather than more of the opening.
+ * @param reflowActive whether the page is being rebuilt underneath.
+ */
+fun classifyNavigatorEmission(
+    requested: NavigatorPositionEvent?,
+    suppressed: Boolean,
+    landed: Boolean,
+    reflowActive: Boolean,
+): NavigatorEmission = NavigatorEmission(
+    event = when {
+        suppressed -> NavigatorPositionEvent.OPENING_RESTORATION
+        requested != null -> requested
+        reflowActive -> NavigatorPositionEvent.PREFERENCE_REFLOW
+        else -> NavigatorPositionEvent.READER_MOVEMENT
+    },
+    markerSurvives = requested != null && suppressed && !landed,
+)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/NavigatorPositionEvent.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/NavigatorPositionEvent.kt
@@ -12,4 +12,10 @@ enum class NavigatorPositionEvent(
     PREFERENCE_REFLOW(persists = false, teachesPace = false, recordsReadingTime = false),
     FRAGMENT_RECREATION(persists = false, teachesPace = false, recordsReadingTime = false),
     LIFECYCLE_REPLAY(persists = false, teachesPace = false, recordsReadingTime = false),
+
+    /**
+     * The navigator reporting itself while a book is still being
+     * reopened, before restoration has landed.
+     */
+    OPENING_RESTORATION(persists = false, teachesPace = false, recordsReadingTime = false),
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
@@ -204,9 +204,23 @@ class ReaderActivity : FragmentActivity() {
                                 val readingTheme = prefs.themeChoice.resolve(appIsDark)
                                 val scrollMode by viewModel.scrollMode.collectAsStateWithLifecycle()
                                 val columnMode = prefs.columnMode.effectiveFor(widthClass())
+                                // Read once, here, alongside the factory that is
+                                // built from it, and handed to the screen as the
+                                // point this navigator is being restored to.
+                                // Reading it again later would not give the same
+                                // answer: onLocatorChanged assigns lastLocator
+                                // before it decides whether the position persists,
+                                // so the navigator's own opening emissions move it.
+                                val restoreTarget = remember(
+                                    s.navigatorFactory,
+                                    columnMode,
+                                    scrollMode,
+                                ) {
+                                    viewModel.lastLocator ?: s.initialLocator
+                                }
                                 remember(s.navigatorFactory, columnMode, scrollMode) {
                                     s.navigatorFactory.createFragmentFactory(
-                                        initialLocator = viewModel.lastLocator ?: s.initialLocator,
+                                        initialLocator = restoreTarget,
                                         initialPreferences = prefs.toEpubPreferences(
                                             theme = readingTheme,
                                             columnMode = columnMode,
@@ -257,6 +271,7 @@ class ReaderActivity : FragmentActivity() {
                                 }
                                 ReaderScreen(
                                     publication = s.publication,
+                                    restoreTarget = restoreTarget,
                                     prefsFlow = viewModel.prefs,
                                     readingTheme = readingTheme,
                                     typographyIsOwnFlow = viewModel.typographyIsOwn,
@@ -312,7 +327,6 @@ class ReaderActivity : FragmentActivity() {
                                                 viewModel::locatorAtOrBeforeProgression,
                                             prepareLocator = viewModel::prepareLocator,
                                             onApproximateResume = viewModel::onApproximateResume,
-                                            currentLocator = { viewModel.lastLocator },
                                         )
                                     },
                                     annotationsFlow = viewModel.annotations,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -348,6 +348,21 @@ fun ReaderScreen(
     }
     val gateOpenedAt = remember(navigator) { SystemClock.elapsedRealtime() }
 
+    // The Readium locator behind the gate's current target. The gate
+    // speaks in RestorePoints, which carry no text anchor, so confirming
+    // arrival at an exact target needs the locator itself — and once a
+    // navigation has retargeted the gate that is the destination, not
+    // the one the book opened on.
+    var gateAnchor by remember(navigator) { mutableStateOf(restoreTarget) }
+
+    // Point the gate at somewhere the reader is being sent, without
+    // releasing it and without moving its deadline. One function so the
+    // anchor and the gate's target cannot drift apart.
+    fun retargetGate(locator: Locator) {
+        gateAnchor = locator
+        gate.onNavigationIssued(locator.restorePoint(exact = ExactLocatorAnchor.isExact(locator)))
+    }
+
     // The deadline runs on a clock rather than on emissions: a navigator
     // that falls silent while gated would otherwise never be released,
     // and a reading session would quietly stop being saved.
@@ -478,7 +493,7 @@ fun ReaderScreen(
         // asynchronous and the marker set with it is single use, so an
         // emission still in flight from the pre-restore position would
         // otherwise take that marker and be saved as the move.
-        gate.onNavigationIssued(locator.restorePoint())
+        retargetGate(locator)
         pendingPositionEvent = event
         nav.go(locator, animated = false)
         if (!verify || !ExactLocatorAnchor.isExact(locator)) return
@@ -491,7 +506,7 @@ fun ReaderScreen(
         }
         val progression = locator.locations.totalProgression ?: return
         val fallback = onProgressAction.locatorAtOrBeforeProgression(progression) ?: return
-        gate.onNavigationIssued(fallback.restorePoint())
+        retargetGate(fallback)
         pendingPositionEvent = event
         nav.go(fallback, animated = false)
         onProgressAction.onApproximateResume()
@@ -593,9 +608,10 @@ fun ReaderScreen(
                 val wasGated = gate.isGated
                 val suppressed = wasGated && gate.onEmission(
                     here = native.restorePoint(),
-                    anchorVerified = restoreTarget != null &&
-                        ExactLocatorAnchor.isExact(restoreTarget) &&
-                        ExactLocatorAnchor.verify(nav, restoreTarget),
+                    anchorVerified = gateAnchor.let {
+                        it != null && ExactLocatorAnchor.isExact(it) &&
+                            ExactLocatorAnchor.verify(nav, it)
+                    },
                     elapsedMs = SystemClock.elapsedRealtime() - gateOpenedAt,
                 ) == OpeningRestorationVerdict.SUPPRESS
                 // Whether this emission is the one that ended the
@@ -695,7 +711,7 @@ fun ReaderScreen(
         // in between takes the marker and the real arrival is left
         // looking like a page turn. Telling the gate where the reader is
         // now being sent keeps it closed until they get there.
-        gate.onNavigationIssued(fallback.restorePoint())
+        retargetGate(fallback)
         nav.go(fallback, animated = false)
         onProgressAction.onApproximateResume()
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -588,26 +588,31 @@ fun ReaderScreen(
             // one-sided remote update into a conflict.
             nav.currentLocator.drop(1).collect { native ->
                 val requested = pendingPositionEvent
-                pendingPositionEvent = null
                 // Only paid for while the gate is closed, which is a
                 // handful of emissions at the start of a session.
-                val suppressed = gate.isGated && gate.onEmission(
+                val wasGated = gate.isGated
+                val suppressed = wasGated && gate.onEmission(
                     here = native.restorePoint(),
                     anchorVerified = restoreTarget != null &&
                         ExactLocatorAnchor.isExact(restoreTarget) &&
                         ExactLocatorAnchor.verify(nav, restoreTarget),
                     elapsedMs = SystemClock.elapsedRealtime() - gateOpenedAt,
                 ) == OpeningRestorationVerdict.SUPPRESS
-                val event = when {
-                    // The navigator reporting where it was before it
-                    // finished being told where to go. Persisting that
-                    // sends the reader's other devices to the top of the
-                    // chapter.
-                    suppressed -> NavigatorPositionEvent.OPENING_RESTORATION
-                    requested != null -> requested
-                    reflow.active -> NavigatorPositionEvent.PREFERENCE_REFLOW
-                    else -> NavigatorPositionEvent.READER_MOVEMENT
-                }
+                // Whether this emission is the one that ended the
+                // restoration, rather than more of the opening noise.
+                val landed = wasGated && !gate.isGated
+                val emission = classifyNavigatorEmission(
+                    requested = requested,
+                    suppressed = suppressed,
+                    landed = landed,
+                    reflowActive = reflow.active,
+                )
+                if (!emission.markerSurvives) pendingPositionEvent = null
+                // OPENING_RESTORATION here is the navigator reporting
+                // where it was before it finished being told where to
+                // go. Persisting that sends the reader's other devices
+                // to the top of the chapter.
+                val event = emission.event
                 // Anywhere the reader actually goes ends the run of
                 // preference changes the held anchor was covering.
                 if (event != NavigatorPositionEvent.PREFERENCE_REFLOW) reflowAnchor = null

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -77,6 +77,7 @@ import androidx.fragment.compose.AndroidFragment
 import android.graphics.RectF
 import android.view.HapticFeedbackConstants
 import android.view.View
+import android.os.SystemClock
 import android.webkit.WebView
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.ui.platform.LocalContext
@@ -126,6 +127,9 @@ import com.chmouel.liseur.reader.chrome.FootnoteCard
 import com.chmouel.liseur.reader.chrome.TypographySheet
 import com.chmouel.liseur.reader.progress.ReaderProgress
 import com.chmouel.liseur.reader.progress.ExactLocatorAnchor
+import com.chmouel.liseur.reader.progress.OpeningRestoration
+import com.chmouel.liseur.reader.progress.OpeningRestorationVerdict
+import com.chmouel.liseur.reader.progress.RestorePoint
 import com.chmouel.liseur.reader.progress.ScrollProgression
 import com.chmouel.liseur.reader.search.SearchScreen
 import com.chmouel.liseur.ui.LocalEInk
@@ -222,6 +226,11 @@ private enum class ReaderSheet { NONE, TYPOGRAPHY, ADVANCED }
 @Composable
 fun ReaderScreen(
     publication: Publication,
+    /**
+     * Where this navigator is being reopened to, snapshotted when it was
+     * built. Null for a book with no saved position.
+     */
+    restoreTarget: Locator?,
     prefsFlow: StateFlow<ReaderPrefs>,
     readingTheme: ReaderTheme,
     typographyIsOwnFlow: StateFlow<Boolean>,
@@ -327,6 +336,25 @@ fun ReaderScreen(
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     val effectScope = rememberCoroutineScope()
     var pendingPositionEvent by remember { mutableStateOf<NavigatorPositionEvent?>(null) }
+
+    // Closed while the book is still being reopened. One per navigator,
+    // because a column or scroll mode change builds a new one and it
+    // restores again. See OpeningRestoration.
+    val gate = remember(navigator) {
+        OpeningRestoration(
+            target = restoreTarget?.restorePoint(exact = ExactLocatorAnchor.isExact(restoreTarget)),
+            timeoutMs = OpeningRestoration.DEFAULT_TIMEOUT_MS,
+        )
+    }
+    val gateOpenedAt = remember(navigator) { SystemClock.elapsedRealtime() }
+
+    // The deadline runs on a clock rather than on emissions: a navigator
+    // that falls silent while gated would otherwise never be released,
+    // and a reading session would quietly stop being saved.
+    LaunchedEffect(navigator) {
+        delay(OpeningRestoration.DEFAULT_TIMEOUT_MS)
+        gate.onDeadline()
+    }
 
     // Open for as long as the page is being rebuilt underneath the reader.
     // See ReflowScope: a locator nobody has claimed while this is open is the
@@ -445,6 +473,12 @@ fun ReaderScreen(
         event: NavigatorPositionEvent,
         verify: Boolean = false,
     ) {
+        // If the book is still opening, this supersedes the restoration
+        // — but only once the reader is actually there. The go below is
+        // asynchronous and the marker set with it is single use, so an
+        // emission still in flight from the pre-restore position would
+        // otherwise take that marker and be saved as the move.
+        gate.onNavigationIssued(locator.restorePoint())
         pendingPositionEvent = event
         nav.go(locator, animated = false)
         if (!verify || !ExactLocatorAnchor.isExact(locator)) return
@@ -457,9 +491,39 @@ fun ReaderScreen(
         }
         val progression = locator.locations.totalProgression ?: return
         val fallback = onProgressAction.locatorAtOrBeforeProgression(progression) ?: return
+        gate.onNavigationIssued(fallback.restorePoint())
         pendingPositionEvent = event
         nav.go(fallback, animated = false)
         onProgressAction.onApproximateResume()
+    }
+
+    suspend fun openingExactAnchorArrived(nav: EpubNavigatorFragment, locator: Locator): Boolean {
+        val elapsedMs = SystemClock.elapsedRealtime() - gateOpenedAt
+        val budgetMs = OpeningRestoration.exactOpenVerifyBudgetMs(elapsedMs)
+        // A budget already spent still buys one look. Two frames cost
+        // nothing against the gate's remaining second, and degrading the
+        // reader to an approximate page without ever asking whether the
+        // exact one was there would be worse than the single attempt
+        // this replaced.
+        if (budgetMs <= 0L) {
+            settleLayout()
+            return ExactLocatorAnchor.verify(nav, locator)
+        }
+        // This is the same asynchronous WebView race as navigate(), but
+        // a cold open is the slowest layout the reader asks for. Poll
+        // for a bounded stretch before degrading to the approximate
+        // locator. The budget helper keeps this below the opening
+        // gate's fail-open deadline: with the current constants it caps
+        // polling at 3000ms and never past 4000ms from gate creation,
+        // leaving at least 1000ms of the 5000ms gate for the fallback
+        // navigation to be issued while the gate is still closed.
+        return withTimeoutOrNull(budgetMs) {
+            repeat(OpeningRestoration.EXACT_OPEN_VERIFY_ATTEMPTS) {
+                settleLayout()
+                if (ExactLocatorAnchor.verify(nav, locator)) return@withTimeoutOrNull true
+            }
+            false
+        } == true
     }
 
     fun navigateLater(
@@ -523,13 +587,27 @@ fun ReaderScreen(
             // must not look like this device turned a page and turn a
             // one-sided remote update into a conflict.
             nav.currentLocator.drop(1).collect { native ->
-                val event = pendingPositionEvent
-                    ?: if (reflow.active) {
-                        NavigatorPositionEvent.PREFERENCE_REFLOW
-                    } else {
-                        NavigatorPositionEvent.READER_MOVEMENT
-                    }
+                val requested = pendingPositionEvent
                 pendingPositionEvent = null
+                // Only paid for while the gate is closed, which is a
+                // handful of emissions at the start of a session.
+                val suppressed = gate.isGated && gate.onEmission(
+                    here = native.restorePoint(),
+                    anchorVerified = restoreTarget != null &&
+                        ExactLocatorAnchor.isExact(restoreTarget) &&
+                        ExactLocatorAnchor.verify(nav, restoreTarget),
+                    elapsedMs = SystemClock.elapsedRealtime() - gateOpenedAt,
+                ) == OpeningRestorationVerdict.SUPPRESS
+                val event = when {
+                    // The navigator reporting where it was before it
+                    // finished being told where to go. Persisting that
+                    // sends the reader's other devices to the top of the
+                    // chapter.
+                    suppressed -> NavigatorPositionEvent.OPENING_RESTORATION
+                    requested != null -> requested
+                    reflow.active -> NavigatorPositionEvent.PREFERENCE_REFLOW
+                    else -> NavigatorPositionEvent.READER_MOVEMENT
+                }
                 // Anywhere the reader actually goes ends the run of
                 // preference changes the held anchor was covering.
                 if (event != NavigatorPositionEvent.PREFERENCE_REFLOW) reflowAnchor = null
@@ -596,14 +674,23 @@ fun ReaderScreen(
 
     LaunchedEffect(navigator) {
         val nav = navigator ?: return@LaunchedEffect
-        val requested = onProgressAction.currentLocator() ?: return@LaunchedEffect
+        // The snapshot this navigator was built with, not
+        // viewModel.lastLocator: onLocatorChanged assigns that before it
+        // decides whether a position persists, so the navigator's own
+        // opening emissions move it out from under this check.
+        val requested = restoreTarget ?: return@LaunchedEffect
         if (!ExactLocatorAnchor.isExact(requested)) return@LaunchedEffect
-        settleLayout()
-        if (ExactLocatorAnchor.verify(nav, requested)) return@LaunchedEffect
+        if (openingExactAnchorArrived(nav, requested)) return@LaunchedEffect
         val progression = requested.locations.totalProgression ?: return@LaunchedEffect
         val fallback = onProgressAction.locatorAtOrBeforeProgression(progression)
             ?: return@LaunchedEffect
         pendingPositionEvent = NavigatorPositionEvent.FRAGMENT_RECREATION
+        // Retarget rather than release. This navigation is asynchronous
+        // and pendingPositionEvent is single-use, so an emission landing
+        // in between takes the marker and the real arrival is left
+        // looking like a page turn. Telling the gate where the reader is
+        // now being sent keeps it closed until they get there.
+        gate.onNavigationIssued(fallback.restorePoint())
         nav.go(fallback, animated = false)
         onProgressAction.onApproximateResume()
     }
@@ -1869,7 +1956,6 @@ class ReaderProgressActions(
     val locatorAtOrBeforeProgression: (Double) -> Locator?,
     val prepareLocator: (Locator) -> Locator,
     val onApproximateResume: () -> Unit,
-    val currentLocator: () -> Locator?,
 )
 
 /** Syncing this one book on purpose, from the Navigate screen. */
@@ -2043,3 +2129,15 @@ private fun consumeInsetsForReadium(view: View) {
     ViewCompat.setOnApplyWindowInsetsListener(view) { _, _ -> WindowInsetsCompat.CONSUMED }
     ViewCompat.requestApplyInsets(view)
 }
+
+/**
+ * A locator, in the terms the opening gate reasons about.
+ *
+ * Nothing here is Readium-shaped on purpose: the decision the gate makes
+ * is worth testing on its own, without a navigator to ask.
+ */
+private fun Locator.restorePoint(exact: Boolean = false) = RestorePoint(
+    href = href.toString(),
+    progression = locations.totalProgression,
+    exact = exact,
+)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/progress/OpeningRestoration.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/progress/OpeningRestoration.kt
@@ -1,0 +1,172 @@
+package com.chmouel.liseur.reader.progress
+
+import kotlin.math.abs
+
+/**
+ * Where a book is being reopened to, in the only terms the gate needs.
+ *
+ * Deliberately not a Readium `Locator`: the decision below is worth
+ * testing without an emulator, and it turns on three facts.
+ */
+data class RestorePoint(
+    val href: String,
+    /** Whole-book, stable across fonts and columns. Null when unknown. */
+    val progression: Double?,
+    /** Whether the point carries an app-owned text anchor. */
+    val exact: Boolean,
+)
+
+/** Whether an emission may be treated as the reader having moved. */
+enum class OpeningRestorationVerdict { SUPPRESS, RELEASE }
+
+/**
+ * The gate that keeps a book's opening out of the sync log.
+ *
+ * A reflowable navigator reports where it is before it has finished
+ * being told where to go. The first emission after the replayed initial
+ * locator is the WebView's own idea of the position — the top of the
+ * resource, near enough — and by then the reader is already active, so
+ * without a gate it is persisted and pushed as a page turn. On the
+ * account this was written for, that produced a position of exactly 0.0
+ * in a chapter the reader was two thirds of the way through, sixteen
+ * seconds before the correct position followed it.
+ *
+ * The gate suppresses until it can see that restoration has landed, and
+ * gives up after a deadline rather than risk holding a session's writes
+ * forever. The emission that shows restoration landed is suppressed too:
+ * it is the restoration arriving, not the reader moving, and writing it
+ * back would republish the stored position under a fresh revision. That
+ * is the other half of the same bug — a device reopening a book exactly
+ * where it left it pushed a ten-hour-old position as new reading, which
+ * on every other device read as the reader jumping backwards.
+ *
+ * Suppression costs at most one unrecorded page turn: the next emission
+ * carries the same place, and the progress bar is driven from an earlier
+ * point in the pipeline so the reader sees nothing.
+ *
+ * One instance per navigator. A new navigator — a column or scroll mode
+ * change rebuilds one — restores again and so needs a fresh gate.
+ */
+class OpeningRestoration(
+    private val target: RestorePoint?,
+    private val timeoutMs: Long,
+) {
+    private var released = target == null
+    private var current = target
+
+    val isGated: Boolean get() = !released
+
+    /**
+     * A position the navigator reported.
+     *
+     * [anchorVerified] answers whether the exact anchor was found on the
+     * page this emission describes; it is only consulted for an exact
+     * target, and the caller only pays for the check while gated.
+     */
+    fun onEmission(
+        here: RestorePoint,
+        anchorVerified: Boolean,
+        elapsedMs: Long,
+    ): OpeningRestorationVerdict {
+        if (released) return OpeningRestorationVerdict.RELEASE
+        if (current?.let { arrived(it, here, anchorVerified) } != false) {
+            // The emission that shows restoration landed *is* the
+            // restoration, so it is the last one suppressed rather than
+            // the first one let through. Publishing it would rewrite the
+            // stored position with itself, and every write bumps the
+            // revision — which is how a book reopened where it was left
+            // came to republish a ten-hour-old locator as fresh reading
+            // and drag the shared position backwards.
+            released = true
+            return OpeningRestorationVerdict.SUPPRESS
+        }
+        if (elapsedMs >= timeoutMs) {
+            // Restoration never visibly landed. Fail open: a position
+            // that might be wrong is recoverable, a reader whose place
+            // silently stops being saved is not.
+            released = true
+            return OpeningRestorationVerdict.RELEASE
+        }
+        return OpeningRestorationVerdict.SUPPRESS
+    }
+
+    /**
+     * The deadline passed.
+     *
+     * Driven by a clock rather than by an emission, because a navigator
+     * that goes quiet while gated would otherwise stay gated for the
+     * whole session however much time went by.
+     */
+    fun onDeadline() {
+        released = true
+    }
+
+    /**
+     * The book is being sent somewhere: restoration falling back to an
+     * approximate point, or the reader tapping a contents entry, a
+     * search hit or a catch-up offer while the book is still opening.
+     *
+     * This retargets rather than releases, and the distinction matters.
+     * The navigation is asynchronous and the caller's own marker for it
+     * is single use, so an emission from the position being left behind
+     * can arrive first and take that marker. Releasing here would hand
+     * that emission through wearing the label of a move the reader made
+     * — which is the pre-restore position the gate exists to catch,
+     * published as reading. Suppressing until the destination is reached
+     * costs nothing instead: the arrival is held, so closing the book
+     * still saves it.
+     *
+     * The deadline is not restarted. Retargeting must not be able to
+     * extend the window, however often it happens.
+     */
+    fun onNavigationIssued(point: RestorePoint) {
+        if (released) return
+        current = point
+    }
+
+    private fun arrived(want: RestorePoint, here: RestorePoint, anchorVerified: Boolean): Boolean {
+        if (want.exact) return anchorVerified
+        if (here.href != want.href) return false
+        val wanted = want.progression ?: return true
+        val reached = here.progression ?: return false
+        return abs(reached - wanted) <= TOLERANCE
+    }
+
+    companion object {
+        /**
+         * How far off an approximate restoration may land.
+         *
+         * Wider than the sync layer's epsilon on purpose: this is asking
+         * "did the navigator go roughly where it was sent", not "are two
+         * devices in the same place".
+         */
+        const val TOLERANCE = 0.01
+
+        /** Long enough for a slow first layout, short enough to notice. */
+        const val DEFAULT_TIMEOUT_MS = 5_000L
+
+        /**
+         * A cold open gets longer than an in-book jump to let the WebView
+         * finish applying the initial locator before the exact anchor is
+         * declared missing. The wall-clock cap is the real bound: thirty
+         * two-frame waits are about one second at 60Hz and two seconds at
+         * 30Hz, but a starved frame clock must not run into the fail-open
+         * deadline.
+         */
+        const val EXACT_OPEN_VERIFY_ATTEMPTS = 30
+        const val EXACT_OPEN_VERIFY_BUDGET_MS = 3_000L
+
+        /**
+         * Time reserved between giving up on the exact anchor and the
+         * gate's fail-open deadline, so the approximate fallback is
+         * issued while the opening gate is still closed.
+         */
+        const val FALLBACK_BEFORE_DEADLINE_MS = 1_000L
+
+        fun exactOpenVerifyBudgetMs(elapsedMs: Long): Long =
+            minOf(
+                EXACT_OPEN_VERIFY_BUDGET_MS,
+                DEFAULT_TIMEOUT_MS - FALLBACK_BEFORE_DEADLINE_MS - elapsedMs,
+            ).coerceAtLeast(0L)
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
@@ -279,7 +279,8 @@ class LiseurSyncPositionSyncTest {
     }
 
     @Test
-    fun `a cursor the server has compacted past starts again from a snapshot`() = runTest {        connect(cursor = 5)
+    fun `a cursor the server has compacted past starts again from a snapshot`() = runTest {
+        connect(cursor = 5)
         db.bookDao().upsert(local())
         alias()
         server.enqueue(MockResponse(code = 410, body = """{"error":"resync_required"}"""))

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
@@ -150,9 +150,136 @@ class LiseurSyncPositionSyncTest {
         assertEquals(0.75, db.readingProgressDao().get(LOCAL)?.totalProgression!!, 0.0001)
     }
 
+    // -- Records this device cannot read -----------------------------------
+    //
+    // A server that writes a null progression — as one did, four times
+    // in seventeen seconds — must not be able to move this reader, and
+    // must not be able to derail the cursor either. The two are
+    // separate: the record still has a sequence number even when it has
+    // no meaning.
+
     @Test
-    fun `a cursor the server has compacted past starts again from a snapshot`() = runTest {
+    fun `an unreadable record moves the cursor without moving the reader`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        server.enqueue(
+            json(
+                """{"ops":[${op(seq = 9, progression = 0.75)},${spoiled(seq = 10)}],
+                    "has_more":false,"high_water":10}
+                """.trimIndent(),
+            ),
+        )
+
+        sync().syncAll(null)
+
+        // Past the spoiled record, so it is never fetched again...
+        assertEquals(10L, db.remoteServerDao().get()?.syncCursorSeq)
+        // ...and the good position behind it still landed.
+        assertEquals(0.75, db.readingProgressDao().get(LOCAL)?.totalProgression!!, 0.0001)
+    }
+
+    @Test
+    fun `a page of nothing but unreadable records does not leap to high water`() = runTest {
+        // high_water is the account's newest sequence across every book,
+        // not this page's last. Dropping the records and falling back to
+        // it would step over every real position in between.
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        server.enqueue(
+            json(
+                """{"ops":[${spoiled(seq = 11)},${spoiled(seq = 12)}],
+                    "has_more":false,"high_water":9999}
+                """.trimIndent(),
+            ),
+        )
+
+        sync().syncAll(null)
+
+        assertEquals(12L, db.remoteServerDao().get()?.syncCursorSeq)
+        assertNull(db.readingProgressDao().get(LOCAL))
+    }
+
+    @Test
+    fun `an unreadable record does not replace a position already pending`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        // Agreed at a third of the way, then read on here, so what the
+        // server sends is held as a disagreement rather than adopted.
+        db.syncPeerStateDao().settle(LOCAL, peer(), 0, 0.3, "reading", NOW)
+        db.readingProgressDao().recordLocal(LOCAL, LOCATOR, 0.5, null, "reading", NOW)
+        server.enqueue(
+            json("""{"ops":[${op(seq = 4, progression = 0.8)}],"has_more":true,"high_water":4}"""),
+        )
+        server.enqueue(
+            json("""{"ops":[${spoiled(seq = 5)}],"has_more":false,"high_water":5}"""),
+        )
+
+        sync().syncAll(null)
+
+        assertEquals(5L, db.remoteServerDao().get()?.syncCursorSeq)
+        assertEquals(1, db.syncPeerStateDao().countPending(peer()))
+        assertEquals(0.5, db.readingProgressDao().get(LOCAL)?.totalProgression!!, 0.0001)
+    }
+
+    @Test
+    fun `a snapshot ignores what it cannot read and lands what it can`() = runTest {
         connect(cursor = 5)
+        db.bookDao().upsert(local())
+        alias()
+        server.enqueue(MockResponse(code = 410, body = """{"error":"resync_required"}"""))
+        server.enqueue(
+            json(
+                """{"ops":[${spoiled(seq = 41)},${op(seq = 40, progression = 0.6)}],
+                    "snapshot_seq":42}
+                """.trimIndent(),
+            ),
+        )
+
+        sync().syncAll(null)
+
+        assertEquals(42L, db.remoteServerDao().get()?.syncCursorSeq)
+        assertEquals(0.6, db.readingProgressDao().get(LOCAL)?.totalProgression!!, 0.0001)
+    }
+
+    @Test
+    fun `a good position is not hidden behind the spoiled ones on top of it`() = runTest {
+        // Exactly the shape the account was found in: four unreadable
+        // ops sitting on a perfectly good one. Answering "nothing known"
+        // there would leave this book unseeded and tell the reader there
+        // is nothing to catch up to.
+        connect()
+        db.bookDao().upsert(local())
+        resolved()
+        server.enqueue(
+            json(
+                """{"ops":[${spoiled(seq = 2148)},${spoiled(seq = 2147)},
+                    ${op(seq = 2144, progression = 0.33)}]}
+                """.trimIndent(),
+            ),
+        )
+        server.enqueue(json("""{"ops":[]}"""))
+
+        sync().syncAll(null)
+
+        assertEquals(0.33, db.readingProgressDao().get(LOCAL)?.totalProgression!!, 0.0001)
+    }
+
+    @Test
+    fun `a book whose every position is unreadable is left alone`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        server.enqueue(json("""{"ops":[${spoiled(seq = 2148)}]}"""))
+
+        assertEquals(PreviewOutcome.NotSynced, sync().previewBook(LOCAL))
+        assertNull(db.readingProgressDao().get(LOCAL))
+    }
+
+    @Test
+    fun `a cursor the server has compacted past starts again from a snapshot`() = runTest {        connect(cursor = 5)
         db.bookDao().upsert(local())
         alias()
         server.enqueue(MockResponse(code = 410, body = """{"error":"resync_required"}"""))
@@ -995,6 +1122,13 @@ class LiseurSyncPositionSyncTest {
     }
 
     private fun json(body: String) = MockResponse(code = 200, body = body)
+
+    /** A record with a sequence number and no position anyone can use. */
+    private fun spoiled(seq: Long): String =
+        """{"op_id":"o-$seq","work_id":"w-1","seq":$seq,
+            "progression":null,
+            "client_ts":"${SyncOps.formatTime(NOW)}"}
+        """.trimIndent()
 
     private fun exactLocator(highlight: String, progression: Double = 0.8): String = JSONObject()
         .put("href", "/c1.xhtml")

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/SyncOpsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/SyncOpsTest.kt
@@ -95,6 +95,142 @@ class SyncOpsTest {
         assertNull(SyncOps.fromJson(JSONObject().put("work_id", "w").put("op_id", "o")))
     }
 
+    // -- What a position may not be ---------------------------------------
+    //
+    // A server that writes `"progression": null` — which is what
+    // JSON.stringify does with a NaN — used to arrive here as a position
+    // of exactly zero and send the reader back to page one. None of
+    // these may be read as a number.
+
+    @Test
+    fun `a null progression is not a position of zero`() {
+        assertNull(SyncOps.fromJson(wire().put("progression", JSONObject.NULL)))
+    }
+
+    @Test
+    fun `an absent progression is not a position of zero`() {
+        val json = wire()
+        json.remove("progression")
+
+        assertNull(SyncOps.fromJson(json))
+    }
+
+    @Test
+    fun `a progression that is not a number is not a position of zero`() {
+        assertNull(SyncOps.fromJson(wire().put("progression", "abc")))
+        assertNull(SyncOps.fromJson(wire().put("progression", JSONObject())))
+    }
+
+    @Test
+    fun `a non-finite progression is refused`() {
+        // org.json refuses to parse a bare NaN or Infinity, so this is
+        // the shape one can still arrive in — and the shape the old
+        // optDouble() turned back into a real NaN and stored.
+        assertNull(SyncOps.fromJson(wire().put("progression", "NaN")))
+        assertNull(SyncOps.fromJson(wire().put("progression", "Infinity")))
+        assertNull(SyncOps.fromJson(wire().put("progression", "-Infinity")))
+    }
+
+    @Test
+    fun `a quoted number is still a position`() {
+        // Out of contract, but not ambiguous, and checked either way.
+        assertEquals(0.25, SyncOps.fromJson(wire().put("progression", "0.25"))!!.progression, 0.0)
+    }
+
+    @Test
+    fun `a progression outside the book is refused`() {
+        assertNull(SyncOps.fromJson(wire().put("progression", -0.1)))
+        assertNull(SyncOps.fromJson(wire().put("progression", 1.5)))
+    }
+
+    @Test
+    fun `a locator whose own progression is unusable is refused`() {
+        // Ops 2145 to 2148: the top-level number had already been
+        // coerced to a legitimate-looking zero, but the locator still
+        // said what really happened.
+        val locator = JSONObject()
+            .put("href", "/c1.xhtml")
+            .put("locations", JSONObject().put("totalProgression", JSONObject.NULL))
+
+        assertNull(SyncOps.fromJson(wire().put("progression", 0.0).put("locator", locator)))
+    }
+
+    @Test
+    fun `a locator whose own progression is out of range is refused`() {
+        val locator = JSONObject()
+            .put("locations", JSONObject().put("totalProgression", 4.2))
+
+        assertNull(SyncOps.fromJson(wire().put("locator", locator)))
+    }
+
+    // -- What a position still is -----------------------------------------
+
+    @Test
+    fun `the start of the book is a real position`() {
+        val op = SyncOps.fromJson(wire().put("progression", 0.0))
+
+        assertEquals(0.0, op!!.progression, 0.0)
+    }
+
+    @Test
+    fun `the end of the book is a real position`() {
+        assertEquals(1.0, SyncOps.fromJson(wire().put("progression", 1.0))!!.progression, 0.0)
+    }
+
+    @Test
+    fun `an op with no locator is a real position`() {
+        // A percentage-only partner sends exactly this.
+        assertEquals(0.5, SyncOps.fromJson(wire())!!.progression, 0.0)
+    }
+
+    @Test
+    fun `a locator with no locations is a real position`() {
+        val json = wire().put("locator", JSONObject().put("href", "/c1.xhtml"))
+
+        assertEquals(0.5, SyncOps.fromJson(json)!!.progression, 0.0)
+    }
+
+    @Test
+    fun `a locator with locations but no progression is a real position`() {
+        val locator = JSONObject()
+            .put("href", "/c1.xhtml")
+            .put("locations", JSONObject().put("position", 208))
+
+        assertEquals(0.5, SyncOps.fromJson(json = wire().put("locator", locator))!!.progression, 0.0)
+    }
+
+    // -- Sequencing, which survives the position ---------------------------
+
+    @Test
+    fun `an unreadable record keeps its sequence number`() {
+        val item = SyncOps.feedItemFrom(
+            wire().put("progression", JSONObject.NULL).put("seq", 2145L),
+        )!!
+
+        assertEquals(2145L, item.seq)
+        assertNull(item.op)
+    }
+
+    @Test
+    fun `a readable record carries both`() {
+        val item = SyncOps.feedItemFrom(wire().put("seq", 2144L))!!
+
+        assertEquals(2144L, item.seq)
+        assertEquals(0.5, item.op!!.progression, 0.0)
+    }
+
+    @Test
+    fun `a record with neither a position nor a sequence number is nothing`() {
+        assertNull(SyncOps.feedItemFrom(wire().put("progression", JSONObject.NULL)))
+        assertNull(SyncOps.feedItemFrom(JSONObject().put("seq", 0L)))
+    }
+
+    private fun wire() = JSONObject()
+        .put("op_id", "op-1")
+        .put("work_id", "w-1")
+        .put("client_ts", SyncOps.formatTime(CLIENT_TS))
+        .put("progression", 0.5)
+
     @Test
     fun `timestamps are read whether or not the server kept the fraction`() {
         assertEquals(

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/ReadingStateMergeTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/ReadingStateMergeTest.kt
@@ -321,4 +321,34 @@ class ReadingStateMergeTest {
         assertEquals(ReadingStatus.READY_TO_READ, ReadingStatus.forProgression(0.0))
         assertEquals(ReadingStatus.READY_TO_READ, ReadingStatus.forProgression(null))
     }
+
+    @Test
+    fun `a missing remote position is not a remote position of zero`() {
+        // The guarantee the server's null-to-zero coercion was
+        // bypassing: a partner that sends only a status must never send
+        // this reader back to the start of the book.
+        val decision = reconcileReadingState(
+            local = state(0.47),
+            remote = state(null, status = ReadingStatus.READING),
+            baseline = baseline(0.47),
+            localDirty = false,
+        )
+
+        assertEquals(SyncDecision.InSync, decision)
+    }
+
+    @Test
+    fun `an unreadable position must never be handed over as a status`() {
+        // Why a malformed op is dropped rather than landed with a null
+        // progression: forProgression(null) is ReadyToRead, and this is
+        // what the merge would then be asked to do with it.
+        val decision = reconcileReadingState(
+            local = state(0.47, status = ReadingStatus.READING),
+            remote = state(null, status = ReadingStatus.READY_TO_READ),
+            baseline = baseline(0.47),
+            localDirty = false,
+        )
+
+        assertEquals(SyncDecision.AdoptStatus(ReadingStatus.READY_TO_READ), decision)
+    }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/NavigatorPositionEventTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/NavigatorPositionEventTest.kt
@@ -1,5 +1,6 @@
 package com.chmouel.liseur.reader
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -38,5 +39,60 @@ class NavigatorPositionEventTest {
         // told where to go. Persisting that pushed a position of zero to
         // the reader's other devices.
         assertFalse(NavigatorPositionEvent.OPENING_RESTORATION.persists)
+    }
+
+    private fun classify(
+        requested: NavigatorPositionEvent? = null,
+        suppressed: Boolean = false,
+        landed: Boolean = false,
+        reflowActive: Boolean = false,
+    ) = classifyNavigatorEmission(requested, suppressed, landed, reflowActive)
+
+    @Test
+    fun `an unmarked emission is the reader moving unless the page is being rebuilt`() {
+        assertEquals(NavigatorPositionEvent.READER_MOVEMENT, classify().event)
+        assertEquals(
+            NavigatorPositionEvent.PREFERENCE_REFLOW,
+            classify(reflowActive = true).event,
+        )
+    }
+
+    @Test
+    fun `a marker outranks a reflow but not the opening gate`() {
+        assertEquals(
+            NavigatorPositionEvent.LOCAL_JUMP,
+            classify(requested = NavigatorPositionEvent.LOCAL_JUMP, reflowActive = true).event,
+        )
+        assertEquals(
+            NavigatorPositionEvent.OPENING_RESTORATION,
+            classify(requested = NavigatorPositionEvent.LOCAL_JUMP, suppressed = true).event,
+        )
+    }
+
+    @Test
+    fun `opening noise does not spend the marker owed to the arrival`() {
+        // go() is asynchronous, so the position being left behind can be
+        // reported first. If that emission takes the marker, the real
+        // arrival is classified as reading: a jump would teach the pace
+        // estimator a distance nobody read, and an adopted remote
+        // position would be published straight back as local movement.
+        val noise = classify(
+            requested = NavigatorPositionEvent.REMOTE_ADOPTION,
+            suppressed = true,
+            landed = false,
+        )
+        assertEquals(NavigatorPositionEvent.OPENING_RESTORATION, noise.event)
+        assertTrue(noise.markerSurvives)
+
+        // Whether the arrival is suppressed or not, it is the navigation
+        // completing, so it settles the marker either way.
+        assertFalse(classify(NavigatorPositionEvent.REMOTE_ADOPTION, true, landed = true).markerSurvives)
+        assertFalse(classify(NavigatorPositionEvent.REMOTE_ADOPTION).markerSurvives)
+    }
+
+    @Test
+    fun `there is no marker to keep when none was set`() {
+        assertFalse(classify(suppressed = true).markerSurvives)
+        assertFalse(classify().markerSurvives)
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/NavigatorPositionEventTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/NavigatorPositionEventTest.kt
@@ -24,10 +24,19 @@ class NavigatorPositionEventTest {
             NavigatorPositionEvent.PREFERENCE_REFLOW,
             NavigatorPositionEvent.FRAGMENT_RECREATION,
             NavigatorPositionEvent.LIFECYCLE_REPLAY,
+            NavigatorPositionEvent.OPENING_RESTORATION,
         ).forEach { event ->
             assertFalse(event.persists)
             assertFalse(event.teachesPace)
             assertFalse(event.recordsReadingTime)
         }
+    }
+
+    @Test
+    fun `a book being reopened is not reading anyone should be sent to`() {
+        // The navigator reports where it is before it has finished being
+        // told where to go. Persisting that pushed a position of zero to
+        // the reader's other devices.
+        assertFalse(NavigatorPositionEvent.OPENING_RESTORATION.persists)
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/progress/OpeningRestorationTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/progress/OpeningRestorationTest.kt
@@ -1,0 +1,249 @@
+package com.chmouel.liseur.reader.progress
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The gate that keeps a book's opening out of the sync log.
+ *
+ * Written against behaviour rather than the enum: what matters is which
+ * emissions are allowed to become a position other devices will be sent
+ * to, and that no arrangement of them can leave the gate shut forever.
+ */
+class OpeningRestorationTest {
+
+    private val timeout = 5_000L
+
+    private fun at(href: String, progression: Double?, exact: Boolean = false) =
+        RestorePoint(href = href, progression = progression, exact = exact)
+
+    private fun OpeningRestoration.emit(
+        here: RestorePoint,
+        anchorVerified: Boolean = false,
+        elapsedMs: Long = 0,
+    ) = onEmission(here, anchorVerified, elapsedMs)
+
+    @Test
+    fun `a book with no saved position is not gated at all`() {
+        val gate = OpeningRestoration(target = null, timeoutMs = timeout)
+
+        assertFalse(gate.isGated)
+        assertEquals(
+            OpeningRestorationVerdict.RELEASE,
+            gate.emit(at("ch1.xhtml", 0.0)),
+        )
+    }
+
+    @Test
+    fun `an exact restoration suppresses until its anchor is found`() {
+        val gate = OpeningRestoration(at("ch7.xhtml", 0.47, exact = true), timeout)
+
+        // The WebView reporting the top of the resource before Readium
+        // has scrolled it. This is op 2149.
+        assertEquals(
+            OpeningRestorationVerdict.SUPPRESS,
+            gate.emit(at("ch7.xhtml", 0.3877), anchorVerified = false),
+        )
+        // The restoration arriving. Suppressed as well: it is not the
+        // reader moving, and writing it back is what produced op 2142.
+        assertEquals(
+            OpeningRestorationVerdict.SUPPRESS,
+            gate.emit(at("ch7.xhtml", 0.4699), anchorVerified = true),
+        )
+        assertFalse(gate.isGated)
+        // The page actually turned afterwards is reading.
+        assertEquals(
+            OpeningRestorationVerdict.RELEASE,
+            gate.emit(at("ch7.xhtml", 0.4720), anchorVerified = false),
+        )
+    }
+
+    @Test
+    fun `reopening a book exactly where it was left publishes nothing`() {
+        // Op 2142: the same device sent a byte-identical locator ten
+        // hours later under a fresh revision, because the first emission
+        // after reopening was written back as reading. Nothing moved, so
+        // nothing may be published.
+        val gate = OpeningRestoration(at("ch7.xhtml", 0.4284, exact = true), timeout)
+
+        assertEquals(
+            OpeningRestorationVerdict.SUPPRESS,
+            gate.emit(at("ch7.xhtml", 0.4284), anchorVerified = true),
+        )
+    }
+
+    @Test
+    fun `an exact restoration is not released by landing near the right place`() {
+        val gate = OpeningRestoration(at("ch7.xhtml", 0.47, exact = true), timeout)
+
+        // Same href, same progression, but the anchor was not found:
+        // the reader is on a page that merely measures the same.
+        assertEquals(
+            OpeningRestorationVerdict.SUPPRESS,
+            gate.emit(at("ch7.xhtml", 0.47), anchorVerified = false),
+        )
+    }
+
+    @Test
+    fun `an approximate restoration releases on href and progression`() {
+        val gate = OpeningRestoration(at("ch7.xhtml", 0.47), timeout)
+
+        assertEquals(
+            OpeningRestorationVerdict.SUPPRESS,
+            gate.emit(at("ch1.xhtml", 0.02)),
+        )
+        assertEquals(
+            OpeningRestorationVerdict.SUPPRESS,
+            gate.emit(at("ch7.xhtml", 0.39)),
+        )
+        assertEquals(
+            OpeningRestorationVerdict.SUPPRESS,
+            gate.emit(at("ch7.xhtml", 0.4705)),
+        )
+        assertFalse(gate.isGated)
+    }
+
+    @Test
+    fun `an approximate target with no progression asks only for the resource`() {
+        val gate = OpeningRestoration(at("ch7.xhtml", null), timeout)
+
+        assertEquals(OpeningRestorationVerdict.SUPPRESS, gate.emit(at("ch1.xhtml", 0.0)))
+        assertEquals(OpeningRestorationVerdict.SUPPRESS, gate.emit(at("ch7.xhtml", null)))
+        assertFalse(gate.isGated)
+    }
+
+    @Test
+    fun `the deadline releases without any further emission`() {
+        val gate = OpeningRestoration(at("ch7.xhtml", 0.47, exact = true), timeout)
+
+        assertEquals(OpeningRestorationVerdict.SUPPRESS, gate.emit(at("ch7.xhtml", 0.0)))
+        assertTrue(gate.isGated)
+
+        gate.onDeadline()
+
+        assertFalse(gate.isGated)
+    }
+
+    @Test
+    fun `an emission past the deadline releases even if restoration never landed`() {
+        val gate = OpeningRestoration(at("ch7.xhtml", 0.47, exact = true), timeout)
+
+        assertEquals(
+            OpeningRestorationVerdict.SUPPRESS,
+            gate.emit(at("ch7.xhtml", 0.0), elapsedMs = timeout - 1),
+        )
+        assertEquals(
+            OpeningRestorationVerdict.RELEASE,
+            gate.emit(at("ch7.xhtml", 0.0), elapsedMs = timeout),
+        )
+    }
+
+    @Test
+    fun `a reader navigating during the window is not overtaken by a stale emission`() {
+        val gate = OpeningRestoration(at("ch7.xhtml", 0.47, exact = true), timeout)
+
+        assertEquals(OpeningRestorationVerdict.SUPPRESS, gate.emit(at("ch7.xhtml", 0.0)))
+
+        // The reader taps a contents entry. nav.go() is asynchronous and
+        // the caller's marker for the move is single use, so this
+        // emission — still in flight from the pre-restore position —
+        // would take the marker and be saved as the reader's jump.
+        gate.onNavigationIssued(at("ch2.xhtml", 0.10))
+
+        assertEquals(OpeningRestorationVerdict.SUPPRESS, gate.emit(at("ch7.xhtml", 0.0)))
+        assertTrue(gate.isGated)
+
+        // Arriving where they asked to go ends the restoration.
+        assertEquals(OpeningRestorationVerdict.SUPPRESS, gate.emit(at("ch2.xhtml", 0.10)))
+        assertFalse(gate.isGated)
+        assertEquals(OpeningRestorationVerdict.RELEASE, gate.emit(at("ch2.xhtml", 0.11)))
+    }
+
+    @Test
+    fun `a fallback retargets and keeps suppressing`() {
+        val gate = OpeningRestoration(at("ch7.xhtml", 0.47, exact = true), timeout)
+
+        gate.onNavigationIssued(at("ch7.xhtml", 0.44))
+
+        // nav.go() is asynchronous: this arrives from the page being
+        // left behind, and releasing on "fallback issued" would let it
+        // through as a page turn.
+        assertEquals(
+            OpeningRestorationVerdict.SUPPRESS,
+            gate.emit(at("ch1.xhtml", 0.0)),
+        )
+        assertEquals(
+            OpeningRestorationVerdict.SUPPRESS,
+            gate.emit(at("ch7.xhtml", 0.0)),
+        )
+        assertEquals(
+            OpeningRestorationVerdict.SUPPRESS,
+            gate.emit(at("ch7.xhtml", 0.4405)),
+        )
+        assertFalse(gate.isGated)
+    }
+
+    @Test
+    fun `a fallback does not extend the deadline`() {
+        val gate = OpeningRestoration(at("ch7.xhtml", 0.47, exact = true), timeout)
+
+        gate.emit(at("ch7.xhtml", 0.0), elapsedMs = timeout - 100)
+        gate.onNavigationIssued(at("ch7.xhtml", 0.44))
+
+        assertEquals(
+            OpeningRestorationVerdict.RELEASE,
+            gate.emit(at("ch1.xhtml", 0.0), elapsedMs = timeout),
+        )
+    }
+
+    @Test
+    fun `a fallback after release does not close the gate again`() {
+        val gate = OpeningRestoration(at("ch7.xhtml", 0.47, exact = true), timeout)
+
+        gate.onDeadline()
+        gate.onNavigationIssued(at("ch7.xhtml", 0.44))
+
+        assertFalse(gate.isGated)
+        assertEquals(OpeningRestorationVerdict.RELEASE, gate.emit(at("ch1.xhtml", 0.0)))
+    }
+
+    @Test
+    fun `releasing is idempotent whichever path arrives first`() {
+        val gate = OpeningRestoration(at("ch7.xhtml", 0.47), timeout)
+
+        gate.onDeadline()
+        gate.onDeadline()
+
+        assertFalse(gate.isGated)
+        assertEquals(OpeningRestorationVerdict.RELEASE, gate.emit(at("ch1.xhtml", 0.0)))
+    }
+
+    @Test
+    fun `a new navigator gets a fresh gate rather than the last one's state`() {
+        val first = OpeningRestoration(at("ch7.xhtml", 0.47), timeout)
+        first.onDeadline()
+        assertFalse(first.isGated)
+
+        // What a column or scroll mode change builds.
+        val second = OpeningRestoration(at("ch7.xhtml", 0.47), timeout)
+
+        assertTrue(second.isGated)
+        assertEquals(OpeningRestorationVerdict.SUPPRESS, second.emit(at("ch1.xhtml", 0.0)))
+    }
+
+    @Test
+    fun `exact opening verification budget leaves room before fail open`() {
+        assertEquals(3_000L, OpeningRestoration.exactOpenVerifyBudgetMs(elapsedMs = 0))
+        assertEquals(2_500L, OpeningRestoration.exactOpenVerifyBudgetMs(elapsedMs = 1_500))
+        assertEquals(1L, OpeningRestoration.exactOpenVerifyBudgetMs(elapsedMs = 3_999))
+        assertEquals(0L, OpeningRestoration.exactOpenVerifyBudgetMs(elapsedMs = 4_000))
+        assertEquals(0L, OpeningRestoration.exactOpenVerifyBudgetMs(elapsedMs = timeout))
+
+        assertTrue(
+            OpeningRestoration.EXACT_OPEN_VERIFY_BUDGET_MS +
+                OpeningRestoration.FALLBACK_BEFORE_DEADLINE_MS <= timeout,
+        )
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/progress/OpeningRestorationTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/progress/OpeningRestorationTest.kt
@@ -199,6 +199,26 @@ class OpeningRestorationTest {
     }
 
     @Test
+    fun `retargeting to a text anchor still waits for that anchor`() {
+        val gate = OpeningRestoration(at("ch7.xhtml", 0.47, exact = true), timeout)
+
+        // A catch-up offer accepted during opening sends the reader to a
+        // text-anchored position close to where they already are. Losing
+        // its exactness would let the page being left behind pass the
+        // 1% tolerance and read as an arrival.
+        gate.onNavigationIssued(at("ch7.xhtml", 0.46, exact = true))
+
+        assertEquals(OpeningRestorationVerdict.SUPPRESS, gate.emit(at("ch7.xhtml", 0.46)))
+        assertTrue(gate.isGated)
+
+        assertEquals(
+            OpeningRestorationVerdict.SUPPRESS,
+            gate.emit(at("ch7.xhtml", 0.46), anchorVerified = true),
+        )
+        assertFalse(gate.isGated)
+    }
+
+    @Test
     fun `a fallback after release does not close the gate again`() {
         val gate = OpeningRestoration(at("ch7.xhtml", 0.47, exact = true), timeout)
 


### PR DESCRIPTION
## Summary

Reopening a book could drag the shared reading position backwards on every
other device, then forwards again a moment later. It was hard to reproduce
because turning pages never triggered it — only *reopening* did.

Three independent defects fed the same shared position, and each one on its
own was enough to move it backwards. Two of them are in this app and are fixed
here; the third was in the server and web reader, fixed separately in
`liseur-sync`. They are fixed independently on purpose, so a phone talking to
an unpatched server is still safe and vice versa.

**How the position moved backwards**

1. *A book reported where it was before it finished opening.* A reflowable
   navigator announces its own idea of the position — the top of the resource
   — before restoration has landed, and the reader already counted as active,
   so that was saved and pushed as though a page had been turned.

2. *Reopening a book republished the position it was already at.* The same
   premature emission also disturbed the "last position" the app compares
   against, so the landing emission looked like a change. Nothing about the
   locator changed, but the revision did — and because sync identifies an
   update by that revision, a book reopened exactly where it was left pushed a
   ten-hour-old position as new reading, which every other device then adopted.

3. *A position that could not be read was stored as zero.* Decoding a
   progression fell back to `0`, and `0` is a legitimate progression — the
   start of the book. Anything unreadable therefore arrived as "this reader is
   on page one".

No linked issue: this was found by reading the op log of a self-hosted
liseur-sync account after the symptom was reported directly.

## Changes

- Hold a book's opening out of the sync log until restoration has visibly
  landed, giving up on a bounded deadline so a reading session can never
  silently stop being saved.
- Treat a move the reader asks for during that window as superseding the
  restoration only once they have actually arrived, so a stale position in
  flight cannot be recorded as their jump.
- Verify the exact resume anchor by looking repeatedly rather than once, since
  a cold open is the slowest layout the app performs and a single look
  downgraded readers to an approximate resume they did not need.
- Refuse an unreadable position instead of defaulting it to zero, while
  keeping the record's sequence number so the sync cursor neither skips
  positions nor stalls, and never letting an unreadable position mark a
  part-read book unread.
- Choose the newest *valid* position from a bounded window rather than
  whatever the single most recent record happens to be, so corruption cannot
  hide a good position behind it.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [ ] Manually tested on a device or emulator, if applicable

Not yet exercised on hardware — that needs installing over a real reading
position, which I have not been authorised to do. The intended check is: open
a book saved partway through and confirm no position below the saved one is
pushed during opening.

The behaviour that is worth trusting is covered by unit tests instead. The
opening gate is pure Kotlin with no Readium or Android types precisely so it
can be, including that the emission proving restoration landed is itself not
published, that no ordering of events can leave the gate shut forever, and
that the anchor-polling budget always expires before the gate's deadline.
Position decoding is pinned against null, absent, non-numeric, non-finite and
out-of-range values, and against a genuine `0`, which must keep working.

## Screenshots or recordings

None: nothing here changes what the reader sees. The progress bar is driven
from an earlier point in the pipeline than the code touched, so it stays live
while the opening is suppressed.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.