### PR TITLE
feat(sync): keep a note that belongs to the whole book

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,20 @@ emulator.
   swept. For the same reason the feed cursor moves by the raw page, not
   by the records this device could represent: `high_water` is only ever
   for a page the server sent empty.
+- Liseur's `NOTE` is a note attached to a passage and maps to a server
+  `highlight` carrying a body. `BOOK_NOTE` is the server's standalone
+  `note`: it has a body and deliberately no locator, progression,
+  excerpt, colour or edition anchor. Keep the two kinds distinct.
+- "No locator" is read generously on the way in: absent, JSON null, an
+  empty string and an empty object all mean the same thing, as they
+  already do in `SyncOps.locatorFor`. Reading one of those as an anchor
+  refuses a standalone note on every pull *and* every reconcile, so the
+  reader never sees it once.
+- Because a book note carries no `edition_sha` and two copies of one
+  book share a `work_id`, `home()` cannot tell which copy it was written
+  against. A note landing the first time gets a copy picked the same way
+  every run; one already filed here goes back where it already lives.
+  Pass the known `bookId` rather than sending `edition_sha` on a note.
 - The annotation pass runs settle → pull → reconcile → push → deletes,
   and that order is not negotiable. Reconciling a work's live set before
   pushing is what stops an offline edit to a swept tombstone being sent

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ library-wide. Auto-scroll runs at a set pace and continues across chapter
 boundaries.
 
 A footer shows time remaining in the chapter. Highlights, margin notes,
-bookmarks, and dictionary lookups are inline. Footnotes open as a card over
+bookmarks, and dictionary lookups are inline; book-level notes live in the
+notebook. Footnotes open as a card over
 the page instead of jumping to the back of the book; long notes get a "Go to
 note" link with a way back.
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/BookAnnotation.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/BookAnnotation.kt
@@ -12,12 +12,12 @@ import androidx.room.Query
 import androidx.room.Upsert
 import kotlinx.coroutines.flow.Flow
 
-/** What the reader marked: a passage, a thought about it, or a place. */
-enum class AnnotationKind { HIGHLIGHT, NOTE, BOOKMARK }
+/** What the reader marked: a passage, a thought about it or the book, or a place. */
+enum class AnnotationKind { HIGHLIGHT, NOTE, BOOK_NOTE, BOOKMARK }
 
 /**
  * Something the reader added to a book: a highlight, a note on a passage,
- * or a bookmark.
+ * a note about the book itself, or a bookmark.
  *
  * Keyed by the book's permanent identity rather than the file it lives in,
  * the same way reading positions are, so annotations survive a calibre-web
@@ -31,6 +31,7 @@ data class BookAnnotation(
     @PrimaryKey val id: String,
     @ColumnInfo(name = "book_id") val bookId: String,
     @ColumnInfo(name = "kind") val kind: String,
+    /** Empty only for an anchorless [AnnotationKind.BOOK_NOTE]. */
     @ColumnInfo(name = "locator_json") val locatorJson: String,
     /** The passage as it reads in the book, for the notebook and export. */
     @ColumnInfo(name = "text") val text: String? = null,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/AnnotationWire.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/AnnotationWire.kt
