### PR TITLE
fix(reader): stop a chapter jump bouncing back to where it came from

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -189,6 +189,13 @@ private const val SELECTION_SETTLE_MS = 90L
 // stopped is worse than a page that stops early.
 private const val CHAPTER_ARRIVAL_MS = 5_000L
 
+// How long the wide-content fit waits for the navigator to publish a
+// position naming the resource it is about to fit. Readium reports
+// having moved a moment after the page is on screen, so this is
+// normally over in a frame or two; it is bounded because a fit is worth
+// applying even when the position it would restore never arrives.
+private const val ANCHOR_ARRIVAL_MS = 2_000L
+
 // The look the last lines of a chapter get before the page moves on,
 // however fast or slow the reader has it set.
 private const val MIN_CHAPTER_DWELL_MS = 400L
@@ -792,15 +799,42 @@ fun ReaderScreen(
             val web = visibleWebView(root) ?: return@collect
             if (web === fitted) return@collect
             fitted = web
+            // Which position to come back to, decided before the reflow
+            // scope opens: the wait below is not a reflow, and holding
+            // the scope through it would read a page the reader turned
+            // in the meantime as text moving under them.
+            //
+            // The anchor is taken from the navigator rather than from
+            // reflowAnchor: that one belongs to a run of preference
+            // changes in the resource being left, and restoring to it
+            // would carry the reader back out of the one they just
+            // turned into.
+            //
+            // For the same reason it is taken only once the navigator's
+            // position names the resource this web view is showing.
+            // Readium puts a resource on screen before it publishes
+            // having moved to it, so the position on hand can still be
+            // the one the reader left — and restoring to that sends
+            // them back to it, which makes the resource they came from
+            // the newly visible one and starts the whole thing over.
+            // The saved position says nothing about that ping-pong,
+            // because a reflow does not persist, until the next page
+            // turn publishes wherever it came to rest.
+            val here = withTimeoutOrNull(ANCHOR_ARRIVAL_MS) {
+                nav.currentLocator.first {
+                    ResourceAddress.shows(web.url, it.href.toString())
+                }
+            }
             reflow.within {
-                // The anchor is captured here rather than taken from
-                // reflowAnchor: that one belongs to a run of preference
-                // changes in the resource being left, and restoring to it
-                // would carry the reader back out of the one they just
-                // turned into.
-                val anchor = capture(nav, nav.currentLocator.value)
+                // A position that never arrives leaves the fit to be
+                // applied without one. Fitting moves the text a little;
+                // restoring the wrong chapter moves the reader out of
+                // the chapter they are in.
+                val anchor = here?.let { capture(nav, it) }
                 val before = ExactLocatorAnchor.layoutSignature(nav)
-                if (WideContentFit.apply(nav) == WideContentFit.Result.CHANGED) {
+                if (WideContentFit.apply(nav) == WideContentFit.Result.CHANGED &&
+                    anchor != null
+                ) {
                     awaitReflowSettled(nav, before)
                     navigate(
                         nav = nav,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -826,22 +826,27 @@ fun ReaderScreen(
                 }
             }
             reflow.within {
-                // A position that never arrives leaves the fit to be
-                // applied without one. Fitting moves the text a little;
-                // restoring the wrong chapter moves the reader out of
-                // the chapter they are in.
                 val anchor = here?.let { capture(nav, it) }
                 val before = ExactLocatorAnchor.layoutSignature(nav)
-                if (WideContentFit.apply(nav) == WideContentFit.Result.CHANGED &&
-                    anchor != null
-                ) {
+                if (WideContentFit.apply(nav) == WideContentFit.Result.CHANGED) {
+                    // Settled before the scope closes whether or not
+                    // there is an anchor: the text the fit moved
+                    // reports where it came to rest either way, and
+                    // outside the scope that reads as a page the reader
+                    // turned.
                     awaitReflowSettled(nav, before)
-                    navigate(
-                        nav = nav,
-                        locator = anchor,
-                        event = NavigatorPositionEvent.PREFERENCE_REFLOW,
-                        verify = true,
-                    )
+                    // A position that never arrived leaves the fit
+                    // applied without one. Fitting moves the text a
+                    // little; restoring the wrong chapter moves the
+                    // reader out of the chapter they are in.
+                    if (anchor != null) {
+                        navigate(
+                            nav = nav,
+                            locator = anchor,
+                            event = NavigatorPositionEvent.PREFERENCE_REFLOW,
+                            verify = true,
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -825,8 +825,19 @@ fun ReaderScreen(
                     ResourceAddress.shows(web.url, it.href.toString())
                 }
             }
+            // Whether the resource this run is for is still the one on
+            // screen and the one the navigator names. Waiting above and
+            // taking the scope below are both places the reader can
+            // turn a page, and everything after them speaks to the
+            // document in front of them: a capture takes its words from
+            // it, a restore puts the reader back into it. Asked again
+            // rather than assumed, at each point where the answer could
+            // have changed.
+            fun stillFitting(): Boolean =
+                web === visibleWebView(root) &&
+                    ResourceAddress.shows(web.url, nav.currentLocator.value.href.toString())
             reflow.within {
-                val anchor = here?.let { capture(nav, it) }
+                val anchor = here?.takeIf { stillFitting() }?.let { capture(nav, it) }
                 val before = ExactLocatorAnchor.layoutSignature(nav)
                 if (WideContentFit.apply(nav) == WideContentFit.Result.CHANGED) {
                     // Settled before the scope closes whether or not
@@ -835,11 +846,12 @@ fun ReaderScreen(
                     // outside the scope that reads as a page the reader
                     // turned.
                     awaitReflowSettled(nav, before)
-                    // A position that never arrived leaves the fit
-                    // applied without one. Fitting moves the text a
-                    // little; restoring the wrong chapter moves the
-                    // reader out of the chapter they are in.
-                    if (anchor != null) {
+                    // A position that never arrived, or one the reader
+                    // has since left, leaves the fit applied without a
+                    // restore. Fitting moves the text a little;
+                    // restoring the wrong chapter moves the reader out
+                    // of the chapter they are in.
+                    if (anchor != null && stillFitting()) {
                         navigate(
                             nav = nav,
                             locator = anchor,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ResourceAddress.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ResourceAddress.kt
@@ -1,0 +1,66 @@
+package com.chmouel.liseur.reader
+
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+
+/**
+ * Whether a web view is showing the resource a locator names.
+ *
+ * Readium lays a resource out and puts it on screen before it publishes
+ * having moved to it, so the position on hand can still name the
+ * resource the reader has just left. Anything that captures a place to
+ * come back to has to know which of the two it is holding, because
+ * restoring a position belonging to the previous resource carries the
+ * reader back out of the chapter they turned into.
+ *
+ * Readium serves each resource from `https://readium_package/<href>`,
+ * where the href is the publication-relative one a locator carries. So
+ * the two are compared as paths: the origin dropped when there is one,
+ * the query and the fragment dropped from either side, and percent
+ * escapes resolved, because a spelling difference in a filename with a
+ * space in it is not a difference in resource.
+ */
+internal object ResourceAddress {
+    /** True when [webUrl] addresses the resource [href] names. */
+    fun shows(webUrl: String?, href: String): Boolean {
+        val shown = path(webUrl) ?: return false
+        val named = path(href) ?: return false
+        return shown == named
+    }
+
+    private fun path(raw: String?): String? {
+        val address = raw?.substringBefore('#')?.substringBefore('?')?.trim() ?: return null
+        if (address.isEmpty()) return null
+        val origin = address.indexOf("://")
+        val path = if (origin < 0) {
+            address
+        } else {
+            address.substring(origin + 3).substringAfter('/', "")
+        }
+        return decode(path).trimStart('/').takeIf { it.isNotEmpty() }
+    }
+
+    /**
+     * Percent decoding, rather than `URLDecoder`, which reads `+` as a
+     * space: that is form encoding, and a book is free to ship a file
+     * whose name has a plus in it.
+     */
+    private fun decode(value: String): String {
+        if (!value.contains('%')) return value
+        val bytes = ByteArrayOutputStream(value.length)
+        var i = 0
+        while (i < value.length) {
+            val escape = value.getOrNull(i)
+                ?.takeIf { it == '%' && i + 2 < value.length }
+                ?.let { value.substring(i + 1, i + 3).toIntOrNull(16) }
+            if (escape != null) {
+                bytes.write(escape)
+                i += 3
+            } else {
+                bytes.write(value[i].toString().toByteArray(StandardCharsets.UTF_8))
+                i++
+            }
+        }
+        return bytes.toString(StandardCharsets.UTF_8.name())
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/ResourceAddressTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/ResourceAddressTest.kt
@@ -1,0 +1,128 @@
+package com.chmouel.liseur.reader
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ResourceAddressTest {
+    @Test
+    fun `readium package url matches the href it serves`() {
+        assertTrue(
+            ResourceAddress.shows(
+                "https://readium_package/epub/text/chapter-81.xhtml",
+                "epub/text/chapter-81.xhtml",
+            ),
+        )
+    }
+
+    @Test
+    fun `a different resource does not match`() {
+        assertFalse(
+            ResourceAddress.shows(
+                "https://readium_package/epub/text/chapter-1.xhtml",
+                "epub/text/chapter-81.xhtml",
+            ),
+        )
+    }
+
+    @Test
+    fun `a fragment on either side is not part of the resource`() {
+        assertTrue(
+            ResourceAddress.shows(
+                "https://readium_package/OPS/book.xhtml#p42",
+                "OPS/book.xhtml",
+            ),
+        )
+        assertTrue(
+            ResourceAddress.shows(
+                "https://readium_package/OPS/book.xhtml",
+                "OPS/book.xhtml#p42",
+            ),
+        )
+    }
+
+    @Test
+    fun `a query string is not part of the resource`() {
+        assertTrue(
+            ResourceAddress.shows(
+                "https://readium_package/OPS/book.xhtml?v=2",
+                "OPS/book.xhtml",
+            ),
+        )
+    }
+
+    @Test
+    fun `a percent escaped name is the name it stands for`() {
+        assertTrue(
+            ResourceAddress.shows(
+                "https://readium_package/OPS/chapter%20one.xhtml",
+                "OPS/chapter one.xhtml",
+            ),
+        )
+        assertTrue(
+            ResourceAddress.shows(
+                "https://readium_package/OPS/caf%C3%A9.xhtml",
+                "OPS/café.xhtml",
+            ),
+        )
+    }
+
+    @Test
+    fun `a plus stays a plus`() {
+        assertTrue(
+            ResourceAddress.shows(
+                "https://readium_package/OPS/a+b.xhtml",
+                "OPS/a+b.xhtml",
+            ),
+        )
+        assertFalse(
+            ResourceAddress.shows(
+                "https://readium_package/OPS/a+b.xhtml",
+                "OPS/a b.xhtml",
+            ),
+        )
+    }
+
+    @Test
+    fun `a stray percent is left alone rather than swallowing the name`() {
+        assertTrue(
+            ResourceAddress.shows(
+                "https://readium_package/OPS/100%.xhtml",
+                "OPS/100%.xhtml",
+            ),
+        )
+    }
+
+    @Test
+    fun `a leading slash on the href is not a difference`() {
+        assertTrue(
+            ResourceAddress.shows(
+                "https://readium_package/OPS/book.xhtml",
+                "/OPS/book.xhtml",
+            ),
+        )
+    }
+
+    @Test
+    fun `no url at all shows nothing`() {
+        assertFalse(ResourceAddress.shows(null, "OPS/book.xhtml"))
+        assertFalse(ResourceAddress.shows("", "OPS/book.xhtml"))
+        assertFalse(ResourceAddress.shows("about:blank", "OPS/book.xhtml"))
+    }
+
+    @Test
+    fun `the origin alone names no resource`() {
+        assertFalse(ResourceAddress.shows("https://readium_package/", "OPS/book.xhtml"))
+        assertFalse(ResourceAddress.shows("https://readium_package/OPS/book.xhtml", ""))
+    }
+
+    @Test
+    fun `a resource served from elsewhere still matches on its path`() {
+        assertTrue(
+            ResourceAddress.shows(
+                "http://127.0.0.1:8080/pub/OPS/book.xhtml",
+                "pub/OPS/book.xhtml",
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #84. Tapping a contents entry for a chapter far from the one on screen rendered the destination, saved it and published it, and then quietly put the reader back where they started. The next page turn carried on from there and published that too, so every device saw the reader jump and immediately snap back.

The wide-content fit is what moved them. It runs once per resource that gets laid out, and captures the position to come back to before fitting, because fitting a table moves the text. It captured that position from the navigator's current locator — but Readium puts a resource on screen before it publishes having moved to it, so the locator on hand still named the chapter being left. Fitting the new chapter restored a position from the old one, which made the old chapter the newly visible resource, which fitted it and restored a position from the new one.

Instrumented log of the failing jump, chapter 1 tapped while chapter 81 was on screen:

```
navigate LOCAL_JUMP        -> chapter-1
webUrl=chapter-1   locator=chapter-81
navigate PREFERENCE_REFLOW -> chapter-81
webUrl=chapter-81  locator=chapter-1
navigate PREFERENCE_REFLOW -> chapter-1
... five round trips, coming to rest on chapter-81
```

None of it reached the saved position, because a reflow does not persist, so the reader's place stayed where the jump had put it while the navigator sat somewhere else. Only the next page turn told the truth, and by then it read as going back.

## Changes

- `ResourceAddress`, a pure comparison of a web view's URL against the href a locator names. Readium serves each resource from `https://readium_package/<href>`, so the two are compared as paths with the origin, query and fragment dropped and percent escapes resolved.
- The wide-content fit takes its anchor only once the navigator's position names the resource the web view being fitted is showing, bounded by 2s. A position that never arrives leaves the fit to be applied without one: fitting moves the text a little, restoring the wrong chapter moves the reader out of the chapter they are in.
- The wait sits outside the reflow scope. Waiting is not reflowing, and a page turned meanwhile belongs to the reader, not the layout.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on emulator-5554 (liseur_phone_api36)

12 new tests in `ResourceAddressTest`, covering the escaped, plus-bearing, query and fragment forms, and the cases that must not match.

Device run, the exact reproduction from #84: cold open Moby Dick at 3.1%, contents, chapter CXXX. Position becomes 0.92040520984081, and three page turns take it to 0.923507126174085. Before this change one page turn took it to 0.4299, back at the opening chapter. The reverse jump, 83% to chapter I, likewise now advances 0.0289 -> 0.0303 -> 0.0318 instead of returning to 83%.

## Screenshots or recordings

None. The defect is in where the reader ends up, not in what a screen looks like; the position values above are the evidence.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.