### PR TITLE
feat: let a long highlight be read in full in Navigate

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ContentsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ContentsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.size
@@ -43,15 +44,20 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -104,6 +110,14 @@ fun ContentsScreen(
     modifier: Modifier = Modifier,
 ) {
     var tab by rememberSaveable { mutableStateOf(ContentsTab.CONTENTS) }
+    // Which marks the reader has opened out to read in full. It lives here
+    // rather than in AnnotationList because each tab is a separate branch of
+    // the `when` below: switching tabs disposes the branch, and state saved
+    // inside a subtree that has been removed does not come back.
+    val expandedIds = rememberSaveable(saver = ExpandedIdsSaver) { mutableStateListOf<String>() }
+    val toggleExpanded: (BookAnnotation) -> Unit = { annotation ->
+        if (!expandedIds.remove(annotation.id)) expandedIds.add(annotation.id)
+    }
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
@@ -216,7 +230,9 @@ fun ContentsScreen(
                         },
                         theme = theme,
                         emptyRes = R.string.reader_no_bookmarks,
+                        expandedIds = expandedIds,
                         onSelected = onAnnotationSelected,
+                        onToggleExpanded = toggleExpanded,
                         onDeleted = onAnnotationDeleted,
                     )
 
@@ -227,7 +243,9 @@ fun ContentsScreen(
                         },
                         theme = theme,
                         emptyRes = R.string.reader_no_highlights,
+                        expandedIds = expandedIds,
                         onSelected = onAnnotationSelected,
+                        onToggleExpanded = toggleExpanded,
                         onDeleted = onAnnotationDeleted,
                     )
 
@@ -235,7 +253,9 @@ fun ContentsScreen(
                         annotations = annotations.filter { !it.note.isNullOrBlank() },
                         theme = theme,
                         emptyRes = R.string.reader_no_notes,
+                        expandedIds = expandedIds,
                         onSelected = onAnnotationSelected,
+                        onToggleExpanded = toggleExpanded,
                         onDeleted = onAnnotationDeleted,
                     )
                 }