@@ -72,10 +72,11 @@ object AnnotationWire {
      * Builds the request item for a mark, or null when it is not
      * something this server can hold.
      *
-     * A highlight and a bookmark have to anchor to the text, and a
-     * locator that cannot be read back is not an anchor. Refusing here
-     * rather than letting the server refuse keeps a broken row from
-     * being offered on every run for ever.
+     * A highlight and a bookmark have to anchor to the text, while a
+     * book note deliberately has no anchor. A locator that cannot be
+     * read back is not an anchor. Refusing here rather than letting the
+     * server refuse keeps a broken row from being offered on every run
+     * for ever.
      */
     fun item(
         annotation: BookAnnotation,
@@ -84,7 +85,8 @@ object AnnotationWire {
         editionSha: String?,
     ): Item? {
         val kind = wireKind(annotation) ?: return null
-        val locator = canonicalLocator(annotation.locatorJson) ?: return null
+        val locator = if (kind == KIND_NOTE) null else canonicalLocator(annotation.locatorJson)
+            ?: return null
         if (!usableId(annotation.id)) return null
 
         // Sent whole. Truncating here would hash the short version as
@@ -97,6 +99,7 @@ object AnnotationWire {
             KIND_BOOKMARK -> ""
             else -> annotation.note.orEmpty()
         }
+        if (kind == KIND_NOTE && body.isEmpty()) return null
         val color = when (kind) {
             KIND_HIGHLIGHT -> color(annotation.tint)
             else -> ""
@@ -109,15 +112,19 @@ object AnnotationWire {
             add("\"id\":" + quote(annotation.id))
             add("\"base_rev\":$baseRev")
             add("\"work_id\":" + quote(workId))
-            if (editionSha != null) add("\"edition_sha\":" + quote(editionSha))
+            if (editionSha != null && kind != KIND_NOTE) {
+                add("\"edition_sha\":" + quote(editionSha))
+            }
             add("\"kind\":" + quote(kind))
-            add("\"locator\":$locator")
-            annotation.totalProgression
-                ?.takeIf { it in 0.0..1.0 }
-                ?.let { add("\"progression\":${number(it)}") }
-            truncate(annotation.text.orEmpty(), MAX_EXCERPT_BYTES)
-                .takeIf { it.isNotEmpty() }
-                ?.let { add("\"excerpt\":" + quote(it)) }
+            locator?.let { add("\"locator\":$it") }
+            if (kind != KIND_NOTE) {
+                annotation.totalProgression
+                    ?.takeIf { it in 0.0..1.0 }
+                    ?.let { add("\"progression\":${number(it)}") }
+                truncate(annotation.text.orEmpty(), MAX_EXCERPT_BYTES)
+                    .takeIf { it.isNotEmpty() }
+                    ?.let { add("\"excerpt\":" + quote(it)) }
+            }
             if (color.isNotEmpty()) add("\"color\":" + quote(color))
             if (body.isNotEmpty()) add("\"body\":" + quote(body))
             add("\"client_ts\":" + quote(clientTs(annotation.updatedAt)))
@@ -154,12 +161,17 @@ object AnnotationWire {
      */
     fun fingerprint(annotation: BookAnnotation, workId: String): String {
         val kind = wireKind(annotation)
+        val anchored = kind != KIND_NOTE
         val parts = listOf(
             workId,
             kind.orEmpty(),
-            canonicalLocator(annotation.locatorJson).orEmpty(),
-            annotation.totalProgression?.takeIf { it in 0.0..1.0 }?.let(::number).orEmpty(),
-            truncate(annotation.text.orEmpty(), MAX_EXCERPT_BYTES),
+            if (anchored) canonicalLocator(annotation.locatorJson).orEmpty() else "",
+            if (anchored) {
+                annotation.totalProgression?.takeIf { it in 0.0..1.0 }?.let(::number).orEmpty()
+            } else {
+                ""
+            },
+            if (anchored) truncate(annotation.text.orEmpty(), MAX_EXCERPT_BYTES) else "",
             if (kind == KIND_HIGHLIGHT) color(annotation.tint) else "",
             if (kind == KIND_BOOKMARK) "" else annotation.note.orEmpty(),
             clientTs(annotation.updatedAt),
@@ -171,12 +183,12 @@ object AnnotationWire {
      * The kind the server would call this mark, or null if it would call
      * it nothing.
      *
-     * A note here is a passage with something written about it, which is
-     * what the server calls a highlight carrying a body — its own `note`
-     * is a body with no anchor, which this app has no way to make.
+     * A passage note is what the server calls a highlight carrying a body;
+     * a book note maps to its anchorless `note` kind.
      */
     fun wireKind(annotation: BookAnnotation): String? = when (annotation.kind) {
         AnnotationKind.HIGHLIGHT.name, AnnotationKind.NOTE.name -> KIND_HIGHLIGHT
+        AnnotationKind.BOOK_NOTE.name -> KIND_NOTE
         AnnotationKind.BOOKMARK.name -> KIND_BOOKMARK
         else -> null
     }
@@ -209,9 +221,7 @@ object AnnotationWire {
      * can trust or represent.
      *
      * Checked as though it were hostile, because a database is not the
-     * place to find out that a colour was a stylesheet. A standalone
-     * note — a body with no anchor — is skipped: there is nowhere here
-     * to put one.
+     * place to find out that a colour was a stylesheet.
      */
     fun record(json: JSONObject): Record? {
         val id = json.optString("id")
@@ -234,12 +244,15 @@ object AnnotationWire {
         }
 
         val kind = json.optString("kind")
-        if (kind != KIND_HIGHLIGHT && kind != KIND_BOOKMARK) return null
+        if (kind != KIND_HIGHLIGHT && kind != KIND_NOTE && kind != KIND_BOOKMARK) return null
         val workId = json.optString("work_id").takeIf { it.isNotEmpty() } ?: return null
 
-        val locator = json.opt("locator")?.takeIf { it != JSONObject.NULL }?.toString()
-            ?: return null
-        if (canonicalLocator(locator) == null) return null
+        val locator = anchor(json.opt("locator"))
+        if (kind == KIND_NOTE) {
+            if (locator != null) return null
+        } else if (locator == null) {
+            return null
+        }
 
         val progression = if (json.isNull("progression")) null else json.optDouble("progression")
         if (progression != null && (progression.isNaN() || progression !in 0.0..1.0)) return null
@@ -253,6 +266,7 @@ object AnnotationWire {
         if (excerpt.toByteArray().size > MAX_EXCERPT_BYTES) return null
         if (body.toByteArray().size > MAX_BODY_BYTES) return null
         if (body.isNotEmpty() && kind == KIND_BOOKMARK) return null
+        if (body.isEmpty() && kind == KIND_NOTE) return null
 
         return Record(
             id = id,
@@ -300,14 +314,13 @@ object AnnotationWire {
      * How far a page of the feed reaches, or null if it says nothing.
      *
      * Counted before anything is skipped: the cursor has to move by
-     * what the server sent, not by what this device could read. A page
-     * of standalone notes reads as nothing here, and taking the
-     * account's high water mark for it would step over every highlight
-     * after them, silently, once, for ever. A seq below 1 is not a
-     * reach either — `optLong` reads a missing or unparseable one as 0,
-     * and treating that as an answer would pin the cursor just as
-     * firmly. Null hands the page back to `high_water`, which is only
-     * for a page that really was empty.
+     * what the server sent, not by what this device could read. Taking
+     * the account's high water mark for a page of unknown records would
+     * step over every readable mark after them, silently, once, for ever.
+     * A seq below 1 is not a reach either — `optLong` reads a missing or
+     * unparseable one as 0, and treating that as an answer would pin the
+     * cursor just as firmly. Null hands the page back to `high_water`,
+     * which is only for a page that really was empty.
      */
     fun pageReach(array: JSONArray?): Long? {
         if (array == null || array.length() == 0) return null
@@ -355,9 +368,11 @@ object AnnotationWire {
      * out of the locator when there is nothing to inherit.
      */
     fun toAnnotation(record: Record, bookId: String, existing: BookAnnotation?): BookAnnotation {
+        val bookNote = record.kind == KIND_NOTE
         val locator = record.locator?.let { runCatching { JSONObject(it) }.getOrNull() }
         val locations = locator?.optJSONObject("locations")
         val kind = when {
+            bookNote -> AnnotationKind.BOOK_NOTE
             record.kind == KIND_BOOKMARK -> AnnotationKind.BOOKMARK
             record.body.isNotEmpty() -> AnnotationKind.NOTE
             else -> AnnotationKind.HIGHLIGHT
@@ -378,24 +393,47 @@ object AnnotationWire {
             // device's own doing — an excerpt goes out truncated to a
             // kilobyte — so keeping the whole passage is restoring
             // precision, not ignoring an edit.
-            text = record.excerpt.takeIf { it.isNotEmpty() }?.let { excerpt ->
+            text = record.excerpt.takeIf { !bookNote && it.isNotEmpty() }?.let { excerpt ->
                 existing?.text
                     ?.takeIf { truncate(it, MAX_EXCERPT_BYTES) == excerpt }
                     ?: excerpt
             },
             note = record.body.takeIf { it.isNotEmpty() },
-            tint = record.color.takeIf { it.isNotEmpty() }?.uppercase(Locale.ROOT),
-            chapter = existing?.chapter
-                ?: locator?.optString("title")?.takeIf { it.isNotEmpty() },
-            position = existing?.position
-                ?: locations?.optInt("position")?.takeIf { it > 0 },
-            totalProgression = record.progression,
+            tint = record.color.takeIf { !bookNote && it.isNotEmpty() }?.uppercase(Locale.ROOT),
+            chapter = if (bookNote) {
+                null
+            } else {
+                existing?.chapter ?: locator?.optString("title")?.takeIf { it.isNotEmpty() }
+            },
+            position = if (bookNote) {
+                null
+            } else {
+                existing?.position ?: locations?.optInt("position")?.takeIf { it > 0 }
+            },
+            totalProgression = if (bookNote) null else record.progression,
             createdAt = existing?.createdAt ?: (record.clientTsMicros / 1000),
             updatedAt = record.clientTsMicros,
         )
     }
 
     // -- Shapes -----------------------------------------------------------
+
+    /**
+     * The anchor a record actually carries, or null when it carries none.
+     *
+     * A peer with nothing to anchor may say so as an absent key, a JSON
+     * null, an empty string or an empty object, and they all mean the
+     * same thing — `SyncOps.locatorFor` has read them that way all
+     * along. Reading one of those spellings as a locator would refuse a
+     * standalone note for ever, since the record is skipped on every
+     * pull and every reconcile alike, and would let an anchored mark
+     * through with an anchor that points at nothing.
+     */
+    fun anchor(value: Any?): String? {
+        val raw = value?.takeIf { it != JSONObject.NULL }?.toString() ?: return null
+        val canonical = canonicalLocator(raw) ?: return null
+        return raw.takeIf { canonical != "{}" }
+    }
 
     /**
      * A locator written one way and one way only, with its keys in

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncAnnotations.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncAnnotations.kt
@@ -271,7 +271,7 @@ class LiseurSyncAnnotations(
         }
 
         val workId = record.workId ?: return false
-        val home = home(peer, record, aliases) ?: return false
+        val home = home(peer, record, aliases, row?.bookId ?: local?.bookId) ?: return false
 
         if (row == null && local != null) {
             // Both sides hold this id and nothing here records them ever
@@ -815,7 +815,7 @@ class LiseurSyncAnnotations(
         }
 
         val workId = record.workId ?: return
-        val home = home(peer, record, aliases) ?: return
+        val home = home(peer, record, aliases, row.bookId) ?: return
         val landed = AnnotationWire.toAnnotation(record, home.bookUrl, annotationDao.byId(row.id))
         val newer = !stillSaying(row)
         if (!newer) annotationDao.upsert(landed)
@@ -998,7 +998,7 @@ class LiseurSyncAnnotations(
                 LiseurSyncHttp.CONFLICT -> {
                     val record = refused.body?.optJSONObject("server")
                         ?.let(AnnotationWire::record)
-                    val home = record?.let { home(peer, it, aliases) }
+                    val home = record?.let { home(peer, it, aliases, row.bookId) }
                     if (record == null || record.deleted || home == null) {
                         syncDao.deleteById(peer.peerId, row.id)
                         return@inTransaction
@@ -1065,16 +1065,27 @@ class LiseurSyncAnnotations(
      * Picking the edition it was actually made against is the honest
      * answer; failing that, any consistent rule will do, as long as it
      * is the same one every run.
+     *
+     * A standalone note carries no edition anchor at all, by design, so
+     * for those the first question can never answer. Choosing a copy for
+     * a note arriving here the first time is fair enough, but a note
+     * this device has already filed somewhere has an answer better than
+     * fair: where it already lives. Without it, a conflict, a re-pair or
+     * any second landing would walk the note over to whichever copy
+     * sorts first, and the reader would watch it move between two copies
+     * of one book.
      */
     private suspend fun home(
         peer: Peer,
         record: AnnotationWire.Record,
         aliases: List<WorkAlias>,
+        known: String?,
     ): WorkAlias? {
         val candidates = aliases.filter { it.workId == record.workId }
         if (candidates.isEmpty()) return null
         val chosen = candidates
             .firstOrNull { it.editionSha != null && it.editionSha == record.editionSha }
+            ?: known?.let { where -> candidates.firstOrNull { it.bookUrl == where } }
             ?: candidates.minByOrNull { it.bookUrl }
             ?: return null
         // The list was read before the call. A different file may have

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/NotebookExport.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/NotebookExport.kt
@@ -20,9 +20,23 @@ fun exportNotebookMarkdown(
     out.append("# ").append(title.ifBlank { "Untitled" }).append('\n')
     if (!author.isNullOrBlank()) out.append('\n').append('*').append(author).append('*').append('\n')
 
-    val ordered = annotations.sortedWith(
-        compareBy({ it.totalProgression ?: Double.MAX_VALUE }, { it.createdAt }),
-    )
+    val bookNotes = annotations
+        .filter { it.kind == AnnotationKind.BOOK_NOTE.name }
+        .sortedBy { it.createdAt }
+    if (bookNotes.isNotEmpty()) {
+        out.append("\n## Book notes\n")
+        for (annotation in bookNotes) {
+            annotation.note?.takeIf { it.isNotBlank() }?.let {
+                out.append('\n').append(it.trim()).append('\n')
+            }
+        }
+    }
+
+    val ordered = annotations
+        .filter { it.kind != AnnotationKind.BOOK_NOTE.name }
+        .sortedWith(
+            compareBy({ it.totalProgression ?: Double.MAX_VALUE }, { it.createdAt }),
+        )
     var chapter: String? = NO_CHAPTER_YET
     for (annotation in ordered) {
         if (annotation.chapter != chapter) {

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
@@ -340,6 +340,7 @@ class ReaderActivity : FragmentActivity() {
                                         ReaderAnnotationActions(
                                             highlight = viewModel::highlight,
                                             addNote = viewModel::addNote,
+                                            saveBookNote = viewModel::saveBookNote,
                                             annotationAt = viewModel::annotationAt,
                                             toggleBookmark = viewModel::toggleBookmark,
                                             remove = viewModel::remove,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -83,6 +83,7 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.IntOffset
 import com.chmouel.liseur.R
+import com.chmouel.liseur.data.db.AnnotationKind
 import com.chmouel.liseur.data.db.BookAnnotation
 import com.chmouel.liseur.data.settings.DefinitionTarget
 import com.chmouel.liseur.reader.annotations.BookmarkRibbon
@@ -337,6 +338,7 @@ fun ReaderScreen(
     val noteShowing by rememberUpdatedState(footnote != null)
     var selection by remember { mutableStateOf<ActiveSelection?>(null) }
     var noteFor by remember { mutableStateOf<ActiveSelection?>(null) }
+    var bookNoteEditor by remember { mutableStateOf<BookNoteEditor?>(null) }
     var defineWord by remember { mutableStateOf<String?>(null) }
     val view = LocalView.current
     val context = LocalContext.current
@@ -1761,6 +1763,20 @@ fun ReaderScreen(
         )
     }
 
+    bookNoteEditor?.let { editor ->
+        NoteDialog(
+            passage = null,
+            initialNote = editor.existing?.note.orEmpty(),
+            titleRes = R.string.annotation_book_note_title,
+            hintRes = R.string.annotation_book_note_hint,
+            onSave = { note ->
+                onAnnotationAction.saveBookNote(note, editor.existing?.id)
+                bookNoteEditor = null
+            },
+            onDismiss = { bookNoteEditor = null },
+        )
+    }
+
     if (sheet == ReaderSheet.TYPOGRAPHY) {
         TypographySheet(
             prefs = prefs,
@@ -1862,12 +1878,19 @@ fun ReaderScreen(
             currentHref = here?.value?.href?.toString(),
             annotations = annotations,
             onAnnotationSelected = { annotation ->
-                annotation.locator()?.let {
-                    showToc = false
-                    chromeVisible = false
-                    onProgressAction.onJump()
-                    navigateLater(it, NavigatorPositionEvent.LOCAL_JUMP)
+                if (annotation.kind == AnnotationKind.BOOK_NOTE.name) {
+                    bookNoteEditor = BookNoteEditor(annotation)
+                } else {
+                    annotation.locator()?.let {
+                        showToc = false
+                        chromeVisible = false
+                        onProgressAction.onJump()
+                        navigateLater(it, NavigatorPositionEvent.LOCAL_JUMP)
+                    }
                 }
+            },
+            onBookNoteAdded = {
+                bookNoteEditor = BookNoteEditor(existing = null)
             },
             onAnnotationDeleted = onAnnotationAction.remove,
             onExport = {
@@ -1910,6 +1933,9 @@ private data class ActiveSelection(
     }
 }
 
+/** The book-level note being written; null [existing] means a new one. */
+private data class BookNoteEditor(val existing: BookAnnotation?)
+
 /** Decorations for search hits live apart from the reader's own marks. */
 private const val SEARCH_DECORATION_GROUP = "search"
 private val SEARCH_HIT_TINT = Color(0xFF80CBC4)
@@ -1927,6 +1953,7 @@ class ReaderSearchActions(
 class ReaderAnnotationActions(
     val highlight: (Locator, HighlightTint, String?) -> Unit,
     val addNote: (Locator, String, String?) -> Unit,
+    val saveBookNote: (String, String?) -> Unit,
     val annotationAt: (Locator) -> BookAnnotation?,
     val toggleBookmark: () -> Unit,
     val remove: (BookAnnotation) -> Unit,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -333,7 +333,7 @@ class ReaderViewModel(
     /** Raised when another device is further along than this page. */
     val catchUp: StateFlow<CatchUp?> = _catchUp.asStateFlow()
 
-    /** Highlights, notes and bookmarks in this book, in reading order. */
+    /** Book notes first, then the anchored marks in reading order. */
     val annotations: StateFlow<List<BookAnnotation>> = annotationDao.observe(bookId)
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
@@ -1128,6 +1128,21 @@ class ReaderViewModel(
         )
     }
 
+    /** Writes a thought about the book itself, without inventing a place for it. */
+    fun saveBookNote(note: String, existingId: String? = null) {
+        val existing = existingId?.let { id -> annotations.value.firstOrNull { it.id == id } }
+        save(
+            BookAnnotation(
+                id = existing?.id ?: UUID.randomUUID().toString(),
+                bookId = bookId,
+                kind = AnnotationKind.BOOK_NOTE.name,
+                locatorJson = "",
+                note = note,
+                createdAt = existing?.createdAt ?: System.currentTimeMillis(),
+            ),
+        )
+    }
+
     /**
      * The mark covering this locator, if the reader selected one they
      * had already made.
@@ -1140,7 +1155,10 @@ class ReaderViewModel(
     fun annotationAt(locator: Locator): BookAnnotation? {
         val selection = locator.markedPassage()
         return annotations.value
-            .filter { it.kind != AnnotationKind.BOOKMARK.name }
+            .filter {
+                it.kind != AnnotationKind.BOOKMARK.name &&
+                    it.kind != AnnotationKind.BOOK_NOTE.name
+            }
             .firstOrNull { mark ->
                 val other = mark.locator()?.markedPassage() ?: return@firstOrNull false
                 isSamePassage(selection, other)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/Annotations.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/Annotations.kt
@@ -47,14 +47,18 @@ const val DECORATION_GROUP = "annotations"
  * Turns stored annotations into what the navigator draws over the page.
  *
  * Bookmarks are deliberately left out: they mark a page, not a passage, and
- * are shown by the corner ribbon instead. A note is drawn like a highlight
- * so the passage it belongs to stays visible — a note with nothing
- * underneath it cannot be found again by eye.
+ * are shown by the corner ribbon instead. Book notes are left out because
+ * they deliberately have no passage. A passage note is drawn like a
+ * highlight so the words it belongs to stay visible.
  */
 @OptIn(ExperimentalReadiumApi::class)
 fun List<BookAnnotation>.toDecorations(): List<Decoration> =
     mapNotNull { annotation ->
-        if (annotation.kind == AnnotationKind.BOOKMARK.name) return@mapNotNull null
+        if (annotation.kind == AnnotationKind.BOOKMARK.name ||
+            annotation.kind == AnnotationKind.BOOK_NOTE.name
+        ) {
+            return@mapNotNull null
+        }
         val locator = annotation.locator() ?: return@mapNotNull null
         Decoration(
             id = annotation.id,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/NoteDialog.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/NoteDialog.kt
@@ -1,5 +1,6 @@
 package com.chmouel.liseur.reader.annotations
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
@@ -23,16 +24,18 @@ import androidx.compose.ui.unit.dp
 import com.chmouel.liseur.R
 
 /**
- * Writing, or reworking, a note about a passage.
+ * Writing, or reworking, a note about a passage or the book itself.
  *
- * The passage itself is shown above the field and stays selectable, because
- * the note is usually a reaction to particular words and it helps to have
- * them in front of you while you write.
+ * When there is a passage it is shown above the field and stays selectable,
+ * because the note is usually a reaction to particular words and it helps
+ * to have them in front of you while you write.
  */
 @Composable
 fun NoteDialog(
     passage: String?,
     initialNote: String,
+    @StringRes titleRes: Int = R.string.annotation_note_title,
+    @StringRes hintRes: Int = R.string.annotation_note_hint,
     onSave: (String) -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -41,7 +44,7 @@ fun NoteDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.annotation_note_title)) },
+        title = { Text(stringResource(titleRes)) },
         text = {
             Column(Modifier.fillMaxWidth()) {
                 passage?.takeIf { it.isNotBlank() }?.let {
@@ -61,7 +64,7 @@ fun NoteDialog(
                     value = note,
                     onValueChange = { note = it },
                     modifier = Modifier.fillMaxWidth(),
-                    placeholder = { Text(stringResource(R.string.annotation_note_hint)) },
+                    placeholder = { Text(stringResource(hintRes)) },
                     minLines = 3,
                 )
             }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ContentsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ContentsScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Notes
+import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.CloudSync
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.Delete
@@ -81,8 +83,8 @@ private enum class ContentsTab(val labelRes: Int) {
  * A book's contents can run to hundreds of lines and is the thing people
  * jump around in, so it gets the full height of the display rather than a
  * sheet that has to be fought to scroll. Bookmarks, highlights and notes
- * sit alongside as tabs, because in practice they are used for the same
- * thing: getting back to a particular place.
+ * sit alongside as tabs: anchored marks get back to a particular place,
+ * while book notes make the notebook useful without inventing one.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -93,6 +95,7 @@ fun ContentsScreen(
     annotations: List<BookAnnotation>,
     onEntrySelected: (Link) -> Unit,
     onAnnotationSelected: (BookAnnotation) -> Unit,
+    onBookNoteAdded: () -> Unit,
     onAnnotationDeleted: (BookAnnotation) -> Unit,
     onExport: () -> Unit,
     onClose: () -> Unit,
@@ -109,7 +112,13 @@ fun ContentsScreen(
         topBar = {
             Column {
                 TopAppBar(
-                    title = { Text(stringResource(R.string.reader_navigate)) },
+                    title = {
+                        Text(
+                            text = stringResource(R.string.reader_navigate),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    },
                     navigationIcon = {
                         IconButton(onClick = onClose) {
                             Icon(
@@ -125,6 +134,15 @@ fun ContentsScreen(
                                     Icons.Outlined.CloudSync,
                                     contentDescription =
                                     stringResource(R.string.reader_sync_book),
+                                )
+                            }
+                        }
+                        if (tab == ContentsTab.NOTES) {
+                            IconButton(onClick = onBookNoteAdded) {
+                                Icon(
+                                    Icons.Outlined.Add,
+                                    contentDescription =
+                                    stringResource(R.string.annotation_add_book_note),
                                 )
                             }
                         }
@@ -204,7 +222,8 @@ fun ContentsScreen(
 
                     ContentsTab.HIGHLIGHTS -> AnnotationList(
                         annotations = annotations.filter {
-                            it.kind != AnnotationKind.BOOKMARK.name
+                            it.kind != AnnotationKind.BOOKMARK.name &&
+                                it.kind != AnnotationKind.BOOK_NOTE.name
                         },
                         theme = theme,
                         emptyRes = R.string.reader_no_highlights,
@@ -318,7 +337,16 @@ private fun AnnotationRow(
             .padding(start = 20.dp, end = 8.dp, top = 14.dp, bottom = 14.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        if (annotation.kind != AnnotationKind.BOOKMARK.name) {
+        if (annotation.kind == AnnotationKind.BOOK_NOTE.name) {
+            Icon(
+                Icons.AutoMirrored.Outlined.Notes,
+                contentDescription = null,
+                tint = theme.foreground.copy(alpha = 0.65f),
+                modifier = Modifier
+                    .padding(top = 1.dp)
+                    .size(18.dp),
+            )
+        } else if (annotation.kind != AnnotationKind.BOOKMARK.name) {
             Box(
                 Modifier
                     .padding(top = 4.dp)
@@ -354,10 +382,22 @@ private fun AnnotationRow(
             annotation.note?.takeIf { it.isNotBlank() }?.let {
                 Text(
                     text = it.trim(),
-                    style = MaterialTheme.typography.bodySmall,
-                    fontStyle = FontStyle.Italic,
-                    color = theme.foreground.copy(alpha = 0.75f),
-                    maxLines = 3,
+                    style = if (annotation.kind == AnnotationKind.BOOK_NOTE.name) {
+                        MaterialTheme.typography.bodyMedium
+                    } else {
+                        MaterialTheme.typography.bodySmall
+                    },
+                    fontStyle = if (annotation.kind == AnnotationKind.BOOK_NOTE.name) {
+                        FontStyle.Normal
+                    } else {
+                        FontStyle.Italic
+                    },
+                    color = if (annotation.kind == AnnotationKind.BOOK_NOTE.name) {
+                        theme.foreground
+                    } else {
+                        theme.foreground.copy(alpha = 0.75f)
+                    },
+                    maxLines = if (annotation.kind == AnnotationKind.BOOK_NOTE.name) 5 else 3,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.padding(top = 6.dp),
                 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -305,7 +305,7 @@
     <string name="reader_notes">Notes</string>
     <string name="reader_no_bookmarks">No bookmarks yet. Tap the top-right corner of a page to mark it.</string>
     <string name="reader_no_highlights">No highlights yet. Select a passage to mark it.</string>
-    <string name="reader_no_notes">No notes yet. Select a passage and choose Note.</string>
+    <string name="reader_no_notes">No notes yet. Add one here or select a passage and choose Note.</string>
     <string name="reader_page_short">p.\u00A0%1$d</string>
     <string name="reader_add_bookmark">Bookmark this page</string>
     <string name="reader_remove_bookmark">Remove bookmark</string>
@@ -318,6 +318,9 @@
     <string name="annotation_note">Note</string>
     <string name="annotation_note_title">Note</string>
     <string name="annotation_note_hint">What did this make you think?</string>
+    <string name="annotation_add_book_note">Add a book note</string>
+    <string name="annotation_book_note_title">Book note</string>
+    <string name="annotation_book_note_hint">What do you want to remember about this book?</string>
     <string name="annotation_look_up">Define</string>
     <string name="annotation_search">Search the web</string>
     <string name="annotation_share">Share</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/AnnotationWireTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/AnnotationWireTest.kt
@@ -33,6 +33,28 @@ class AnnotationWireTest {
     }
 
     @Test
+    fun `a book note carries words without an anchor`() {
+        val item = AnnotationWire.item(
+            mark(
+                kind = AnnotationKind.BOOK_NOTE,
+                locator = "",
+                text = "not an excerpt",
+                note = "worth remembering",
+            ),
+            WORK,
+            0,
+            "edition-sha",
+        )
+        val sent = JSONObject(item!!.json)
+
+        assertEquals("note", sent.getString("kind"))
+        assertEquals("worth remembering", sent.getString("body"))
+        for (anchored in listOf("locator", "edition_sha", "progression", "excerpt", "color")) {
+            assertFalse(anchored, sent.has(anchored))
+        }
+    }
+
+    @Test
     fun `a highlight with a body comes back as a note`() {
         val record = AnnotationWire.record(
             server(kind = "highlight", body = "worth arguing with"),
@@ -105,6 +127,29 @@ class AnnotationWireTest {
         assertNotEquals(base, AnnotationWire.fingerprint(mark(text = "other"), WORK))
         assertNotEquals(base, AnnotationWire.fingerprint(mark(updatedAt = 9), WORK))
         assertNotEquals(base, AnnotationWire.fingerprint(mark(), "other-work"))
+    }
+
+    @Test
+    fun `book note fingerprints ignore fields the server never receives`() {
+        val clean = mark(
+            kind = AnnotationKind.BOOK_NOTE,
+            locator = "",
+            text = null,
+            note = "remember this",
+            tint = null,
+        )
+        val strayAnchors = mark(
+            kind = AnnotationKind.BOOK_NOTE,
+            locator = LOCATOR,
+            text = "not an excerpt",
+            note = "remember this",
+            tint = "PURPLE",
+        )
+
+        assertEquals(
+            AnnotationWire.fingerprint(clean, WORK),
+            AnnotationWire.fingerprint(strayAnchors, WORK),
+        )
     }
 
     @Test
@@ -239,14 +284,61 @@ class AnnotationWireTest {
     }
 
     @Test
-    fun `a standalone note is skipped rather than guessed at`() {
-        // The server's own `note` is a body with no anchor. Liseur has
-        // nowhere to hang one, and inventing an anchor would put the
-        // reader's words at a place they never chose.
+    fun `a standalone note lands without an invented anchor`() {
         val note = JSONObject(
-            """{"id":"n","rev":1,"seq":1,"work_id":"$WORK","kind":"note","body":"standalone"}""",
+            """{"id":"n","rev":1,"seq":1,"work_id":"$WORK","kind":"note","body":"standalone","client_ts":"$STAMP"}""",
         )
-        assertNull(AnnotationWire.record(note))
+        val landed = AnnotationWire.toAnnotation(
+            AnnotationWire.record(note)!!,
+            BOOK,
+            mark(id = "n", note = "old passage note"),
+        )
+
+        assertEquals(AnnotationKind.BOOK_NOTE.name, landed.kind)
+        assertEquals("standalone", landed.note)
+        assertEquals("", landed.locatorJson)
+        assertNull(landed.text)
+        assertNull(landed.tint)
+        assertNull(landed.chapter)
+        assertNull(landed.position)
+        assertNull(landed.totalProgression)
+    }
+
+    @Test
+    fun `a standalone note requires a body and forbids an anchor`() {
+        val bare = JSONObject(
+            """{"id":"n","rev":1,"seq":1,"work_id":"$WORK","kind":"note","client_ts":"$STAMP"}""",
+        )
+        assertNull(AnnotationWire.record(bare))
+        val anchored = JSONObject(bare.toString())
+            .put("body", "words")
+            .put("locator", JSONObject(LOCATOR))
+        assertNull(AnnotationWire.record(anchored))
+    }
+
+    @Test
+    fun `a note anchored to nothing at all is still a note`() {
+        // A peer with no anchor to give may write it as a JSON null, an
+        // empty string or an empty object. Reading any of those as an
+        // anchor would refuse the note on every pull and every reconcile
+        // alike, so the reader would never see it once.
+        val said = JSONObject(
+            """{"id":"n","rev":1,"seq":1,"work_id":"$WORK","kind":"note","body":"standalone","client_ts":"$STAMP"}""",
+        )
+        listOf(JSONObject.NULL, "", "{}", JSONObject()).forEach { spelling ->
+            val record = AnnotationWire.record(JSONObject(said.toString()).put("locator", spelling))
+            assertEquals(AnnotationKind.BOOK_NOTE.name, AnnotationWire.toAnnotation(record!!, BOOK, null).kind)
+            assertNull(record.locator)
+        }
+    }
+
+    @Test
+    fun `an anchored mark whose anchor holds nothing is refused`() {
+        // An empty object is not a place in a book. Landing it would put
+        // a highlight over no text at all.
+        listOf("", "{}").forEach { spelling ->
+            assertNull(AnnotationWire.record(server(locator = spelling)))
+        }
     }
 
     @Test
@@ -360,11 +452,11 @@ class AnnotationWireTest {
     @Test
     fun `how far a page reaches is counted before anything is skipped`() {
         val readable = server(id = "a", seq = 3).toString()
-        val standalone = JSONObject()
+        val unreadable = JSONObject()
             .put("id", "b").put("rev", 1).put("seq", 11)
-            .put("work_id", WORK).put("kind", "note").put("body", "a thought")
+            .put("work_id", WORK).put("kind", "future-kind")
             .put("client_ts", STAMP).toString()
-        val page = JSONArray("[$readable,$standalone]")
+        val page = JSONArray("[$readable,$unreadable]")
 
         assertEquals(1, AnnotationWire.records(page).size)
         assertEquals(11L, AnnotationWire.pageReach(page))

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncAnnotationsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncAnnotationsTest.kt
@@ -104,6 +104,29 @@ class LiseurSyncAnnotationsTest {
     }
 
     @Test
+    fun `a new book note is offered without an anchor`() = runTest {
+        connect()
+        // A real edition hash on the alias, or asserting the note leaves
+        // `edition_sha` off would pass for a highlight too.
+        alias(editionSha = "edition-sha")
+        reconciled()
+        db.annotationDao().upsert(bookNote())
+        emptyFeed()
+        server.enqueue(results("""{"id":"book-note","status":"applied","rev":1,"seq":7}"""))
+
+        sync()
+
+        val sent = JSONObject(pushBody()).getJSONArray("annotations").getJSONObject(0)
+        assertEquals("book-note", sent.getString("id"))
+        assertEquals("note", sent.getString("kind"))
+        assertEquals("remember this", sent.getString("body"))
+        assertNull(sent.opt("locator"))
+        assertNull(sent.opt("progression"))
+        assertNull(sent.opt("edition_sha"))
+        assertEquals(1, db.annotationSyncDao().get(peer(), "book-note")!!.rev)
+    }
+
+    @Test
     fun `an interrupted push is repeated to the byte`() = runTest {
         // The server tells a retry from a fresh write by comparing the
         // whole payload. A replay that rebuilt the request could order
@@ -197,6 +220,41 @@ class LiseurSyncAnnotationsTest {
         assertEquals(11, db.remoteServerDao().get()!!.annotationCursorSeq)
         // The whole point: it arrived, so it is not owed back.
         assertEquals(0, pushes())
+    }
+
+    @Test
+    fun `a book note another device made arrives and can be edited`() = runTest {
+        connect()
+        alias()
+        reconciled()
+        server.enqueue(
+            json(
+                """{"annotations":[${bookNoteRecord(rev = 3, seq = 11)}],
+                    "high_water":11,"has_more":false}
+                """.trimIndent(),
+            ),
+        )
+
+        sync()
+
+        val landed = db.annotationDao().byId("book-note")!!
+        assertEquals(AnnotationKind.BOOK_NOTE.name, landed.kind)
+        assertEquals("remember this", landed.note)
+        assertEquals("", landed.locatorJson)
+        assertEquals(0, pushes())
+
+        db.annotationDao().upsert(landed.copy(note = "remember this instead", updatedAt = MICROS + 1))
+        emptyFeed()
+        liveSet(bookNoteRecord(rev = 3, seq = 11))
+        server.enqueue(results("""{"id":"book-note","status":"applied","rev":4,"seq":12}"""))
+
+        sync()
+
+        val sent = JSONObject(pushBody()).getJSONArray("annotations").getJSONObject(0)
+        assertEquals(3, sent.getLong("base_rev"))
+        assertEquals("note", sent.getString("kind"))
+        assertEquals("remember this instead", sent.getString("body"))
+        assertEquals(4, db.annotationSyncDao().get(peer(), "book-note")!!.rev)
     }
 
     @Test
@@ -295,6 +353,21 @@ class LiseurSyncAnnotationsTest {
         assertNotNull(db.annotationDao().byId("old"))
         assertTrue(requests().any { it.target == "/v1/works/$WORK/annotations" })
         assertTrue(db.workIdentityDao().alias(BOOK, peer())!!.annotationsReconciledAt > 0)
+    }
+
+    @Test
+    fun `reconciliation recovers a book note skipped by an older client`() = runTest {
+        connect()
+        alias()
+        emptyFeed()
+        liveSet(bookNoteRecord(rev = 3, seq = 7))
+
+        sync()
+
+        val landed = db.annotationDao().byId("book-note")!!
+        assertEquals(AnnotationKind.BOOK_NOTE.name, landed.kind)
+        assertEquals("remember this", landed.note)
+        assertEquals(3, db.annotationSyncDao().get(peer(), "book-note")!!.rev)
     }
 
     @Test
@@ -787,22 +860,134 @@ class LiseurSyncAnnotationsTest {
         connect()
         alias()
         reconciled()
-        // Standalone notes: a body with no anchor, which this app has
-        // nowhere to put. The cursor has to move by what the server
-        // sent, not by what could be read, or the account's high water
-        // mark would be taken for a page of nothing and every record
-        // after these would be stepped over — once, silently, for ever.
-        val note = JSONObject()
-            .put("id", "note-1").put("rev", 1).put("seq", 4)
-            .put("work_id", WORK).put("kind", "note")
-            .put("body", "a thought about the book")
+        // A future server kind this version cannot represent. The cursor
+        // still moves by what the server sent, or the account's high water
+        // mark would be taken for a page of nothing and every record after
+        // this would be stepped over — once, silently, for ever.
+        val unknown = JSONObject()
+            .put("id", "unknown-1").put("rev", 1).put("seq", 4)
+            .put("work_id", WORK).put("kind", "future-kind")
             .put("device_id", "other-device").put("client_ts", STAMP)
             .toString()
-        server.enqueue(json("""{"annotations":[$note],"high_water":9000,"has_more":false}"""))
+        server.enqueue(json("""{"annotations":[$unknown],"high_water":9000,"has_more":false}"""))
 
         sync()
 
         assertEquals(4, db.remoteServerDao().get()!!.annotationCursorSeq)
+    }
+
+    @Test
+    fun `a note this device must refuse still moves the cursor past it`() = runTest {
+        connect()
+        alias()
+        reconciled()
+        // The two shapes the accept rule turns away: a standalone note
+        // is meant to have no anchor, and it is meant to say something.
+        // Refusing the record is right; letting it hold the cursor back,
+        // or counting the page as empty, is not.
+        val anchored = JSONObject(bookNoteRecord(id = "anchored-note", seq = 4))
+            .put("locator", JSONObject(LOCATOR))
+            .toString()
+        val silent = bookNoteRecord(id = "silent-note", seq = 5, body = "")
+        server.enqueue(
+            json(
+                """{"annotations":[$anchored,$silent,${record(id = "mark-1", rev = 1, seq = 6)}],
+                    "high_water":9000,"has_more":false}
+                """.trimIndent(),
+            ),
+        )
+
+        sync()
+
+        assertNull(db.annotationDao().byId("anchored-note"))
+        assertNull(db.annotationDao().byId("silent-note"))
+        // The readable record on the same page still lands.
+        assertNotNull(db.annotationDao().byId("mark-1"))
+        assertEquals(6, db.remoteServerDao().get()!!.annotationCursorSeq)
+    }
+
+    @Test
+    fun `a book note keeps the copy it already lives in`() = runTest {
+        connect()
+        alias(bookUrl = BOOK)
+        alias(bookUrl = OTHER_BOOK)
+        reconciled()
+        reconciled(bookUrl = OTHER_BOOK)
+        // A note carries no edition anchor, so nothing in the record
+        // says which copy it belongs to. What this device already wrote
+        // down does, and alphabetical luck must not overrule it.
+        db.annotationDao().upsert(bookNote().copy(bookId = OTHER_BOOK))
+        db.annotationSyncDao().upsert(
+            syncRow(
+                id = "book-note",
+                bookId = OTHER_BOOK,
+                rev = 1,
+                acked = AnnotationWire.fingerprint(bookNote(), WORK),
+            ),
+        )
+        server.enqueue(
+            json(
+                """{"annotations":[${bookNoteRecord(rev = 2, seq = 8, body = "edited elsewhere")}],
+                    "high_water":8,"has_more":false}
+                """.trimIndent(),
+            ),
+        )
+
+        sync()
+
+        val landed = db.annotationDao().byId("book-note")!!
+        assertEquals("edited elsewhere", landed.note)
+        assertEquals(OTHER_BOOK, landed.bookId)
+        assertEquals(OTHER_BOOK, db.annotationSyncDao().get(peer(), "book-note")!!.bookId)
+    }
+
+    @Test
+    fun `a book note edited on both sides gives way to the server`() = runTest {
+        connect()
+        alias()
+        reconciled()
+        db.annotationDao().upsert(bookNote(body = "mine"))
+        db.annotationSyncDao().upsert(syncRow(id = "book-note", rev = 1, acked = "stale"))
+        emptyFeed()
+        server.enqueue(
+            results(
+                """{"id":"book-note","status":"conflict",
+                    "server":${bookNoteRecord(rev = 4, seq = 12, body = "theirs")}}
+                """.trimIndent(),
+            ),
+        )
+
+        sync()
+
+        val landed = db.annotationDao().byId("book-note")!!
+        assertEquals("theirs", landed.note)
+        assertEquals(AnnotationKind.BOOK_NOTE.name, landed.kind)
+        // Still standalone: the server's word must not anchor it.
+        assertEquals("", landed.locatorJson)
+        assertEquals(4, db.annotationSyncDao().get(peer(), "book-note")!!.rev)
+    }
+
+    @Test
+    fun `a tombstone in the feed removes a book note here too`() = runTest {
+        connect()
+        alias()
+        reconciled()
+        db.annotationDao().upsert(bookNote())
+        db.annotationSyncDao().upsert(
+            syncRow(id = "book-note", rev = 1, acked = AnnotationWire.fingerprint(bookNote(), WORK)),
+        )
+        server.enqueue(
+            json(
+                """{"annotations":[{"id":"book-note","rev":2,"seq":9,"deleted":true}],
+                    "high_water":9,"has_more":false}
+                """.trimIndent(),
+            ),
+        )
+
+        sync()
+
+        assertNull(db.annotationDao().byId("book-note"))
+        assertNull(db.annotationSyncDao().get(peer(), "book-note"))
     }
 
     @Test
@@ -1240,11 +1425,15 @@ class LiseurSyncAnnotationsTest {
      * about disagreement says so, with [liveSet] or [liveSetIs].
      */
     private fun agreed(workId: String): MockResponse = runBlocking {
-        val held = db.annotationSyncDao().forWork(peer(), workId)
-            .filter { it.rev >= 1 }
-            .joinToString(",") { row ->
+        val records = mutableListOf<String>()
+        for (row in db.annotationSyncDao().forWork(peer(), workId).filter { it.rev >= 1 }) {
+            records += if (db.annotationDao().byId(row.id)?.kind == AnnotationKind.BOOK_NOTE.name) {
+                bookNoteRecord(id = row.id, rev = row.rev, seq = row.seq, workId = workId)
+            } else {
                 record(id = row.id, rev = row.rev, seq = row.seq, workId = workId)
             }
+        }
+        val held = records.joinToString(",")
         json("""{"annotations":[$held]}""")
     }
 
@@ -1284,6 +1473,23 @@ class LiseurSyncAnnotationsTest {
         .apply { editionSha?.let { put("edition_sha", it) } }
         .toString()
 
+    private fun bookNoteRecord(
+        id: String = "book-note",
+        rev: Long = 1,
+        seq: Long = 1,
+        workId: String = WORK,
+        body: String = "remember this",
+    ): String = JSONObject()
+        .put("id", id)
+        .put("rev", rev)
+        .put("seq", seq)
+        .put("work_id", workId)
+        .put("kind", "note")
+        .put("body", body)
+        .put("device_id", "other-device")
+        .put("client_ts", STAMP)
+        .toString()
+
     private fun mark(
         id: String = "mark-1",
         note: String? = null,
@@ -1299,6 +1505,20 @@ class LiseurSyncAnnotationsTest {
         chapter = "Chapter One",
         position = 12,
         totalProgression = 0.25,
+        createdAt = NOW,
+        updatedAt = updatedAt,
+    )
+
+    private fun bookNote(
+        id: String = "book-note",
+        body: String = "remember this",
+        updatedAt: Long = MICROS,
+    ) = BookAnnotation(
+        id = id,
+        bookId = BOOK,
+        kind = AnnotationKind.BOOK_NOTE.name,
+        locatorJson = "",
+        note = body,
         createdAt = NOW,
         updatedAt = updatedAt,
     )

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/AnnotationBackupTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/AnnotationBackupTest.kt
@@ -1,5 +1,6 @@
 package com.chmouel.liseur.domain
 
+import com.chmouel.liseur.data.db.AnnotationKind
 import com.chmouel.liseur.data.db.BookAnnotation
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -42,6 +43,15 @@ class AnnotationBackupTest {
         createdAt = 1_700_000_001_000,
     )
 
+    private val bookNote = BookAnnotation(
+        id = "a3",
+        bookId = "calibre:uuid-1",
+        kind = AnnotationKind.BOOK_NOTE.name,
+        locatorJson = "",
+        note = "remember the argument",
+        createdAt = 1_700_000_002_000,
+    )
+
     private fun roundTrip(books: List<BackedUpBook>): List<BackedUpBook> {
         val decoded = decodeAnnotationBackup(encodeAnnotationBackup(books))
         assertTrue("$decoded", decoded is BackupContents.Readable)
@@ -60,6 +70,12 @@ class AnnotationBackupTest {
     fun `a bookmark with nothing written on it comes back empty, not blank`() {
         val back = roundTrip(listOf(BackedUpBook("calibre:uuid-1", null, null, listOf(bare))))
         assertEquals(bare, back.single().annotations.single())
+    }
+
+    @Test
+    fun `a book note comes back without an invented locator`() {
+        val back = roundTrip(listOf(BackedUpBook("calibre:uuid-1", null, null, listOf(bookNote))))
+        assertEquals(bookNote, back.single().annotations.single())
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/NotebookExportTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/NotebookExportTest.kt
@@ -102,6 +102,24 @@ class NotebookExportTest {
     }
 
     @Test
+    fun `book notes lead the notebook in creation order`() {
+        val md = exportNotebookMarkdown(
+            title = "A book",
+            author = null,
+            annotations = listOf(
+                annotation(text = "a passage", chapter = "One", progression = 0.1),
+                annotation(kind = AnnotationKind.BOOK_NOTE, note = "second", createdAt = 2),
+                annotation(kind = AnnotationKind.BOOK_NOTE, note = "first", createdAt = 1),
+            ),
+        )
+
+        assertTrue(md.contains("## Book notes"))
+        assertTrue(md.indexOf("## Book notes") < md.indexOf("## One"))
+        assertTrue(md.indexOf("first") < md.indexOf("second"))
+        assertFalse(md.contains("## Elsewhere"))
+    }
+
+    @Test
     fun `annotations outside any known chapter still get a home`() {
         val md = exportNotebookMarkdown(
             title = "A book",

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/annotations/AnnotationSurfacesTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/annotations/AnnotationSurfacesTest.kt
@@ -1,0 +1,79 @@
+package com.chmouel.liseur.reader.annotations
+
+import com.chmouel.liseur.data.db.AnnotationKind
+import com.chmouel.liseur.data.db.BookAnnotation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * A standalone book note has no passage, so it must not reach the two
+ * surfaces that assume one.
+ *
+ * Both guards are string comparisons against a kind name, which the
+ * compiler cannot check for us: nothing about adding a kind to the enum
+ * makes a `!=` fail to build. So they are pinned here instead.
+ *
+ * Robolectric because reading a locator back goes through `Uri`, which is
+ * a stub in android.jar.
+ */
+@Config(sdk = [35], application = android.app.Application::class)
+@RunWith(RobolectricTestRunner::class)
+class AnnotationSurfacesTest {
+
+    @Test
+    fun `a book note is never drawn over the page`() {
+        val drawn = listOf(highlight(), passageNote(), bookNote(), bookmark()).toDecorations()
+
+        assertEquals(listOf("highlight", "passage-note"), drawn.map { it.id })
+    }
+
+    @Test
+    fun `a book note has no locator to look a passage up by`() {
+        // What keeps it out of `annotationAt` even if the kind filter
+        // there were ever dropped: there is no passage to match, and
+        // reading the sentinel back does not throw on the way to finding
+        // that out.
+        assertNull(bookNote().locator())
+        assertNull(bookNote().copy(locatorJson = "not json").locator())
+        assertNotNull(highlight().locator())
+    }
+
+    private fun annotation(
+        id: String,
+        kind: AnnotationKind,
+        locatorJson: String,
+        note: String? = null,
+    ) = BookAnnotation(
+        id = id,
+        bookId = BOOK,
+        kind = kind.name,
+        locatorJson = locatorJson,
+        text = "a passage",
+        note = note,
+        tint = "YELLOW",
+        createdAt = 0,
+        updatedAt = 0,
+    )
+
+    private fun highlight() = annotation("highlight", AnnotationKind.HIGHLIGHT, LOCATOR)
+
+    private fun passageNote() =
+        annotation("passage-note", AnnotationKind.NOTE, LOCATOR, note = "in the margin")
+
+    private fun bookmark() = annotation("bookmark", AnnotationKind.BOOKMARK, LOCATOR)
+
+    private fun bookNote() =
+        annotation("book-note", AnnotationKind.BOOK_NOTE, "", note = "about the whole book")
+
+    private companion object {
+        const val BOOK = "content://sd/a-book.epub"
+        const val LOCATOR =
+            """{"href":"/ch1.xhtml","type":"application/xhtml+xml",""" +
+                """"locations":{"progression":0.25},"text":{"highlight":"a passage"}}"""
+    }
+}

--- a/docs/adr/0011-annotation-sync.md
+++ b/docs/adr/0011-annotation-sync.md
@@ -195,9 +195,34 @@ commits it: a different file may have taken over the path since the
 feed was asked, and writing the record against the name the book used to
 have would anchor another book's highlight into text that never held it.
 
-Anchorless server notes (a body with no locator) are skipped on pull.
-Liseur has no such record; giving it one is a separate decision, filed
-as [#77](https://github.com/chmouel/liseur/issues/77).
+Anchorless server notes (a body with no locator) are stored as `BOOK_NOTE`.
+They remain distinct from Liseur's `NOTE`, which is a passage highlight
+carrying a body on the wire. A book note carries only its body and work:
+no locator, progression, excerpt, colour or edition anchor. It appears in
+the notebook rather than on the page and follows the same revision,
+conflict and tombstone rules as every other annotation.
+
+Version 0.11.0 already advanced its cursor over notes it could not store.
+They are recovered when the ordinary seven-day live-set reconciliation next
+checks that work. The cursor and Room schema are deliberately not reset for
+this additive local representation.
+
+"No locator" is read generously on the way in: an absent key, a JSON null,
+an empty string and an empty object all mean the same thing, as they
+already do in `SyncOps.locatorFor`. Reading one of the latter spellings as
+an anchor would refuse a note on every pull *and* every reconcile, so the
+reader would never see it at all. The same normalisation refuses an
+anchored mark whose locator holds nothing, which anchors no text.
+
+Because a book note carries no `edition_sha`, `home()` cannot tell which
+copy of a work it was written against, and two copies of one book share a
+`work_id`. A note landing here for the first time goes to a copy chosen the
+same way every run. A note this device has already filed goes back where it
+already lives: the `annotation_sync` row, or failing that the annotation,
+is consulted before that fallback. Without it a conflict, a re-pair or any
+second landing would walk the note over to whichever copy sorts first, and
+the reader would watch it move between two copies of one book. Sending
+`edition_sha` on a note instead would contradict the wire shape above.
 
 ## Consequences
 


### PR DESCRIPTION
## Summary

A note with no locator is a note about the book rather than about a passage, and
liseur-sync has always been able to hold one. Liseur could not, so every one the server
sent was dropped on the floor: skipped on the way in, never shown, never written.

Fixes #77.

## Changes

- **`BOOK_NOTE`** is that note. It maps to the server's standalone `note` and stays
  distinct from `NOTE`, which is a passage highlight carrying a body. It has a body and
  deliberately nothing else — no locator, progression, excerpt, colour or edition anchor —
  so it is kept out of the decorations drawn over the page, out of `annotationAt`, and out
  of the highlights tab.
- The notes tab grows an add action, rows can be tapped to edit and deleted from the row,
  and an export files standalone notes under their own `## Book notes` heading.
- **Reading "no locator" needs a generous ear.** A peer with nothing to anchor may write an
  absent key, a JSON null, an empty string or an empty object, and `SyncOps.locatorFor` has
  read all four alike for as long as it has existed. Reading either of the last two as an
  anchor would refuse the note on every pull *and* every reconcile, so the reader would
  never see it once. The same rule now refuses an anchored mark whose locator holds
  nothing, which anchors no text.
- **Homing a note takes more care than homing a highlight.** Two copies of one book share a
  `work_id`, and `edition_sha` is what usually tells them apart — but a book note carries
  none, by design. A note arriving for the first time can go to a copy chosen the same way
  every run. A note already filed here has a better answer: where it already lives. Without
  consulting it, a conflict or a re-pair would walk the note over to whichever copy sorts
  first, and the reader would watch a note move between two copies of one book.
- The cursor and the Room schema are left alone. Notes skipped by earlier versions come
  back on the next seven-day live-set reconciliation, and the backup format carries the new
  kind without a bump.
- `AGENTS.md` and `docs/adr/0011-annotation-sync.md` record both rules.

## Testing

- [x] `./gradlew testDebugUnitTest` — 1387 tests green
- [x] `./gradlew lintDebug` — 0 errors
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

Round-tripped against a disposable liseur-sync server from an emulator: the note was
created locally, stored server-side as `kind=note` with no locator, edited from a second
token to `rev=2`/`seq=2`, then pulled back and displayed.

New coverage worth calling out, since each was a live failure candidate rather than a
happy path: a note with a locator and a note with an empty body both leave the cursor
intact; `locator: ""` and `locator: {}` are accepted as standalone; a book note keeps the
copy it already lives in; edited on both sides the server wins; a remote tombstone removes
it; and `AnnotationSurfacesTest` pins it out of `toDecorations()`.

## Screenshots or recordings

The notes tab showing a standalone book note that was written on this device, edited from
another client, and pulled back:

![A standalone book note in the notes tab, showing text edited remotely](https://github.com/user-attachments/assets/450bb8db-7870-40cf-be91-6b14216beffe)

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.