### PR TITLE
feat: Redesign the reading stats screens

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/domain/ReadingStats.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/ReadingStats.kt
@@ -27,6 +27,8 @@ data class BookReadingStats(
     val sessions: Int = 0,
     /** How many of [sessions] no server has been told about yet. */
     val pendingSessions: Int = 0,
+    val coverPath: String? = null,
+    val coverUrl: String? = null,
 )
 
 /** How much was read on one day. */
@@ -116,6 +118,8 @@ data class StatsBook(
     val author: String?,
     val progression: Double?,
     val finished: Boolean,
+    val coverPath: String? = null,
+    val coverUrl: String? = null,
 )
 
 /** How many days of history the dashboard shows day by day by default. */
@@ -166,6 +170,8 @@ fun readingStats(
             finished = book?.finished == true,
             sessions = spans.size,
             pendingSessions = spans.count { !it.uploaded },
+            coverPath = book?.coverPath,
+            coverUrl = book?.coverUrl,
         )
     }.sortedWith(compareByDescending<BookReadingStats> { it.totalMs }.thenBy { it.title })
 

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/BookReadingStatsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/BookReadingStatsScreen.kt
@@ -1,28 +1,50 @@
 package com.chmouel.liseur.ui.stats
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.MenuBook
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material.icons.outlined.DateRange
+import androidx.compose.material.icons.outlined.HourglassBottom
+import androidx.compose.material.icons.outlined.Timer
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.chmouel.liseur.R
 import com.chmouel.liseur.data.liseursync.WorkInsights
 import com.chmouel.liseur.domain.BookReadingStats
