### PR TITLE
refactor(settings): pick a server kind from a row and a sheet

### DIFF
--- a/app/src/main/assets/licences/agpl-3.0.txt
+++ b/app/src/main/assets/licences/agpl-3.0.txt
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/app/src/main/assets/licences/gpl-3.0.txt
+++ b/app/src/main/assets/licences/gpl-3.0.txt
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/ServerKind.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/ServerKind.kt
@@ -1,6 +1,33 @@
 package com.chmouel.liseur.data.remote
 
 /**
+ * How much of a reading position a kind of server can carry.
+ *
+ * A claim about the *kind*, answerable before anything has been typed,
+ * which is what makes it the thing the server picker can show: choosing
+ * where your library lives is partly choosing whether your place in a
+ * book follows you, and finding that out after connecting is finding it
+ * out too late.
+ *
+ * Deliberately not [com.chmouel.liseur.data.db.RemoteServer.canSync],
+ * which asks a different question — whether *this* account is ready to
+ * sync right now, and for calibre-web that waits on a Kobo token. The
+ * two must not be folded together: a picker that read `canSync` would
+ * have to invent an account to ask, and a repository that read this
+ * would offer calibre-web a sync it has no token for.
+ */
+enum class SyncAbility {
+    /** The exact spot in the book, restored on every device. */
+    EXACT,
+
+    /** How far through the book, but not the exact spot. */
+    PROGRESSION,
+
+    /** Nothing: the server has nowhere to put a reading position. */
+    NONE,
+}
+
+/**
  * Which kind of server the library is connected to.
  *
  * One server is connected at a time, and its kind is what decides which
@@ -77,6 +104,22 @@ enum class ServerKind(
         get() = when (this) {
             CALIBRE, GRIMMORY -> true
             KOMGA, LISEUR_SYNC -> false
+        }
+
+    /**
+     * How much of a reading position this kind can carry, as something
+     * to say before an account exists.
+     *
+     * calibre-web is [SyncAbility.PROGRESSION] because the Kobo
+     * protocol exchanges a percentage and nothing else, so the page
+     * comes back approximately. Komga and liseur-sync exchange a whole
+     * locator. Grimmory's shim answers 404 to every progress route.
+     */
+    val syncAbility: SyncAbility
+        get() = when (this) {
+            CALIBRE -> SyncAbility.PROGRESSION
+            KOMGA, LISEUR_SYNC -> SyncAbility.EXACT
+            GRIMMORY -> SyncAbility.NONE
         }
 
     companion object {

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/LicencesScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/LicencesScreen.kt
@@ -57,6 +57,9 @@ private data class Component(
  * small, deliberately all free software, and being able to read it without
  * building the app is the point. The fonts include the ones Readium brings
  * with it, because they ship inside the app whether or not we chose them.
+ * The last entries are artwork rather than code: the server logos are
+ * copyleft, and the licence asks for the notice and the text to travel
+ * with them.
  */
 private val Components = listOf(
     Component("Readium Kotlin Toolkit", "BSD 3-Clause"),
@@ -111,6 +114,20 @@ private val Components = listOf(
         licence = "SIL Open Font License 1.1",
         notice = "Copyright (c) 2017 IBM Corp.",
         licenceAsset = "licences/ia-writer-duospace.txt",
+    ),
+    Component(
+        name = "calibre-web logo",
+        licence = "GPL-3.0-or-later",
+        notice = "Copyright (c) The calibre-web contributors\n" +
+            "github.com/janeczku/calibre-web",
+        licenceAsset = "licences/gpl-3.0.txt",
+    ),
+    Component(
+        name = "Grimmory logo",
+        licence = "AGPL-3.0-or-later",
+        notice = "Copyright (c) The Grimmory contributors\n" +
+            "github.com/grimmory-tools/grimmory",
+        licenceAsset = "licences/agpl-3.0.txt",
     ),
 )
 

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -57,7 +56,6 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
@@ -390,51 +388,6 @@ private fun BulkDownloadStatus(
  * address: a face to recognise it by, a line on what it does, and
  * somewhere to go for the one they have not got yet.
  */
-@Composable
-private fun KindCard(kind: ServerKind) {
-    val uriHandler = LocalUriHandler.current
-    Card(
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-        ),
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Column(
-            Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp),
-        ) {
-            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                Text(
-                    stringResource(kind.labelRes()),
-                    style = MaterialTheme.typography.titleMedium,
-                )
-                Text(
-                    stringResource(kind.taglineRes()),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            Text(
-                stringResource(kind.introRes()),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            TextButton(
-                onClick = { runCatching { uriHandler.openUri(kind.homeUrl()) } },
-                contentPadding = PaddingValues(0.dp),
-            ) {
-                Text(stringResource(kind.linkRes()))
-                Spacer(Modifier.width(6.dp))
-                Icon(
-                    imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
-                    contentDescription = null,
-                    modifier = Modifier.size(16.dp),
-                )
-            }
-        }
-    }
-}
-
 /**
  * One concern of a connected server — what it downloads, what it syncs,
  * what it accepts — kept in its own card, because the settled screen is
@@ -485,33 +438,40 @@ private fun ConnectForm(
     onDeviceTokenChange: (String) -> Unit,
     onConnect: (Boolean) -> Unit,
 ) {
-    Text(
-        stringResource(R.string.server_kind),
-        style = MaterialTheme.typography.bodyMedium,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-    )
-    // Chips that wrap, rather than a segmented control that cannot.
-    // With four kinds -- "calibre-web", "Komga", "Grimmory",
-    // "liseur-sync" -- the labels no longer fit one row on a narrow
-    // phone, and a segmented control's answer to that is to squeeze
-    // them until they are unreadable.
-    FlowRow(
-        modifier = Modifier
-            .fillMaxWidth()
-            .selectableGroup(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        ServerKind.entries.forEach { kind ->
-            FilterChip(
-                selected = state.kind == kind,
-                onClick = { onKindChange(kind) },
-                enabled = !state.connecting,
-                label = { Text(stringResource(kind.labelRes())) },
+    var picking by rememberSaveable { mutableStateOf(false) }
+    val uriHandler = LocalUriHandler.current
+    // The row and its link are one thing, so they share a gap rather
+    // than each spending one of the column's: the whole point of the
+    // redesign is the height at the top of this form.
+    Column {
+        ServerKindRow(
+            kind = state.kind,
+            enabled = !state.connecting,
+            onClick = { picking = true },
+        )
+        TextButton(
+            onClick = { runCatching { uriHandler.openUri(state.kind.homeUrl()) } },
+            contentPadding = PaddingValues(0.dp),
+        ) {
+            Text(stringResource(state.kind.linkRes()))
+            Spacer(Modifier.width(6.dp))
+            Icon(
+                imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
             )
         }
     }
-    KindCard(state.kind)
+    if (picking) {
+        ServerKindSheet(
+            selected = state.kind,
+            onPick = {
+                onKindChange(it)
+                picking = false
+            },
+            onDismiss = { picking = false },
+        )
+    }
     OutlinedTextField(
         value = state.url,
         onValueChange = onUrlChange,
@@ -982,7 +942,7 @@ private fun AdvancedSection(server: RemoteServer, onKoboToken: (String) -> Unit)
 }
 
 /** Where to get a liseur-sync server, for a reader who has not got one yet. */
-private const val LISEUR_SYNC_SERVER_URL = "https://github.com/chmouel/liseur-sync"
+internal const val LISEUR_SYNC_SERVER_URL = "https://github.com/chmouel/liseur-sync"
 
 /**
  * The liseur-sync way in: sign in and let the app mint a device token,
@@ -1153,45 +1113,6 @@ internal fun Notice(text: String, tone: NoticeTone) {
         )
         Text(text, style = MaterialTheme.typography.bodyMedium, color = color)
     }
-}
-
-private fun ServerKind.labelRes(): Int = when (this) {
-    ServerKind.CALIBRE -> R.string.server_kind_calibre
-    ServerKind.KOMGA -> R.string.server_kind_komga
-    ServerKind.GRIMMORY -> R.string.server_kind_grimmory
-    ServerKind.LISEUR_SYNC -> R.string.server_kind_liseur_sync
-}
-
-private fun ServerKind.introRes(): Int = when (this) {
-    ServerKind.CALIBRE -> R.string.server_intro_calibre
-    ServerKind.KOMGA -> R.string.server_intro_komga
-    ServerKind.GRIMMORY -> R.string.server_intro_grimmory
-    ServerKind.LISEUR_SYNC -> R.string.server_intro_liseur_sync
-}
-
-/**
- * Where a reader who has not got this kind of server yet can read about
- * it. Every kind gets one: the form otherwise gives them nowhere to go.
- */
-private fun ServerKind.homeUrl(): String = when (this) {
-    ServerKind.CALIBRE -> "https://github.com/janeczku/calibre-web"
-    ServerKind.KOMGA -> "https://komga.org"
-    ServerKind.GRIMMORY -> "https://github.com/grimmory-tools/grimmory"
-    ServerKind.LISEUR_SYNC -> LISEUR_SYNC_SERVER_URL
-}
-
-private fun ServerKind.linkRes(): Int = when (this) {
-    ServerKind.CALIBRE -> R.string.server_link_calibre
-    ServerKind.KOMGA -> R.string.server_link_komga
-    ServerKind.GRIMMORY -> R.string.server_link_grimmory
-    ServerKind.LISEUR_SYNC -> R.string.liseur_sync_get_one
-}
-
-private fun ServerKind.taglineRes(): Int = when (this) {
-    ServerKind.CALIBRE -> R.string.server_tagline_calibre
-    ServerKind.KOMGA -> R.string.server_tagline_komga
-    ServerKind.GRIMMORY -> R.string.server_tagline_grimmory
-    ServerKind.LISEUR_SYNC -> R.string.server_tagline_liseur_sync
 }
 
 private fun AccountError.messageRes(kind: ServerKind): Int = when (this) {

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountScreen.kt
@@ -941,9 +941,6 @@ private fun AdvancedSection(server: RemoteServer, onKoboToken: (String) -> Unit)
     }
 }
 
-/** Where to get a liseur-sync server, for a reader who has not got one yet. */
-internal const val LISEUR_SYNC_SERVER_URL = "https://github.com/chmouel/liseur-sync"
-
 /**
  * The liseur-sync way in: sign in and let the app mint a device token,
  * or paste a token minted on the server.

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerKindPicker.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerKindPicker.kt
@@ -1,0 +1,172 @@
+package com.chmouel.liseur.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ExpandMore
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import com.chmouel.liseur.R
+import com.chmouel.liseur.data.remote.ServerKind
+import com.chmouel.liseur.data.remote.SyncAbility
+
+/**
+ * Choosing which kind of server the library lives on.
+ *
+ * A choice most readers make once, so it is a single row that says what
+ * is currently picked and opens a sheet, rather than a control laid out
+ * across the top of the form. It used to be a segmented button, then a
+ * `FlowRow` of chips once four labels stopped fitting a phone's width,
+ * and a fifth kind would have wrapped it to a third row (issue #96).
+ * A row and a sheet cost the same height whatever the count, and the
+ * sheet is the only place any of this has ever been comparable: the
+ * chips carried bare names, and the card under them explained only the
+ * kind already selected.
+ *
+ * Kept out of `ServerAccountScreen.kt`, which is long enough.
+ */
+@Composable
+internal fun ServerKindRow(
+    kind: ServerKind,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    OutlinedCard(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        ListItem(
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            overlineContent = { Text(stringResource(R.string.server_kind)) },
+            headlineContent = { Text(stringResource(kind.labelRes())) },
+            supportingContent = { KindSupport(kind) },
+            trailingContent = {
+                Icon(
+                    imageVector = Icons.Outlined.ExpandMore,
+                    contentDescription = stringResource(R.string.server_kind_change),
+                )
+            },
+        )
+    }
+}
+
+/**
+ * Every kind at once, which is the thing the reader could not do
+ * before: the tagline says what the server is for, and the line under
+ * it says whether your place in a book will follow you there. Grimmory
+ * cannot carry one at all, and that is worth knowing before typing a
+ * password rather than after.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ServerKindSheet(
+    selected: ServerKind,
+    onPick: (ServerKind) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            Modifier
+                .verticalScroll(rememberScrollState())
+                .navigationBarsPadding()
+                .selectableGroup(),
+        ) {
+            Text(
+                stringResource(R.string.server_kind),
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(start = 24.dp, end = 24.dp, bottom = 8.dp),
+            )
+            ServerKind.entries.forEach { kind ->
+                ListItem(
+                    modifier = Modifier.selectable(
+                        selected = kind == selected,
+                        role = Role.RadioButton,
+                        onClick = { onPick(kind) },
+                    ),
+                    colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                    headlineContent = { Text(stringResource(kind.labelRes())) },
+                    supportingContent = { KindSupport(kind) },
+                    trailingContent = {
+                        // Null, not a second handler: the row already
+                        // carries the click, and giving the button one
+                        // too makes TalkBack read two targets.
+                        RadioButton(selected = kind == selected, onClick = null)
+                    },
+                )
+            }
+        }
+    }
+}
+
+/** What a kind is for, and whether it keeps your place. */
+@Composable
+private fun KindSupport(kind: ServerKind) {
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(stringResource(kind.taglineRes()))
+        Text(
+            stringResource(kind.syncAbility.lineRes()),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private fun SyncAbility.lineRes(): Int = when (this) {
+    SyncAbility.EXACT -> R.string.server_sync_exact
+    SyncAbility.PROGRESSION -> R.string.server_sync_progression
+    SyncAbility.NONE -> R.string.server_sync_none
+}
+
+internal fun ServerKind.labelRes(): Int = when (this) {
+    ServerKind.CALIBRE -> R.string.server_kind_calibre
+    ServerKind.KOMGA -> R.string.server_kind_komga
+    ServerKind.GRIMMORY -> R.string.server_kind_grimmory
+    ServerKind.LISEUR_SYNC -> R.string.server_kind_liseur_sync
+}
+
+internal fun ServerKind.taglineRes(): Int = when (this) {
+    ServerKind.CALIBRE -> R.string.server_tagline_calibre
+    ServerKind.KOMGA -> R.string.server_tagline_komga
+    ServerKind.GRIMMORY -> R.string.server_tagline_grimmory
+    ServerKind.LISEUR_SYNC -> R.string.server_tagline_liseur_sync
+}
+
+/**
+ * Where a reader who has not got this kind of server yet can read about
+ * it. Every kind gets one: the form otherwise gives them nowhere to go.
+ */
+internal fun ServerKind.homeUrl(): String = when (this) {
+    ServerKind.CALIBRE -> "https://github.com/janeczku/calibre-web"
+    ServerKind.KOMGA -> "https://komga.org"
+    ServerKind.GRIMMORY -> "https://github.com/grimmory-tools/grimmory"
+    ServerKind.LISEUR_SYNC -> LISEUR_SYNC_SERVER_URL
+}
+
+internal fun ServerKind.linkRes(): Int = when (this) {
+    ServerKind.CALIBRE -> R.string.server_link_calibre
+    ServerKind.KOMGA -> R.string.server_link_komga
+    ServerKind.GRIMMORY -> R.string.server_link_grimmory
+    ServerKind.LISEUR_SYNC -> R.string.liseur_sync_get_one
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerKindPicker.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerKindPicker.kt
@@ -168,7 +168,8 @@ private fun ServerKind.logoRes(): Int = when (this) {
 
 /** What a kind is for, and whether it keeps your place. */
 @Composable
-private fun KindSupport(kind: ServerKind) {    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+private fun KindSupport(kind: ServerKind) {
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
         Text(stringResource(kind.taglineRes()))
         Text(
             stringResource(kind.syncAbility.lineRes()),
@@ -197,6 +198,9 @@ internal fun ServerKind.taglineRes(): Int = when (this) {
     ServerKind.GRIMMORY -> R.string.server_tagline_grimmory
     ServerKind.LISEUR_SYNC -> R.string.server_tagline_liseur_sync
 }
+
+/** Where to get a liseur-sync server, for a reader who has not got one yet. */
+private const val LISEUR_SYNC_SERVER_URL = "https://github.com/chmouel/liseur-sync"
 
 /**
  * Where a reader who has not got this kind of server yet can read about

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerKindPicker.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerKindPicker.kt
@@ -1,10 +1,12 @@
 package com.chmouel.liseur.ui.settings
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
@@ -23,6 +25,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
@@ -62,6 +65,7 @@ internal fun ServerKindRow(
             overlineContent = { Text(stringResource(R.string.server_kind)) },
             headlineContent = { Text(stringResource(kind.labelRes())) },
             supportingContent = { KindSupport(kind) },
+            leadingContent = { ServerKindLogo(kind) },
             trailingContent = {
                 Icon(
                     imageVector = Icons.Outlined.ExpandMore,
@@ -108,6 +112,7 @@ internal fun ServerKindSheet(
                     colors = ListItemDefaults.colors(containerColor = Color.Transparent),
                     headlineContent = { Text(stringResource(kind.labelRes())) },
                     supportingContent = { KindSupport(kind) },
+                    leadingContent = { ServerKindLogo(kind) },
                     trailingContent = {
                         // Null, not a second handler: the row already
                         // carries the click, and giving the button one
@@ -120,10 +125,50 @@ internal fun ServerKindSheet(
     }
 }
 
+/**
+ * A kind's own logo, where we are allowed to ship it.
+ *
+ * Komga's is not: its repository is MIT, but the icon is, by their own
+ * README, "based on an icon made by Freepik from flaticon.com", whose
+ * licence is neither transferable nor sublicensable — so Komga cannot
+ * pass it on to us and F-Droid, which requires every bundled asset to
+ * be redistributable, would not take it. Drawing a lookalike would be
+ * worse than either shipping theirs or shipping none, since it puts an
+ * invented mark under their name. So Komga gets the neutral glyph, and
+ * it is tinted rather than left in its own colours to read as a
+ * placeholder rather than as a brand.
+ *
+ * If Komga ever relicenses the icon, this is a one-line change.
+ */
+@Composable
+private fun ServerKindLogo(kind: ServerKind) {
+    val size = Modifier.size(32.dp)
+    when (kind) {
+        ServerKind.KOMGA -> Icon(
+            painter = painterResource(R.drawable.ic_server_generic),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = size,
+        )
+
+        else -> Image(
+            painter = painterResource(kind.logoRes()),
+            contentDescription = null,
+            modifier = size,
+        )
+    }
+}
+
+private fun ServerKind.logoRes(): Int = when (this) {
+    ServerKind.CALIBRE -> R.drawable.ic_server_calibre_web
+    ServerKind.KOMGA -> R.drawable.ic_server_generic
+    ServerKind.GRIMMORY -> R.drawable.ic_server_grimmory
+    ServerKind.LISEUR_SYNC -> R.drawable.ic_server_liseur_sync
+}
+
 /** What a kind is for, and whether it keeps your place. */
 @Composable
-private fun KindSupport(kind: ServerKind) {
-    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+private fun KindSupport(kind: ServerKind) {    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
         Text(stringResource(kind.taglineRes()))
         Text(
             stringResource(kind.syncAbility.lineRes()),

--- a/app/src/main/res/drawable/ic_server_calibre_web.xml
+++ b/app/src/main/res/drawable/ic_server_calibre_web.xml
@@ -1,0 +1,13 @@
+<!--
+    calibre-web's icon, from github.com/janeczku/calibre-web (cps/static/icon.svg),
+    GPL-3.0-or-later. Converted to a VectorDrawable; the artwork is unchanged.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="140"
+    android:viewportHeight="140">
+    <path
+        android:fillColor="#45B29D"
+        android:pathData="M70.5 5.5C87.77 3.13 97.44 10.46 99.5 27.5 95.64 46.7 84.3 59.2 65.5 65 60.91 66.39 56.24 66.73 51.5 66 50.07 65.53 48.9 64.7 48 63.5 47.33 60.5 47.33 57.5 48 54.5 62.25 56.05 73.58 50.72 82 38.5 85.03 33.89 86.03 28.89 85 23.5 83.05 19.29 79.72 17.29 75 17.5 65.53 19.08 57.86 23.74 52 31.5 38.31 51.64 33.97 73.64 39 97.5 44.56 116.53 56.73 122.7 75.5 116 80.6 113.39 85.27 110.22 89.5 106.5 95.19 108.89 96.69 112.89 94 118.5 78.42 132.15 61.25 134.65 42.5 126 31.52 117.21 25.35 105.71 24 91.5 21 65.85 27.33 42.85 43 22.5 50.62 14.12 59.78 8.45 70.5 5.5Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_server_generic.xml
+++ b/app/src/main/res/drawable/ic_server_generic.xml
@@ -1,0 +1,24 @@
+<!--
+    A neutral book-server glyph, drawn for this project. Used for a kind whose
+    own logo cannot be redistributed under a free licence.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M5,4.25h14A1.75,1.75 0,0 1,20.75 6v3.5A1.75,1.75 0,0 1,19 11.25h-14A1.75,1.75 0,0 1,3.25 9.5V6A1.75,1.75 0,0 1,5 4.25Z"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="1.5" />
+    <path
+        android:pathData="M5,12.75h14A1.75,1.75 0,0 1,20.75 14.5v3.5A1.75,1.75 0,0 1,19 19.75h-14A1.75,1.75 0,0 1,3.25 18v-3.5A1.75,1.75 0,0 1,5 12.75Z"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="1.5" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7,7.75m-1.15,0a1.15,1.15 0,1 0,2.3 0a1.15,1.15 0,1 0,-2.3 0" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7,16.25m-1.15,0a1.15,1.15 0,1 0,2.3 0a1.15,1.15 0,1 0,-2.3 0" />
+</vector>

--- a/app/src/main/res/drawable/ic_server_grimmory.xml
+++ b/app/src/main/res/drawable/ic_server_grimmory.xml
@@ -1,0 +1,51 @@
+<!--
+    Grimmory's icon, from github.com/grimmory-tools/grimmory
+    (frontend/public/icons/icon.svg), AGPL-3.0. Converted to a VectorDrawable;
+    the artwork is unchanged.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="100"
+    android:viewportHeight="126">
+    <path
+        android:fillColor="#FF2126"
+        android:pathData="M25.81 106.61V113.08 119.54 126L32.26 119.54 38.71 126V119.54 113.08 106.61H25.81Z"/>
+    <path
+        android:pathData="M38.71 29.08H96.77C98.55 29.08 100 27.63 100 25.85V3.23C100 1.45 98.55 0 96.77 0H12.9C10.55 0 8.35 0.63 6.45 1.73 4.49 2.87 2.86 4.5 1.73 6.46 0.63 8.36 0 10.57 0 12.92V106.61C0 113.75 5.78 119.54 12.9 119.54H21.15V113.08H12.9C9.34 113.08 6.45 110.18 6.45 106.61 6.45 103.04 9.34 100.15 12.9 100.15H93.55C97.11 100.15 100 97.26 100 93.69V42C100 38.43 97.11 35.54 93.55 35.54H38.71C36.93 35.54 35.48 36.98 35.48 38.77V61.38C35.48 63.17 36.93 64.61 38.71 64.61H67.74C69.52 64.61 70.97 66.06 70.97 67.84 70.97 69.63 69.52 71.07 67.74 71.07H38.71C33.36 71.07 29.03 66.73 29.03 61.38V38.76C29.03 33.41 33.36 29.07 38.71 29.07V29.08Z">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:type="linear"
+                android:startX="50"
+                android:startY="0"
+                android:endX="50"
+                android:endY="119.54">
+                <item
+                    android:color="#FFFBB042"
+                    android:offset="0"/>
+                <item
+                    android:color="#FFF16422"
+                    android:offset="1"/>
+            </gradient>
+        </aapt:attr>
+    </path>
+    <path
+        android:pathData="M96.77 113.08H43.55V119.54H96.77C98.55 119.54 100 118.09 100 116.31 100 114.52 98.55 113.08 96.77 113.08Z">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:type="linear"
+                android:startX="50"
+                android:startY="0"
+                android:endX="50"
+                android:endY="119.54">
+                <item
+                    android:color="#FFFBB042"
+                    android:offset="0"/>
+                <item
+                    android:color="#FFF16422"
+                    android:offset="1"/>
+            </gradient>
+        </aapt:attr>
+    </path>
+</vector>

--- a/app/src/main/res/drawable/ic_server_liseur_sync.xml
+++ b/app/src/main/res/drawable/ic_server_liseur_sync.xml
@@ -1,0 +1,31 @@
+<!--
+    liseur-sync's mark: a bookmark inside a sync ring. Drawn for this project.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="512"
+    android:viewportHeight="512">
+    <path
+        android:fillColor="#7A4A2B"
+        android:pathData="M116,0H396A116,116 0,0 1,512 116V396A116,116 0,0 1,396 512H116A116,116 0,0 1,0 396V116A116,116 0,0 1,116 0Z" />
+    <path
+        android:pathData="M88.6,226.5A170,170 0,0 1,423.4 226.5"
+        android:strokeColor="#F6F1EA"
+        android:strokeWidth="38"
+        android:strokeLineCap="butt" />
+    <path
+        android:pathData="M423.4,285.5A170,170 0,0 1,88.6 285.5"
+        android:strokeColor="#F6F1EA"
+        android:strokeWidth="38"
+        android:strokeLineCap="butt" />
+    <path
+        android:fillColor="#F6F1EA"
+        android:pathData="M433.5,283.6L460.8,219.9 386,233.1Z" />
+    <path
+        android:fillColor="#F6F1EA"
+        android:pathData="M78.5,228.4L51.2,292.1 126,278.9Z" />
+    <path
+        android:fillColor="#F6F1EA"
+        android:pathData="M206,178H306V334L256,288 206,334Z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,10 +170,10 @@
     <string name="server_kind_komga">Komga</string>
     <string name="server_kind_grimmory">Grimmory</string>
     <string name="server_kind_liseur_sync">liseur-sync</string>
-    <string name="server_intro_calibre">Give the address of your calibre-web server and the login you use for it. Liseur works out the rest on its own.</string>
-    <string name="server_intro_komga">Give the address of your Komga server and an API key from its account page. Liseur works out the rest on its own.</string>
-    <string name="server_intro_grimmory">Give the address of your Grimmory server and the username and password of an OPDS user — not the login you sign into Grimmory with in a browser. Liseur browses and downloads; it cannot keep your place in a book here.</string>
-    <string name="server_intro_liseur_sync">Give the address of your liseur-sync server. It holds your books and keeps your place in them across devices, including books that came from nowhere but this phone.</string>
+    <string name="server_kind_change">Change the kind of server</string>
+    <string name="server_sync_exact">Keeps your exact place in a book across devices</string>
+    <string name="server_sync_progression">Keeps how far through a book you are across devices</string>
+    <string name="server_sync_none">Browsing and downloads only — it cannot keep your place</string>
     <string name="server_link_calibre">What calibre-web is, and how to run one</string>
     <string name="server_link_komga">What Komga is, and how to run one</string>
     <string name="server_link_grimmory">What Grimmory is, and how to run one</string>
@@ -181,7 +181,7 @@
     <string name="server_tagline_calibre">Your calibre library, served over the web</string>
     <string name="server_tagline_komga">A server for comics, manga and books</string>
     <string name="server_tagline_grimmory">A self-hosted library for your ebooks</string>
-    <string name="server_tagline_liseur_sync">Your books, and your place in them, on every device</string>
+    <string name="server_tagline_liseur_sync">Your books on every device — even books only on this phone</string>
     <string name="server_section_server">Server</string>
     <string name="server_section_sync">Reading positions</string>
     <string name="server_api_key">API key</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/ServerKindTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/ServerKindTest.kt
@@ -4,6 +4,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import com.chmouel.liseur.data.db.RemoteServer
 
 /**
  * The spellings written into the database.
@@ -60,4 +61,49 @@ class ServerKindTest {
         assertEquals(ServerKind.CALIBRE, ServerKind.fromStored("SOMETHING_FROM_THE_FUTURE"))
         assertEquals(ServerKind.LISEUR_SYNC, ServerKind.fromStored("LISEUR_SYNC"))
     }
+
+    @Test
+    fun `every kind says what it can do with a reading position`() {
+        // What the server picker shows before an account exists, so a
+        // reader learns Grimmory cannot keep their place while they can
+        // still choose otherwise.
+        assertEquals(SyncAbility.PROGRESSION, ServerKind.CALIBRE.syncAbility)
+        assertEquals(SyncAbility.EXACT, ServerKind.KOMGA.syncAbility)
+        assertEquals(SyncAbility.EXACT, ServerKind.LISEUR_SYNC.syncAbility)
+        assertEquals(SyncAbility.NONE, ServerKind.GRIMMORY.syncAbility)
+    }
+
+    @Test
+    fun `the picker's claim matches what a settled account can actually sync`() {
+        // The invariant a fifth kind has to satisfy: promising a sync in
+        // the picker and refusing one on the connected screen is the
+        // same bug twice, and only this pins them together. Asked of an
+        // account holding every secret, because the calibre-web Kobo
+        // token is a question about the account, not about the kind.
+        ServerKind.entries.forEach { kind ->
+            assertEquals(
+                "${kind.name} promises ${kind.syncAbility} but canSync disagrees",
+                kind.syncAbility != SyncAbility.NONE,
+                fullyCredentialed(kind).canSync,
+            )
+        }
+    }
+
+    /** An account of [kind] that has finished every setup step it has. */
+    private fun fullyCredentialed(kind: ServerKind) = RemoteServer(
+        kind = kind,
+        baseUrl = "https://books.example.com",
+        username = "reader",
+        passwordCipher = "cipher",
+        apiKeyCipher = "cipher",
+        accountId = "1",
+        userId = 1,
+        koboTokenCipher = "cipher",
+        canDownload = true,
+        addedAt = 0L,
+        catalogSyncedAt = null,
+        positionSyncedAt = null,
+        syncToken = null,
+        liseurTokenCipher = "cipher",
+    )
 }

--- a/docs/adr/0013-server-kind-picker.md
+++ b/docs/adr/0013-server-kind-picker.md
@@ -117,3 +117,28 @@ four names ever were.
 `ServerAccountScreen.kt` was 1300 lines. The picker leaving for
 `ServerKindPicker.kt` takes the per-kind label, tagline, home URL and
 link lookups with it, which is where the next kind will be added.
+
+## Logos, and the one we cannot ship
+
+Rows carry each kind's own mark, which is what makes a list of four
+scannable rather than four paragraphs to read. Three are ours to ship:
+calibre-web's is GPL-3.0 and Grimmory's AGPL-3.0, both with the rest of
+their source and with no carve-out for the artwork, and liseur-sync's
+was drawn here. The two upstream marks are unmodified, converted to
+VectorDrawables, with their notices and licence texts added to the
+Licences screen.
+
+Komga's is not. Its repository is MIT, but the icon is, by Komga's own
+README, "based on an icon made by Freepik from flaticon.com", and
+Flaticon's licence is neither transferable nor sublicensable — so
+Komga's MIT cannot reach it, and F-Droid's inclusion policy requires
+every bundled asset to be redistributable. Komga therefore gets a
+neutral book-server glyph, tinted with the theme rather than left in
+colours of its own, so it reads as a placeholder and not as a mark
+somebody chose. Drawing something Komga-shaped instead would have been
+worse than either shipping theirs or shipping none: it puts invented
+artwork under their name.
+
+This is a licensing fact about one upstream project, not a rule about
+the picker. If Komga relicenses the icon, `ServerKindLogo` gains a
+branch and loses one.

--- a/docs/adr/0013-server-kind-picker.md
+++ b/docs/adr/0013-server-kind-picker.md
@@ -1,0 +1,119 @@
+# 13. Picking a kind of server from a row and a sheet
+
+Status: accepted
+
+## Context
+
+[Issue #96](https://github.com/chmouel/liseur/issues/96). The kind picker
+on the book-server screen has been rebuilt once per kind added. It was a
+`SingleChoiceSegmentedButtonRow` while there were two, and adding
+Grimmory (#94) took four labels — "calibre-web", "Komga", "Grimmory",
+"liseur-sync" — past what a phone's width holds. A segmented control does
+not wrap, so it became a `FlowRow` of `FilterChip`s.
+
+That works, and on a phone it is two rows of chips above a
+`surfaceContainerHigh` card of 20.dp padding above three fields above a
+button. The whole first screenful is spent on a choice most readers make
+once, and three things are wrong with it:
+
+- **The chips carry no information.** A reader who does not already know
+  which of these they run learns nothing from four product names, and
+  the card underneath explains only the kind already selected. There is
+  no state of this screen in which the four can be compared.
+- **It gets worse as it grows.** Every kind added makes every chip
+  narrower. A fifth wraps to a third row or starts truncating.
+- **The card is tall and mostly says what the fields say.** Two of the
+  four `server_intro_*` strings are "give the address of your server and
+  the login you use for it", which is the `Server address` and `Password`
+  labels restated at four times the height.
+
+## Decision
+
+One `OutlinedCard` holding a `ListItem` — overline "Which kind of
+server?", headline the selected kind, supporting its tagline and one
+line on whether it keeps your place, trailing a chevron — which opens a
+`ModalBottomSheet` listing every kind in the same shape with a radio
+button. `ServerKindRow` and `ServerKindSheet`, in their own file.
+
+The height at the top of the form goes from two chip rows plus a
+five-line card to one three-line row plus a link, which puts the address
+and credential fields above the fold on a phone. The sheet is where
+comparison finally happens, and it scrolls, so a fifth kind is a `when`
+branch and three strings with no layout consequence at all. That is the
+test the issue sets, and it is the one the chips fail.
+
+### The rejected directions
+
+**A list of kinds, with the form on a second screen.** The most room per
+kind, and the most expensive: a nav destination, a back stack that has to
+survive process death holding a half-typed form, and a reader who wants
+to change kind after a failed connect going back a screen to do it. It
+also makes the first thing a reader sees a wall of prose, when most of
+them know which server they run and want the address box.
+
+**An `ExposedDropdownMenuBox`.** The smallest footprint, and it fixes
+height and scaling — but a menu item is one line, so the taglines have
+nowhere to go and we are back to four bare names. It also reads as a
+form field among form fields, when it is the switch deciding which form
+fields exist.
+
+**Keeping the chips and collapsing the card to its tagline.** The
+smallest diff by far, and it leaves the fault that will bring us back
+here: the chips still narrow with every kind. It makes the comparison
+problem worse, too, by moving the explanation off-screen entirely.
+
+## What the `server_intro_*` strings became
+
+Retiring them is the only lossy part, so each clause was placed rather
+than dropped:
+
+- Grimmory's "not the login you sign into Grimmory with in a browser"
+  was already duplicated in `server_opds_user_help`, shown inline under
+  the password field. It stays exactly there. Naming the credential a
+  server actually wants is the thing this screen most has to get right,
+  and it belongs next to the box, not in a paragraph above it.
+- Grimmory's "it cannot keep your place in a book here" is now its sync
+  line, which the reader sees *before* choosing rather than after. The
+  issue asks that this survive; it is better served than it was.
+- liseur-sync's "books that came from nowhere but this phone" moved into
+  its tagline, where it is the distinguishing thing to say about it.
+- calibre-web's and Komga's are "give the address and the login", which
+  the field labels and `server_api_key_help` say already.
+
+## A kind's sync ability is not an account's
+
+`ServerKind.syncAbility` (`EXACT` / `PROGRESSION` / `NONE`) is new, and
+deliberately not `RemoteServer.canSync`. They answer different
+questions: the picker asks what a kind *can ever* do, with no account in
+existence yet, while `canSync` asks whether this account is ready now —
+and for calibre-web that waits on a Kobo token, which is an account's
+problem and not a reason to warn a reader off the kind. Folding them
+together would mean a picker inventing an account to interrogate, or a
+repository offering calibre-web a sync it has no token for.
+
+They still have to agree about the one case that matters, so
+`ServerKindTest` pins it: for an account holding every secret,
+`canSync` is true exactly when `syncAbility` is not `NONE`. A fifth kind
+cannot promise a sync in the picker and refuse it on the connected
+screen.
+
+`PROGRESSION` versus `EXACT` is not decoration. calibre-web's Kobo
+protocol exchanges `locations.totalProgression` and nothing else, so the
+page comes back approximately; Komga and liseur-sync exchange a whole
+locator. A reader choosing where their library lives is entitled to know
+that before typing a password.
+
+## Consequences
+
+The form is one screen, one ViewModel, no navigation change and no
+persisted state: sheet visibility is a local `rememberSaveable`, so
+rotation is free and `onKindChange` keeps its signature.
+
+Switching kinds costs one more tap than a chip did. That is the trade,
+and it is a small one — switching is something a reader does while
+working out which server they have, and the sheet is better at that than
+four names ever were.
+
+`ServerAccountScreen.kt` was 1300 lines. The picker leaving for
+`ServerKindPicker.kt` takes the per-kind label, tagline, home URL and
+link lookups with it, which is where the next kind will be added.


### PR DESCRIPTION
## Summary

Closes #96. Adding Grimmory (#94) took the kind picker past what a phone's
width holds, so it became a `FlowRow` of chips above a card that explained
only the kind already selected. Two rows of chips plus a five-line card is
the whole first screenful of a form, spent on a choice most readers make
once, and a fifth kind would have wrapped it to a third row.

The picker is now one row saying which kind is selected, what it is for and
whether it keeps your place, opening a bottom sheet that lists every kind in
the same shape. The row costs the same height whatever the count and the
sheet scrolls, so a fifth kind is a `when` branch and three strings. It is
also the first time the four have been comparable without tapping through
them one at a time.

The three alternatives the issue raised — a list with the form on a second
screen, a dropdown, and trimming the card while keeping the chips — are
weighed in [ADR 0013](docs/adr/0013-server-kind-picker.md).

## Changes

- `ServerKindPicker.kt` (new): `ServerKindRow` and `ServerKindSheet`, plus the
  per-kind label, tagline, home URL and link lookups that moved out of the
  1300-line screen. This is where the next kind gets added.
- `ServerKind.syncAbility` (`EXACT` / `PROGRESSION` / `NONE`): deliberately not
  `RemoteServer.canSync`. The picker asks what a kind can *ever* do with no
  account in existence; `canSync` asks whether this account is ready now,
  which for calibre-web waits on a Kobo token. `ServerKindTest` pins them
  together for the case that matters, so a fifth kind cannot promise a sync in
  the picker and refuse it once connected.
- `ConnectForm` loses the `FlowRow` of `FilterChip`s and `KindCard`.
- `server_intro_*` retired. Each was "give the address and the login" — which
  the field labels already say — welded to one clause worth keeping, and each
  of those was placed rather than dropped: Grimmory's browser-login warning
  stays inline under its password field, its missing position sync became a
  sync line the reader now sees *before* choosing, and liseur-sync's local
  books moved into its tagline.
- Each kind gets its own logo, which is what makes a list of four scannable.
  calibre-web's is GPL-3.0 and Grimmory's AGPL-3.0, both covered by the licence
  on the rest of their source, so both ship unmodified with their notices and
  licence texts on the Licences screen; liseur-sync's was drawn for it here.
  Komga's cannot ship — the repository is MIT but its README says the icon is
  "based on an icon made by Freepik from flaticon.com", and Flaticon's licence
  is neither transferable nor sublicensable, so MIT cannot reach it and F-Droid
  will not take it. Komga gets a neutral book-server glyph, tinted rather than
  coloured so it reads as a placeholder rather than as a mark somebody chose.
- ADR 0013.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on `emulator-5554`: picked each kind, connected a
      Grimmory server end to end, and left the emulator on the same account it
      started on.

## Screenshots or recordings

The whole form now fits one screenful, with the address and credential fields
above the fold:

![Collapsed picker](https://github.com/user-attachments/assets/ee63af8d-0f50-42b4-ad1f-bbee5ec5200c)

All four kinds side by side, which no state of the old screen offered:

![Kind sheet](https://github.com/user-attachments/assets/a5eb95ff-10ef-4ce6-bdbf-5e27443f8fb8)

The two things the old screen got right, kept: Grimmory's OPDS-user warning is
still next to the box it is about, and "it cannot keep your place" is now read
before choosing rather than after connecting.

![Grimmory selected](https://github.com/user-attachments/assets/481e25a9-1532-4f65-a655-b46b0b9d978c)

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

