### PR TITLE
refactor(reader): put the settings a reader never changes behind Advanced

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,4 +230,12 @@ emulator.
   `viewModelScope` is reached from the main thread.
 - Reader settings map to Readium `EpubPreferences`; reading themes
   (Light/Sepia/Dark/Black) are decoupled from the app's Material theme.
+- A new reading setting goes in the Advanced sheet
+  (`reader/chrome/AdvancedSheet.kt`), and behind the collapsed Advanced
+  section on Settings → Reading appearance. The typography sheet is the
+  short list a reader changes often — theme, size, brightness, font, and
+  how the book is read — and it only grows for a setting that genuinely
+  belongs there. Make that case in the pull request; the default is
+  Advanced. It grew to eleven controls once, one reasonable row at a
+  time. See `docs/adr/0001-advanced-reading-menu.md`.
 - Bundled fonts must be under open licenses (OFL): Literata et al.

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -1730,8 +1730,9 @@ fun ReaderScreen(
     if (sheet == ReaderSheet.ADVANCED) {
         AdvancedSheet(
             prefs = prefs,
-            scrollMode = scrollMode,
-            autoScrollOffered = effectiveScrolling,
+            // Not the reader's own answer but the page's: vertical text
+            // runs rather than turns whatever the setting says.
+            scrolling = effectiveScrolling,
             autoScrolling = autoScrollArmed,
             autoScrollSpeed = prefs.autoScrollSpeed,
             typographyIsOwn = typographyIsOwn,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -1714,26 +1714,14 @@ fun ReaderScreen(
         TypographySheet(
             prefs = prefs,
             readingTheme = readingTheme,
-            typographyIsOwn = typographyIsOwn,
-            onTypographyIsOwnChanged = onPrefsAction.setTypographyIsOwn,
             onFontSelected = onPrefsAction.setFont,
             onFontSizeChanged = onPrefsAction.setFontSize,
             onThemeSelected = onPrefsAction.setTheme,
-            onLineHeightChanged = onPrefsAction.setLineHeight,
-            onPageMarginsChanged = onPrefsAction.setPageMargins,
             onBrightnessChanged = onPrefsAction.setBrightness,
-            onPageTurnAnimationChanged = onPrefsAction.setPageTurnAnimation,
-            onFooterModeChanged = onProgressAction.setFooterMode,
-            onColumnModeChanged = onPrefsAction.setColumnMode,
             keepScreenOn = keepScreenOn,
             onKeepScreenOnChanged = onKeepScreenOnChanged,
             scrollMode = scrollMode,
             onScrollModeChanged = onScrollModeChanged,
-            // Nothing lives behind Advanced yet but auto-scroll, and
-            // auto-scroll is only offered to a scrolled book. A paginated
-            // one would open an empty sheet, so it is not offered the way
-            // in either.
-            advancedOffered = effectiveScrolling,
             onOpenAdvanced = { sheet = ReaderSheet.ADVANCED },
             onDismiss = { sheet = ReaderSheet.NONE },
         )
@@ -1741,11 +1729,20 @@ fun ReaderScreen(
 
     if (sheet == ReaderSheet.ADVANCED) {
         AdvancedSheet(
+            prefs = prefs,
+            scrollMode = scrollMode,
             autoScrollOffered = effectiveScrolling,
             autoScrolling = autoScrollArmed,
             autoScrollSpeed = prefs.autoScrollSpeed,
+            typographyIsOwn = typographyIsOwn,
+            onLineHeightChanged = onPrefsAction.setLineHeight,
+            onPageMarginsChanged = onPrefsAction.setPageMargins,
+            onColumnModeChanged = onPrefsAction.setColumnMode,
+            onFooterModeChanged = onProgressAction.setFooterMode,
+            onPageTurnAnimationChanged = onPrefsAction.setPageTurnAnimation,
             onAutoScrollChanged = { autoScrollArmed = it },
             onAutoScrollSpeedChanged = onPrefsAction.setAutoScrollSpeed,
+            onTypographyIsOwnChanged = onPrefsAction.setTypographyIsOwn,
             // Back to typography, not back to the book: this sheet was
             // reached from there, and that is where the reader left off.
             onDismiss = { sheet = ReaderSheet.TYPOGRAPHY },

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
@@ -1,6 +1,5 @@
 package com.chmouel.liseur.reader.chrome
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -140,7 +139,11 @@ private fun JustThisBookToggle(enabled: Boolean, onChanged: (Boolean) -> Unit) {
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { onChanged(!enabled) },
+            .toggleable(
+                value = enabled,
+                role = Role.Switch,
+                onValueChange = onChanged,
+            ),
     ) {
         Column(Modifier.weight(1f)) {
             Text(
@@ -157,7 +160,7 @@ private fun JustThisBookToggle(enabled: Boolean, onChanged: (Boolean) -> Unit) {
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-        Switch(checked = enabled, onCheckedChange = onChanged)
+        Switch(checked = enabled, onCheckedChange = null)
     }
 }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
@@ -54,14 +54,20 @@ import com.chmouel.liseur.ui.windowWidth
  * issue, and the shape of the sheet is the point: five rows, or ten, it
  * is the same sheet and the reader learns it once.
  *
+ * [scrolling] is whether the text runs rather than turns, which is not
+ * only the reader's own choice: vertical text is laid out that way
+ * whatever the setting says. Three rows turn on it, and they are the
+ * same question asked once — a page that scrolls has no columns to
+ * count and no turn to animate, and is the only kind that can be
+ * scrolled along on its own.
+ *
  * See `docs/adr/0001-advanced-reading-menu.md`.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AdvancedSheet(
     prefs: ReaderPrefs,
-    scrollMode: Boolean,
-    autoScrollOffered: Boolean,
+    scrolling: Boolean,
     autoScrolling: Boolean,
     autoScrollSpeed: Float,
     typographyIsOwn: Boolean,
@@ -92,7 +98,7 @@ fun AdvancedSheet(
                 // A scrolled chapter is one running column, so the count
                 // has nothing to divide and the control would take a tap
                 // and change nothing.
-                showColumns = !scrollMode,
+                showColumns = !scrolling,
                 onLineHeightChanged = onLineHeightChanged,
                 onPageMarginsChanged = onPageMarginsChanged,
                 onColumnModeChanged = onColumnModeChanged,
@@ -103,13 +109,13 @@ fun AdvancedSheet(
             )
             // Nothing lifts off the screen when the text is scrolled, so
             // the animation has no page to describe.
-            if (!scrollMode) {
+            if (!scrolling) {
                 ReadingPageTurnAnimationToggle(
                     enabled = prefs.pageTurnAnimation,
                     onChanged = onPageTurnAnimationChanged,
                 )
             }
-            if (autoScrollOffered) {
+            if (scrolling) {
                 AutoScrollRow(
                     enabled = autoScrolling,
                     speed = autoScrollSpeed,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
@@ -1,5 +1,6 @@
 package com.chmouel.liseur.reader.chrome
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -27,7 +28,13 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.chmouel.liseur.R
 import com.chmouel.liseur.data.settings.AutoScrollPreference
+import com.chmouel.liseur.data.settings.ColumnMode
+import com.chmouel.liseur.data.settings.FooterMode
+import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.ui.contentWidthCap
+import com.chmouel.liseur.ui.reading.ReadingFooterModeDropdown
+import com.chmouel.liseur.ui.reading.ReadingLayoutControls
+import com.chmouel.liseur.ui.reading.ReadingPageTurnAnimationToggle
 import com.chmouel.liseur.ui.reading.ReadingSectionLabel
 import com.chmouel.liseur.ui.windowWidth
 
@@ -35,25 +42,38 @@ import com.chmouel.liseur.ui.windowWidth
  * The second sheet, reached from the typography sheet's last row.
  *
  * It exists so that the typography sheet does not have to grow: that one
- * stays the four or five answers a reader changes often, and everything
+ * stays the handful of answers a reader changes often — the theme, the
+ * size, the light, the face, and how the book is read — and everything
  * rarer lives a tap further in. Dismissing this lands back on
  * typography, and dismissing that lands back on the page.
  *
- * Today it holds one row. The rest of what belongs here — finer
- * typography, read-aloud, imported fonts, tap-zone presets — arrives with
- * its own issue, and the shape of the sheet is the point: one row, or
- * five, it is the same sheet and the reader learns it once.
+ * What it holds is what a reader sets once, if ever: the shape of the
+ * text block, what the footer says, whether pages turn with an
+ * animation, whether the page moves on its own, and whether any of it is
+ * this book's alone. The rest of what belongs here — finer typography,
+ * read-aloud, imported fonts, tap-zone presets — arrives with its own
+ * issue, and the shape of the sheet is the point: five rows, or ten, it
+ * is the same sheet and the reader learns it once.
  *
  * See `docs/adr/0001-advanced-reading-menu.md`.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AdvancedSheet(
+    prefs: ReaderPrefs,
+    scrollMode: Boolean,
     autoScrollOffered: Boolean,
     autoScrolling: Boolean,
     autoScrollSpeed: Float,
+    typographyIsOwn: Boolean,
+    onLineHeightChanged: (Double?) -> Unit,
+    onPageMarginsChanged: (Double?) -> Unit,
+    onColumnModeChanged: (ColumnMode) -> Unit,
+    onFooterModeChanged: (FooterMode) -> Unit,
+    onPageTurnAnimationChanged: (Boolean) -> Unit,
     onAutoScrollChanged: (Boolean) -> Unit,
     onAutoScrollSpeedChanged: (Float) -> Unit,
+    onTypographyIsOwnChanged: (Boolean) -> Unit,
     onDismiss: () -> Unit,
 ) {
     ModalBottomSheet(onDismissRequest = onDismiss) {
@@ -66,6 +86,30 @@ fun AdvancedSheet(
                 .padding(bottom = 24.dp),
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
+            ReadingLayoutControls(
+                lineHeight = prefs.lineHeight,
+                pageMargins = prefs.pageMargins,
+                columnMode = prefs.columnMode,
+                // A scrolled chapter is one running column, so the count
+                // has nothing to divide and the control would take a tap
+                // and change nothing.
+                showColumns = !scrollMode,
+                onLineHeightChanged = onLineHeightChanged,
+                onPageMarginsChanged = onPageMarginsChanged,
+                onColumnModeChanged = onColumnModeChanged,
+            )
+            ReadingFooterModeDropdown(
+                selected = prefs.footerMode,
+                onSelected = onFooterModeChanged,
+            )
+            // Nothing lifts off the screen when the text is scrolled, so
+            // the animation has no page to describe.
+            if (!scrollMode) {
+                ReadingPageTurnAnimationToggle(
+                    enabled = prefs.pageTurnAnimation,
+                    onChanged = onPageTurnAnimationChanged,
+                )
+            }
             if (autoScrollOffered) {
                 AutoScrollRow(
                     enabled = autoScrolling,
@@ -74,7 +118,46 @@ fun AdvancedSheet(
                     onSpeedChanged = onAutoScrollSpeedChanged,
                 )
             }
+            JustThisBookToggle(
+                enabled = typographyIsOwn,
+                onChanged = onTypographyIsOwnChanged,
+            )
         }
+    }
+}
+
+/**
+ * Sets the book apart from the shared reading settings.
+ *
+ * Last in the sheet, and only about the settings that are genuinely the
+ * book's: what it is set in, how big, how open, how wide. The theme and
+ * the brightness are about the room, so they carry on being shared
+ * however this is left.
+ */
+@Composable
+private fun JustThisBookToggle(enabled: Boolean, onChanged: (Boolean) -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onChanged(!enabled) },
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.reader_typography_own),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                text = if (enabled) {
+                    stringResource(R.string.reader_typography_own_on)
+                } else {
+                    stringResource(R.string.reader_typography_own_off)
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(checked = enabled, onCheckedChange = onChanged)
     }
 }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/TypographySheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/TypographySheet.kt
@@ -92,8 +92,8 @@ fun TypographySheet(
                 enabled = keepScreenOn,
                 onChanged = onKeepScreenOnChanged,
             )
-            // Last, and always: what is behind it applies to every book,
-            // read either way, so it can no longer open an empty sheet.
+            // Last, and always. The sheet behind it has rows for any
+            // book, read either way, so it can no longer open empty.
             AdvancedRow(onClick = onOpenAdvanced)
         }
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/TypographySheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/TypographySheet.kt
@@ -25,8 +25,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.chmouel.liseur.R
-import com.chmouel.liseur.data.settings.ColumnMode
-import com.chmouel.liseur.data.settings.FooterMode
 import com.chmouel.liseur.data.settings.ReaderFont
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.ReaderTheme
@@ -35,42 +33,36 @@ import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.reading.ReadingBrightnessSlider
 import com.chmouel.liseur.ui.reading.ReadingFontDropdown
 import com.chmouel.liseur.ui.reading.ReadingFontSizeSlider
-import com.chmouel.liseur.ui.reading.ReadingFooterModeDropdown
-import com.chmouel.liseur.ui.reading.ReadingLayoutControls
-import com.chmouel.liseur.ui.reading.ReadingPageTurnAnimationToggle
 import com.chmouel.liseur.ui.reading.ReadingThemeRow
 import com.chmouel.liseur.ui.windowWidth
 
 /**
- * Kindle-style "Aa" sheet: reading theme, font, size, brightness
- * and layout, applied live as they change.
+ * Kindle-style "Aa" sheet: reading theme, font, size and brightness,
+ * applied live as they change.
  *
  * The controls themselves live in `ui/reading`, because Settings shows
  * the same ones on a screen of its own. This sheet is the quick path to
- * them with a book open, and adds the three answers that only make
- * sense with one: scrolling, the screen, and setting this book apart.
+ * them with a book open, and adds the two answers that only make sense
+ * with one: how the book is read, and whether the screen stays awake for
+ * it.
+ *
+ * It is deliberately short. Everything a reader sets once, if ever, is a
+ * tap further in, behind the Advanced row at the bottom — see
+ * `docs/adr/0001-advanced-reading-menu.md`.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TypographySheet(
     prefs: ReaderPrefs,
     readingTheme: ReaderTheme,
-    typographyIsOwn: Boolean,
-    onTypographyIsOwnChanged: (Boolean) -> Unit,
     onFontSelected: (ReaderFont) -> Unit,
     onFontSizeChanged: (Double) -> Unit,
     onThemeSelected: (ReaderThemeChoice) -> Unit,
-    onLineHeightChanged: (Double?) -> Unit,
-    onPageMarginsChanged: (Double?) -> Unit,
     onBrightnessChanged: (Float?) -> Unit,
-    onPageTurnAnimationChanged: (Boolean) -> Unit,
-    onFooterModeChanged: (FooterMode) -> Unit,
-    onColumnModeChanged: (ColumnMode) -> Unit,
     keepScreenOn: Boolean,
     onKeepScreenOnChanged: (Boolean) -> Unit,
     scrollMode: Boolean,
     onScrollModeChanged: (Boolean) -> Unit,
-    advancedOffered: Boolean,
     onOpenAdvanced: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -92,48 +84,17 @@ fun TypographySheet(
             ReadingFontSizeSlider(value = prefs.fontSize, onChanged = onFontSizeChanged)
             ReadingBrightnessSlider(value = prefs.brightness, onChanged = onBrightnessChanged)
             ReadingFontDropdown(selected = prefs.font, onSelected = onFontSelected)
-            ReadingLayoutControls(
-                lineHeight = prefs.lineHeight,
-                pageMargins = prefs.pageMargins,
-                columnMode = prefs.columnMode,
-                // A scrolled chapter is one running column, so the count
-                // has nothing to divide and the control would take a tap
-                // and change nothing.
-                showColumns = !scrollMode,
-                onLineHeightChanged = onLineHeightChanged,
-                onPageMarginsChanged = onPageMarginsChanged,
-                onColumnModeChanged = onColumnModeChanged,
-            )
-            ReadingFooterModeDropdown(
-                selected = prefs.footerMode,
-                onSelected = onFooterModeChanged,
-            )
             ScrollModeToggle(
                 enabled = scrollMode,
                 onChanged = onScrollModeChanged,
             )
-            // Nothing lifts off the screen when the text is scrolled, so
-            // the animation has no page to describe.
-            if (!scrollMode) {
-                ReadingPageTurnAnimationToggle(
-                    enabled = prefs.pageTurnAnimation,
-                    onChanged = onPageTurnAnimationChanged,
-                )
-            }
             KeepScreenOnToggle(
                 enabled = keepScreenOn,
                 onChanged = onKeepScreenOnChanged,
             )
-            JustThisBookToggle(
-                enabled = typographyIsOwn,
-                onChanged = onTypographyIsOwnChanged,
-            )
-            // Last, and only when there is something behind it. An
-            // Advanced row that opens an empty sheet is worse than no
-            // row at all.
-            if (advancedOffered) {
-                AdvancedRow(onClick = onOpenAdvanced)
-            }
+            // Last, and always: what is behind it applies to every book,
+            // read either way, so it can no longer open an empty sheet.
+            AdvancedRow(onClick = onOpenAdvanced)
         }
     }
 }
@@ -226,40 +187,5 @@ private fun KeepScreenOnToggle(enabled: Boolean, onChanged: (Boolean) -> Unit) {
             )
         }
         Switch(checked = enabled, onCheckedChange = null)
-    }
-}
-
-/**
- * Sets the book apart from the shared reading settings.
- *
- * Last in the sheet, and only about the four settings above it that are
- * genuinely the book's: what it is set in, how big, how open, how wide.
- * The theme and the brightness are about the room, so they carry on
- * being shared however this is left.
- */
-@Composable
-private fun JustThisBookToggle(enabled: Boolean, onChanged: (Boolean) -> Unit) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable { onChanged(!enabled) },
-    ) {
-        Column(Modifier.weight(1f)) {
-            Text(
-                text = stringResource(R.string.reader_typography_own),
-                style = MaterialTheme.typography.bodyLarge,
-            )
-            Text(
-                text = if (enabled) {
-                    stringResource(R.string.reader_typography_own_on)
-                } else {
-                    stringResource(R.string.reader_typography_own_off)
-                },
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-        Switch(checked = enabled, onCheckedChange = onChanged)
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
@@ -1,5 +1,12 @@
 package com.chmouel.liseur.ui.settings
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -20,9 +27,14 @@ import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -39,6 +51,7 @@ import com.chmouel.liseur.data.settings.ReaderFont
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.ReaderTheme
 import com.chmouel.liseur.data.settings.ReaderThemeChoice
+import com.chmouel.liseur.ui.LocalEInk
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.reading.ReadingBrightnessSlider
 import com.chmouel.liseur.ui.reading.ReadingFontDropdown
@@ -119,25 +132,13 @@ fun ReadingAppearanceScreen(
                 ReadingFontSizeSlider(value = prefs.fontSize, onChanged = onFontSize)
                 ReadingBrightnessSlider(value = prefs.brightness, onChanged = onBrightness)
                 ReadingFontDropdown(selected = prefs.font, onSelected = onFont)
-                ReadingLayoutControls(
-                    lineHeight = prefs.lineHeight,
-                    pageMargins = prefs.pageMargins,
-                    columnMode = prefs.columnMode,
-                    // Unlike the sheet, there is no book here to be
-                    // scrolled, so the count always has something to
-                    // divide and the control is always worth offering.
-                    showColumns = true,
-                    onLineHeightChanged = onLineHeight,
-                    onPageMarginsChanged = onPageMargins,
-                    onColumnModeChanged = onColumnMode,
-                )
-                ReadingFooterModeDropdown(
-                    selected = prefs.footerMode,
-                    onSelected = onFooterMode,
-                )
-                ReadingPageTurnAnimationToggle(
-                    enabled = prefs.pageTurnAnimation,
-                    onChanged = onPageTurnAnimation,
+                AdvancedSection(
+                    prefs = prefs,
+                    onLineHeight = onLineHeight,
+                    onPageMargins = onPageMargins,
+                    onColumnMode = onColumnMode,
+                    onFooterMode = onFooterMode,
+                    onPageTurnAnimation = onPageTurnAnimation,
                 )
                 Text(
                     text = stringResource(R.string.settings_reading_appearance_detail),
@@ -145,6 +146,66 @@ fun ReadingAppearanceScreen(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
+        }
+    }
+}
+
+/**
+ * The same split the reader sees, on the screen that has no book.
+ *
+ * What is behind the "Aa" sheet's Advanced row is behind this too, in
+ * the same order: a reader who learned where the margins live in one
+ * place should not have to learn it again in the other. See
+ * `docs/adr/0001-advanced-reading-menu.md`.
+ */
+@Composable
+private fun AdvancedSection(
+    prefs: ReaderPrefs,
+    onLineHeight: (Double?) -> Unit,
+    onPageMargins: (Double?) -> Unit,
+    onColumnMode: (ColumnMode) -> Unit,
+    onFooterMode: (FooterMode) -> Unit,
+    onPageTurnAnimation: (Boolean) -> Unit,
+) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+
+    TextButton(onClick = { expanded = !expanded }) {
+        Text(
+            stringResource(
+                if (expanded) R.string.reading_hide_advanced else R.string.reading_show_advanced,
+            ),
+        )
+    }
+    // Sliding this open on electronic paper is a full repaint of the
+    // lower half of the screen for every frame; it is the same list
+    // either way, so it simply appears.
+    val eInk = LocalEInk.current
+    AnimatedVisibility(
+        visible = expanded,
+        enter = if (eInk) EnterTransition.None else fadeIn() + expandVertically(),
+        exit = if (eInk) ExitTransition.None else fadeOut() + shrinkVertically(),
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+            ReadingLayoutControls(
+                lineHeight = prefs.lineHeight,
+                pageMargins = prefs.pageMargins,
+                columnMode = prefs.columnMode,
+                // Unlike the sheet, there is no book here to be
+                // scrolled, so the count always has something to
+                // divide and the control is always worth offering.
+                showColumns = true,
+                onLineHeightChanged = onLineHeight,
+                onPageMarginsChanged = onPageMargins,
+                onColumnModeChanged = onColumnMode,
+            )
+            ReadingFooterModeDropdown(
+                selected = prefs.footerMode,
+                onSelected = onFooterMode,
+            )
+            ReadingPageTurnAnimationToggle(
+                enabled = prefs.pageTurnAnimation,
+                onChanged = onPageTurnAnimation,
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
@@ -172,7 +172,7 @@ private fun AdvancedSection(
     TextButton(onClick = { expanded = !expanded }) {
         Text(
             stringResource(
-                if (expanded) R.string.reading_hide_advanced else R.string.reading_show_advanced,
+                if (expanded) R.string.reader_hide_advanced else R.string.reader_advanced,
             ),
         )
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
@@ -153,9 +153,14 @@ fun ReadingAppearanceScreen(
 /**
  * The same split the reader sees, on the screen that has no book.
  *
- * What is behind the "Aa" sheet's Advanced row is behind this too, in
- * the same order: a reader who learned where the margins live in one
- * place should not have to learn it again in the other. See
+ * The shared settings behind the "Aa" sheet's Advanced row are behind
+ * this too, in the same order: a reader who learned where the margins
+ * live in one place should not have to learn it again in the other.
+ *
+ * Only the shared ones. The rest of that sheet has no meaning here —
+ * auto-scroll needs a page that is running, and setting a book apart
+ * needs a book — so this holds the layout controls, the footer mode and
+ * the page-turn animation, and nothing else. See
  * `docs/adr/0001-advanced-reading-menu.md`.
  */
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -433,6 +433,8 @@
     <string name="reader_typography_own_on">Font, size and layout stay with this book.</string>
     <string name="reader_typography_own_off">Font, size and layout are shared with every book.</string>
     <string name="reader_advanced">Advanced</string>
+    <string name="reading_show_advanced">Advanced</string>
+    <string name="reading_hide_advanced">Hide advanced</string>
     <string name="reader_auto_scroll">Scroll the page for me</string>
     <string name="reader_auto_scroll_detail">The page carries itself along, and the screen stays awake. Touch it to stop, touch it again to carry on.</string>
     <string name="reader_auto_scroll_speed">Scrolling speed</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -433,8 +433,7 @@
     <string name="reader_typography_own_on">Font, size and layout stay with this book.</string>
     <string name="reader_typography_own_off">Font, size and layout are shared with every book.</string>
     <string name="reader_advanced">Advanced</string>
-    <string name="reading_show_advanced">Advanced</string>
-    <string name="reading_hide_advanced">Hide advanced</string>
+    <string name="reader_hide_advanced">Hide advanced</string>
     <string name="reader_auto_scroll">Scroll the page for me</string>
     <string name="reader_auto_scroll_detail">The page carries itself along, and the screen stays awake. Touch it to stop, touch it again to carry on.</string>
     <string name="reader_auto_scroll_speed">Scrolling speed</string>

--- a/docs/adr/0001-advanced-reading-menu.md
+++ b/docs/adr/0001-advanced-reading-menu.md
@@ -52,10 +52,35 @@ first, not a navigation destination: dismissing it lands back on the
 typography sheet, and dismissing that lands back on the page.
 
 It exists as of auto-scroll ([ADR 6](0006-auto-scroll.md)), which was
-the first of the five to be built and so brought the sheet with it. It
-holds that one row, and the **Advanced** row that opens it is hidden
-when it would be empty — today, in a book read by turning pages. The
+the first of the five to be built and so brought the sheet with it. The
 other four arrive with their own issues.
 
+The typography sheet did grow anyway, one reasonable row at a time,
+until it carried eleven controls and the Advanced row held one. Six of
+them have since moved behind Advanced — line height, page margins,
+columns, the footer mode, the page-turn animation and the
+just-this-book toggle — leaving the first sheet the five answers a
+reader changes often: the theme, the size, the light, the face, and
+whether the book is read by scrolling or by turning pages. Keeping the
+screen awake stays there too, being a thing a reader reaches for
+mid-chapter.
+
+The Advanced row is no longer conditional. It was hidden in a paginated
+book while auto-scroll was all that lived behind it, because the way in
+to an empty sheet is worse than no way in; with six more rows there, it
+cannot be empty. The rows that do not apply still hide themselves —
+auto-scroll only in a scrolled book, the page-turn animation only in a
+paginated one, columns only when there is width for two.
+
+Settings → Reading appearance shows the same controls without a book,
+so it carries the same split: the six live behind a collapsed
+**Advanced** section there. A reader who learned where the margins are
+in one place does not have to learn it again in the other.
+
+New reading settings default to Advanced. `AGENTS.md` carries that as a
+convention, so the next reasonable row has to argue its way onto the
+first sheet rather than simply land there.
+
 *Where:* `reader/chrome/TypographySheet.kt`,
-`reader/chrome/AdvancedSheet.kt`.
+`reader/chrome/AdvancedSheet.kt`,
+`ui/settings/ReadingAppearanceScreen.kt`.

--- a/docs/adr/0002-typography-fine-tuning.md
+++ b/docs/adr/0002-typography-fine-tuning.md
@@ -50,4 +50,4 @@ the row does not promise otherwise.
 
 *Where:* `data/settings/ReaderPrefs.kt`,
 `data/settings/ReaderPreferencesRepository.kt`,
-`reader/ReaderPreferencesMapper.kt`, `reader/chrome/TypographySheet.kt`.
+`reader/ReaderPreferencesMapper.kt`, `reader/chrome/AdvancedSheet.kt`.


### PR DESCRIPTION
## Summary

The typography sheet was meant to stay the handful of answers a reader changes often, with everything rarer a tap further in behind Advanced. It grew to eleven controls anyway, one reasonable row at a time, while the Advanced sheet it was supposed to feed held exactly one row.

Six controls move across. `AGENTS.md` gains the rule that stops it happening again: a new reading setting lands in Advanced unless there is a case for the first sheet.

## Changes

- Move line height, page margins, columns, footer mode, page-turn animation and the just-this-book toggle from `TypographySheet` into `AdvancedSheet`.
- Leave the "Aa" sheet with the theme, size, brightness, font, how the book is read, and whether the screen stays awake for it.
- Drop `advancedOffered`. The row was hidden in a paginated book because auto-scroll was all that lived behind it, and the way in to an empty sheet is worse than no way in. With six more rows there it cannot be empty. Rows that do not apply still hide themselves: auto-scroll only when scrolled, the animation only when paginated, columns only when there is width for two.
- Mirror the split on Settings, Reading appearance, behind a collapsed Advanced section that does not animate on electronic paper.
- Add the default-to-Advanced convention to `AGENTS.md`, rewrite the Consequences of ADR 0001, and repoint ADR 0002 at `AdvancedSheet.kt`.

No preference, persistence or mapper change. `ReaderPrefs`, DataStore and `ReaderPreferencesMapper` are untouched, and per-book typography covers exactly the fields it did before.

## Testing

- [x] `./gradlew testDebugUnitTest` (1360 tests, 0 failures)
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on an emulator

## Screenshots or recordings

| The "Aa" sheet | Advanced | Settings, Reading appearance |
| --- | --- | --- |
| ![Aa sheet](https://github.com/user-attachments/assets/4c71c45e-cf0f-4322-b9b4-faabc81dd075) | ![Advanced sheet](https://github.com/user-attachments/assets/8fc09e03-b8ca-4f0f-a1b0-19bfb349f5c5) | ![Settings](https://github.com/user-attachments/assets/89f69d5a-2edc-4306-829c-7fa407620438) |

The whole "Aa" sheet now fits on one screen without scrolling. Columns and auto-scroll are absent from the Advanced shot because this is a phone reading a paginated book, which is the gating working.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