@@ -36,10 +58,8 @@ import java.time.ZoneId
 import java.util.concurrent.TimeUnit
 
 /**
- * How much of one book has been read, and when it was last opened.
- *
- * Reached from the book's own long-press sheet, so it opens already
- * knowing which book is meant and never has to be searched for.
+ * Detailed reading metrics for an individual book with hero cover artwork
+ * and structured bento metrics.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -54,7 +74,12 @@ fun BookReadingStatsScreen(
         topBar = {
             TopAppBar(
                 title = {
-                    Text(title, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    Text(
+                        title,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        style = MaterialTheme.typography.titleMedium,
+                    )
                 },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
@@ -72,7 +97,7 @@ fun BookReadingStatsScreen(
                 .fillMaxSize()
                 .padding(padding),
             contentAlignment = if (state is BookReadingStatsUiState.Ready) {
-                Alignment.TopStart
+                Alignment.TopCenter
             } else {
                 Alignment.Center
             },
@@ -81,107 +106,289 @@ fun BookReadingStatsScreen(
                 BusyIndicator()
                 return@Box
             }
-            Column(
+            if (state is BookReadingStatsUiState.Empty) {
+                Surface(
+                    shape = RoundedCornerShape(20.dp),
+                    color = MaterialTheme.colorScheme.surfaceContainerLow,
+                    modifier = Modifier
+                        .widthIn(max = contentWidthCap(windowWidth()))
+                        .padding(24.dp),
+                ) {
+                    Column(
+                        modifier = Modifier.padding(28.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Text(
+                            text = stringResource(
+                                if (range == StatsRange.ALL_TIME) {
+                                    R.string.reading_stats_book_empty
+                                } else {
+                                    R.string.reading_stats_empty_range
+                                },
+                            ),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                }
+                return@Box
+            }
+            val stats = (state as BookReadingStatsUiState.Ready).stats
+            LazyColumn(
                 modifier = Modifier
                     .widthIn(max = contentWidthCap(windowWidth()))
-                    .padding(horizontal = 24.dp, vertical = 16.dp),
+                    .fillMaxSize(),
+                contentPadding = PaddingValues(horizontal = 20.dp, vertical = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                if (state is BookReadingStatsUiState.Empty) {
-                    Text(
-                        // A book excluded by the span the reader picked
-                        // has not gone unread; it has gone unread lately.
-                        text = stringResource(
-                            if (range == StatsRange.ALL_TIME) {
-                                R.string.reading_stats_book_empty
-                            } else {
-                                R.string.reading_stats_empty_range
-                            },
-                        ),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    return@Column
+                // Book Hero Header with Artwork
+                item {
+                    BookHeroHeader(stats = stats)
                 }
-                val stats = (state as BookReadingStatsUiState.Ready).stats
-                Text(
-                    text = stringResource(R.string.reading_stats_total),
-                    style = MaterialTheme.typography.labelLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Text(
-                    text = readingDuration(stats.totalMs),
-                    style = MaterialTheme.typography.displaySmall,
-                )
-                // The dashboard's span follows the reader here, so this
-                // total must name it. Without the caption the same book
-                // would appear to lose hours whenever the span narrowed.
-                Text(
-                    text = range.days(LocalDate.now())?.let {
-                        stringResource(R.string.reading_stats_in_last_days_local, it)
-                    } ?: stringResource(R.string.reading_stats_in_total),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(Modifier.height(20.dp))
-                Text(
-                    text = stringResource(
-                        R.string.reading_stats_last_read,
-                        Instant.ofEpochMilli(stats.lastReadAt)
-                            .atZone(ZoneId.systemDefault())
-                            .toLocalDate()
-                            .format(lastReadFormat()),
-                    ),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    text = if (stats.finished) {
-                        stringResource(R.string.state_finished)
-                    } else {
-                        stats.progression?.let {
-                            stringResource(
-                                R.string.reading_stats_progress,
-                                (it * 100).toInt(),
+
+                // Time Spent Feature Card
+                item {
+                    Surface(
+                        shape = RoundedCornerShape(20.dp),
+                        color = MaterialTheme.colorScheme.surfaceContainer,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Column(modifier = Modifier.padding(20.dp)) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Outlined.Timer,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(16.dp),
+                                    tint = MaterialTheme.colorScheme.primary,
+                                )
+                                Text(
+                                    text = stringResource(R.string.reading_stats_total).uppercase(),
+                                    style = MaterialTheme.typography.labelMedium.copy(
+                                        letterSpacing = 1.sp,
+                                        fontWeight = FontWeight.SemiBold,
+                                    ),
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                            Spacer(Modifier.height(8.dp))
+                            Text(
+                                text = readingDuration(stats.totalMs),
+                                style = MaterialTheme.typography.displaySmall.copy(
+                                    fontWeight = FontWeight.Bold,
+                                ),
+                                color = MaterialTheme.colorScheme.onSurface,
                             )
-                        }.orEmpty()
-                    },
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                // How the time was spent, not just how much of it. A book
-                // read in two long sittings and one read in forty short
-                // ones are different books to have read, and the total
-                // alone cannot tell them apart.
-                if (stats.sessions > 0) {
-                    Spacer(Modifier.height(4.dp))
-                    Text(
-                        text = if (stats.sessions == 1) {
-                            stringResource(R.string.reading_stats_book_sessions_one)
-                        } else {
-                            stringResource(R.string.reading_stats_book_sessions, stats.sessions)
-                        },
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                            Spacer(Modifier.height(8.dp))
+                            Surface(
+                                shape = RoundedCornerShape(8.dp),
+                                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                            ) {
+                                Text(
+                                    text = range.days(LocalDate.now())?.let {
+                                        stringResource(R.string.reading_stats_in_last_days_local, it)
+                                    } ?: stringResource(R.string.reading_stats_in_total),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                                )
+                            }
+                        }
+                    }
                 }
-                // Only ever shown when the server had one to give. It
-                // knows how fast this reader gets through books on every
-                // device, which this screen cannot work out on its own,
-                // and it answers null rather than guessing when it has
-                // nothing to divide by. That null is respected here: no
-                // estimate beats an invented one.
-                serverInsights?.etaSeconds?.let { seconds ->
-                    Spacer(Modifier.height(16.dp))
+
+                // 2x2 Bento Metric Tiles
+                item {
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            val lastDate = Instant.ofEpochMilli(stats.lastReadAt)
+                                .atZone(ZoneId.systemDefault())
+                                .toLocalDate()
+                                .format(lastReadFormat())
+                            BookMetricTile(
+                                icon = Icons.Outlined.DateRange,
+                                value = lastDate,
+                                label = stringResource(R.string.reading_stats_last_read_label),
+                                modifier = Modifier.weight(1f),
+                            )
+                            BookMetricTile(
+                                icon = Icons.AutoMirrored.Outlined.MenuBook,
+                                value = if (stats.sessions == 1) {
+                                    stringResource(R.string.reading_stats_book_sessions_one)
+                                } else {
+                                    stringResource(R.string.reading_stats_book_sessions, stats.sessions)
+                                },
+                                label = stringResource(R.string.reading_stats_sessions),
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+
+                        serverInsights?.etaSeconds?.let { seconds ->
+                            val etaText = readingDuration(TimeUnit.SECONDS.toMillis(seconds.toLong()))
+                            Surface(
+                                shape = RoundedCornerShape(16.dp),
+                                color = MaterialTheme.colorScheme.surfaceContainerLow,
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                Row(
+                                    modifier = Modifier.padding(16.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Outlined.HourglassBottom,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(24.dp),
+                                        tint = MaterialTheme.colorScheme.primary,
+                                    )
+                                    Column {
+                                        Text(
+                                            text = stringResource(R.string.reading_stats_time_left, etaText),
+                                            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                                            color = MaterialTheme.colorScheme.onSurface,
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BookHeroHeader(stats: BookReadingStats) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        StatsCoverThumbnail(
+            title = stats.title,
+            coverPath = stats.coverPath,
+            coverUrl = stats.coverUrl,
+            modifier = Modifier
+                .width(100.dp)
+                .height(150.dp),
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = stats.title,
+            style = MaterialTheme.typography.titleLarge.copy(
+                fontFamily = FontFamily.Serif,
+                fontWeight = FontWeight.Bold,
+            ),
+            textAlign = TextAlign.Center,
+        )
+        stats.author?.let { author ->
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = author,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+        Spacer(Modifier.height(12.dp))
+        if (stats.finished) {
+            Surface(
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.primaryContainer,
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Check,
+                        contentDescription = null,
+                        modifier = Modifier.size(14.dp),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
                     Text(
-                        text = stringResource(
-                            R.string.reading_stats_time_left,
-                            readingDuration(TimeUnit.SECONDS.toMillis(seconds.toLong())),
-                        ),
-                        style = MaterialTheme.typography.bodyLarge,
+                        text = stringResource(R.string.state_finished),
+                        style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
                     )
                 }
             }
+        } else if (stats.progression != null) {
+            Column(
+                modifier = Modifier.widthIn(max = 200.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                LinearProgressIndicator(
+                    progress = { stats.progression.toFloat() },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(6.dp)
+                        .clip(RoundedCornerShape(3.dp)),
+                    strokeCap = StrokeCap.Round,
+                )
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    text = stringResource(R.string.reading_stats_progress, (stats.progression * 100).toInt()),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BookMetricTile(
+    icon: ImageVector,
+    value: String,
+    label: String,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        modifier = modifier,
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodyLarge.copy(
+                    fontWeight = FontWeight.Bold,
+                ),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingHeatmap.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingHeatmap.kt
@@ -155,7 +155,7 @@ private fun HeatmapCell(day: ReadingDay?, busiest: Long) {
     Box(
         Modifier
             .size(CELL_SIZE)
-            .clip(RoundedCornerShape(2.dp))
+            .clip(RoundedCornerShape(3.dp))
             .background(
                 if (read) {
                     MaterialTheme.colorScheme.primary.copy(alpha = shade)
@@ -172,6 +172,6 @@ private fun DayOfWeek.initial(locale: java.util.Locale): String =
     getDisplayName(TextStyle.NARROW, locale).take(1)
 
 private const val DAYS_IN_WEEK = 7
-private val CELL_SIZE = 12.dp
-private val CELL_GAP = 3.dp
+private val CELL_SIZE = 13.dp
+private val CELL_GAP = 3.5.dp
 private val MONTH_ROW_HEIGHT = 16.dp

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
@@ -853,5 +853,3 @@ private fun EmptyStats(modifier: Modifier = Modifier, narrowedByRange: Boolean =
 internal fun lastReadFormat(): DateTimeFormatter = DateTimeFormatter
     .ofLocalizedDate(FormatStyle.MEDIUM)
     .withLocale(LocalLocale.current.platformLocale)
-
-    .withLocale(LocalLocale.current.platformLocale)

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
@@ -1,33 +1,46 @@
 package com.chmouel.liseur.ui.stats
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.MenuBook
+import androidx.compose.material.icons.outlined.AutoStories
+import androidx.compose.material.icons.outlined.CalendarMonth
 import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.DateRange
+import androidx.compose.material.icons.outlined.Speed
+import androidx.compose.material.icons.outlined.Timer
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -38,18 +51,30 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLocale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.SubcomposeAsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import com.chmouel.liseur.R
 import com.chmouel.liseur.domain.BookReadingStats
 import com.chmouel.liseur.domain.ReadingDay
 import com.chmouel.liseur.domain.ReadingStats
 import com.chmouel.liseur.domain.StatsRange
 import com.chmouel.liseur.ui.BusyIndicator
+import com.chmouel.liseur.ui.LocalEInk
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.windowWidth
 import java.time.LocalDate
@@ -57,14 +82,17 @@ import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.time.format.TextStyle
 import kotlin.math.roundToInt
+
 /**
  * What the reader has actually read, added up.
  *
- * Deliberately a small screen. The temptation with reading statistics
- * is to turn reading into a score — streaks to keep, targets to miss —
+ * The layout is a card grid now, but the rule behind it has not
+ * changed. The temptation with reading statistics is to turn reading
+ * into a score — streaks to keep, targets to miss, a best day to beat —
  * and a book people feel guilty about is a book they stop opening. So
- * this reports and does not grade: how long, which books, and which
- * days had reading in them.
+ * every tile here reports and none of them grades: no figure is
+ * singled out as an achievement, no day is drawn as a record, and the
+ * streak is a count of days like any other count.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -119,67 +147,623 @@ fun ReadingStatsScreen(
             )
             return@Scaffold
         }
-        LazyColumn(
-            modifier = Modifier
+        // Capped and centred, like every other screen in the app. A card
+        // stretched the width of a tablet puts its label and its figure
+        // a hand apart, and thirty bars across that width are a fence.
+        Box(
+            Modifier
                 .fillMaxSize()
                 .padding(padding),
-            contentPadding = androidx.compose.foundation.layout.PaddingValues(
-                start = 24.dp,
-                end = 24.dp,
-                bottom = 32.dp,
-            ),
+            contentAlignment = Alignment.TopCenter,
         ) {
-            item {
-                Headline(stats, ready.headline)
-                Spacer(Modifier.height(24.dp))
-            }
-            item {
-                // Bars while a day is still a readable unit, a grid once
-                // it is not. Both draw the same days; only the span the
-                // reader asked for decides which can be read.
-                val daily = ready.range.suitsDailyBars(LocalDate.now())
-                // "This past week" is only true when it is one. Thirty
-                // bars under that heading is the screen telling the
-                // reader something it can see is false.
-                SectionTitle(
-                    stringResource(
-                        if (daily && ready.range == StatsRange.LAST_7_DAYS) {
-                            R.string.reading_stats_recent
-                        } else {
-                            R.string.reading_stats_calendar
-                        },
-                    ),
-                )
-                if (daily) {
-                    WeekBars(stats.recent)
-                } else {
-                    ReadingHeatmap(stats.recent)
+            LazyColumn(
+                modifier = Modifier
+                    .widthIn(max = contentWidthCap(windowWidth()))
+                    .fillMaxSize(),
+                contentPadding = PaddingValues(
+                    start = 20.dp,
+                    end = 20.dp,
+                    bottom = 36.dp,
+                    top = 8.dp,
+                ),
+                verticalArrangement = Arrangement.spacedBy(20.dp),
+            ) {
+                item {
+                    BentoHero(stats, ready.headline)
                 }
-                Spacer(Modifier.height(24.dp))
-            }
-            item { SectionTitle(stringResource(R.string.reading_stats_by_book)) }
-            items(stats.books, key = { it.bookUrl }) { book ->
-                BookRow(book, onClick = { onOpenBook(book) })
+                item {
+                    ActivityCard(stats = stats, range = ready.range)
+                }
+                if (stats.books.isNotEmpty()) {
+                    item {
+                        BooksSectionHeader(count = stats.books.size)
+                    }
+                    items(stats.books, key = { it.bookUrl }) { book ->
+                        BookStatCard(book = book, onClick = { onOpenBook(book) })
+                    }
+                }
             }
         }
     }
 }
 
 /**
- * How far back to look.
+ * The numbers worth leading with, from wherever reading happened.
  *
- * A menu rather than a row of chips: six spans across a phone would
- * either wrap or shrink to initials, and this is a control the reader
- * touches rarely and deliberately, not one they sweep through.
+ * One figure, not one per device. When the sync server answered, the
+ * total is its count of every device for the span the reader chose;
+ * when it did not, the total is this device's own for the same span.
+ * The reader is never asked to reconcile two, and never sees their
+ * history shrink because they connected a server.
+ *
+ * The tallies are always present, whether or not a server answered.
+ * A row that changes shape depending on what a network call returned
+ * reads as a fault, and this device can count its own sittings, streak
+ * and pace perfectly well. Pace is the one that can genuinely be
+ * unknown — it needs sessions that recorded where in the book they
+ * happened, and the oldest ones did not — so it is left out entirely
+ * rather than shown as nought, which would read as a verdict on the
+ * reader.
+ *
+ * Laid out two to a row, in pairs, so a tile added or dropped rearranges
+ * the grid instead of leaving a hole in it.
+ */
+@Composable
+private fun BentoHero(stats: ReadingStats, headline: StatsHeadline) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        // The one figure the screen leads with.
+        Surface(
+            shape = RoundedCornerShape(20.dp),
+            color = MaterialTheme.colorScheme.surfaceContainer,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column(
+                modifier = Modifier.padding(20.dp),
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Timer,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    Text(
+                        text = stringResource(R.string.reading_stats_total).uppercase(),
+                        style = MaterialTheme.typography.labelMedium.copy(
+                            letterSpacing = 1.sp,
+                            fontWeight = FontWeight.SemiBold,
+                        ),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = readingDuration(headline.totalMs),
+                    style = MaterialTheme.typography.displaySmall.copy(
+                        fontWeight = FontWeight.Bold,
+                    ),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(Modifier.height(8.dp))
+                Surface(
+                    shape = RoundedCornerShape(8.dp),
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                ) {
+                    Text(
+                        text = headline.rangeDays?.let {
+                            stringResource(R.string.reading_stats_in_last_days, it)
+                        } ?: stringResource(R.string.reading_stats_in_total),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                    )
+                }
+            }
+        }
+
+        // Each tally keeps its own plain label. "Books finished" over a
+        // fraction would leave the reader guessing what the denominator
+        // counted, and the two are different facts: one is how many
+        // books had reading in them, the other how many were seen out.
+        val tiles = buildList {
+            add(
+                Tally(
+                    icon = Icons.Outlined.AutoStories,
+                    value = stats.booksRead.toString(),
+                    label = stringResource(R.string.reading_stats_books_read),
+                ),
+            )
+            add(
+                Tally(
+                    icon = Icons.Outlined.Check,
+                    value = stats.booksFinished.toString(),
+                    label = stringResource(R.string.reading_stats_books_finished),
+                ),
+            )
+            add(
+                Tally(
+                    icon = Icons.Outlined.CalendarMonth,
+                    value = headline.streakDays.toString(),
+                    label = stringResource(R.string.reading_stats_streak),
+                ),
+            )
+            add(
+                Tally(
+                    icon = Icons.AutoMirrored.Outlined.MenuBook,
+                    value = headline.sessions.toString(),
+                    label = stringResource(R.string.reading_stats_sessions),
+                ),
+            )
+            headline.progressionPerHour?.let { pace ->
+                add(
+                    Tally(
+                        icon = Icons.Outlined.Speed,
+                        value = stringResource(
+                            R.string.reading_stats_pace_value,
+                            (pace * 100).roundToInt(),
+                        ),
+                        label = stringResource(R.string.reading_stats_pace),
+                    ),
+                )
+            }
+        }
+        tiles.chunked(TILES_PER_ROW).forEach { row ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                row.forEach { tile ->
+                    BentoTile(
+                        icon = tile.icon,
+                        value = tile.value,
+                        label = tile.label,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+                // An odd tile last would otherwise stretch to the full
+                // width and read as more important than the four above.
+                repeat(TILES_PER_ROW - row.size) {
+                    Spacer(Modifier.weight(1f))
+                }
+            }
+        }
+    }
+}
+
+/** One figure and what it counts. */
+private data class Tally(val icon: ImageVector, val value: String, val label: String)
+
+/** How many tallies share a row. */
+private const val TILES_PER_ROW = 2
+
+@Composable
+private fun BentoTile(
+    icon: ImageVector,
+    value: String,
+    label: String,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        modifier = modifier,
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = value,
+                style = MaterialTheme.typography.titleLarge.copy(
+                    fontWeight = FontWeight.Bold,
+                ),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+    }
+}
+
+/**
+ * The chart, in a card with its own heading.
+ *
+ * Bars while a day is still a readable unit, a grid once it is not.
+ * Both draw the same days; only the span the reader asked for decides
+ * which can be read. "This past week" is only true when it is one —
+ * thirty bars under that heading is the screen telling the reader
+ * something it can see is false.
+ */
+@Composable
+private fun ActivityCard(stats: ReadingStats, range: StatsRange) {
+    val daily = range.suitsDailyBars(LocalDate.now())
+    Surface(
+        shape = RoundedCornerShape(18.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(
+            // Narrower at the sides than at the top and bottom: every dp
+            // taken off the width here comes out of the bars, and a
+            // month of them has none to spare.
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 16.dp),
+        ) {
+            Text(
+                text = stringResource(
+                    if (daily && range == StatsRange.LAST_7_DAYS) {
+                        R.string.reading_stats_recent
+                    } else {
+                        R.string.reading_stats_calendar
+                    },
+                ),
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(horizontal = 4.dp),
+            )
+            Spacer(Modifier.height(16.dp))
+            if (daily) {
+                WeekBars(stats.recent)
+            } else {
+                ReadingHeatmap(stats.recent)
+            }
+        }
+    }
+}
+
+/**
+ * A short span of reading, one bar a day.
+ *
+ * Bars rather than a line: a week is too few days for a line to mean
+ * anything, and a bar of nothing reads correctly as a day with no
+ * reading in it, which a line would smooth over.
+ *
+ * Every bar that has reading in it is drawn the same. Singling out the
+ * longest day would make the chart a scoreboard with a record to beat,
+ * and the height already says which day was the longest.
+ *
+ * The gap between bars narrows as they multiply, because the bars are
+ * weighted and the gaps are not: thirty-one fixed 8dp gaps eat almost
+ * the whole width of a phone and leave hatching where the chart was.
+ *
+ * Only some of the bars are captioned once there are more than a
+ * week of them. Three letters under a column a few millimetres wide
+ * wrap to one letter a line, which is not a label but a puzzle; a
+ * caption every seventh bar names the same weekday down the chart and
+ * lets the reader count from it.
+ */
+@Composable
+private fun WeekBars(days: List<ReadingDay>) {
+    val busiest = days.maxOfOrNull { it.totalMs }?.coerceAtLeast(1) ?: 1
+    // Read as observable state, so the letters change with the language
+    // rather than staying in whatever it was when the screen was built.
+    val locale = LocalLocale.current.platformLocale
+    // Counted back from the end so the last bar — today — is always one
+    // of the captioned ones.
+    val lastIndex = days.lastIndex
+    val everyBar = days.size <= DAYS_IN_WEEK
+    val gap = when {
+        days.size <= DAYS_IN_WEEK -> 8.dp
+        days.size <= DAYS_IN_WEEK * 2 -> 5.dp
+        days.size <= DAYS_IN_WEEK * 3 -> 3.dp
+        else -> 2.dp
+    }
+    // A 6dp radius on a bar 6dp wide is a lozenge, not a bar.
+    val corner = if (days.size <= DAYS_IN_WEEK) 6.dp else 2.dp
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(130.dp),
+        horizontalArrangement = Arrangement.spacedBy(gap),
+        verticalAlignment = Alignment.Bottom,
+    ) {
+        days.forEachIndexed { index, day ->
+            val captioned = everyBar || (lastIndex - index) % DAYS_IN_WEEK == 0
+            val amount = readingDuration(day.totalMs)
+            val weekday = day.date.dayOfWeek.getDisplayName(TextStyle.SHORT, locale)
+            val barHeight = if (day.totalMs > 0) {
+                (92.dp * (day.totalMs.toFloat() / busiest)).coerceAtLeast(8.dp)
+            } else {
+                4.dp
+            }
+            val spoken = if (day.totalMs > 0) {
+                stringResource(R.string.reading_stats_day_read, amount, weekday)
+            } else {
+                stringResource(R.string.reading_stats_no_reading_day, weekday)
+            }
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    // The bar and its letter are one fact, and read out
+                    // separately they are two thirds of a sentence.
+                    .clearAndSetSemantics { contentDescription = spoken },
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Bottom,
+            ) {
+                Box(
+                    Modifier
+                        .fillMaxWidth()
+                        // Heights must share the same scale. Weighting a
+                        // lone child inside each separate column makes
+                        // every bar fill its column and look identical.
+                        .height(barHeight)
+                        .clip(RoundedCornerShape(corner))
+                        .background(
+                            if (day.totalMs > 0) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.surfaceContainerHighest
+                            },
+                        ),
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = if (captioned) weekday else "",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    softWrap = false,
+                    overflow = TextOverflow.Visible,
+                )
+            }
+        }
+    }
+}
+
+/** Days in a week, and so the spacing of the bar chart's captions. */
+private const val DAYS_IN_WEEK = 7
+
+@Composable
+private fun BooksSectionHeader(count: Int) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 4.dp, bottom = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = stringResource(R.string.reading_stats_by_book),
+            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+        )
+        Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ) {
+            Text(
+                text = count.toString(),
+                style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+            )
+        }
+    }
+}
+
+/**
+ * Editorial card for an individual book's reading breakdown.
+ */
+@Composable
+private fun BookStatCard(book: BookReadingStats, onClick: () -> Unit) {
+    Surface(
+        shape = RoundedCornerShape(14.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Book Cover Thumbnail
+            StatsCoverThumbnail(
+                title = book.title,
+                coverPath = book.coverPath,
+                coverUrl = book.coverUrl,
+                modifier = Modifier
+                    .width(44.dp)
+                    .height(64.dp),
+            )
+            Spacer(Modifier.width(14.dp))
+            Column(
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = book.title,
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontFamily = FontFamily.Serif,
+                        fontWeight = FontWeight.SemiBold,
+                    ),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                book.author?.let { author ->
+                    Text(
+                        text = author,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Spacer(Modifier.height(6.dp))
+                if (book.finished) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Check,
+                            contentDescription = null,
+                            modifier = Modifier.size(14.dp),
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                        Text(
+                            text = stringResource(R.string.state_finished),
+                            style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Medium),
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                } else if (book.progression != null) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        LinearProgressIndicator(
+                            progress = { book.progression.toFloat() },
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(4.dp)
+                                .clip(RoundedCornerShape(2.dp)),
+                            strokeCap = StrokeCap.Round,
+                        )
+                        Text(
+                            text = stringResource(R.string.reading_stats_progress, (book.progression * 100).toInt()),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+            Spacer(Modifier.width(12.dp))
+            Column(
+                horizontalAlignment = Alignment.End,
+            ) {
+                Text(
+                    text = readingDuration(book.totalMs),
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                if (book.sessions > 0) {
+                    Text(
+                        text = if (book.sessions == 1) {
+                            stringResource(R.string.reading_stats_book_sessions_one)
+                        } else {
+                            stringResource(R.string.reading_stats_book_sessions, book.sessions)
+                        },
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Cover thumbnail for stats lists and headers.
+ */
+@Composable
+internal fun StatsCoverThumbnail(
+    title: String,
+    coverPath: String?,
+    coverUrl: String?,
+    modifier: Modifier = Modifier,
+) {
+    val artwork = coverPath ?: coverUrl
+    val shape = RoundedCornerShape(8.dp)
+    val borderModifier = modifier
+        .clip(shape)
+        .border(
+            BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.35f)),
+            shape,
+        )
+
+    if (artwork != null) {
+        val context = LocalContext.current
+        val eInk = LocalEInk.current
+        val request = remember(artwork, eInk, context) {
+            ImageRequest.Builder(context)
+                .data(artwork)
+                .crossfade(!eInk)
+                .build()
+        }
+        SubcomposeAsyncImage(
+            model = request,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = borderModifier,
+            error = { StatsCoverPlaceholder(title) },
+            loading = { StatsCoverPlaceholder(title) },
+        )
+    } else {
+        Box(modifier = borderModifier) {
+            StatsCoverPlaceholder(title)
+        }
+    }
+}
+
+@Composable
+private fun StatsCoverPlaceholder(title: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.7f)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.padding(4.dp),
+        ) {
+            Text(
+                text = title.take(2).uppercase(),
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = FontFamily.Serif,
+                ),
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+/**
+ * Dropdown menu for selecting stats time span.
  */
 @Composable
 private fun RangeMenu(selected: StatsRange, onSelect: (StatsRange) -> Unit) {
     var open by remember { mutableStateOf(false) }
     Box {
-        IconButton(onClick = { open = true }) {
+        FilledTonalButton(
+            onClick = { open = true },
+            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp),
+            modifier = Modifier.height(36.dp),
+        ) {
             Icon(
                 Icons.Outlined.DateRange,
                 contentDescription = stringResource(R.string.reading_stats_range),
+                modifier = Modifier.size(16.dp),
+            )
+            Spacer(Modifier.width(6.dp))
+            Text(
+                text = stringResource(selected.label),
+                style = MaterialTheme.typography.labelMedium,
             )
         }
         DropdownMenu(expanded = open, onDismissRequest = { open = false }) {
@@ -214,246 +798,46 @@ private val StatsRange.label: Int
         StatsRange.ALL_TIME -> R.string.reading_stats_range_all
     }
 
-/**
- * The numbers worth leading with, from wherever reading happened.
- *
- * One figure, not one per device. When the sync server answered, the
- * total is its count of every device for the span the reader chose;
- * when it did not, the total is this device's own for the same span.
- * The reader is never asked to reconcile two, and never sees their
- * history shrink because they connected a server.
- *
- * The tallies are always present, whether or not a server answered.
- * A row that changes shape depending on what a network call returned
- * reads as a fault, and this device can count its own sittings, streak
- * and pace perfectly well.
- */
-@Composable
-private fun Headline(stats: ReadingStats, headline: StatsHeadline) {
-    Column(Modifier.fillMaxWidth()) {
-        Text(
-            text = stringResource(R.string.reading_stats_total),
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Text(
-            text = readingDuration(headline.totalMs),
-            style = MaterialTheme.typography.displaySmall,
-        )
-        Text(
-            text = headline.rangeDays?.let {
-                stringResource(R.string.reading_stats_in_last_days, it)
-            } ?: stringResource(R.string.reading_stats_in_total),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Spacer(Modifier.height(12.dp))
-        // Wrapped rather than scrolled sideways. A row running off the
-        // edge hides a tally behind a gesture nothing suggests, and a
-        // half-drawn word at the margin reads as a fault rather than an
-        // invitation.
-        FlowRow(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(32.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Tally(stats.booksRead.toString(), stringResource(R.string.reading_stats_books_read))
-            Tally(
-                stats.booksFinished.toString(),
-                stringResource(R.string.reading_stats_books_finished),
-            )
-            Tally(headline.streakDays.toString(), stringResource(R.string.reading_stats_streak))
-            Tally(headline.sessions.toString(), stringResource(R.string.reading_stats_sessions))
-            // Pace is the one tally that can genuinely be unknown: it
-            // needs sessions that recorded where in the book they
-            // happened, and the oldest ones did not. An invented figure
-            // would be worse than a missing one.
-            headline.progressionPerHour?.let { pace ->
-                Tally(
-                    stringResource(R.string.reading_stats_pace_value, (pace * 100).roundToInt()),
-                    stringResource(R.string.reading_stats_pace),
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun Tally(value: String, label: String) {
-    Column {
-        Text(value, style = MaterialTheme.typography.headlineSmall)
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
-}
-
-@Composable
-private fun SectionTitle(text: String) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.titleMedium,
-        modifier = Modifier.padding(bottom = 8.dp),
-    )
-}
-
-/**
- * A short span of reading, one bar a day.
- *
- * Bars rather than a line: a week is too few days for a line to mean
- * anything, and a bar of nothing reads correctly as a day with no
- * reading in it, which a line would smooth over.
- *
- * Only some of the bars are captioned once there are more than a
- * week of them. Three letters under a column a few millimetres wide
- * wrap to one letter a line, which is not a label but a puzzle; a
- * caption every seventh bar names the same weekday down the chart and
- * lets the reader count from it.
- */
-@Composable
-private fun WeekBars(days: List<ReadingDay>) {
-    val busiest = days.maxOfOrNull { it.totalMs }?.coerceAtLeast(1) ?: 1
-    // Read as observable state, so the letters change with the language
-    // rather than staying in whatever it was when the screen was built.
-    val locale = LocalLocale.current.platformLocale
-    // Counted back from the end so the last bar — today — is always one
-    // of the captioned ones.
-    val lastIndex = days.lastIndex
-    val everyBar = days.size <= DAYS_IN_WEEK
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(120.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalAlignment = Alignment.Bottom,
-    ) {
-        days.forEachIndexed { index, day ->
-            val captioned = everyBar || (lastIndex - index) % DAYS_IN_WEEK == 0
-            val amount = readingDuration(day.totalMs)
-            val weekday = day.date.dayOfWeek.getDisplayName(TextStyle.SHORT, locale)
-            val barHeight = if (day.totalMs > 0) {
-                (88.dp * (day.totalMs.toFloat() / busiest)).coerceAtLeast(6.dp)
-            } else {
-                2.dp
-            }
-            val spoken = if (day.totalMs > 0) {
-                stringResource(R.string.reading_stats_day_read, amount, weekday)
-            } else {
-                stringResource(R.string.reading_stats_no_reading_day, weekday)
-            }
-            Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxHeight()
-                    // The bar and its letter are one fact, and read out
-                    // separately they are two thirds of a sentence.
-                    .clearAndSetSemantics { contentDescription = spoken },
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Bottom,
-            ) {
-                Box(
-                    Modifier
-                        .fillMaxWidth()
-                        // Heights must share the same scale. Weighting a
-                        // lone child inside each separate column makes
-                        // every bar fill its column and look identical.
-                        .height(barHeight)
-                        .clip(RoundedCornerShape(4.dp))
-                        .background(
-                            if (day.totalMs > 0) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.surfaceVariant
-                            },
-                        ),
-                )
-                Spacer(Modifier.height(6.dp))
-                Text(
-                    text = if (captioned) weekday else "",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    softWrap = false,
-                    overflow = TextOverflow.Visible,
-                )
-            }
-        }
-    }
-}
-
-/** Days in a week, and so the spacing of the bar chart's captions. */
-private const val DAYS_IN_WEEK = 7
-
-@Composable
-private fun BookRow(book: BookReadingStats, onClick: () -> Unit) {
-    Column(
-        Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(vertical = 12.dp),
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Text(
-                text = book.title,
-                style = MaterialTheme.typography.bodyLarge,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f),
-            )
-            Spacer(Modifier.widthIn(min = 12.dp))
-            Text(readingDuration(book.totalMs), style = MaterialTheme.typography.bodyMedium)
-        }
-        val subtitle = bookSubtitle(book)
-        if (subtitle.isNotEmpty()) {
-            Text(
-                text = subtitle,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
-    }
-}
-
-/** The line under a title: who wrote it and how far in. */
-@Composable
-private fun bookSubtitle(book: BookReadingStats): String = buildList {
-    book.author?.let(::add)
-    if (book.finished) {
-        add(stringResource(R.string.state_finished))
-    } else {
-        book.progression?.let { add(stringResource(R.string.reading_stats_progress, (it * 100).toInt())) }
-    }
-}.joinToString(" · ")
-
 @Composable
 private fun EmptyStats(modifier: Modifier = Modifier, narrowedByRange: Boolean = false) {
     Box(modifier, contentAlignment = Alignment.Center) {
-        Column(
+        Surface(
+            shape = RoundedCornerShape(20.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerLow,
             modifier = Modifier
                 .widthIn(max = contentWidthCap(windowWidth()))
-                .padding(32.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
+                .padding(24.dp),
         ) {
-            Text(
-                text = stringResource(R.string.reading_stats_empty_title),
-                style = MaterialTheme.typography.titleMedium,
-            )
-            Spacer(Modifier.height(8.dp))
-            Text(
-                text = stringResource(
-                    if (narrowedByRange) {
-                        R.string.reading_stats_empty_range
-                    } else {
-                        R.string.reading_stats_empty_detail
-                    },
-                ),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            Column(
+                modifier = Modifier.padding(28.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.AutoStories,
+                    contentDescription = null,
+                    modifier = Modifier.size(48.dp),
+                    tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.8f),
+                )
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    text = stringResource(R.string.reading_stats_empty_title),
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = stringResource(
+                        if (narrowedByRange) {
+                            R.string.reading_stats_empty_range
+                        } else {
+                            R.string.reading_stats_empty_detail
+                        },
+                    ),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
         }
     }
 }
@@ -468,4 +852,6 @@ private fun EmptyStats(modifier: Modifier = Modifier, narrowedByRange: Boolean =
 @Composable
 internal fun lastReadFormat(): DateTimeFormatter = DateTimeFormatter
     .ofLocalizedDate(FormatStyle.MEDIUM)
+    .withLocale(LocalLocale.current.platformLocale)
+
     .withLocale(LocalLocale.current.platformLocale)

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
@@ -233,6 +233,8 @@ class ReadingStatsViewModel(
                 author = book.displayAuthor,
                 progression = progressionByUrl[book.url],
                 finished = book.finished,
+                coverPath = book.coverPath,
+                coverUrl = book.coverUrl,
             )
         }
         LocalStats(
@@ -427,6 +429,8 @@ class ReadingStatsViewModel(
                             insight.sessions + rows.sumOf { it.pendingSessions },
                         ),
                         pendingSessions = rows.sumOf { it.pendingSessions },
+                        coverPath = metadata.coverPath,
+                        coverUrl = metadata.coverUrl,
                     )
                 }
             val books = mergedBooks.values.sortedWith(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -556,6 +556,7 @@
     <string name="reading_stats_book_empty">You have not read any of this one yet.</string>
     <string name="reading_stats_no_reading_day">Nothing read on %1$s</string>
     <string name="reading_stats_last_read">Last read %1$s</string>
+    <string name="reading_stats_last_read_label">Last read</string>
     <string name="reading_stats_progress">%1$d%% through</string>
     <string name="reading_stats_day_read">%1$s on %2$s</string>
     <string name="reading_stats_in_last_days">In the last %1$d days, on every device</string>


### PR DESCRIPTION
## Summary

The reading stats dashboard was a plain stack of headlines and rows that gave every figure the same weight and made the page hard to read at a glance. Both stats screens have been rebuilt as a card grid.

Nothing here grades the reader. The tallies are the same ones as before, each keeps a plain label, the streak is a count of days like any other count, and no day in the chart is drawn as a record — the original "reports and does not grade" rule is unchanged and its rationale comments are intact.

## Changes

- **Main dashboard** — total reading time leads in a hero card; each tally (books read from, books finished, day streak, sittings, pace) sits in its own tile, laid out two to a row so a tile added or dropped rearranges the grid instead of leaving a hole. Pace is omitted entirely when it cannot be worked out rather than shown as a dash. The range picker is now a labelled button showing the active span.
- **Activity chart** — bar spacing and corner radius narrow as the bars multiply, so a month of them stays legible on a phone instead of collapsing to hatching.
- **Per-book breakdown** — book cards now carry cover thumbnails. `coverPath`/`coverUrl` were threaded through `BookReadingStats` and `StatsBook`.
- **Per-book stats screen** — a cover-led hero header with title, author and either a finished badge or a progress bar, over metric tiles and the estimate card.
- Added `reading_stats_last_read_label` so the "Last read" label is a string of its own instead of the sentence form with its argument trimmed off.
- Content on the main dashboard is now width-capped and centred, matching the rest of the app.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

Verified on `emulator-5554` with a seeded demo library.

## Screenshots or recordings

Reading stats, last 30 days:

<img src="https://github.com/user-attachments/assets/b6b19fe3-9e4c-41a9-a77f-3d4b75e7784b" width="340" />

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
