### PR TITLE
fix: refuse a feed hiding a document type inside a comment

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/data/calibre/OpdsParser.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/calibre/OpdsParser.kt
@@ -126,15 +126,19 @@ object OpdsParser {
             }
             i = when {
                 xml.startsWith(COMMENT, open) -> xml.endOf(COMMENT, "-->", open)
+                // CDATA is not legal in a prolog either. It is skipped
+                // rather than refused because its extent is unambiguous,
+                // which keeps its body from being read as markup.
                 xml.startsWith(CDATA, open) -> xml.endOf(CDATA, "]]>", open)
                 xml.startsWith(PI, open) -> xml.endOf(PI, "?>", open)
                 // A prolog holds the XML declaration, other processing
-                // instructions, comments and one DOCTYPE. A markup
-                // declaration that is none of those is malformed
-                // whatever it is, so a stray <!ENTITY out here is a feed
-                // to refuse rather than one to step over carefully.
-                // Refusing it also saves measuring an internal subset,
-                // whose first > can sit inside a quoted entity value.
+                // instructions, comments and one DOCTYPE, and CDATA is
+                // already dealt with above. Anything else opening <! is
+                // malformed whatever it is, so a stray <!ENTITY out here
+                // is a feed to refuse rather than one to step over
+                // carefully. Refusing it also saves measuring an
+                // internal subset, whose first > can sit inside a quoted
+                // entity value.
                 xml.startsWith("<!", open) -> malformed()
                 // Anything else opens the root element, so the prolog is
                 // over and a DOCTYPE can no longer legally appear.

--- a/app/src/main/kotlin/com/chmouel/liseur/data/calibre/OpdsParser.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/calibre/OpdsParser.kt
@@ -59,6 +59,12 @@ object OpdsParser {
     private const val IMAGE_REL = "http://opds-spec.org/image"
     private const val THUMBNAIL_REL = "http://opds-spec.org/image/thumbnail"
 
+    private const val COMMENT = "<!--"
+    private const val CDATA = "<![CDATA["
+    private const val PI = "<?"
+    private const val DOCTYPE = "<!DOCTYPE"
+    private const val XML_SPACE = " \t\r\n"
+
     /**
      * A parser that will not go and fetch things on the feed's behalf.
      *
@@ -103,35 +109,79 @@ object OpdsParser {
      * cannot be talked out of by anything later in the document. A feed
      * that trips it is refused as malformed, which is what it is: OPDS
      * has no document type to declare.
+     *
+     * The scan walks the prolog construct by construct rather than
+     * cutting it out and searching the text for the word. Stepping over
+     * a comment without reading a character of it is what stops a
+     * DOCTYPE hiding inside one, and what stops a comment that merely
+     * writes the word being taken for a feed that declares one.
      */
     private fun rejectsDoctype(xml: String) {
-        if (prologOf(xml).contains("<!DOCTYPE")) {
-            throw SAXException("the feed declares a document type, which OPDS never needs")
+        var i = 0
+        while (i < xml.length) {
+            val open = xml.indexOf('<', i)
+            if (open < 0) return
+            if (xml.startsWithDoctype(open)) {
+                throw SAXException("the feed declares a document type, which OPDS never needs")
+            }
+            i = when {
+                xml.startsWith(COMMENT, open) -> xml.endOf(COMMENT, "-->", open)
+                xml.startsWith(CDATA, open) -> xml.endOf(CDATA, "]]>", open)
+                xml.startsWith(PI, open) -> xml.endOf(PI, "?>", open)
+                // A prolog holds the XML declaration, other processing
+                // instructions, comments and one DOCTYPE. A markup
+                // declaration that is none of those is malformed
+                // whatever it is, so a stray <!ENTITY out here is a feed
+                // to refuse rather than one to step over carefully.
+                // Refusing it also saves measuring an internal subset,
+                // whose first > can sit inside a quoted entity value.
+                xml.startsWith("<!", open) -> malformed()
+                // Anything else opens the root element, so the prolog is
+                // over and a DOCTYPE can no longer legally appear.
+                else -> return
+            }
         }
     }
 
     /**
-     * Everything before the root element opens.
+     * Where the markup opening at [at] ends, one past its terminator.
      *
-     * A DOCTYPE is only ever legal here, so this is the only place worth
-     * looking -- and looking only here means a document that merely
-     * quotes the word, in a title or a CDATA block, is not mistaken for
-     * one that declares it.
+     * Not the next `>`. A comment ends at `-->`, CDATA at `]]>` and a
+     * processing instruction at `?>`, and XML lets all three carry a
+     * bare `>` in the body. Stopping at that one leaves the walk
+     * standing inside the construct, reading its text as markup: the
+     * first `<` it meets there is taken for the root element, the
+     * prolog ends early, and every declaration after it falls out of
+     * sight.
+     *
+     * The search starts past [opener] so that an empty construct,
+     * `<!---->` or `<?p?>`, cannot terminate on its own opening
+     * characters.
      */
-    private fun prologOf(xml: String): String {
-        var i = 0
-        while (i < xml.length) {
-            val open = xml.indexOf('<', i)
-            if (open < 0) return xml
-            // Anything that is not <? or <! is the root element.
-            val next = xml.getOrNull(open + 1)
-            if (next != '?' && next != '!') return xml.take(open)
-            val close = xml.indexOf('>', open)
-            if (close < 0) return xml
-            i = close + 1
-        }
-        return xml
+    private fun String.endOf(opener: String, terminator: String, at: Int): Int {
+        val end = indexOf(terminator, at + opener.length)
+        // A construct that never closes is not a prolog whose shape can
+        // be trusted, and the document will not parse either way.
+        if (end < 0) malformed()
+        return end + terminator.length
     }
+
+    /**
+     * Whether a document type is declared at [at].
+     *
+     * XML wants whitespace after the name, so `<!DOCTYPEfoo` declares
+     * nothing. The walk still refuses it, as it refuses anything
+     * opening `<!` it does not recognise, but as malformed rather than
+     * as a document type.
+     */
+    private fun String.startsWithDoctype(at: Int): Boolean {
+        if (!startsWith(DOCTYPE, at)) return false
+        val after = getOrNull(at + DOCTYPE.length) ?: return false
+        return after in XML_SPACE
+    }
+
+    private fun malformed(): Nothing =
+        throw SAXException("the feed's prolog is not well-formed XML")
 
     fun parse(xml: String): OpdsPage {
         rejectsDoctype(xml)

--- a/app/src/test/kotlin/com/chmouel/liseur/data/calibre/OpdsParserTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/calibre/OpdsParserTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.fail
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.xml.sax.SAXException
 
 class OpdsParserTest {
 
@@ -98,21 +99,188 @@ class OpdsParserTest {
      */
     @Test
     fun `a feed that declares entities is refused rather than resolved`() {
-        val hostile = """
+        refusedAsDoctype(
+            """
             <?xml version="1.0"?>
             <!DOCTYPE feed [<!ENTITY secret SYSTEM "file:///etc/hostname">]>
             <feed xmlns="http://www.w3.org/2005/Atom">
               <entry><id>urn:uuid:1</id><title>&secret;</title></entry>
             </feed>
-        """.trimIndent()
+            """.trimIndent(),
+        )
+    }
 
-        try {
-            OpdsParser.parse(hostile)
-            fail("the parser accepted a document that declared an external entity")
-        } catch (e: org.xml.sax.SAXException) {
-            // Refused outright, which upstream turns into "your server
-            // answered with something unexpected".
-        }
+    /**
+     * A comment ends at `-->`, not at the first `>` inside it. A scan
+     * that stops at the latter carries on reading the comment's text as
+     * markup, takes the `<a` in it for the root element, and calls the
+     * prolog finished before the DOCTYPE on the next line. That is how
+     * a feed hides one in plain sight.
+     */
+    @Test
+    fun `a doctype behind a comment carrying a bracket is still refused`() {
+        refusedAsDoctype(
+            """
+            <!-- > <a -->
+            <!DOCTYPE feed [<!ENTITY secret SYSTEM "file:///etc/hostname">]>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <entry><id>urn:uuid:1</id><title>&secret;</title></entry>
+            </feed>
+            """.trimIndent(),
+        )
+    }
+
+    /**
+     * The same trick through a processing instruction, whose body may
+     * hold anything but `?>` and so may hold both a `>` and a `<`.
+     */
+    @Test
+    fun `a doctype behind a processing instruction carrying a bracket is still refused`() {
+        refusedAsDoctype(
+            """
+            <?liseur > <a ?>
+            <!DOCTYPE feed [<!ENTITY secret SYSTEM "file:///etc/hostname">]>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <entry><id>urn:uuid:1</id><title>&secret;</title></entry>
+            </feed>
+            """.trimIndent(),
+        )
+    }
+
+    /**
+     * CDATA does not belong in a prolog, so this feed is malformed
+     * whatever we do. It is skipped to `]]>` all the same, because
+     * nothing opening `<` gets to end early.
+     */
+    @Test
+    fun `a doctype behind a cdata section carrying a bracket is still refused`() {
+        refusedAsDoctype(
+            """
+            <![CDATA[ > <a ]]>
+            <!DOCTYPE feed [<!ENTITY secret SYSTEM "file:///etc/hostname">]>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <entry><id>urn:uuid:1</id><title>&secret;</title></entry>
+            </feed>
+            """.trimIndent(),
+        )
+    }
+
+    /**
+     * A prolog we cannot read to the end is a prolog we cannot vouch
+     * for. Such a feed will not parse either, so refusing it costs
+     * nothing and leaves the scan with no way to accept what it failed
+     * to make sense of.
+     */
+    @Test
+    fun `a comment that never closes is refused`() {
+        refusedAsMalformed(
+            """
+            <!-- <!DOCTYPE feed [<!ENTITY secret SYSTEM "file:///etc/hostname">]>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <entry><id>urn:uuid:1</id><title>x</title></entry>
+            </feed>
+            """.trimIndent(),
+        )
+    }
+
+    /**
+     * XML wants whitespace after the name, so this declares nothing. It
+     * is refused for being malformed rather than for declaring a
+     * document type, which is a different thing to tell the user.
+     */
+    @Test
+    fun `a doctype lookalike with no space after the name is refused as malformed`() {
+        refusedAsMalformed(
+            """
+            <!DOCTYPEfoo>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <entry><id>urn:uuid:1</id><title>x</title></entry>
+            </feed>
+            """.trimIndent(),
+        )
+    }
+
+    /**
+     * Skipping a comment whole is what keeps the check from firing on a
+     * feed that declares nothing. A server admin's note about
+     * hand-written HTML is prose, and a scan that searched the prolog's
+     * text instead of walking it would refuse this feed outright.
+     */
+    @Test
+    fun `a comment that quotes a doctype is not a feed that declares one`() {
+        val page = OpdsParser.parse(
+            """
+            <!-- the admin's note on writing <!DOCTYPE html> by hand -->
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <entry><id>urn:uuid:abc</id><title>Moby Dick</title></entry>
+            </feed>
+            """.trimIndent(),
+        )
+
+        assertEquals(listOf("abc"), page.books.map { it.uuid })
+    }
+
+    @Test
+    fun `a processing instruction that quotes a doctype is not a feed that declares one`() {
+        val page = OpdsParser.parse(
+            """
+            <?liseur note="<!DOCTYPE html>" ?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <entry><id>urn:uuid:abc</id><title>Moby Dick</title></entry>
+            </feed>
+            """.trimIndent(),
+        )
+
+        assertEquals(listOf("abc"), page.books.map { it.uuid })
+    }
+
+    /** The adversarial characters, with nothing adversarial behind them. */
+    @Test
+    fun `a comment carrying a bracket does not stop an honest feed parsing`() {
+        val page = OpdsParser.parse(
+            """
+            <!-- > <a -->
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <entry><id>urn:uuid:abc</id><title>Moby Dick</title></entry>
+            </feed>
+            """.trimIndent(),
+        )
+
+        assertEquals(listOf("abc"), page.books.map { it.uuid })
+    }
+
+    @Test
+    fun `a processing instruction carrying a bracket does not stop an honest feed parsing`() {
+        val page = OpdsParser.parse(
+            """
+            <?liseur > <a ?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <entry><id>urn:uuid:abc</id><title>Moby Dick</title></entry>
+            </feed>
+            """.trimIndent(),
+        )
+
+        assertEquals(listOf("abc"), page.books.map { it.uuid })
+    }
+
+    /**
+     * An empty comment and a bodyless instruction pin where the search
+     * for a terminator starts. Begin it one character too early and
+     * `<!---->` closes on its own opening dashes; begin it too late and
+     * neither closes at all.
+     */
+    @Test
+    fun `an empty comment and a bodyless instruction are read to their ends`() {
+        val page = OpdsParser.parse(
+            """
+            <!----><?p?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <entry><id>urn:uuid:abc</id><title>Moby Dick</title></entry>
+            </feed>
+            """.trimIndent(),
+        )
+
+        assertEquals(listOf("abc"), page.books.map { it.uuid })
     }
 
     @Test
@@ -144,6 +312,31 @@ class OpdsParserTest {
         )
 
         assertEquals(listOf("abc"), page.books.map { it.uuid })
+    }
+
+    private fun refusedAsDoctype(feed: String) =
+        refused(feed, "the feed declares a document type, which OPDS never needs")
+
+    private fun refusedAsMalformed(feed: String) =
+        refused(feed, "the feed's prolog is not well-formed XML")
+
+    /**
+     * Asserts the refusal came from the parser's own scan of the prolog.
+     *
+     * A `SAXException` on its own proves nothing. Xerces honours
+     * `disallow-doctype-decl` on the JVM, so even a scan that missed the
+     * DOCTYPE entirely ends in one, thrown by the factory switch this
+     * check exists precisely not to depend on, and on Android possibly
+     * not thrown at all. The message is what tells the two layers apart.
+     */
+    private fun refused(feed: String, message: String) {
+        try {
+            OpdsParser.parse(feed)
+        } catch (e: SAXException) {
+            assertEquals(message, e.message)
+            return
+        }
+        fail("the parser accepted a feed it should have refused")
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes #92.

`OpdsParser.rejectsDoctype()` is the layer that has to hold when an Android
SAX implementation refuses `disallow-doctype-decl` and the factory settings
enforce nothing. It walked the prolog by jumping from each markup construct
to the next `>`. A comment ends at `-->` and a processing instruction at
`?>`, and XML lets both carry a bare `>` in the body, so the jump landed
inside the construct and the scan carried on reading its text as markup. The
first `<` it met there passed for the root element, which put a DOCTYPE
declared after the comment outside the prolog, where nothing looked for it.

Two things turned up while reproducing it:

- **The issue's own example is caught.** `<!-- > -->` followed by a DOCTYPE
  does not slip through: the resumed scan still meets `<!DOCTYPE`, sees the
  `!`, and skips it as markup, so the DOCTYPE stays inside the prolog. The
  bypass needs a `<a` inside the comment body, which is read as the root
  element opening. A test copied from the issue verbatim would have passed
  against the broken parser.
- **Processing instructions are a second way in**, which the issue does not
  mention. A PI body may hold anything but `?>`, so `<?pi > <a ?>` is
  well-formed and hides a DOCTYPE exactly the same way.

Rather than repair the terminator arithmetic, this drops `prologOf()`. Cutting
out a substring and running `contains("<!DOCTYPE")` over it is the flaw, and it
already misfires in the other direction today: a feed whose prolog carries an
ordinary comment about hand-written HTML is refused, because the search reads
inside a construct it should not be looking at. `rejectsDoctype()` now walks
the prolog construct by construct and never builds a string.

Severity is low either way, as the issue says. `disallow-doctype-decl` still
holds on Android, so this was a weakened second layer rather than an open door,
and nothing is known to be exploitable through it.

## Changes

- `rejectsDoctype()` walks the prolog: a DOCTYPE is recognised only where a
  construct begins, comments, CDATA and processing instructions are skipped to
  `-->`, `]]>` and `?>` without a character of them being read, and anything
  else opening `<!` is refused.
- Dropped the "skip a markup declaration to its next `>`" branch. A prolog
  admits the XML declaration, other processing instructions, comments and one
  DOCTYPE, so a stray `<!ENTITY` out there is a feed to refuse. That also
  removes the internal subset as something to measure, since its first `>` can
  sit inside a quoted entity value.
- A DOCTYPE needs whitespace after the name, so `<!DOCTYPEfoo>` is refused as
  malformed rather than reported as a declaration.
- Two messages, one meaning each: the feed declares a document type, or its
  prolog is not well-formed XML.
- Eleven test cases. Every refusal asserts the **message**, not just that a
  `SAXException` came out: Xerces honours `disallow-doctype-decl` on the JVM,
  so a broken scan still ends in one, thrown a layer too late by the switch
  this check exists not to depend on. Only the message tells the two apart.
  The existing entity test now asserts its message too.
- Six of the cases are feeds that must still parse, including a comment and a
  PI that quote `<!DOCTYPE html>` as text. Both are refused by `main` today.

Seven of the new tests fail against the parser as it stands.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [ ] Manually tested on a device or emulator, if applicable

Also checked the new tests red against the unfixed parser before green against
the fixed one, so the suite is known to catch both the bypass and the false
positive.

## Screenshots or recordings

Nothing to show. This changes a parser, with no user-visible surface beyond a
refused feed reaching the existing "your server answered with something
unexpected" path.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.