@@ -300,7 +320,9 @@ private fun AnnotationList(
     annotations: List<BookAnnotation>,
     theme: ReaderTheme,
     emptyRes: Int,
+    expandedIds: List<String>,
     onSelected: (BookAnnotation) -> Unit,
+    onToggleExpanded: (BookAnnotation) -> Unit,
     onDeleted: (BookAnnotation) -> Unit,
 ) {
     if (annotations.isEmpty()) {
@@ -315,7 +337,9 @@ private fun AnnotationList(
             AnnotationRow(
                 annotation = annotation,
                 theme = theme,
+                expanded = annotation.id in expandedIds,
                 onClick = { onSelected(annotation) },
+                onToggleExpanded = { onToggleExpanded(annotation) },
                 onDelete = { onDeleted(annotation) },
             )
             HorizontalDivider(color = theme.foreground.copy(alpha = 0.08f))
@@ -323,13 +347,34 @@ private fun AnnotationList(
     }
 }
 
+/**
+ * Whether a mark still has more to show.
+ *
+ * Measured overflow is only believed while the row is collapsed: an
+ * expanded row has no line cap, so it always reports that it fits, and
+ * taking that at face value would delete the very control the reader needs
+ * to fold it back up.
+ */
+internal fun latchedOverflow(previous: Boolean, expanded: Boolean, measured: Boolean): Boolean =
+    if (expanded) previous else measured
+
 @Composable
 private fun AnnotationRow(
     annotation: BookAnnotation,
     theme: ReaderTheme,
+    expanded: Boolean,
     onClick: () -> Unit,
+    onToggleExpanded: () -> Unit,
     onDelete: () -> Unit,
 ) {
+    val excerpt = annotation.text?.trim()?.takeIf { it.isNotEmpty() }
+    val note = annotation.note?.trim()?.takeIf { it.isNotEmpty() }
+    val bookNote = annotation.kind == AnnotationKind.BOOK_NOTE.name
+    // Keyed on the words themselves: a mark keeps its id when it is edited,
+    // so a note trimmed down to nothing would otherwise leave a "Show more"
+    // behind with nothing left to show.
+    var excerptOverflow by remember(excerpt) { mutableStateOf(false) }
+    var noteOverflow by remember(note) { mutableStateOf(false) }
     Row(
         Modifier
             .fillMaxWidth()
@@ -337,7 +382,7 @@ private fun AnnotationRow(
             .padding(start = 20.dp, end = 8.dp, top = 14.dp, bottom = 14.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        if (annotation.kind == AnnotationKind.BOOK_NOTE.name) {
+        if (bookNote) {
             Icon(
                 Icons.AutoMirrored.Outlined.Notes,
                 contentDescription = null,
@@ -369,38 +414,70 @@ private fun AnnotationRow(
                     overflow = TextOverflow.Ellipsis,
                 )
             }
-            annotation.text?.takeIf { it.isNotBlank() }?.let {
+            excerpt?.let {
                 Text(
-                    text = it.trim(),
+                    text = it,
                     style = MaterialTheme.typography.bodyMedium,
                     color = theme.foreground,
-                    maxLines = 4,
-                    overflow = TextOverflow.Ellipsis,
+                    maxLines = if (expanded) Int.MAX_VALUE else 4,
+                    overflow = if (expanded) TextOverflow.Clip else TextOverflow.Ellipsis,
+                    onTextLayout = { layout ->
+                        excerptOverflow =
+                            latchedOverflow(excerptOverflow, expanded, layout.hasVisualOverflow)
+                    },
                     modifier = Modifier.padding(top = 2.dp),
                 )
             }
-            annotation.note?.takeIf { it.isNotBlank() }?.let {
+            note?.let {
                 Text(
-                    text = it.trim(),
-                    style = if (annotation.kind == AnnotationKind.BOOK_NOTE.name) {
+                    text = it,
+                    style = if (bookNote) {
                         MaterialTheme.typography.bodyMedium
                     } else {
                         MaterialTheme.typography.bodySmall
                     },
-                    fontStyle = if (annotation.kind == AnnotationKind.BOOK_NOTE.name) {
-                        FontStyle.Normal
-                    } else {
-                        FontStyle.Italic
-                    },
-                    color = if (annotation.kind == AnnotationKind.BOOK_NOTE.name) {
+                    fontStyle = if (bookNote) FontStyle.Normal else FontStyle.Italic,
+                    color = if (bookNote) {
                         theme.foreground
                     } else {
                         theme.foreground.copy(alpha = 0.75f)
                     },
-                    maxLines = if (annotation.kind == AnnotationKind.BOOK_NOTE.name) 5 else 3,
-                    overflow = TextOverflow.Ellipsis,
+                    maxLines = when {
+                        expanded -> Int.MAX_VALUE
+                        bookNote -> 5
+                        else -> 3
+                    },
+                    overflow = if (expanded) TextOverflow.Clip else TextOverflow.Ellipsis,
+                    onTextLayout = { layout ->
+                        noteOverflow =
+                            latchedOverflow(noteOverflow, expanded, layout.hasVisualOverflow)
+                    },
                     modifier = Modifier.padding(top = 6.dp),
                 )
+            }
+            if (excerptOverflow || noteOverflow) {
+                // Its own click target, so opening a mark out to read it is
+                // never mistaken for asking to be taken to it.
+                Box(
+                    Modifier
+                        .clip(RoundedCornerShape(6.dp))
+                        .clickable(role = Role.Button, onClick = onToggleExpanded)
+                        .heightIn(min = 48.dp)
+                        .padding(horizontal = 4.dp),
+                    contentAlignment = Alignment.CenterStart,
+                ) {
+                    Text(
+                        text = stringResource(
+                            if (expanded) {
+                                R.string.annotation_show_less
+                            } else {
+                                R.string.annotation_show_more
+                            },
+                        ),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = theme.foreground.copy(alpha = 0.75f),
+                    )
+                }
             }
         }
         IconButton(onClick = onDelete) {
@@ -477,3 +554,14 @@ private fun List<Link>.flatten(depth: Int = 0): List<ContentsEntry> =
     flatMap { link ->
         listOf(ContentsEntry(depth, link)) + link.children.flatten(depth + 1)
     }
+
+/**
+ * Keeps the opened-out marks across a rotation.
+ *
+ * A [SnapshotStateList] is not something a Bundle can hold, so it is saved
+ * as the plain list of ids it stands for.
+ */
+private val ExpandedIdsSaver = listSaver<SnapshotStateList<String>, String>(
+    save = { it.toList() },
+    restore = { it.toMutableStateList() },
+)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ContentsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ContentsScreen.kt
@@ -352,11 +352,26 @@ private fun AnnotationList(
  *
  * Measured overflow is only believed while the row is collapsed: an
  * expanded row has no line cap, so it always reports that it fits, and
- * taking that at face value would delete the very control the reader needs
- * to fold it back up.
+ * taking that at face value would make the control flicker away on the
+ * frame the row folds back up.
  */
 internal fun latchedOverflow(previous: Boolean, expanded: Boolean, measured: Boolean): Boolean =
     if (expanded) previous else measured
+
+/**
+ * Whether the row shows its open/close control.
+ *
+ * An open row always shows it, whatever the last measurement said. Rows
+ * are torn down as they scroll out of a lazy list and their measurements
+ * go with them, and an open row that comes back has no line cap to
+ * overflow: deciding this on the measurement alone would leave a mark
+ * opened out with no way to fold it again.
+ */
+internal fun showsExpandToggle(
+    expanded: Boolean,
+    excerptOverflow: Boolean,
+    noteOverflow: Boolean,
+): Boolean = expanded || excerptOverflow || noteOverflow
 
 @Composable
 private fun AnnotationRow(
@@ -455,7 +470,7 @@ private fun AnnotationRow(
                     modifier = Modifier.padding(top = 6.dp),
                 )
             }
-            if (excerptOverflow || noteOverflow) {
+            if (showsExpandToggle(expanded, excerptOverflow, noteOverflow)) {
                 // Its own click target, so opening a mark out to read it is
                 // never mistaken for asking to be taken to it.
                 Box(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -334,6 +334,8 @@
     <string name="annotation_share">Share</string>
     <string name="annotation_delete">Delete</string>
     <string name="annotation_export">Export as Markdown</string>
+    <string name="annotation_show_more">Show more</string>
+    <string name="annotation_show_less">Show less</string>
     <string name="reader_search">Search in book</string>
     <string name="search_hint">Search in this book</string>
     <string name="search_prompt">Type a word or phrase to find it anywhere in the book.</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/ContentsScreenTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/ContentsScreenTest.kt
@@ -22,4 +22,19 @@ class ContentsScreenTest {
     fun `expanding never invents something to show`() {
         assertFalse(latchedOverflow(previous = false, expanded = true, measured = true))
     }
+
+    @Test
+    fun `a collapsed row offers the control only when something is hidden`() {
+        assertFalse(showsExpandToggle(false, excerptOverflow = false, noteOverflow = false))
+        assertTrue(showsExpandToggle(false, excerptOverflow = true, noteOverflow = false))
+        assertTrue(showsExpandToggle(false, excerptOverflow = false, noteOverflow = true))
+    }
+
+    @Test
+    fun `an open row can always be closed again`() {
+        // A row torn down by the lazy list loses its measurements, and an
+        // open one has no cap left to overflow. Without this the mark comes
+        // back opened out and stuck that way.
+        assertTrue(showsExpandToggle(true, excerptOverflow = false, noteOverflow = false))
+    }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/ContentsScreenTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/ContentsScreenTest.kt
@@ -1,0 +1,25 @@
+package com.chmouel.liseur.reader.chrome
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ContentsScreenTest {
+    @Test
+    fun `collapsed row believes what it measured`() {
+        assertTrue(latchedOverflow(previous = false, expanded = false, measured = true))
+        assertFalse(latchedOverflow(previous = true, expanded = false, measured = false))
+    }
+
+    @Test
+    fun `expanded row keeps the answer it had while collapsed`() {
+        // An expanded Text has no line cap, so it always reports that it
+        // fits. Believing that would take the "Show less" control away.
+        assertTrue(latchedOverflow(previous = true, expanded = true, measured = false))
+    }
+
+    @Test
+    fun `expanding never invents something to show`() {
+        assertFalse(latchedOverflow(previous = false, expanded = true, measured = true))
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #90.

Navigate (the reader's Contents / Bookmarks / Highlights / Notes screen) cut
every highlighted passage off at four lines and every note at three, with no
way to see the rest. The only escape hatch was Markdown export, which leaves
the app. Tapping the row jumps to the passage and closes the screen, so you
also lost your place in the list.

Rows whose text is genuinely cut off now carry a **Show more** control that
opens the mark out in place. Tapping the row itself still means what it always
did: go to the passage.

## Changes

- `AnnotationRow` measures its own overflow through `onTextLayout` and only
  offers **Show more** when something is actually hidden; a two-line highlight
  gets no control.
- Expanded rows drop the line cap on both the passage and the note.
- The overflow measurement is latched while expanded (`latchedOverflow`): an
  uncapped `Text` always reports that it fits, and believing that would take
  **Show less** away the moment the row opened.
- The overflow flags are keyed on the displayed words, so a note edited down to
  nothing does not leave an orphaned control behind, since annotations keep their id
  across an edit.
- The set of opened marks lives in `ContentsScreen`, above the `when (tab)`, so
  it survives scrolling in the `LazyColumn` and switching tabs, and is saved
  through an explicit `listSaver` so it survives a rotation.
- The control is its own click target with `Role.Button` and a 48 dp minimum
  height, so it never reaches the row's navigate click and reads correctly to
  TalkBack.
- Applies to all three annotation tabs, since they share `AnnotationList`; a
  long book note had the same problem. Bookmarks carry no text, so they simply
  never show it.

Presentation only: no schema change, nothing in `data/`, `domain/` or `sync/`,
and no new dependency.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

New JVM test `ContentsScreenTest` covers the two rules that are easy to get
wrong: when a measurement is believed, and when the control is shown.

Checked by hand on the emulator with a 795-character highlight carrying a note:
short marks show no control, the row body still jumps to the passage, and the
opened-out row keeps its control after the lazy list disposes and rebuilds it,
after switching tabs, and across a rotation.

## Screenshots or recordings

Navigate -> Highlights on `liseur_phone_api36`. Short marks are untouched; the
two that are cut off carry the control.

| Collapsed | Opened out |
| --- | --- |
| ![collapsed](https://github.com/user-attachments/assets/31e5aed3-0f2e-4151-bac8-f94b730be222) | ![expanded](https://github.com/user-attachments/assets/2f4435f4-2b71-40e9-a3c1-6a9f8bd90e37) |

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

