### PR TITLE
fix(catalog): see a book missing twice before believing it has gone

### DIFF
--- a/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/41.json
+++ b/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/41.json
@@ -1,0 +1,1230 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 41,
+    "identityHash": "6b276fb599d131a9d6711c6ed291f001",
+    "entities": [
+      {
+        "tableName": "reading_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `total_progression` REAL, `reading_speed` REAL, `reading_seconds_per_position` REAL, `reading_pace_samples` INTEGER NOT NULL DEFAULT 0, `reading_pace_elapsed_ms` INTEGER NOT NULL DEFAULT 0, `reading_pace_evidence` REAL NOT NULL DEFAULT 0, `updated_at` INTEGER NOT NULL, `status` TEXT, `synced_at` INTEGER, `local_revision` INTEGER NOT NULL DEFAULT 0, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `agreed_account` TEXT, `pending_progression` REAL, `pending_locator_json` TEXT, `pending_status` TEXT, `pending_updated_at` INTEGER, `pending_account` TEXT, `owner_account` TEXT, `remote_updated_at` INTEGER, `finished_override` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSpeed",
+            "columnName": "reading_speed",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSecondsPerPosition",
+            "columnName": "reading_seconds_per_position",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingPaceSamples",
+            "columnName": "reading_pace_samples",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceElapsedMs",
+            "columnName": "reading_pace_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceEvidence",
+            "columnName": "reading_pace_evidence",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localRevision",
+            "columnName": "local_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "agreedAccount",
+            "columnName": "agreed_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingLocatorJson",
+            "columnName": "pending_locator_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingAccount",
+            "columnName": "pending_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ownerAccount",
+            "columnName": "owner_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "finishedOverride",
+            "columnName": "finished_override",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `cover_path` TEXT, `source` TEXT, `added_at` INTEGER NOT NULL, `last_opened_at` INTEGER, `local_uri` TEXT, `remote_uuid` TEXT, `remote_book_id` INTEGER, `cover_url` TEXT, `download_href` TEXT, `download_state` TEXT NOT NULL, `remote_updated_at` INTEGER, `downloaded_at` INTEGER, `file_modified_at` INTEGER, `work_id` TEXT, `finished_at` INTEGER, `archived_at` INTEGER, `remote_page_count` INTEGER, `size_bytes` INTEGER, `series_name` TEXT, `series_index` REAL, `file_series_name` TEXT, `file_series_index` REAL, `series_id` TEXT, `series_checked` INTEGER NOT NULL, `catalog_series_name` TEXT, `catalog_series_index` REAL, `catalog_folder_id` TEXT, `catalog_series_source` TEXT, `user_series_name` TEXT, `user_series_index` REAL, `series_override` INTEGER NOT NULL, `user_series_updated_at` INTEGER, `series_claim_pending` INTEGER NOT NULL, `series_claim_reset` INTEGER NOT NULL, `personal_series_updated_at` INTEGER, `series_index_override` INTEGER NOT NULL, `catalog_missing_since` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "last_opened_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localUri",
+            "columnName": "local_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUuid",
+            "columnName": "remote_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteBookId",
+            "columnName": "remote_book_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadHref",
+            "columnName": "download_href",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadState",
+            "columnName": "download_state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloaded_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finished_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archived_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remotePageCount",
+            "columnName": "remote_page_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "size_bytes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fileSeriesName",
+            "columnName": "file_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileSeriesIndex",
+            "columnName": "file_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesChecked",
+            "columnName": "series_checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSeriesName",
+            "columnName": "catalog_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesIndex",
+            "columnName": "catalog_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "catalogFolderId",
+            "columnName": "catalog_folder_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesSource",
+            "columnName": "catalog_series_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesName",
+            "columnName": "user_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesIndex",
+            "columnName": "user_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesOverridden",
+            "columnName": "series_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userSeriesUpdatedAt",
+            "columnName": "user_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesClaimPending",
+            "columnName": "series_claim_pending",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesClaimReset",
+            "columnName": "series_claim_reset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personalSeriesUpdatedAt",
+            "columnName": "personal_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "indexOverridden",
+            "columnName": "series_index_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogMissingSince",
+            "columnName": "catalog_missing_since",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_books_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_books_url` ON `${TABLE_NAME}` (`url`)"
+          },
+          {
+            "name": "index_books_series_name",
+            "unique": false,
+            "columnNames": [
+              "series_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_series_name` ON `${TABLE_NAME}` (`series_name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "library_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `added_at` INTEGER NOT NULL, PRIMARY KEY(`url`))",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "url"
+          ]
+        }
+      },
+      {
+        "tableName": "remote_server",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `kind` TEXT NOT NULL, `base_url` TEXT NOT NULL, `username` TEXT, `password_cipher` TEXT, `api_key_cipher` TEXT, `account_id` TEXT, `user_id` INTEGER, `kobo_token` TEXT, `can_download` INTEGER NOT NULL, `can_manage_library` INTEGER NOT NULL, `can_upload` INTEGER NOT NULL, `can_delete` INTEGER NOT NULL, `can_admin` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `catalog_synced_at` INTEGER, `position_synced_at` INTEGER, `sync_token` TEXT, `liseur_token_cipher` TEXT, `liseur_account_id` TEXT, `sync_cursor_seq` INTEGER NOT NULL DEFAULT 0, `annotation_cursor_seq` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "passwordCipher",
+            "columnName": "password_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiKeyCipher",
+            "columnName": "api_key_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "koboTokenCipher",
+            "columnName": "kobo_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "canDownload",
+            "columnName": "can_download",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canManageLibrary",
+            "columnName": "can_manage_library",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canUpload",
+            "columnName": "can_upload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canDelete",
+            "columnName": "can_delete",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canAdmin",
+            "columnName": "can_admin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSyncedAt",
+            "columnName": "catalog_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "positionSyncedAt",
+            "columnName": "position_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncToken",
+            "columnName": "sync_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurTokenCipher",
+            "columnName": "liseur_token_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurAccountId",
+            "columnName": "liseur_account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncCursorSeq",
+            "columnName": "sync_cursor_seq",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "annotationCursorSeq",
+            "columnName": "annotation_cursor_seq",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `book_id` TEXT NOT NULL, `kind` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `text` TEXT, `note` TEXT, `tint` TEXT, `chapter` TEXT, `position` INTEGER, `total_progression` REAL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tint",
+            "columnName": "tint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapter",
+            "columnName": "chapter",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_typography",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `font` TEXT NOT NULL, `font_size` REAL NOT NULL, `line_height` REAL, `page_margins` REAL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "font",
+            "columnName": "font",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "font_size",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineHeight",
+            "columnName": "line_height",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pageMargins",
+            "columnName": "page_margins",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_screen",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `keep_screen_on` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keepScreenOn",
+            "columnName": "keep_screen_on",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_reading_mode",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `scroll` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scroll",
+            "columnName": "scroll",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `book_url` TEXT NOT NULL, `started_at` INTEGER NOT NULL, `ended_at` INTEGER, `last_checkpoint_at` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `start_progression` REAL, `end_progression` REAL, `idle_ms` INTEGER, `uploaded_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "ended_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastCheckpointAt",
+            "columnName": "last_checkpoint_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startProgression",
+            "columnName": "start_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "endProgression",
+            "columnName": "end_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "idleMs",
+            "columnName": "idle_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "uploadedAt",
+            "columnName": "uploaded_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_sessions_book_url",
+            "unique": false,
+            "columnNames": [
+              "book_url"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_book_url` ON `${TABLE_NAME}` (`book_url`)"
+          },
+          {
+            "name": "index_reading_sessions_started_at",
+            "unique": false,
+            "columnNames": [
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_started_at` ON `${TABLE_NAME}` (`started_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_peer_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `pending_progression` REAL, `pending_locator_json` TEXT, `pending_edition_sha` TEXT, `pending_status` TEXT, `pending_updated_at` INTEGER, `has_pending` INTEGER NOT NULL DEFAULT 0, `remote_updated_at` INTEGER, `synced_at` INTEGER, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingLocatorJson",
+            "columnName": "pending_locator_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingEditionSha",
+            "columnName": "pending_edition_sha",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasPending",
+            "columnName": "has_pending",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_peer_state_peer_id",
+            "unique": false,
+            "columnNames": [
+              "peer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_peer_state_peer_id` ON `${TABLE_NAME}` (`peer_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_fingerprint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `sha256` TEXT NOT NULL, `partial_md5` TEXT NOT NULL, `file_size` INTEGER NOT NULL, `file_modified_at` INTEGER, `computed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256",
+            "columnName": "sha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partialMd5",
+            "columnName": "partial_md5",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "computedAt",
+            "columnName": "computed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "work_alias",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_id` TEXT NOT NULL, `confidence` TEXT NOT NULL, `confirmed` INTEGER NOT NULL, `seeded` INTEGER NOT NULL DEFAULT 0, `source_sent` INTEGER NOT NULL DEFAULT 0, `edition_sha` TEXT, `annotations_reconciled_at` INTEGER NOT NULL DEFAULT 0, `resolved_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confirmed",
+            "columnName": "confirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seeded",
+            "columnName": "seeded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceSent",
+            "columnName": "source_sent",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "editionSha",
+            "columnName": "edition_sha",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "annotationsReconciledAt",
+            "columnName": "annotations_reconciled_at",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "resolvedAt",
+            "columnName": "resolved_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "work_ambiguity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_ids` TEXT NOT NULL, `noticed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workIds",
+            "columnName": "work_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noticedAt",
+            "columnName": "noticed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_extra",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`series_id` TEXT NOT NULL, `summary` TEXT, `status` TEXT, `total_book_count` INTEGER, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`series_id`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalBookCount",
+            "columnName": "total_book_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "series_id"
+          ]
+        }
+      },
+      {
+        "tableName": "annotation_sync",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `book_id` TEXT NOT NULL, `work_id` TEXT NOT NULL, `rev` INTEGER NOT NULL, `seq` INTEGER NOT NULL, `acked_fingerprint` TEXT, `pending_kind` TEXT, `pending_json` TEXT, `pending_rev` INTEGER NOT NULL, `pending_fingerprint` TEXT, `rejected_fingerprint` TEXT, `retry_not_before` INTEGER NOT NULL, PRIMARY KEY(`id`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rev",
+            "columnName": "rev",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seq",
+            "columnName": "seq",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ackedFingerprint",
+            "columnName": "acked_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingKind",
+            "columnName": "pending_kind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingJson",
+            "columnName": "pending_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingRev",
+            "columnName": "pending_rev",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pendingFingerprint",
+            "columnName": "pending_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "rejectedFingerprint",
+            "columnName": "rejected_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "retryNotBefore",
+            "columnName": "retry_not_before",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotation_sync_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotation_sync_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          },
+          {
+            "name": "index_annotation_sync_work_id",
+            "unique": false,
+            "columnNames": [
+              "work_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotation_sync_work_id` ON `${TABLE_NAME}` (`work_id`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6b276fb599d131a9d6711c6ed291f001')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/Book.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/Book.kt
@@ -169,6 +169,23 @@ data class Book(
      * about its number both mean the source no longer decides it.
      */
     @ColumnInfo(name = "series_index_override") val indexOverridden: Boolean = false,
+    /**
+     * When a finished catalog walk first failed to find this book, and
+     * null while the catalog is still naming it.
+     *
+     * A book is not removed for being absent once. Every server here is
+     * read a page at a time by offset, so a catalog edited between two
+     * of those requests shifts under the offset and skips a book that is
+     * still on it — with nothing in the envelope to give it away, because
+     * a deletion and an addition leave the count where it was. Losing a
+     * book that way costs its reading position, its sittings and its
+     * history, so absence has to be seen twice running before it is
+     * believed. The mark is what carries that between refreshes.
+     *
+     * A time rather than a flag, so a bug report can say when the book
+     * fell out of sight. Nothing decides anything by its value.
+     */
+    @ColumnInfo(name = "catalog_missing_since") val catalogMissingSince: Long? = null,
 ) {
     val finished: Boolean get() = finishedAt != null
 
@@ -242,6 +259,7 @@ interface BookDao {
             "download_href = NULL, remote_updated_at = NULL, remote_page_count = NULL, " +
             "catalog_series_name = NULL, catalog_series_index = NULL, " +
             "catalog_folder_id = NULL, catalog_series_source = NULL, " +
+            "catalog_missing_since = NULL, " +
             "series_name = CASE WHEN series_override = 1 THEN user_series_name " +
             "ELSE file_series_name END, " +
             "series_index = CASE " +
@@ -266,6 +284,7 @@ interface BookDao {
             "download_href = NULL, remote_updated_at = NULL, remote_page_count = NULL, " +
             "catalog_series_name = NULL, catalog_series_index = NULL, " +
             "catalog_folder_id = NULL, catalog_series_source = NULL, " +
+            "catalog_missing_since = NULL, " +
             "series_name = CASE WHEN series_override = 1 THEN user_series_name " +
             "ELSE file_series_name END, " +
             "series_index = CASE " +
@@ -279,6 +298,20 @@ interface BookDao {
             "WHERE url IN (:urls)",
     )
     suspend fun unlinkFromRemote(urls: List<String>)
+
+    /**
+     * Notes that a finished walk did not find these books.
+     *
+     * Nothing is removed by this: the mark is the first of the two
+     * sightings of absence that a removal needs. See
+     * [Book.catalogMissingSince].
+     */
+    @Query("UPDATE books SET catalog_missing_since = :at WHERE url IN (:urls)")
+    suspend fun markCatalogMissing(urls: List<String>, at: Long)
+
+    /** Takes that note back, because the catalog has named the book again. */
+    @Query("UPDATE books SET catalog_missing_since = NULL WHERE url IN (:urls)")
+    suspend fun clearCatalogMissing(urls: List<String>)
 
     @Query("SELECT url FROM books WHERE source = :source")
     suspend fun urlsForSource(source: String): List<String>
@@ -600,6 +633,13 @@ interface BookDao {
             catalog_series_index = :catalogSeriesIndex,
             catalog_folder_id = :catalogFolderId,
             catalog_series_source = :catalogSeriesSource,
+            -- Naming a book is the catalog saying it is still there, so
+            -- any note that a walk had lost sight of it is now wrong.
+            -- Here rather than only in the reconciliation at the end,
+            -- because a walk that dies half way still stores its pages:
+            -- a book seen by an unfinished walk must not be one miss
+            -- away from deletion.
+            catalog_missing_since = NULL,
             personal_series_updated_at = CASE
                 WHEN series_claim_pending = 0
                     AND user_series_updated_at IS :expectedUserSeriesUpdatedAt
@@ -732,7 +772,8 @@ interface BookDao {
         UPDATE books
         SET remote_uuid = :remoteUuid, download_href = :downloadHref,
             cover_url = COALESCE(cover_url, :coverUrl),
-            remote_updated_at = :remoteUpdatedAt
+            remote_updated_at = :remoteUpdatedAt,
+            catalog_missing_since = NULL
         WHERE url = :url
         """,
     )

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
@@ -25,7 +25,7 @@ import androidx.sqlite.execSQL
         SeriesExtra::class,
         AnnotationSync::class,
     ],
-    version = 40,
+    version = 41,
     exportSchema = true,
 )
 abstract class LiseurDatabase : RoomDatabase() {
@@ -1033,6 +1033,21 @@ abstract class LiseurDatabase : RoomDatabase() {
          * because a stamp that changes on every push is a stamp that
          * makes every retry a new payload.
          */
+        /**
+         * Where a book that a finished catalog walk did not find is
+         * noted, so that absence can be seen twice before it is
+         * believed. Existing rows start unmarked: nothing has been
+         * missed yet, and pruning on the strength of an assumption is
+         * the very thing this column exists to stop.
+         */
+        val MIGRATION_40_41 = object : Migration(40, 41) {
+            override fun migrate(connection: SQLiteConnection) {
+                connection.execSQL(
+                    "ALTER TABLE `books` ADD COLUMN `catalog_missing_since` INTEGER",
+                )
+            }
+        }
+
         val MIGRATION_39_40 = object : Migration(39, 40) {
             override fun migrate(connection: SQLiteConnection) {
                 connection.execSQL(
@@ -1146,6 +1161,7 @@ abstract class LiseurDatabase : RoomDatabase() {
             MIGRATION_37_38,
             MIGRATION_38_39,
             MIGRATION_39_40,
+            MIGRATION_40_41,
         )
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepository.kt
@@ -163,7 +163,7 @@ class RemoteCatalogRepository(
                 // new account's books, or bring the old account back from
                 // the dead, so the whole answer is dropped instead.
                 forAccount(server) {
-                    dropVanished(seen)
+                    reconcileVanished(seen)
                     serverDao.setCatalogSyncedAt(System.currentTimeMillis())
                 }
                 _status.value = CatalogStatus.Idle
@@ -376,11 +376,29 @@ class RemoteCatalogRepository(
     }
 
     /**
-     * Forgets books that are no longer in the catalog, unless they are on
-     * the device: a book the user has downloaded stays readable even if
-     * it is removed from the server.
+     * Decides what a finished walk means for the books it did not name.
+     *
+     * Not by removing them: a book absent from one walk is only
+     * suspected of having gone. Every catalog here is read a page at a
+     * time by offset, and a catalog edited between two of those requests
+     * shifts under the offset, so a book still on the server is never
+     * sent — while every check on the envelope passes, because a
+     * deletion and an addition together leave the declared count exactly
+     * where it was. Believing a single absence is how the reader loses a
+     * book, and with it their place, their sittings and their history.
+     *
+     * So absence must be seen by two finished walks running. The first
+     * marks; the second acts, and does what this always did — a book
+     * with no file goes, one on the device keeps its file and loses its
+     * link. Being named again at any point clears the mark, including by
+     * a walk that never finished, which is done as the page is stored.
+     *
+     * The cost is that a book genuinely deleted on the server lingers
+     * until the refresh after next. That is the right way round: an
+     * extra refresh showing a book that has gone is a moment's
+     * confusion, and the alternative is unrecoverable.
      */
-    private suspend fun dropVanished(seenUuids: Set<String>) {
+    private suspend fun reconcileVanished(seenUuids: Set<String>) {
         // Only rows the catalog itself introduced are the catalog's to
         // forget. A book of the reader's own that was uploaded and
         // linked is not one: its file is its URL rather than a
@@ -388,17 +406,30 @@ class RemoteCatalogRepository(
         // to open, and a walk that began before the upload cannot have
         // seen its id. Between them they would delete the book and
         // every page ever read of it.
-        val gone = bookDao.allRemote()
+        val remote = bookDao.allRemote()
+        val gone = remote
             .filter { it.remoteUuid !in seenUuids && ServerKind.isRemoteUrl(it.url) }
+        val (confirmed, suspected) = gone.partition { it.catalogMissingSince != null }
         // Only a book with a file of its own is worth keeping. One that
         // was queued or failed has nothing to read, so it goes with the
         // rest rather than staying as a row that can never be opened.
-        val (onDevice, noFile) = gone.partition { it.localUri != null }
-        if (noFile.isNotEmpty()) bookRemoval.deleteByUrls(noFile.map { it.url })
+        val (onDevice, noFile) = confirmed.partition { it.localUri != null }
+        noFile.map { it.url }.chunkedForSql { bookRemoval.deleteByUrls(it) }
         // A book that is here but no longer there keeps its file and loses
         // its link: syncing it would keep asking the server about an id it
         // has forgotten, and be told no every time.
-        if (onDevice.isNotEmpty()) bookDao.unlinkFromRemote(onDevice.map { it.url })
+        onDevice.map { it.url }.chunkedForSql { bookDao.unlinkFromRemote(it) }
+        val now = System.currentTimeMillis()
+        suspected.map { it.url }.chunkedForSql { bookDao.markCatalogMissing(it, now) }
+        // Storing a page already clears the mark on everything it names,
+        // so this ought to find nothing. It stays because the invariant
+        // it keeps -- named means unmarked -- is what stops a single
+        // absence being fatal, and it should not depend on one write in
+        // another file continuing to be unconditional.
+        remote
+            .filter { it.remoteUuid in seenUuids && it.catalogMissingSince != null }
+            .map { it.url }
+            .chunkedForSql { bookDao.clearCatalogMissing(it) }
     }
 
     /**
@@ -424,6 +455,22 @@ class RemoteCatalogRepository(
     private companion object {
         const val TAG = "RemoteCatalog"
     }
+}
+
+/**
+ * How many URLs to name in one statement.
+ *
+ * `IN (:urls)` binds a variable per book and SQLite refuses more than
+ * 999 of them before API 31. A whole library can vanish from a catalog
+ * at once — a misconfigured server, a library unshared — and the throw
+ * would land in the middle of the reconciliation.
+ */
+private const val URL_CHUNK = 500
+
+/** Runs [write] over the URLs in batches SQLite will accept, and not at all for none. */
+private suspend fun List<String>.chunkedForSql(write: suspend (List<String>) -> Unit) {
+    if (isEmpty()) return
+    chunked(URL_CHUNK).forEach { write(it) }
 }
 
 /**
@@ -614,5 +661,13 @@ internal fun mergeCatalogEntry(
         } else {
             book.personalSeriesUpdatedAt
         },
+        // The catalog is naming this book, so whatever an earlier walk
+        // failed to find, it was not this. Clearing it here rather than
+        // only at the end of a walk is deliberate: an unfinished walk
+        // still stores its pages, and a book it saw must not be left one
+        // absence away from deletion. It also makes a row that differs
+        // by nothing else fail the "unchanged, skip it" test in `store`,
+        // which is what carries the clear as far as the database.
+        catalogMissingSince = null,
     )
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
@@ -814,10 +814,38 @@ class MigrationTest {
             }
     }
 
+    @Test
+    fun `a book already on the shelf is not suspected of having gone`() {
+        // The column decides whether a book absent from a catalog walk
+        // is deleted or merely watched. A row restored with anything but
+        // null would be one walk away from deletion the moment the app
+        // is upgraded, which is the opposite of what it is for.
+        helper.createDatabase(TEST_DB, 40).use { old ->
+            old.execSQL(
+                """
+                INSERT INTO books (url, title, author, cover_path, source, added_at,
+                                   last_opened_at, download_state, series_checked,
+                                   series_override, series_index_override,
+                                   series_claim_pending, series_claim_reset)
+                VALUES ('komga:b1', 'A Book', NULL, NULL, NULL, 0, NULL, 'REMOTE', 0, 0, 0, 0, 0)
+                """.trimIndent(),
+            )
+        }
+
+        helper.runMigrationsAndValidate(TEST_DB, LATEST, true, *LiseurDatabase.MIGRATIONS)
+            .use { db ->
+                db.query("SELECT catalog_missing_since FROM books WHERE url = 'komga:b1'")
+                    .use { cursor ->
+                        assertTrue(cursor.moveToFirst())
+                        assertTrue(cursor.isNull(0))
+                    }
+            }
+    }
+
     private companion object {
         const val TEST_DB = "migration-test.db"
 
         /** Kept in step with the `version` on [LiseurDatabase]. */
-        const val LATEST = 40
+        const val LATEST = 41
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepositoryTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepositoryTest.kt
@@ -290,15 +290,140 @@ class RemoteCatalogRepositoryTest {
     @Test
     fun `a walk that did finish is still allowed to prune`() = runTest {
         // The other half of the rule, so the test above cannot be
-        // satisfied by never pruning at all.
+        // satisfied by never pruning at all. Twice, because one absence
+        // is only a suspicion now.
+        connect(ServerKind.KOMGA)
+        shelve("b1", progressedTo = 0.4)
+        shelve("b2", progressedTo = 0.9)
+
+        val catalog = FakeCatalog { onPage -> onPage(listOf(book("b1"))) }
+        repository(catalog).refresh()
+        repository(catalog).refresh()
+
+        assertEquals(null, db.bookDao().getByUrl("komga:b2"))
+        assertNotNull(db.bookDao().getByUrl("komga:b1"))
+    }
+
+    /**
+     * The bug this rule exists for.
+     *
+     * Every catalog here is paged by offset. Delete a book from page one
+     * and add another while the walk is between requests, and page two
+     * starts past a book nobody has been shown -- with the declared
+     * count unmoved, the ids distinct and the arithmetic exact, so
+     * nothing in the answer looks wrong. The book is still on the server.
+     */
+    @Test
+    fun `a book skipped by pages shifting under the walk is not pruned`() = runTest {
+        connect(ServerKind.KOMGA)
+        listOf("b1", "b2", "b3", "b4").forEach { shelve(it, progressedTo = 0.5) }
+
+        // Page 0 of [1,2,3,4] gives 1,2. Then 1 goes and 5 arrives, so
+        // page 1 -- offset 2 of [2,3,4,5] -- gives 4,5. Book 3 was never
+        // sent, and the walk finished perfectly happily.
+        val shifted = FakeCatalog { onPage ->
+            onPage(listOf(book("b1"), book("b2")))
+            onPage(listOf(book("b4"), book("b5")))
+        }
+        assertEquals(true, repository(shifted).refresh().completed)
+
+        val survivor = db.bookDao().getByUrl("komga:b3")
+        assertNotNull("a book still on the server was pruned", survivor)
+        assertEquals(0.5, db.readingProgressDao().get("komga:b3")?.totalProgression)
+        assertTrue(
+            "the sittings went with it",
+            db.readingSessionDao().observeAll().first().any { it.bookUrl == "komga:b3" },
+        )
+    }
+
+    @Test
+    fun `a book missing from one finished walk is only suspected`() = runTest {
         connect(ServerKind.KOMGA)
         shelve("b1", progressedTo = 0.4)
         shelve("b2", progressedTo = 0.9)
 
         repository(FakeCatalog { onPage -> onPage(listOf(book("b1"))) }).refresh()
 
-        assertEquals(null, db.bookDao().getByUrl("komga:b2"))
-        assertNotNull(db.bookDao().getByUrl("komga:b1"))
+        val suspected = db.bookDao().getByUrl("komga:b2")
+        assertNotNull("one absence was treated as proof", suspected)
+        assertNotNull("nothing was noted, so the next walk starts over", suspected?.catalogMissingSince)
+        assertEquals(0.9, db.readingProgressDao().get("komga:b2")?.totalProgression)
+    }
+
+    @Test
+    fun `a book named again is no longer suspected`() = runTest {
+        connect(ServerKind.KOMGA)
+        shelve("b1", progressedTo = 0.4)
+        shelve("b2", progressedTo = 0.9)
+
+        val partial = FakeCatalog { onPage -> onPage(listOf(book("b1"))) }
+        val whole = FakeCatalog { onPage -> onPage(listOf(book("b1"), book("b2"))) }
+        repository(partial).refresh()
+        repository(whole).refresh()
+        assertEquals(null, db.bookDao().getByUrl("komga:b2")?.catalogMissingSince)
+
+        // And the count really did start again: one more absence is
+        // still only the first.
+        repository(partial).refresh()
+
+        assertNotNull("a single absence pruned it", db.bookDao().getByUrl("komga:b2"))
+    }
+
+    /**
+     * A walk that gave up half way still stored the pages it did read,
+     * and a book on one of them has plainly not gone anywhere.
+     *
+     * Clearing the suspicion only at the end of a finished walk would
+     * leave that book marked, and the next walk to miss it once -- for
+     * the paging reason this whole rule is about -- would delete it on
+     * the strength of an absence recorded before it was last seen.
+     */
+    @Test
+    fun `a book seen by a walk that did not finish is no longer suspected`() = runTest {
+        connect(ServerKind.KOMGA)
+        shelve("b1", progressedTo = 0.4)
+        shelve("b2", progressedTo = 0.9)
+
+        repository(FakeCatalog { onPage -> onPage(listOf(book("b1"))) }).refresh()
+        repository(
+            FakeCatalog(complete = false) { onPage -> onPage(listOf(book("b1"), book("b2"))) },
+        ).refresh()
+        assertEquals(null, db.bookDao().getByUrl("komga:b2")?.catalogMissingSince)
+
+        repository(FakeCatalog { onPage -> onPage(listOf(book("b1"))) }).refresh()
+
+        assertNotNull("an unfinished sighting did not count", db.bookDao().getByUrl("komga:b2"))
+    }
+
+    @Test
+    fun `a walk that did not finish suspects nothing`() = runTest {
+        connect(ServerKind.KOMGA)
+        shelve("b1", progressedTo = 0.4)
+        shelve("b2", progressedTo = 0.9)
+
+        repository(FakeCatalog(complete = false) { onPage -> onPage(listOf(book("b1"))) }).refresh()
+
+        assertEquals(null, db.bookDao().getByUrl("komga:b2")?.catalogMissingSince)
+    }
+
+    /**
+     * A library can go all at once -- a share withdrawn, an address
+     * pointed at the wrong server -- and `IN (:urls)` binds a variable
+     * per book, which SQLite refuses past 999 of before API 31.
+     */
+    @Test
+    fun `a whole library vanishing at once is more books than one statement holds`() = runTest {
+        connect(ServerKind.KOMGA)
+        val shelved = (1..1200).map { "b$it" }
+        shelved.forEach { shelve(it, progressedTo = 0.1) }
+
+        val empty = FakeCatalog { }
+        repository(empty).refresh()
+        assertEquals(shelved.size, db.bookDao().allOnce().size)
+
+        assertEquals(true, repository(empty).refresh().completed)
+
+        assertEquals(0, db.bookDao().allOnce().size)
     }
 
     /** A book already on the shelf, read partway, with an hour behind it. */
@@ -677,7 +802,11 @@ class RemoteCatalogRepositoryTest {
             state = com.chmouel.liseur.data.db.DownloadState.DOWNLOADED,
             localUri = "content://downloads/b1.epub",
         )
-        repository(FakeCatalog { }).refresh()
+        // Twice: the first absence only raises the suspicion.
+        val gone = FakeCatalog { }
+        repository(gone).refresh()
+        assertEquals("b1", db.bookDao().allOnce().single().remoteUuid)
+        repository(gone).refresh()
         assertEquals(null, db.bookDao().allOnce().single().remoteUuid)
 
         assertEquals(true, repository(full).refresh().completed)
@@ -686,6 +815,27 @@ class RemoteCatalogRepositoryTest {
         assertEquals(1, books.size)
         assertEquals("b1", books.single().remoteUuid)
         assertEquals("content://downloads/b1.epub", books.single().localUri)
+    }
+
+    /** Unlinking clears the suspicion too, or the row would come back marked. */
+    @Test
+    fun `a downloaded book cut loose from the catalog keeps its file`() = runTest {
+        connect()
+        val full = FakeCatalog { onPage -> onPage(listOf(book("b1"))) }
+        repository(full).refresh()
+        db.bookDao().setDownloadState(
+            url = db.bookDao().allRemote().single().url,
+            state = com.chmouel.liseur.data.db.DownloadState.DOWNLOADED,
+            localUri = "content://downloads/b1.epub",
+        )
+        val gone = FakeCatalog { }
+        repository(gone).refresh()
+        repository(gone).refresh()
+
+        val cut = db.bookDao().allOnce().single()
+        assertEquals(null, cut.remoteUuid)
+        assertEquals("content://downloads/b1.epub", cut.localUri)
+        assertEquals(null, cut.catalogMissingSince)
     }
 
     /** A claim route that records what the retry actually asked for. */


### PR DESCRIPTION
## Summary

A catalog walk that reported `complete` was taken at its word: every catalogued book it had not named was pruned, together with its reading position, its sittings and its history. Every server here is paged by offset, so a catalog edited between two of those requests shifts under the offset and skips a book that is still on it.

Page 0 of `[1,2,3,4]` gives `1,2`; book `1` is deleted and `5` added; page 1, at offset 2 of `[2,3,4,5]`, gives `4,5`. Book `3` was never sent and is destroyed, while book `1`, which really did go, stays. Nothing in the answer looks wrong — the declared count is unchanged, the ids are distinct, the arithmetic exact — which is why no client can catch it. It is a property of offset pagination, not of Komga, calibre-web or Grimmory, so the fix goes where the pruning decision is made once for all of them.

A book absent from a finished walk is now **noted** rather than removed, and removed only when a second finished walk also fails to find it. The cost is that a book genuinely deleted on the server lingers for one more refresh — the right way round against a loss nothing can undo.

Fixes #93

## Changes

- `books.catalog_missing_since` (nullable, DB 40 → 41 with `MIGRATION_40_41` and `41.json`) holds when a finished walk first failed to find a book. A time rather than a flag so a bug report can say when; nothing decides anything by its value.
- `dropVanished` becomes `reconcileVanished`: a book absent from a finished walk with no mark is marked; one that already carries a mark is deleted, or unlinked if it is on the device, exactly as before.
- Being named again clears the mark, and that clearing rides on the catalog write for the page rather than waiting for the end of the walk. A walk that gave up half way still stored what it read, and a book on one of those pages must not be left one absence away from deletion. `mergeCatalogEntry` returns the row with the mark cleared, which also stops `store()`'s "unchanged, skip it" shortcut swallowing it; `updateCatalogFields` sets the column to `NULL`. The reconciliation keeps a second clear for anything seen but still marked, so the invariant does not rest on one write in another file staying unconditional.
- `unlinkFromRemote`, `unlinkDownloadedFromRemote` and `linkToRemote` clear the mark, so a row that leaves the catalog or is adopted by an upload never carries an old one back in.
- The new `IN (:urls)` writes are chunked at 500, matching `BulkDownloadCleanupWorker.RESET_CHUNK`; the confirmed delete and unlink go the same way. A whole library can leave a catalog at once, and SQLite refuses more than 999 bound variables before API 31. The whole reconciliation is still one Room transaction.

## Testing

- [x] `./gradlew testDebugUnitTest` — 1478 tests, 0 failures
- [x] `./gradlew lintDebug` — 0 errors
- [x] `./gradlew assembleDebug`
- [ ] Manually tested on a device or emulator, if applicable

New tests in `RemoteCatalogRepositoryTest`:

- the issue's own reproduction — pages shifting under the walk — asserting the skipped book keeps its row, its progress and its sittings
- one absence marks but does not prune; two consecutive finished absences do prune
- being named again clears the mark and the count starts over
- a book seen by a walk that did **not** finish is no longer suspected, so a later single absence does not delete it
- an unfinished walk marks nothing
- 1200 books vanishing at once, for the chunking
- a downloaded book needs two absences before it is cut loose, and keeps its file and a clear mark

`MigrationTest` covers a book row coming through 40 → 41 unmarked.

No screenshots: this change has no UI.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
