### PR TITLE
Keep your place through a KOReader (kosync) sync server

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ shelf from a connected server in one go.
 
 Reading position syncs across devices through calibre-web, Komga and
 liseur-sync, down to the exact sentence on the last two. liseur-sync also
-syncs standalone EPUBs that never came from a catalog. Grimmory browses and
-downloads only; what each server can and cannot do is in
+syncs standalone EPUBs that never came from a catalog. A KOReader sync
+(kosync) server can be paired alongside any catalog — it is how Grimmory
+syncs positions, and it works with any kosync-compatible server. What
+each server can and cannot do is in
 [`docs/SERVER_CAPABILITIES.md`](docs/SERVER_CAPABILITIES.md).
 
 No trackers, no analytics, no ads, no subscriptions. Liseur only talks to the

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ shelf from a connected server in one go.
 
 Reading position syncs across devices through calibre-web, Komga and
 liseur-sync, down to the exact sentence on the last two. liseur-sync also
-syncs standalone EPUBs that never came from a catalog. A KOReader sync
-(kosync) server can be paired alongside any catalog — it is how Grimmory
-syncs positions, and it works with any kosync-compatible server. What
-each server can and cannot do is in
+syncs standalone EPUBs that never came from a catalog. Grimmory keeps
+your books but not your place in them, so it can be paired with a
+KOReader sync (kosync) server, which is how positions travel there; any
+kosync-compatible server works. What each server can and cannot do is in
 [`docs/SERVER_CAPABILITIES.md`](docs/SERVER_CAPABILITIES.md).
 
 No trackers, no analytics, no ads, no subscriptions. Liseur only talks to the

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -186,6 +186,7 @@ dependencies {
     // Lets the calibre-web clients be tested against a real socket, which is
     // the only way to cover redirects, failed logins and refused deletes.
     testImplementation(libs.mockwebserver)
+    testImplementation(libs.okhttp.tls)
     // Gives the sync coordinator's tests a clock they control, which is
     // the only way to pin down what happens when two requests overlap.
     testImplementation(libs.coroutines.test)

--- a/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/42.json
+++ b/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/42.json
@@ -1,0 +1,1277 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 42,
+    "identityHash": "7307d985a0fdb06356b195d45b3d721e",
+    "entities": [
+      {
+        "tableName": "reading_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `total_progression` REAL, `reading_speed` REAL, `reading_seconds_per_position` REAL, `reading_pace_samples` INTEGER NOT NULL DEFAULT 0, `reading_pace_elapsed_ms` INTEGER NOT NULL DEFAULT 0, `reading_pace_evidence` REAL NOT NULL DEFAULT 0, `updated_at` INTEGER NOT NULL, `status` TEXT, `synced_at` INTEGER, `local_revision` INTEGER NOT NULL DEFAULT 0, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `agreed_account` TEXT, `pending_progression` REAL, `pending_locator_json` TEXT, `pending_status` TEXT, `pending_updated_at` INTEGER, `pending_account` TEXT, `owner_account` TEXT, `remote_updated_at` INTEGER, `finished_override` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSpeed",
+            "columnName": "reading_speed",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSecondsPerPosition",
+            "columnName": "reading_seconds_per_position",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingPaceSamples",
+            "columnName": "reading_pace_samples",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceElapsedMs",
+            "columnName": "reading_pace_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceEvidence",
+            "columnName": "reading_pace_evidence",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localRevision",
+            "columnName": "local_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "agreedAccount",
+            "columnName": "agreed_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingLocatorJson",
+            "columnName": "pending_locator_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingAccount",
+            "columnName": "pending_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ownerAccount",
+            "columnName": "owner_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "finishedOverride",
+            "columnName": "finished_override",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `cover_path` TEXT, `source` TEXT, `added_at` INTEGER NOT NULL, `last_opened_at` INTEGER, `local_uri` TEXT, `remote_uuid` TEXT, `remote_book_id` INTEGER, `cover_url` TEXT, `download_href` TEXT, `download_state` TEXT NOT NULL, `remote_updated_at` INTEGER, `downloaded_at` INTEGER, `file_modified_at` INTEGER, `work_id` TEXT, `finished_at` INTEGER, `archived_at` INTEGER, `remote_page_count` INTEGER, `size_bytes` INTEGER, `series_name` TEXT, `series_index` REAL, `file_series_name` TEXT, `file_series_index` REAL, `series_id` TEXT, `series_checked` INTEGER NOT NULL, `catalog_series_name` TEXT, `catalog_series_index` REAL, `catalog_folder_id` TEXT, `catalog_series_source` TEXT, `user_series_name` TEXT, `user_series_index` REAL, `series_override` INTEGER NOT NULL, `user_series_updated_at` INTEGER, `series_claim_pending` INTEGER NOT NULL, `series_claim_reset` INTEGER NOT NULL, `personal_series_updated_at` INTEGER, `series_index_override` INTEGER NOT NULL, `catalog_missing_since` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "last_opened_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localUri",
+            "columnName": "local_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUuid",
+            "columnName": "remote_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteBookId",
+            "columnName": "remote_book_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadHref",
+            "columnName": "download_href",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadState",
+            "columnName": "download_state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloaded_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finished_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archived_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remotePageCount",
+            "columnName": "remote_page_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "size_bytes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fileSeriesName",
+            "columnName": "file_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileSeriesIndex",
+            "columnName": "file_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesChecked",
+            "columnName": "series_checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSeriesName",
+            "columnName": "catalog_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesIndex",
+            "columnName": "catalog_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "catalogFolderId",
+            "columnName": "catalog_folder_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesSource",
+            "columnName": "catalog_series_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesName",
+            "columnName": "user_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesIndex",
+            "columnName": "user_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesOverridden",
+            "columnName": "series_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userSeriesUpdatedAt",
+            "columnName": "user_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesClaimPending",
+            "columnName": "series_claim_pending",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesClaimReset",
+            "columnName": "series_claim_reset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personalSeriesUpdatedAt",
+            "columnName": "personal_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "indexOverridden",
+            "columnName": "series_index_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogMissingSince",
+            "columnName": "catalog_missing_since",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_books_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_books_url` ON `${TABLE_NAME}` (`url`)"
+          },
+          {
+            "name": "index_books_series_name",
+            "unique": false,
+            "columnNames": [
+              "series_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_series_name` ON `${TABLE_NAME}` (`series_name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "library_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `added_at` INTEGER NOT NULL, PRIMARY KEY(`url`))",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "url"
+          ]
+        }
+      },
+      {
+        "tableName": "remote_server",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `kind` TEXT NOT NULL, `base_url` TEXT NOT NULL, `username` TEXT, `password_cipher` TEXT, `api_key_cipher` TEXT, `account_id` TEXT, `user_id` INTEGER, `kobo_token` TEXT, `can_download` INTEGER NOT NULL, `can_manage_library` INTEGER NOT NULL, `can_upload` INTEGER NOT NULL, `can_delete` INTEGER NOT NULL, `can_admin` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `catalog_synced_at` INTEGER, `position_synced_at` INTEGER, `sync_token` TEXT, `liseur_token_cipher` TEXT, `liseur_account_id` TEXT, `sync_cursor_seq` INTEGER NOT NULL DEFAULT 0, `annotation_cursor_seq` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "passwordCipher",
+            "columnName": "password_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiKeyCipher",
+            "columnName": "api_key_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "koboTokenCipher",
+            "columnName": "kobo_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "canDownload",
+            "columnName": "can_download",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canManageLibrary",
+            "columnName": "can_manage_library",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canUpload",
+            "columnName": "can_upload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canDelete",
+            "columnName": "can_delete",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canAdmin",
+            "columnName": "can_admin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSyncedAt",
+            "columnName": "catalog_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "positionSyncedAt",
+            "columnName": "position_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncToken",
+            "columnName": "sync_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurTokenCipher",
+            "columnName": "liseur_token_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurAccountId",
+            "columnName": "liseur_account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncCursorSeq",
+            "columnName": "sync_cursor_seq",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "annotationCursorSeq",
+            "columnName": "annotation_cursor_seq",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `book_id` TEXT NOT NULL, `kind` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `text` TEXT, `note` TEXT, `tint` TEXT, `chapter` TEXT, `position` INTEGER, `total_progression` REAL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tint",
+            "columnName": "tint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapter",
+            "columnName": "chapter",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_typography",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `font` TEXT NOT NULL, `font_size` REAL NOT NULL, `line_height` REAL, `page_margins` REAL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "font",
+            "columnName": "font",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "font_size",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineHeight",
+            "columnName": "line_height",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pageMargins",
+            "columnName": "page_margins",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_screen",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `keep_screen_on` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keepScreenOn",
+            "columnName": "keep_screen_on",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_reading_mode",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `scroll` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scroll",
+            "columnName": "scroll",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `book_url` TEXT NOT NULL, `started_at` INTEGER NOT NULL, `ended_at` INTEGER, `last_checkpoint_at` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `start_progression` REAL, `end_progression` REAL, `idle_ms` INTEGER, `uploaded_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "ended_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastCheckpointAt",
+            "columnName": "last_checkpoint_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startProgression",
+            "columnName": "start_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "endProgression",
+            "columnName": "end_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "idleMs",
+            "columnName": "idle_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "uploadedAt",
+            "columnName": "uploaded_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_sessions_book_url",
+            "unique": false,
+            "columnNames": [
+              "book_url"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_book_url` ON `${TABLE_NAME}` (`book_url`)"
+          },
+          {
+            "name": "index_reading_sessions_started_at",
+            "unique": false,
+            "columnNames": [
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_started_at` ON `${TABLE_NAME}` (`started_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_peer_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `pending_progression` REAL, `pending_locator_json` TEXT, `pending_edition_sha` TEXT, `pending_status` TEXT, `pending_updated_at` INTEGER, `has_pending` INTEGER NOT NULL DEFAULT 0, `remote_updated_at` INTEGER, `synced_at` INTEGER, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingLocatorJson",
+            "columnName": "pending_locator_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingEditionSha",
+            "columnName": "pending_edition_sha",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasPending",
+            "columnName": "has_pending",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_peer_state_peer_id",
+            "unique": false,
+            "columnNames": [
+              "peer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_peer_state_peer_id` ON `${TABLE_NAME}` (`peer_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_fingerprint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `sha256` TEXT NOT NULL, `partial_md5` TEXT NOT NULL, `file_size` INTEGER NOT NULL, `file_modified_at` INTEGER, `computed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256",
+            "columnName": "sha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partialMd5",
+            "columnName": "partial_md5",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "computedAt",
+            "columnName": "computed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "work_alias",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_id` TEXT NOT NULL, `confidence` TEXT NOT NULL, `confirmed` INTEGER NOT NULL, `seeded` INTEGER NOT NULL DEFAULT 0, `source_sent` INTEGER NOT NULL DEFAULT 0, `edition_sha` TEXT, `annotations_reconciled_at` INTEGER NOT NULL DEFAULT 0, `resolved_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confirmed",
+            "columnName": "confirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seeded",
+            "columnName": "seeded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceSent",
+            "columnName": "source_sent",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "editionSha",
+            "columnName": "edition_sha",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "annotationsReconciledAt",
+            "columnName": "annotations_reconciled_at",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "resolvedAt",
+            "columnName": "resolved_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "work_ambiguity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_ids` TEXT NOT NULL, `noticed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workIds",
+            "columnName": "work_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noticedAt",
+            "columnName": "noticed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_extra",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`series_id` TEXT NOT NULL, `summary` TEXT, `status` TEXT, `total_book_count` INTEGER, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`series_id`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalBookCount",
+            "columnName": "total_book_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "series_id"
+          ]
+        }
+      },
+      {
+        "tableName": "annotation_sync",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `book_id` TEXT NOT NULL, `work_id` TEXT NOT NULL, `rev` INTEGER NOT NULL, `seq` INTEGER NOT NULL, `acked_fingerprint` TEXT, `pending_kind` TEXT, `pending_json` TEXT, `pending_rev` INTEGER NOT NULL, `pending_fingerprint` TEXT, `rejected_fingerprint` TEXT, `retry_not_before` INTEGER NOT NULL, PRIMARY KEY(`id`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rev",
+            "columnName": "rev",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seq",
+            "columnName": "seq",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ackedFingerprint",
+            "columnName": "acked_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingKind",
+            "columnName": "pending_kind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingJson",
+            "columnName": "pending_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingRev",
+            "columnName": "pending_rev",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pendingFingerprint",
+            "columnName": "pending_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "rejectedFingerprint",
+            "columnName": "rejected_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "retryNotBefore",
+            "columnName": "retry_not_before",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotation_sync_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotation_sync_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          },
+          {
+            "name": "index_annotation_sync_work_id",
+            "unique": false,
+            "columnNames": [
+              "work_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotation_sync_work_id` ON `${TABLE_NAME}` (`work_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kosync_peer",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `base_url` TEXT NOT NULL, `username` TEXT NOT NULL, `key_cipher` TEXT NOT NULL, `added_at` INTEGER NOT NULL, `position_synced_at` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keyCipher",
+            "columnName": "key_cipher",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSyncedAt",
+            "columnName": "position_synced_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7307d985a0fdb06356b195d45b3d721e')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -40,6 +40,8 @@ import com.chmouel.liseur.data.liseursync.LiseurSyncServerSetup
 import com.chmouel.liseur.data.liseursync.LiseurSyncSeriesClient
 import com.chmouel.liseur.data.liseursync.LiseurSyncUploadClient
 import com.chmouel.liseur.data.liseursync.WorkResolver
+import com.chmouel.liseur.data.kosync.KosyncAccountRepository
+import com.chmouel.liseur.data.kosync.KosyncPositionSync
 import com.chmouel.liseur.data.remote.RemoteAccountRepository
 import com.chmouel.liseur.data.remote.RemoteCatalogRepository
 import com.chmouel.liseur.data.remote.SeriesExtrasRepository
@@ -237,6 +239,30 @@ class AppContainer(context: Context) {
     )
 
     /**
+     * The KOReader kosync partner (issue #95): position sync alongside
+     * the catalog server, for servers — Grimmory above all — that hold
+     * positions behind kosync rather than their catalog API.
+     */
+    val kosyncAccount = KosyncAccountRepository(
+        dao = database.kosyncPeerDao(),
+        peerStateDao = database.syncPeerStateDao(),
+        reporting = syncReporting,
+    )
+
+    val kosyncSync = KosyncPositionSync(
+        kosyncDao = database.kosyncPeerDao(),
+        bookDao = database.bookDao(),
+        progressDao = database.readingProgressDao(),
+        peerStateDao = database.syncPeerStateDao(),
+        fingerprints = bookFingerprints,
+        device = { deviceIdentity.current() },
+        finishedState = finishedState,
+        reporting = syncReporting,
+        networkAvailability = networkAvailability,
+        inTransaction = { work -> database.withTransaction { work() } },
+    )
+
+    /**
      * liseur-sync's position sync: the append-only op log, bound to the
      * catalog account like the other kinds' syncs are.
      */
@@ -321,14 +347,14 @@ class AppContainer(context: Context) {
     /**
      * Every partner reading positions are kept in step with.
      *
-     * Today that is the one connected server, whichever kind it is; the
-     * composite stays because the coordinator's ordering rules are
-     * written against it, and a partner added later — a dedicated sync
-     * server again, say — is one list entry away.
+     * The catalog server first — it is the one whose own interface shows
+     * the position too — and the kosync partner after it. The composite
+     * runs them in turn, so the coordinator's ordering rules hold across
+     * both without being written twice.
      */
     val positionSync = PositionSyncCoordinator(
         CompositePositionSync(
-            listOf(RoutedPositionSync(remoteRouter)),
+            listOf(RoutedPositionSync(remoteRouter), kosyncSync),
         ),
     )
 

--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -160,6 +160,10 @@ class AppContainer(context: Context) {
         identityDao = database.workIdentityDao(),
         sessionDao = database.readingSessionDao(),
         annotationSyncDao = database.annotationSyncDao(),
+        // Declared later in this file, so it is reached through the
+        // lambda rather than held: the pairing is only ever put down
+        // after a connection has landed, never while one is being built.
+        forgetKosyncPeer = { kosyncAccount.disconnect() },
         setups = mapOf(
             ServerKind.CALIBRE to com.chmouel.liseur.data.calibre.CalibreSetupClient(),
             ServerKind.KOMGA to com.chmouel.liseur.data.komga.KomgaSetupClient(),
@@ -257,6 +261,7 @@ class AppContainer(context: Context) {
         fingerprints = bookFingerprints,
         device = { deviceIdentity.current() },
         finishedState = finishedState,
+        connectedKind = { database.remoteServerDao().get()?.kind },
         reporting = syncReporting,
         networkAvailability = networkAvailability,
         inTransaction = { work -> database.withTransaction { work() } },

--- a/app/src/main/kotlin/com/chmouel/liseur/LiseurApplication.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/LiseurApplication.kt
@@ -71,6 +71,7 @@ class LiseurApplication : Application(), SingletonImageLoader.Factory {
                         val due = shouldSyncOnForeground(
                             container.remoteAccount.current(),
                             now,
+                            kosync = container.kosyncAccount.current(),
                         )
                         if (!due) return@launch
                         runCatching { container.positionSync.request(SyncScope.Full, now) }

--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -465,6 +465,12 @@ private fun ServerAccountRoute(
         onDownloadAll = viewModel::downloadAll,
         onCancelDownloadAll = viewModel::cancelDownloadAll,
         onDismissBatch = viewModel::dismissBatch,
+        onKosyncUrlChange = viewModel::setKosyncUrl,
+        onKosyncUsernameChange = viewModel::setKosyncUsername,
+        onKosyncPasswordChange = viewModel::setKosyncPassword,
+        onKosyncRegisterChange = viewModel::setKosyncRegister,
+        onKosyncConnect = viewModel::connectKosync,
+        onKosyncDisconnect = viewModel::disconnectKosync,
         onBack = onBack,
     )
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/KosyncPeer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/KosyncPeer.kt
@@ -1,0 +1,89 @@
+package com.chmouel.liseur.data.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.Ignore
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.Upsert
+import com.chmouel.liseur.data.calibre.CredentialCipher
+import com.chmouel.liseur.data.kosync.KosyncCredentials
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * The kosync partner reading positions are also kept in step with.
+ *
+ * A row of its own rather than more columns on `remote_server`, because
+ * the two connections have separate lives: kosync is configured
+ * *alongside* whatever catalog server is connected — that is the whole
+ * point for Grimmory, whose Komga shim carries no position — and
+ * disconnecting one must not take the other with it.
+ *
+ * Only one row ever exists ([SINGLE_ID]). What is stored is the derived
+ * auth key, never the password: the key is what travels on the wire, so
+ * the password itself has no business being on disk. Sealed with the
+ * Keystore like every other credential; see `CredentialCipher`.
+ */
+@Entity(tableName = "kosync_peer")
+data class KosyncPeer(
+    @PrimaryKey val id: Long = SINGLE_ID,
+    /** The protocol's mount root, e.g. `https://host/api/koreader`. */
+    @ColumnInfo(name = "base_url") val baseUrl: String,
+    val username: String,
+    /** The Keystore-sealed hex-MD5 auth key. */
+    @ColumnInfo(name = "key_cipher") val keyCipher: String,
+    @ColumnInfo(name = "added_at") val addedAt: Long,
+    @ColumnInfo(name = "position_synced_at") val positionSyncedAt: Long? = null,
+) {
+    /**
+     * How to sign a kosync request, or null when the key cannot be read
+     * back — a database restored onto another phone arrives with
+     * ciphertext this Keystore cannot open.
+     */
+    @get:Ignore
+    val credentials: KosyncCredentials?
+        get() = CredentialCipher.decrypt(keyCipher)?.let { KosyncCredentials(username, it) }
+
+    /**
+     * Who this partner's agreements belong to.
+     *
+     * The key `sync_peer_state` rows are stored under. It names the
+     * account rather than the protocol, so signing in as a different
+     * kosync user strands the old agreements rather than adopting them —
+     * the same rule every other kind of server follows.
+     */
+    @get:Ignore
+    val accountKey: String
+        get() = "kosync|$baseUrl|$username"
+
+    companion object {
+        const val SINGLE_ID = 1L
+
+        /** Wraps a freshly derived key for storage. */
+        fun seal(key: String): String = CredentialCipher.encrypt(key)
+    }
+}
+
+@Dao
+interface KosyncPeerDao {
+    @Query("SELECT * FROM kosync_peer WHERE id = :id")
+    fun observe(id: Long = KosyncPeer.SINGLE_ID): Flow<KosyncPeer?>
+
+    @Query("SELECT * FROM kosync_peer WHERE id = :id")
+    suspend fun get(id: Long = KosyncPeer.SINGLE_ID): KosyncPeer?
+
+    @Upsert
+    suspend fun upsert(peer: KosyncPeer)
+
+    /**
+     * Marks how far a run got, touching nothing else — writing the whole
+     * row back would carry the copy of the credentials the run started
+     * with over one stored in the meantime.
+     */
+    @Query("UPDATE kosync_peer SET position_synced_at = :at WHERE id = :id")
+    suspend fun setPositionSyncedAt(at: Long, id: Long = KosyncPeer.SINGLE_ID)
+
+    @Query("DELETE FROM kosync_peer WHERE id = :id")
+    suspend fun delete(id: Long = KosyncPeer.SINGLE_ID)
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
@@ -24,8 +24,9 @@ import androidx.sqlite.execSQL
         WorkAmbiguity::class,
         SeriesExtra::class,
         AnnotationSync::class,
+        KosyncPeer::class,
     ],
-    version = 41,
+    version = 42,
     exportSchema = true,
 )
 abstract class LiseurDatabase : RoomDatabase() {
@@ -38,6 +39,7 @@ abstract class LiseurDatabase : RoomDatabase() {
     abstract fun seriesOrderDao(): SeriesOrderDao
     abstract fun libraryFolderDao(): LibraryFolderDao
     abstract fun remoteServerDao(): RemoteServerDao
+    abstract fun kosyncPeerDao(): KosyncPeerDao
     abstract fun annotationDao(): BookAnnotationDao
     abstract fun annotationSyncDao(): AnnotationSyncDao
     abstract fun typographyDao(): BookTypographyDao
@@ -1048,6 +1050,25 @@ abstract class LiseurDatabase : RoomDatabase() {
             }
         }
 
+        /** Adds the kosync partner (ADR-0014). */
+        val MIGRATION_41_42 = object : Migration(41, 42) {
+            override fun migrate(connection: SQLiteConnection) {
+                connection.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `kosync_peer` (
+                        `id` INTEGER NOT NULL,
+                        `base_url` TEXT NOT NULL,
+                        `username` TEXT NOT NULL,
+                        `key_cipher` TEXT NOT NULL,
+                        `added_at` INTEGER NOT NULL,
+                        `position_synced_at` INTEGER,
+                        PRIMARY KEY(`id`)
+                    )
+                    """.trimIndent(),
+                )
+            }
+        }
+
         val MIGRATION_39_40 = object : Migration(39, 40) {
             override fun migrate(connection: SQLiteConnection) {
                 connection.execSQL(
@@ -1162,6 +1183,7 @@ abstract class LiseurDatabase : RoomDatabase() {
             MIGRATION_38_39,
             MIGRATION_39_40,
             MIGRATION_40_41,
+            MIGRATION_41_42,
         )
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncAccountRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncAccountRepository.kt
@@ -1,0 +1,155 @@
+package com.chmouel.liseur.data.kosync
+
+import com.chmouel.liseur.data.db.KosyncPeer
+import com.chmouel.liseur.data.db.KosyncPeerDao
+import com.chmouel.liseur.data.db.SyncPeerStateDao
+import com.chmouel.liseur.data.remote.PeerPositionSync
+import com.chmouel.liseur.data.remote.RemoteResult
+import com.chmouel.liseur.data.remote.SetupFailure
+import com.chmouel.liseur.data.remote.SyncFailure
+import com.chmouel.liseur.data.remote.SyncReporting
+import kotlinx.coroutines.flow.Flow
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+
+/** What came of trying to pair with a kosync server. */
+sealed interface KosyncSetupOutcome {
+    data object Success : KosyncSetupOutcome
+    data class Failure(val reason: SetupFailure) : KosyncSetupOutcome
+}
+
+/**
+ * The kosync partner's lifecycle: pairing, forgetting, and the one
+ * door per-account state is cleared through.
+ *
+ * Deliberately separate from `RemoteAccountRepository`: the kosync
+ * partner lives alongside whatever catalog server is connected, and
+ * disconnecting either one must leave the other standing.
+ */
+class KosyncAccountRepository(
+    private val dao: KosyncPeerDao,
+    private val peerStateDao: SyncPeerStateDao,
+    private val reporting: SyncReporting = SyncReporting(),
+    private val client: KosyncClient = KosyncClient(),
+    private val now: () -> Long = System::currentTimeMillis,
+) {
+
+    val peer: Flow<KosyncPeer?> = dao.observe()
+
+    suspend fun current(): KosyncPeer? = dao.get()
+
+    /**
+     * Pairs with a kosync server, proving the credentials work before
+     * anything is stored.
+     *
+     * The password is hashed into the protocol's auth key here and the
+     * key alone is kept. With [register] the credential is created on
+     * the server first — liseur-sync redeems a pairing code that way —
+     * and registering is an explicit ask rather than a fallback, because
+     * against a stock kosync server an automatic retry-as-register would
+     * turn a typo into a fresh account.
+     */
+    suspend fun connect(
+        url: String,
+        username: String,
+        password: String,
+        register: Boolean = false,
+    ): KosyncSetupOutcome {
+        val root = normalise(url) ?: return KosyncSetupOutcome.Failure(SetupFailure.WrongServer)
+        val login = username.trim()
+        if (login.isEmpty() || password.isEmpty()) {
+            return KosyncSetupOutcome.Failure(SetupFailure.BadCredentials)
+        }
+
+        if (register) {
+            // Registering is the one call that carries the password as
+            // typed rather than the derived key. It does not go out in
+            // the clear.
+            if (root.startsWith("http://")) {
+                return KosyncSetupOutcome.Failure(SetupFailure.InsecureTransport)
+            }
+            when (val created = client.register(root, login, password)) {
+                is RemoteResult.Ok -> Unit
+                is RemoteResult.Failed -> return KosyncSetupOutcome.Failure(setupReason(created.reason))
+            }
+        }
+
+        val credentials = KosyncCredentials(login, KosyncCredentials.keyFor(password))
+        when (val asked = client.authorize(root, credentials)) {
+            is RemoteResult.Ok -> Unit
+            is RemoteResult.Failed -> return KosyncSetupOutcome.Failure(setupReason(asked.reason))
+        }
+
+        val fresh = KosyncPeer(
+            baseUrl = root,
+            username = login,
+            keyCipher = KosyncPeer.seal(credentials.key),
+            addedAt = now(),
+        )
+        // A different account's agreements are somebody else's: signing
+        // in as a new user strands them rather than adopting them, the
+        // same rule every other kind of server follows.
+        val old = dao.get()
+        if (old != null && old.accountKey != fresh.accountKey) {
+            forget(old)
+        }
+        dao.upsert(fresh)
+        return KosyncSetupOutcome.Success
+    }
+
+    /**
+     * Forgets the partner. The reading itself stays — it is this
+     * device's — but the record of what this server had agreed goes,
+     * because it means nothing once the server is no longer talked to.
+     */
+    suspend fun disconnect() {
+        dao.get()?.let { forget(it) }
+        dao.delete()
+    }
+
+    /**
+     * Forgets a partner whose key can no longer be read back — a
+     * database restored onto another phone arrives with ciphertext this
+     * Keystore cannot open, and asking for the password again is better
+     * than looking connected while every request quietly fails.
+     */
+    suspend fun forgetUnreadable(): Boolean {
+        val peer = dao.get() ?: return false
+        if (peer.credentials != null) return false
+        forget(peer)
+        dao.delete()
+        return true
+    }
+
+    private suspend fun forget(peer: KosyncPeer) {
+        peerStateDao.forgetPeer(peer.accountKey)
+        reporting.forget(PeerPositionSync.KOSYNC)
+    }
+
+    /**
+     * The mount root as stored: scheme defaulted to https, whitespace
+     * and trailing slashes gone, and the whole thing proven parseable —
+     * OkHttp throws on a malformed URL from outside [KosyncClient]'s
+     * error mapping, so a root nothing could ever address is refused
+     * here rather than thrown later. The reader's own spelling of the
+     * path is kept: mount roots are case-preserving.
+     */
+    private fun normalise(url: String): String? {
+        val trimmed = url.trim()
+        if (trimmed.isEmpty()) return null
+        val withScheme = if ("://" in trimmed) trimmed else "https://$trimmed"
+        if (!withScheme.startsWith("http://") && !withScheme.startsWith("https://")) return null
+        // Parse before trimming slashes: "https://" must fail as
+        // host-less here, not survive as the host "https:".
+        if (withScheme.toHttpUrlOrNull() == null) return null
+        return withScheme.trimEnd('/')
+    }
+
+    private fun setupReason(reason: SyncFailure): SetupFailure = when (reason) {
+        SyncFailure.Unauthorised, SyncFailure.Forbidden -> SetupFailure.BadCredentials
+        // The mount root is part of the address: a 404 here is the
+        // wrong path, not a missing book.
+        SyncFailure.NotFound, SyncFailure.Malformed -> SetupFailure.WrongServer
+        SyncFailure.InsecureTransport -> SetupFailure.InsecureTransport
+        else -> SetupFailure.Unreachable(reason.label, httpMayWork = false)
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncAccountRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncAccountRepository.kt
@@ -126,22 +126,36 @@ class KosyncAccountRepository(
     }
 
     /**
-     * The mount root as stored: scheme defaulted to https, whitespace
-     * and trailing slashes gone, and the whole thing proven parseable —
-     * OkHttp throws on a malformed URL from outside [KosyncClient]'s
-     * error mapping, so a root nothing could ever address is refused
-     * here rather than thrown later. The reader's own spelling of the
-     * path is kept: mount roots are case-preserving.
+     * The mount root as stored: scheme lowercased and defaulted to
+     * https, whitespace, query, fragment and trailing slashes gone, and
+     * the whole thing proven parseable — OkHttp throws on a malformed
+     * URL from outside [KosyncClient]'s error mapping, so a root nothing
+     * could ever address is refused here rather than thrown later. The
+     * reader's own spelling of the path is kept: mount roots are
+     * case-preserving.
+     *
+     * A query or fragment is dropped rather than refused. Endpoints are
+     * built by appending to this string, so `…/koreader?x=1` would
+     * become `…/koreader?x=1/users/auth`, which addresses nothing. There
+     * is no kosync route that takes one, and a reader who pasted their
+     * address out of a browser bar should not have to notice why.
      */
     private fun normalise(url: String): String? {
         val trimmed = url.trim()
         if (trimmed.isEmpty()) return null
         val withScheme = if ("://" in trimmed) trimmed else "https://$trimmed"
-        if (!withScheme.startsWith("http://") && !withScheme.startsWith("https://")) return null
+        val scheme = withScheme.substringBefore("://").lowercase()
+        if (scheme != "http" && scheme != "https") return null
+        val spelled = scheme + withScheme.substring(scheme.length)
         // Parse before trimming slashes: "https://" must fail as
         // host-less here, not survive as the host "https:".
-        if (withScheme.toHttpUrlOrNull() == null) return null
-        return withScheme.trimEnd('/')
+        val parsed = spelled.toHttpUrlOrNull() ?: return null
+        return parsed.newBuilder()
+            .query(null)
+            .fragment(null)
+            .build()
+            .toString()
+            .trimEnd('/')
     }
 
     private fun setupReason(reason: SyncFailure): SetupFailure = when (reason) {

--- a/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncClient.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncClient.kt
@@ -1,0 +1,238 @@
+package com.chmouel.liseur.data.kosync
+
+import com.chmouel.liseur.data.remote.RemoteHttp
+import com.chmouel.liseur.data.remote.RemoteHttpFailure
+import com.chmouel.liseur.data.remote.RemoteResult
+import com.chmouel.liseur.data.remote.SyncFailure
+import com.chmouel.liseur.data.remote.failureForCode
+import com.chmouel.liseur.data.remote.remoteCall
+import java.security.MessageDigest
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import org.json.JSONObject
+
+/**
+ * How a kosync request proves who it is.
+ *
+ * The protocol's `x-auth-key` is the hex MD5 of the password, as
+ * KOReader derives it. Only the derived key ever exists here: the
+ * password is hashed the moment it is typed and never stored, so what
+ * is at risk in the database is a credential for this one protocol and
+ * not something the reader may have reused.
+ */
+data class KosyncCredentials(val username: String, val key: String) {
+    companion object {
+        /** KOReader's derivation: the auth key is the hex MD5 of the password. */
+        fun keyFor(password: String): String {
+            val digest = MessageDigest.getInstance("MD5").digest(password.toByteArray())
+            return digest.joinToString("") { "%02x".format(it) }
+        }
+    }
+}
+
+/** Where the other side last was, as the kosync protocol says it. */
+data class KosyncProgress(
+    /** How far through the book, 0..1. */
+    val percentage: Double,
+    /** The device that reported it, when the server says. */
+    val device: String?,
+    val deviceId: String?,
+    /** The server's own timestamp, in epoch milliseconds. Display only. */
+    val timestamp: Long?,
+)
+
+/**
+ * KOReader's kosync protocol: three endpoints under a mount root.
+ *
+ * The root differs per server — Grimmory serves it at `/api/koreader`,
+ * liseur-sync at `/adapter/kosync`, a stock kosync server at `/` — so
+ * the stored URL is the mount root and the endpoints are appended here.
+ *
+ * Positions travel as a percentage plus KOReader's own `progress`
+ * string. This client reads and writes only the percentage: `progress`
+ * is an engine-specific position (a CRe xpointer, a page number) that
+ * means nothing to Readium, so on the way out it carries the percentage
+ * as a bare string — the shape KOReader itself accepts for engines
+ * without an xpointer, and the one liseur-sync answers with.
+ *
+ * Blocking I/O moves to [Dispatchers.IO] here, not in callers: the
+ * suspend signature is a promise that the thread is safe.
+ *
+ * Redirects are never followed. The shared client follows them because
+ * calibre-web 308-redirects sloppy download paths, and OkHttp protects
+ * that case by stripping `Authorization` when a redirect changes host —
+ * but kosync signs with custom `x-auth-*` headers, which OkHttp would
+ * forward wholesale, and a register body even carries the raw password.
+ * No kosync endpoint legitimately redirects (the mount root is typed by
+ * the reader), so a 3xx reads as the wrong address, not a hop to take.
+ */
+class KosyncClient(
+    private val http: RemoteHttp = RemoteHttp(
+        RemoteHttp.default().newBuilder()
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .build(),
+    ),
+) {
+
+    /** Whether the server accepts these credentials. */
+    suspend fun authorize(
+        rootUrl: String,
+        credentials: KosyncCredentials,
+    ): RemoteResult<Unit> = withContext(Dispatchers.IO) {
+        remoteCall {
+            call(request(rootUrl, "users/auth", credentials).get().build()).use { response ->
+                if (!response.isSuccessful) throw RemoteHttpFailure(failureFor(response.code))
+            }
+        }
+    }
+
+    /**
+     * Registers this credential with the server, for servers that take
+     * one — liseur-sync redeems a pairing code this way; Grimmory
+     * forbids the route outright.
+     *
+     * The body carries the password as typed, per the protocol; only
+     * the derived key is ever kept afterwards.
+     */
+    suspend fun register(
+        rootUrl: String,
+        username: String,
+        password: String,
+    ): RemoteResult<Unit> = withContext(Dispatchers.IO) {
+        remoteCall {
+            val body = JSONObject()
+                .put("username", username)
+                .put("password", password)
+                .toString()
+                .toRequestBody(JSON)
+            val request = Request.Builder()
+                .url(url(rootUrl, "users/create"))
+                .post(body)
+                .build()
+            call(request).use { response ->
+                if (!response.isSuccessful) throw RemoteHttpFailure(failureFor(response.code))
+            }
+        }
+    }
+
+    /**
+     * Where the server thinks the reader is in one document, or null
+     * when it has never heard of it — kosync says that with an empty
+     * 200 body rather than a 404.
+     */
+    suspend fun getProgress(
+        rootUrl: String,
+        credentials: KosyncCredentials,
+        document: String,
+    ): RemoteResult<KosyncProgress?> = withContext(Dispatchers.IO) {
+        remoteCall {
+            val request = request(rootUrl, "syncs/progress/${document(document)}", credentials)
+                .get()
+                .build()
+            call(request).use { response ->
+                if (!response.isSuccessful) throw RemoteHttpFailure(failureFor(response.code))
+                parseProgress(JSONObject(response.body?.string().orEmpty().ifBlank { "{}" }))
+            }
+        }
+    }
+
+    /** Sends where the reader is in one document. */
+    suspend fun putProgress(
+        rootUrl: String,
+        credentials: KosyncCredentials,
+        document: String,
+        percentage: Double,
+        device: String,
+        deviceId: String,
+        /** From stored state, in epoch milliseconds; the wire wants seconds. */
+        timestampMs: Long,
+    ): RemoteResult<Unit> = withContext(Dispatchers.IO) {
+        remoteCall {
+            document(document)
+            val clamped = percentage.coerceIn(0.0, 1.0)
+            val body = JSONObject()
+                .put("document", document)
+                // The percentage said twice: once as the number the
+                // protocol reads, once as the string KOReader shows a
+                // reader whose engine has no anchor of its own.
+                .put("percentage", clamped)
+                .put("progress", clamped.toString())
+                .put("device", device)
+                .put("device_id", deviceId)
+                .put("timestamp", timestampMs / 1000)
+                .toString()
+                .toRequestBody(JSON)
+            val request = request(rootUrl, "syncs/progress", credentials).put(body).build()
+            call(request).use { response ->
+                if (!response.isSuccessful) throw RemoteHttpFailure(failureFor(response.code))
+            }
+        }
+    }
+
+    private fun call(request: Request): Response = http.client.newCall(request).execute()
+
+    /**
+     * What an unsuccessful answer means here. On top of the shared
+     * mapping: with redirects disabled a 3xx arrives as the answer
+     * itself, and since no kosync endpoint redirects, it means the
+     * mount root is not a kosync server — malformed, not retryable.
+     */
+    private fun failureFor(code: Int): SyncFailure =
+        if (code in 300..399) SyncFailure.Malformed else failureForCode(code)
+
+    private fun request(
+        rootUrl: String,
+        path: String,
+        credentials: KosyncCredentials,
+    ): Request.Builder = Request.Builder()
+        .url(url(rootUrl, path))
+        .header("x-auth-user", credentials.username)
+        .header("x-auth-key", credentials.key)
+
+    private fun url(rootUrl: String, path: String): String =
+        rootUrl.trimEnd('/') + "/" + path
+
+    /**
+     * A document name fit to put in a URL path.
+     *
+     * It is a hex hash and nothing else. The check is what stands
+     * between an id that is carried and an id that is *addressed*: a
+     * value like `..` would be resolved by the URL before the server
+     * ever saw it, so anything but hex is refused rather than sent.
+     */
+    private fun document(value: String): String {
+        if (!DOCUMENT.matches(value)) throw RemoteHttpFailure(SyncFailure.Malformed)
+        return value
+    }
+
+    private fun parseProgress(body: JSONObject): KosyncProgress? {
+        // An unknown document is `{}`; some servers spell it with an
+        // "error" field instead. Either way there is no percentage, and
+        // no percentage means nothing to sync rather than a fault.
+        if (!body.has("percentage")) return null
+        val percentage = body.optDouble("percentage")
+        if (percentage.isNaN() || percentage < 0.0 || percentage > 1.0) {
+            throw RemoteHttpFailure(SyncFailure.Malformed)
+        }
+        return KosyncProgress(
+            percentage = percentage,
+            device = body.optString("device").takeIf { it.isNotBlank() },
+            deviceId = body.optString("device_id").takeIf { it.isNotBlank() },
+            timestamp = body.optLong("timestamp", 0L).takeIf { it > 0 }?.times(1000),
+        )
+    }
+
+    private companion object {
+        val JSON = "application/json; charset=utf-8".toMediaType()
+
+        // Exactly KOReader's partial-MD5 shape: this client only ever
+        // addresses documents it computed itself, and those are always
+        // 32 lowercase hex characters.
+        val DOCUMENT = Regex("^[0-9a-f]{32}$")
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSync.kt
@@ -1,0 +1,528 @@
+package com.chmouel.liseur.data.kosync
+
+import android.util.Log
+import com.chmouel.liseur.data.NetworkAvailability
+import com.chmouel.liseur.data.db.Book
+import com.chmouel.liseur.data.db.BookDao
+import com.chmouel.liseur.data.db.KosyncPeer
+import com.chmouel.liseur.data.db.KosyncPeerDao
+import com.chmouel.liseur.data.db.ReadingProgress
+import com.chmouel.liseur.data.db.ReadingProgressDao
+import com.chmouel.liseur.data.db.SyncPeerState
+import com.chmouel.liseur.data.db.SyncPeerStateDao
+import com.chmouel.liseur.data.library.BookFingerprintStore
+import com.chmouel.liseur.data.library.FinishedState
+import com.chmouel.liseur.data.remote.DeviceIdentity
+import com.chmouel.liseur.data.remote.PeerPositionSync
+import com.chmouel.liseur.data.remote.PositionSyncStatus
+import com.chmouel.liseur.data.remote.PreviewOutcome
+import com.chmouel.liseur.data.remote.RemoteResult
+import com.chmouel.liseur.data.remote.ResolveOutcome
+import com.chmouel.liseur.data.remote.ServerKind
+import com.chmouel.liseur.data.remote.SyncFailure
+import com.chmouel.liseur.data.remote.SyncIdentity
+import com.chmouel.liseur.data.remote.SyncMove
+import com.chmouel.liseur.data.remote.SyncOutcome
+import com.chmouel.liseur.data.remote.SyncPreview
+import com.chmouel.liseur.data.remote.SyncReport
+import com.chmouel.liseur.data.remote.SyncReporting
+import com.chmouel.liseur.data.remote.SyncSnapshot
+import com.chmouel.liseur.domain.FinishedOverride
+import com.chmouel.liseur.domain.ReadingBaseline
+import com.chmouel.liseur.domain.ReadingState
+import com.chmouel.liseur.domain.ReadingStatus
+import com.chmouel.liseur.domain.SyncDecision
+import com.chmouel.liseur.domain.needsReconciling
+import com.chmouel.liseur.domain.readingStatusFor
+import com.chmouel.liseur.domain.reconcileReadingState
+
+/** What one book's reconciliation did, and why it stopped if it did. */
+private data class BookOutcome(
+    val moved: SyncMove? = null,
+    val failure: SyncFailure? = null,
+    /** Set when the server said nothing at all — the cue to stop the run. */
+    val unreachable: SyncFailure? = null,
+)
+
+/**
+ * Keeps reading positions in step with a kosync server (issue #95).
+ *
+ * A partner alongside the catalog server, not a kind of it: Grimmory is
+ * browsed through its Komga shim, which carries no reading position,
+ * while its kosync endpoint does — so the two are configured separately
+ * and this peer runs after the catalog's in `CompositePositionSync`.
+ *
+ * kosync names a book by KOReader's partial MD5 of the file, so only a
+ * book whose bytes are on this device can be spoken about, and the same
+ * book downloaded from somewhere else is a different document. Positions
+ * travel as a percentage; there is no locator to carry, so a pull lands
+ * at roughly the right page the way calibre-web's does.
+ *
+ * There is no feed and no cursor: each run asks about each candidate
+ * outright. The candidates are the catalog server's downloaded books,
+ * which is a bounded set, and a server that stops answering ends the
+ * walk early rather than paying a connect timeout per remaining book.
+ *
+ * Agreements live in `sync_peer_state` under this account's key, so the
+ * catalog server's baselines and this partner's cannot overwrite each
+ * other. The merge itself is `reconcileReadingState`, unchanged: a
+ * fourth kind of partner is not a fourth set of rules.
+ */
+class KosyncPositionSync(
+    private val kosyncDao: KosyncPeerDao,
+    private val bookDao: BookDao,
+    private val progressDao: ReadingProgressDao,
+    private val peerStateDao: SyncPeerStateDao,
+    private val fingerprints: BookFingerprintStore,
+    private val device: suspend () -> DeviceIdentity,
+    private val finishedState: FinishedState,
+    private val client: KosyncClient = KosyncClient(),
+    private val reporting: SyncReporting = SyncReporting(),
+    private val networkAvailability: NetworkAvailability = NetworkAvailability { true },
+    private val now: () -> Long = System::currentTimeMillis,
+    private val inTransaction: suspend (suspend () -> Unit) -> Unit = { it() },
+) : PeerPositionSync {
+
+    override val peerId: String get() = PeerPositionSync.KOSYNC
+
+    override suspend fun syncAll(snapshot: SyncSnapshot?): SyncOutcome = run(book = null)
+
+    override suspend fun syncBook(bookUrl: String): SyncOutcome = run(book = bookUrl)
+
+    override suspend fun canSync(bookUrl: String): Boolean {
+        account() ?: return false
+        val book = bookDao.getByUrl(bookUrl) ?: return false
+        return book.isCandidate
+    }
+
+    override suspend fun previewBook(bookUrl: String): PreviewOutcome {
+        val account = account() ?: return PreviewOutcome.NotSynced
+        val book = bookDao.getByUrl(bookUrl)?.takeIf { it.isCandidate }
+            ?: return PreviewOutcome.NotSynced
+        val document = fingerprints.of(book)?.partialMd5 ?: return PreviewOutcome.NotSynced
+        if (!networkAvailability.isAvailable()) return PreviewOutcome.Failed(SyncFailure.Offline)
+
+        val remote = when (val asked = client.getProgress(account.baseUrl, account.credentials, document)) {
+            is RemoteResult.Failed -> return PreviewOutcome.Failed(asked.reason)
+            is RemoteResult.Ok -> asked.value
+        }
+        if (remote != null) {
+            forAccount(account) {
+                peerStateDao.persistPending(
+                    bookUrl = bookUrl,
+                    peerId = account.peerId,
+                    progression = remote.percentage,
+                    status = ReadingStatus.forProgression(remote.percentage).wireName,
+                    remoteUpdatedAt = remote.timestamp,
+                )
+            }
+        }
+        return PreviewOutcome.Ready(
+            SyncPreview(
+                local = progressDao.get(bookUrl)?.totalProgression,
+                remote = remote?.percentage,
+                remoteAt = remote?.timestamp?.takeIf { it > 0 },
+            ),
+        )
+    }
+
+    override suspend fun preservedConflict(bookUrl: String): SyncPreview? {
+        val account = account() ?: return null
+        val state = peerStateDao.get(bookUrl, account.peerId) ?: return null
+        if (!state.hasPending) return null
+        val there = state.pendingProgression ?: return null
+        return SyncPreview(
+            local = progressDao.get(bookUrl)?.totalProgression,
+            remote = there,
+            remoteAt = state.remoteUpdatedAt?.takeIf { it > 0 },
+        ).takeIf { !it.agrees }
+    }
+
+    override suspend fun takeRemotePosition(bookUrl: String, atRevision: Long): ResolveOutcome {
+        val account = account() ?: return ResolveOutcome.Done
+        val state = peerStateDao.get(bookUrl, account.peerId) ?: return ResolveOutcome.Done
+        val progression = state.pendingProgression ?: return ResolveOutcome.Done
+        val status = ReadingStatus.fromWire(state.pendingStatus)
+        var applied = false
+        inTransaction {
+            applied = progressDao.applyPeerPull(
+                bookUrl = bookUrl,
+                expectedRevision = atRevision,
+                progression = progression,
+                status = status.wireName,
+                now = now(),
+                remoteUpdatedAt = state.pendingUpdatedAt,
+            )
+            if (applied) {
+                peerStateDao.settle(
+                    bookUrl = bookUrl,
+                    peerId = account.peerId,
+                    ackedRevision = atRevision + 1,
+                    progression = progression,
+                    status = status.wireName,
+                    now = now(),
+                )
+            }
+        }
+        if (!applied) return ResolveOutcome.Superseded
+        finishedState.refreshFromProgress(bookUrl)
+        return ResolveOutcome.Done
+    }
+
+    /**
+     * Keeps what is here and stops the server's answer being offered
+     * again. Nothing is sent from here: clearing the disagreement leaves
+     * the book dirty, so the next run pushes whatever page is actually
+     * open by then.
+     */
+    override suspend fun keepLocalPosition(bookUrl: String): ResolveOutcome {
+        val account = account() ?: return ResolveOutcome.Done
+        peerStateDao.clearPending(bookUrl, account.peerId)
+        return ResolveOutcome.Done
+    }
+
+    override suspend fun refreshUnresolved() {
+        val account = account() ?: return
+        reporting.reportUnresolved(peerStateDao.countPending(account.peerId), peerId)
+    }
+
+    override suspend fun identity(): SyncIdentity? {
+        val account = account() ?: return null
+        // Nothing is stranded by a kosync account change: agreements are
+        // per account already, and the reading itself was never stamped.
+        return SyncIdentity(login = account.login, strandedBooks = 0)
+    }
+
+    // -- The account ------------------------------------------------------
+
+    /** The paired kosync partner, as one run saw it. */
+    private class Account(
+        val baseUrl: String,
+        val credentials: KosyncCredentials,
+        /** The key this partner's per-book agreements are stored under. */
+        val peerId: String,
+        val login: String,
+    )
+
+    private suspend fun account(): Account? {
+        val peer = kosyncDao.get() ?: return null
+        val credentials = peer.credentials ?: return null
+        return Account(
+            baseUrl = peer.baseUrl,
+            credentials = credentials,
+            peerId = peer.accountKey,
+            login = peer.username,
+        )
+    }
+
+    // -- The run ----------------------------------------------------------
+
+    private suspend fun run(book: String?): SyncOutcome {
+        val peer = kosyncDao.get() ?: run {
+            reporting.report(PositionSyncStatus.Idle, peerId)
+            return SyncOutcome.NotApplicable
+        }
+        val credentials = peer.credentials ?: run {
+            // The key cannot be read back: a database restored onto
+            // another phone arrives with ciphertext this Keystore
+            // cannot open.
+            reporting.report(PositionSyncStatus.Unavailable, peerId)
+            return SyncOutcome.NotApplicable
+        }
+        if (!networkAvailability.isAvailable()) {
+            reporting.report(PositionSyncStatus.Failed(SyncFailure.Offline), peerId)
+            return SyncOutcome.Failure(SyncFailure.Offline)
+        }
+        val account = Account(
+            baseUrl = peer.baseUrl,
+            credentials = credentials,
+            peerId = peer.accountKey,
+            login = peer.username,
+        )
+
+        reporting.report(PositionSyncStatus.Syncing, peerId)
+        val identity = device()
+        val books = bookDao.allRemote()
+            .filter { book == null || it.url == book }
+            .filter { it.isCandidate }
+
+        var firstFailure: SyncFailure? = null
+        var unreachable: SyncFailure? = null
+        var pulled = 0
+        var pushed = 0
+        for (candidate in books) {
+            val outcome = reconcileBook(account, identity, candidate)
+            when (outcome.moved) {
+                SyncMove.PULLED -> pulled++
+                SyncMove.PUSHED -> pushed++
+                SyncMove.UNRESOLVED, null -> Unit
+            }
+            if (outcome.failure != null && firstFailure == null) firstFailure = outcome.failure
+            // Nothing more is learned by asking the next book of a
+            // server that has stopped answering, and each question
+            // costs a whole connect timeout.
+            unreachable = outcome.unreachable
+            if (unreachable != null) {
+                Log.i(TAG, "Stopping the run early: ${unreachable.label}")
+                break
+            }
+        }
+
+        val at = now()
+        reporting.report(
+            SyncReport(
+                at = at,
+                pulled = pulled,
+                pushed = pushed,
+                // Counted from disk: a disagreement outlives the run
+                // that found it.
+                unresolved = peerStateDao.countPending(account.peerId),
+            ),
+            peerId,
+        )
+        val failure = unreachable ?: firstFailure
+        return if (failure == null) {
+            forAccount(account) { kosyncDao.setPositionSyncedAt(at) }
+            reporting.report(PositionSyncStatus.Synced(at), peerId)
+            SyncOutcome.Success
+        } else {
+            Log.i(TAG, "Some positions did not settle: ${failure.label}")
+            reporting.report(PositionSyncStatus.Failed(failure), peerId)
+            if (pulled > 0 || pushed > 0) SyncOutcome.Partial(failure) else SyncOutcome.Failure(failure)
+        }
+    }
+
+    /**
+     * Settles one book: asks the server where it stands, lands the
+     * answer, and acts on the comparison.
+     *
+     * The server is asked every run because kosync has no feed — silence
+     * cannot be told apart from "nothing new" without asking. What was
+     * already pending from an earlier run is folded in, so an answer
+     * that landed and was never acted on is not lost to a crash.
+     */
+    private suspend fun reconcileBook(
+        account: Account,
+        identity: DeviceIdentity,
+        book: Book,
+    ): BookOutcome {
+        // A book whose file cannot be read has no name here; that is
+        // not a failure, there is simply nothing to say.
+        val document = fingerprints.of(book)?.partialMd5 ?: return BookOutcome()
+
+        val remote = when (val asked = client.getProgress(account.baseUrl, account.credentials, document)) {
+            is RemoteResult.Failed -> return BookOutcome(
+                failure = asked.reason,
+                unreachable = asked.unreachable,
+            )
+            is RemoteResult.Ok -> asked.value
+        }
+        if (remote != null) {
+            forAccount(account) {
+                peerStateDao.persistPending(
+                    bookUrl = book.url,
+                    peerId = account.peerId,
+                    progression = remote.percentage,
+                    status = ReadingStatus.forProgression(remote.percentage).wireName,
+                    remoteUpdatedAt = remote.timestamp,
+                )
+            }
+        }
+
+        val stored = progressDao.get(book.url)
+        val state = peerStateDao.get(book.url, account.peerId)
+        val dirty = state?.isDirty(stored?.localRevision ?: 0)
+            ?: ((stored?.localRevision ?: 0) > 0)
+
+        if (!needsReconciling(remote != null, state?.hasPending == true, dirty)) {
+            return BookOutcome()
+        }
+
+        val decision = reconcileReadingState(
+            local = stored?.asReadingState(),
+            remote = state?.pendingState(),
+            baseline = state?.baseline(),
+            localDirty = dirty,
+            localUnreadOverride = stored?.override == FinishedOverride.UNREAD,
+        )
+        return act(account, identity, book, document, stored, state, decision)
+    }
+
+    private suspend fun act(
+        account: Account,
+        identity: DeviceIdentity,
+        book: Book,
+        document: String,
+        stored: ReadingProgress?,
+        state: SyncPeerState?,
+        decision: SyncDecision,
+    ): BookOutcome {
+        val at = now()
+        when (decision) {
+            SyncDecision.InSync -> {
+                // Agreeing is worth writing down: it is what later tells
+                // a deliberate reread apart from the other device having
+                // moved on.
+                forAccount(account) {
+                    peerStateDao.settle(
+                        bookUrl = book.url,
+                        peerId = account.peerId,
+                        ackedRevision = stored?.localRevision ?: 0,
+                        progression = stored?.totalProgression,
+                        status = stored?.statusOrDerived()?.wireName,
+                        now = at,
+                    )
+                }
+                return BookOutcome()
+            }
+
+            is SyncDecision.Pull -> {
+                val progression = decision.state.progression ?: return BookOutcome()
+                val expected = stored?.localRevision ?: 0
+                var applied = false
+                forAccount(account) {
+                    applied = progressDao.applyUnattendedPeerPull(
+                        bookUrl = book.url,
+                        expectedRevision = expected,
+                        progression = progression,
+                        status = decision.state.status.wireName,
+                        now = at,
+                        remoteUpdatedAt = state?.pendingUpdatedAt,
+                    )
+                    if (applied) {
+                        peerStateDao.settle(
+                            bookUrl = book.url,
+                            peerId = account.peerId,
+                            ackedRevision = expected + 1,
+                            progression = progression,
+                            status = decision.state.status.wireName,
+                            now = at,
+                        )
+                    }
+                }
+                if (!applied) {
+                    // A page was turned here while this was being
+                    // decided: a disagreement rather than a handover.
+                    // What the server said stays on disk.
+                    return BookOutcome()
+                }
+                finishedState.refreshFromProgress(book.url)
+                return BookOutcome(moved = SyncMove.PULLED)
+            }
+
+            is SyncDecision.AdoptStatus -> {
+                var adopted = false
+                forAccount(account) {
+                    adopted = progressDao.adoptPeerStatus(book.url, decision.status.wireName, at)
+                    if (adopted) peerStateDao.clearPending(book.url, account.peerId)
+                }
+                if (adopted) finishedState.refreshFromProgress(book.url)
+                return BookOutcome(moved = if (adopted) SyncMove.PULLED else SyncMove.UNRESOLVED)
+            }
+
+            is SyncDecision.Conflict -> {
+                // Preserve both, choose neither: the remote state is
+                // already on disk, and the reader is the only one who
+                // knows which device they last read on.
+                Log.i(TAG, "Both sides moved for a book; leaving it to be asked about")
+                return BookOutcome(moved = SyncMove.UNRESOLVED)
+            }
+
+            is SyncDecision.Push -> {
+                val revision = stored?.localRevision ?: return BookOutcome()
+                val progression = decision.state.progression ?: return BookOutcome()
+                val sent = client.putProgress(
+                    rootUrl = account.baseUrl,
+                    credentials = account.credentials,
+                    document = document,
+                    percentage = progression,
+                    device = identity.name,
+                    deviceId = identity.id,
+                    // From the stored row, never from the clock, so a
+                    // retry says the same thing it said the first time.
+                    timestampMs = stored.updatedAt,
+                )
+                return when (sent) {
+                    is RemoteResult.Failed -> BookOutcome(
+                        failure = sent.reason,
+                        unreachable = sent.unreachable,
+                    )
+                    is RemoteResult.Ok -> {
+                        var acked = false
+                        forAccount(account) {
+                            peerStateDao.settle(
+                                bookUrl = book.url,
+                                peerId = account.peerId,
+                                // Exactly the revision that was compared:
+                                // a page turned since was never weighed
+                                // against the partner, so the book stays
+                                // owed rather than quietly settled.
+                                ackedRevision = revision,
+                                progression = progression,
+                                status = decision.state.status.wireName,
+                                now = now(),
+                            )
+                            acked = true
+                        }
+                        BookOutcome(moved = if (acked) SyncMove.PUSHED else null)
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Writes only while [account] is still the paired partner, in one
+     * go. The request already left — that side effect is the network's —
+     * but nothing lands against an account that was replaced while it
+     * was in the air.
+     */
+    private suspend fun forAccount(account: Account, work: suspend () -> Unit) {
+        inTransaction {
+            if (kosyncDao.get()?.accountKey == account.peerId) work()
+        }
+    }
+
+    /**
+     * Whether kosync can speak about this book at all: it came from the
+     * connected catalog server and its bytes are on this device to hash.
+     *
+     * The URL check is what holds the confirmed scope: a locally added
+     * book *adopted* after an upload to liseur-sync also carries a
+     * `remoteUuid`, but keeps its own local `url` by design — its
+     * positions already travel natively, and kosync leaves it alone.
+     */
+    private val Book.isCandidate: Boolean
+        get() = remoteUuid != null && openableUrl != null && ServerKind.isRemoteUrl(url)
+
+    private fun ReadingProgress.statusOrDerived(): ReadingStatus =
+        status?.let { ReadingStatus.fromWire(it) }
+            ?: readingStatusFor(totalProgression, override)
+
+    private fun ReadingProgress.asReadingState() = ReadingState(
+        progression = totalProgression,
+        status = statusOrDerived(),
+        updatedAt = updatedAt,
+    )
+
+    private fun SyncPeerState.pendingState(): ReadingState? {
+        if (!hasPending) return null
+        return ReadingState(
+            progression = pendingProgression,
+            status = ReadingStatus.fromWire(pendingStatus),
+            updatedAt = pendingUpdatedAt ?: 0L,
+        )
+    }
+
+    private fun SyncPeerState.baseline(): ReadingBaseline? {
+        if (agreedProgression == null && agreedStatus == null) return null
+        return ReadingBaseline(
+            progression = agreedProgression,
+            status = ReadingStatus.fromWire(agreedStatus),
+        )
+    }
+
+    private companion object {
+        const val TAG = "kosync"
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSync.kt
@@ -369,8 +369,24 @@ class KosyncPositionSync(
 
         val stored = progressDao.get(book.url)
         val state = peerStateDao.get(book.url, account.peerId)
-        val dirty = state?.isDirty(stored?.localRevision ?: 0)
+        val agreed = state?.isDirty(stored?.localRevision ?: 0)
             ?: ((stored?.localRevision ?: 0) > 0)
+
+        // A server that answers with nothing about a book it has already
+        // agreed a position for has lost the record: reset, evicted,
+        // restored from an older backup. Left alone, this device would
+        // sit on a position the server does not have until the reader
+        // happened to turn a page, and every other device would pull
+        // nothing meanwhile.
+        //
+        // That is precisely what dirty means — something here the server
+        // lacks — so it is said that way, and `reconcileReadingState`
+        // pushes for the same reason it pushes anything else.
+        val forgotten = remote == null &&
+            state?.hasPending != true &&
+            state?.baseline() != null &&
+            stored != null
+        val dirty = agreed || forgotten
 
         if (!needsReconciling(remote != null, state?.hasPending == true, dirty)) {
             return BookOutcome()

--- a/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSync.kt
@@ -52,6 +52,12 @@ private data class BookOutcome(
  * while its kosync endpoint does — so the two are configured separately
  * and this peer runs after the catalog's in `CompositePositionSync`.
  *
+ * It runs only where [ServerKind.hostsKosyncPeer] says the pairing
+ * belongs. Where a server carries positions itself, a second source for
+ * the same book is a conflict the reader can neither see nor resolve,
+ * so a peer that outlived the server it was paired with stays quiet
+ * rather than syncing on its own authority.
+ *
  * kosync names a book by KOReader's partial MD5 of the file, so only a
  * book whose bytes are on this device can be spoken about, and the same
  * book downloaded from somewhere else is a different document. Positions
@@ -76,6 +82,15 @@ class KosyncPositionSync(
     private val fingerprints: BookFingerprintStore,
     private val device: suspend () -> DeviceIdentity,
     private val finishedState: FinishedState,
+    /**
+     * The kind of server the library is connected to right now, or null
+     * when nothing is connected.
+     *
+     * Read on every run rather than captured once: an account switch
+     * does not rebuild this object, and a peer that outlived the server
+     * it was paired with must go quiet the moment the switch lands.
+     */
+    private val connectedKind: suspend () -> ServerKind?,
     private val client: KosyncClient = KosyncClient(),
     private val reporting: SyncReporting = SyncReporting(),
     private val networkAvailability: NetworkAvailability = NetworkAvailability { true },
@@ -205,6 +220,7 @@ class KosyncPositionSync(
     )
 
     private suspend fun account(): Account? {
+        if (!eligible()) return null
         val peer = kosyncDao.get() ?: return null
         val credentials = peer.credentials ?: return null
         return Account(
@@ -215,9 +231,26 @@ class KosyncPositionSync(
         )
     }
 
+    /**
+     * Whether the connected server is one the pairing belongs to.
+     *
+     * A saved peer is not permission to sync. Nothing guarantees the
+     * peer is removed before another server is connected — an account
+     * switch that fails halfway, a crash, or a database restored onto a
+     * phone that never made the pairing all leave one behind — and this
+     * is the test that keeps such a peer from talking to a server on
+     * behalf of a library it knows nothing about.
+     */
+    private suspend fun eligible(): Boolean =
+        connectedKind()?.hostsKosyncPeer == true
+
     // -- The run ----------------------------------------------------------
 
     private suspend fun run(book: String?): SyncOutcome {
+        if (!eligible()) {
+            reporting.report(PositionSyncStatus.Idle, peerId)
+            return SyncOutcome.NotApplicable
+        }
         val peer = kosyncDao.get() ?: run {
             reporting.report(PositionSyncStatus.Idle, peerId)
             return SyncOutcome.NotApplicable

--- a/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSync.kt
@@ -275,9 +275,14 @@ class KosyncPositionSync(
 
         reporting.report(PositionSyncStatus.Syncing, peerId)
         val identity = device()
-        val books = bookDao.allRemote()
-            .filter { book == null || it.url == book }
-            .filter { it.isCandidate }
+        val books = if (book == null) {
+            bookDao.allRemote()
+        } else {
+            // kosync has no list endpoint, so syncing one book has no
+            // reason to read the whole remote shelf and throw all but
+            // one row away.
+            listOfNotNull(bookDao.getByUrl(book))
+        }.filter { it.isCandidate }
 
         var firstFailure: SyncFailure? = null
         var unreachable: SyncFailure? = null

--- a/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSync.kt
@@ -185,14 +185,31 @@ class KosyncPositionSync(
     }
 
     /**
-     * Keeps what is here and stops the server's answer being offered
-     * again. Nothing is sent from here: clearing the disagreement leaves
-     * the book dirty, so the next run pushes whatever page is actually
-     * open by then.
+     * Keeps what is here, and makes the server agree.
+     *
+     * Clearing the disagreement is not enough on its own. kosync has no
+     * feed, so every run asks the server outright and gets the same
+     * answer back; with the old agreement still standing, both sides
+     * still read as having moved and the reader is asked the same
+     * question on every sync until they happen to turn a page.
+     *
+     * So the answer that was just rejected is written down as the place
+     * the two sides last agreed on. The revision is deliberately left
+     * where it was: this device has not sent anything, so the book is
+     * still owed to the server. Next run the server looks still and this
+     * side looks moved, which is the ordinary shape of a push.
      */
     override suspend fun keepLocalPosition(bookUrl: String): ResolveOutcome {
         val account = account() ?: return ResolveOutcome.Done
-        peerStateDao.clearPending(bookUrl, account.peerId)
+        val state = peerStateDao.get(bookUrl, account.peerId) ?: return ResolveOutcome.Done
+        peerStateDao.settle(
+            bookUrl = bookUrl,
+            peerId = account.peerId,
+            ackedRevision = state.ackedRevision,
+            progression = state.pendingProgression ?: state.agreedProgression,
+            status = state.pendingStatus ?: state.agreedStatus,
+            now = now(),
+        )
         return ResolveOutcome.Done
     }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/PeerPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/PeerPositionSync.kt
@@ -21,6 +21,9 @@ interface PeerPositionSync : PositionSync {
     companion object {
         /** The server the library browses and downloads from. */
         const val CATALOG = "catalog"
+
+        /** The KOReader kosync partner, configured alongside it. */
+        const val KOSYNC = "kosync"
     }
 }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepository.kt
@@ -54,6 +54,16 @@ class RemoteAccountRepository(
      * in. Null in tests that do not exercise a liseur-sync account.
      */
     private val annotationSyncDao: AnnotationSyncDao? = null,
+    /**
+     * Drops a KOReader pairing that the newly connected server cannot
+     * host ([ServerKind.hostsKosyncPeer]).
+     *
+     * A lambda onto `KosyncAccountRepository.disconnect` rather than the
+     * tables, so a pairing is put down through one door however it goes:
+     * clearing its agreements and its reported status is that
+     * repository's job and it should not be spelled out twice.
+     */
+    private val forgetKosyncPeer: suspend () -> Unit = {},
     private val setups: Map<ServerKind, ServerSetup> = mapOf(
         ServerKind.CALIBRE to CalibreSetupClient(),
         ServerKind.KOMGA to KomgaSetupClient(),
@@ -336,6 +346,14 @@ class RemoteAccountRepository(
         val existing = stored?.takeIf { sameAccount }
 
         if (stored != null && !sameAccount) retireForAccountSwitch()
+        // A pairing the new server cannot host goes with the switch,
+        // rather than sitting there invisibly. Here rather than when the
+        // reader starts connecting, because an attempt that fails leaves
+        // the old server standing and would otherwise have taken a
+        // working Grimmory pairing with it. This is tidiness: what keeps
+        // a stray peer from syncing is that the peer and the foreground
+        // policy both ask `hostsKosyncPeer` on every run.
+        if (!kind.hostsKosyncPeer) forgetKosyncPeer()
 
         dao.upsert(
             RemoteServer(

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/ServerKind.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/ServerKind.kt
@@ -107,6 +107,30 @@ enum class ServerKind(
         }
 
     /**
+     * Whether a KOReader sync (kosync) partner may be paired alongside
+     * this kind of server.
+     *
+     * The pairing exists for servers that catalog books but carry no
+     * reading position, which today is Grimmory alone. Offering it
+     * where the server already syncs natively would leave one book with
+     * two sources of truth and a conflict the reader can neither see nor
+     * resolve, so the answer is no for calibre-web, Komga and
+     * liseur-sync.
+     *
+     * Asked of the kind rather than read off the interface, because the
+     * peer runs from `CompositePositionSync` and the foreground policy
+     * whether or not the section is on screen. Both consult this, so a
+     * peer left behind by an account switch, a crash or a restored
+     * database stays quiet rather than syncing against a server nobody
+     * paired it with.
+     */
+    val hostsKosyncPeer: Boolean
+        get() = when (this) {
+            GRIMMORY -> true
+            CALIBRE, KOMGA, LISEUR_SYNC -> false
+        }
+
+    /**
      * How much of a reading position this kind can carry, as something
      * to say before an account exists.
      *

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/ForegroundSyncPolicy.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/ForegroundSyncPolicy.kt
@@ -18,7 +18,11 @@ const val FOREGROUND_SYNC_FRESH_FOR_MS = 60L * 60L * 1000L
  *
  * The kosync partner is asked about on its own terms: it lives alongside
  * the catalog server, and a Grimmory account that cannot sync positions
- * itself is exactly the account a kosync partner is paired next to.
+ * itself is exactly the account a kosync partner is paired next to. But
+ * only where the connected server is one the pairing belongs to
+ * ([com.chmouel.liseur.data.remote.ServerKind.hostsKosyncPeer]) — a peer
+ * left behind by an account switch or restored with a backup would
+ * otherwise wake a sync against a server nobody paired it with.
  *
  * The gesture that means "look again", and the hourly worker, do not ask
  * this. They are asking on purpose.
@@ -31,7 +35,8 @@ fun shouldSyncOnForeground(
 ): Boolean {
     val catalogDue = server != null && server.canSync &&
         due(server.positionSyncedAt, now, freshForMs)
-    val kosyncDue = kosync != null && due(kosync.positionSyncedAt, now, freshForMs)
+    val kosyncDue = kosync != null && server?.kind?.hostsKosyncPeer == true &&
+        due(kosync.positionSyncedAt, now, freshForMs)
     return catalogDue || kosyncDue
 }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/ForegroundSyncPolicy.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/ForegroundSyncPolicy.kt
@@ -1,5 +1,6 @@
 package com.chmouel.liseur.domain
 
+import com.chmouel.liseur.data.db.KosyncPeer
 import com.chmouel.liseur.data.db.RemoteServer
 
 /** How long a completed full sync stands for before the app asks again. */
@@ -15,6 +16,10 @@ const val FOREGROUND_SYNC_FRESH_FOR_MS = 60L * 60L * 1000L
  * difference and a shelf full of books is not re-reconciled every time
  * the system decides to reclaim some memory.
  *
+ * The kosync partner is asked about on its own terms: it lives alongside
+ * the catalog server, and a Grimmory account that cannot sync positions
+ * itself is exactly the account a kosync partner is paired next to.
+ *
  * The gesture that means "look again", and the hourly worker, do not ask
  * this. They are asking on purpose.
  */
@@ -22,9 +27,12 @@ fun shouldSyncOnForeground(
     server: RemoteServer?,
     now: Long,
     freshForMs: Long = FOREGROUND_SYNC_FRESH_FOR_MS,
+    kosync: KosyncPeer? = null,
 ): Boolean {
-    return server != null && server.canSync &&
+    val catalogDue = server != null && server.canSync &&
         due(server.positionSyncedAt, now, freshForMs)
+    val kosyncDue = kosync != null && due(kosync.positionSyncedAt, now, freshForMs)
+    return catalogDue || kosyncDue
 }
 
 private fun due(syncedAt: Long?, now: Long, freshForMs: Long): Boolean {

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
@@ -121,6 +122,12 @@ fun ServerAccountScreen(
     onDownloadAll: () -> Unit,
     onCancelDownloadAll: () -> Unit,
     onDismissBatch: () -> Unit,
+    onKosyncUrlChange: (String) -> Unit,
+    onKosyncUsernameChange: (String) -> Unit,
+    onKosyncPasswordChange: (String) -> Unit,
+    onKosyncRegisterChange: (Boolean) -> Unit,
+    onKosyncConnect: () -> Unit,
+    onKosyncDisconnect: () -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -212,6 +219,21 @@ fun ServerAccountScreen(
                             )
                         }
                     }
+                }
+                // The KOReader sync partner lives alongside whichever
+                // catalog server is connected; with none connected there
+                // is nothing for it to cover, so the section only stays
+                // to let a leftover pairing be disconnected.
+                if (server != null || state.kosync != null) {
+                    KosyncSection(
+                        state = state,
+                        onUrlChange = onKosyncUrlChange,
+                        onUsernameChange = onKosyncUsernameChange,
+                        onPasswordChange = onKosyncPasswordChange,
+                        onRegisterChange = onKosyncRegisterChange,
+                        onConnect = onKosyncConnect,
+                        onDisconnect = onKosyncDisconnect,
+                    )
                 }
                 val secretNote = when (server?.kind ?: state.kind) {
                     ServerKind.CALIBRE, ServerKind.GRIMMORY ->
@@ -870,6 +892,157 @@ private fun ConnectedCard(
     OutlinedButton(onClick = onDisconnect, modifier = Modifier.fillMaxWidth()) {
         Text(stringResource(R.string.server_disconnect))
     }
+}
+
+/**
+ * The KOReader sync (kosync) partner, paired alongside the catalog
+ * server rather than instead of it.
+ *
+ * This is how Grimmory's positions reach the app: its Komga shim
+ * carries none, while its kosync endpoint does. The section speaks the
+ * generic protocol, so a stock kosync server works the same way.
+ */
+@Composable
+private fun KosyncSection(
+    state: ServerAccountUiState,
+    onUrlChange: (String) -> Unit,
+    onUsernameChange: (String) -> Unit,
+    onPasswordChange: (String) -> Unit,
+    onRegisterChange: (Boolean) -> Unit,
+    onConnect: () -> Unit,
+    onDisconnect: () -> Unit,
+) {
+    ServerSection(title = stringResource(R.string.kosync_section)) {
+        val peer = state.kosync
+        if (peer != null) {
+            Notice(
+                text = stringResource(
+                    R.string.kosync_connected,
+                    peer.username,
+                    peer.baseUrl.substringAfter("://"),
+                ),
+                tone = NoticeTone.GOOD,
+            )
+            DetailLine(text = state.kosyncStatus.describe(peer.positionSyncedAt))
+            OutlinedButton(onClick = onDisconnect, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(R.string.kosync_disconnect))
+            }
+            return@ServerSection
+        }
+
+        Text(
+            text = stringResource(R.string.kosync_summary),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        OutlinedTextField(
+            value = state.kosyncUrl,
+            onValueChange = onUrlChange,
+            label = { Text(stringResource(R.string.kosync_url)) },
+            singleLine = true,
+            enabled = !state.kosyncConnecting,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Uri,
+                imeAction = ImeAction.Next,
+            ),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        OutlinedTextField(
+            value = state.kosyncUsername,
+            onValueChange = onUsernameChange,
+            label = { Text(stringResource(R.string.server_username)) },
+            singleLine = true,
+            enabled = !state.kosyncConnecting,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        var secretShown by rememberSaveable { mutableStateOf(false) }
+        OutlinedTextField(
+            value = state.kosyncPassword,
+            onValueChange = onPasswordChange,
+            label = { Text(stringResource(R.string.server_password)) },
+            singleLine = true,
+            enabled = !state.kosyncConnecting,
+            visualTransformation = if (secretShown) {
+                VisualTransformation.None
+            } else {
+                PasswordVisualTransformation()
+            },
+            trailingIcon = {
+                IconButton(onClick = { secretShown = !secretShown }) {
+                    Icon(
+                        imageVector = if (secretShown) {
+                            Icons.Outlined.VisibilityOff
+                        } else {
+                            Icons.Outlined.Visibility
+                        },
+                        contentDescription = stringResource(
+                            if (secretShown) R.string.hide_password else R.string.show_password,
+                        ),
+                    )
+                }
+            },
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Password,
+                imeAction = ImeAction.Done,
+            ),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column(Modifier.weight(1f)) {
+                Text(
+                    stringResource(R.string.kosync_register),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Text(
+                    stringResource(R.string.kosync_register_help),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Switch(
+                checked = state.kosyncRegister,
+                onCheckedChange = onRegisterChange,
+                enabled = !state.kosyncConnecting,
+            )
+        }
+        state.kosyncError?.let { error ->
+            Notice(
+                text = stringResource(error.kosyncMessageRes()),
+                tone = NoticeTone.PROBLEM,
+            )
+        }
+        Button(
+            onClick = onConnect,
+            enabled = !state.kosyncConnecting &&
+                state.kosyncUrl.isNotBlank() &&
+                state.kosyncUsername.isNotBlank() &&
+                state.kosyncPassword.isNotBlank(),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            if (state.kosyncConnecting) {
+                BusyIndicator(
+                    Modifier.size(18.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                )
+            } else {
+                Text(stringResource(R.string.kosync_connect))
+            }
+        }
+    }
+}
+
+private fun AccountError.kosyncMessageRes(): Int = when (this) {
+    AccountError.BAD_CREDENTIALS -> R.string.kosync_error_credentials
+    AccountError.WRONG_SERVER -> R.string.kosync_error_not_kosync
+    AccountError.INSECURE_TRANSPORT -> R.string.server_sync_insecure
+    AccountError.RATE_LIMITED -> R.string.server_error_rate_limited
+    else -> R.string.server_error_unreachable
 }
 
 /**

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountScreen.kt
@@ -1,5 +1,7 @@
 package com.chmouel.liseur.ui.settings
 
+import android.text.format.DateUtils
+import android.text.format.Formatter
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
@@ -7,8 +9,6 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
-import android.text.format.DateUtils
-import android.text.format.Formatter
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -18,14 +18,15 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -40,17 +41,13 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import com.chmouel.liseur.data.calibre.BulkBatch
-import com.chmouel.liseur.data.calibre.BulkDownloadEstimate
-import com.chmouel.liseur.data.calibre.BulkStopReason
-import com.chmouel.liseur.data.calibre.SpaceVerdict
-import com.chmouel.liseur.ui.BusyIndicator
-import com.chmouel.liseur.ui.LocalEInk
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -64,35 +61,42 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.chmouel.liseur.R
-import com.chmouel.liseur.data.remote.PositionSyncStatus
+import com.chmouel.liseur.data.calibre.BulkBatch
+import com.chmouel.liseur.data.calibre.BulkDownloadEstimate
+import com.chmouel.liseur.data.calibre.BulkStopReason
+import com.chmouel.liseur.data.calibre.SpaceVerdict
 import com.chmouel.liseur.data.calibre.StorageUse
+import com.chmouel.liseur.data.db.RemoteServer
+import com.chmouel.liseur.data.remote.PositionSyncStatus
+import com.chmouel.liseur.data.remote.ServerKind
 import com.chmouel.liseur.data.remote.SyncIdentity
 import com.chmouel.liseur.data.remote.SyncReport
-import com.chmouel.liseur.ui.messageRes
-import com.chmouel.liseur.data.db.RemoteServer
-import com.chmouel.liseur.data.remote.ServerKind
 import com.chmouel.liseur.data.settings.UploadPolicy
+import com.chmouel.liseur.ui.BusyIndicator
+import com.chmouel.liseur.ui.LocalEInk
 import com.chmouel.liseur.ui.contentWidthCap
+import com.chmouel.liseur.ui.messageRes
 import com.chmouel.liseur.ui.windowWidth
 
 /**
@@ -917,15 +921,16 @@ private fun KosyncSection(
     ServerSection(title = stringResource(R.string.kosync_section)) {
         val peer = state.kosync
         if (peer != null) {
+            val active = state.server?.kind?.hostsKosyncPeer == true
             Notice(
                 text = stringResource(
-                    R.string.kosync_connected,
+                    if (active) R.string.kosync_connected else R.string.kosync_stranded,
                     peer.username,
                     peer.baseUrl.substringAfter("://"),
                 ),
-                tone = NoticeTone.GOOD,
+                tone = if (active) NoticeTone.GOOD else NoticeTone.PROBLEM,
             )
-            DetailLine(text = state.kosyncStatus.describe(peer.positionSyncedAt))
+            if (active) DetailLine(text = state.kosyncStatus.describe(peer.positionSyncedAt))
             OutlinedButton(onClick = onDisconnect, modifier = Modifier.fillMaxWidth()) {
                 Text(stringResource(R.string.kosync_disconnect))
             }
@@ -990,28 +995,24 @@ private fun KosyncSection(
             ),
             modifier = Modifier.fillMaxWidth(),
         )
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Column(Modifier.weight(1f)) {
-                Text(
-                    stringResource(R.string.kosync_register),
-                    style = MaterialTheme.typography.bodyMedium,
+        ListItem(
+            headlineContent = { Text(stringResource(R.string.kosync_register)) },
+            supportingContent = { Text(stringResource(R.string.kosync_register_help)) },
+            trailingContent = {
+                Switch(
+                    checked = state.kosyncRegister,
+                    onCheckedChange = null,
+                    enabled = !state.kosyncConnecting,
                 )
-                Text(
-                    stringResource(R.string.kosync_register_help),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            Switch(
-                checked = state.kosyncRegister,
-                onCheckedChange = onRegisterChange,
+            },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            modifier = Modifier.toggleable(
+                value = state.kosyncRegister,
                 enabled = !state.kosyncConnecting,
-            )
-        }
+                role = Role.Switch,
+                onValueChange = onRegisterChange,
+            ),
+        )
         state.kosyncError?.let { error ->
             Notice(
                 text = stringResource(error.kosyncMessageRes()),

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountScreen.kt
@@ -220,11 +220,13 @@ fun ServerAccountScreen(
                         }
                     }
                 }
-                // The KOReader sync partner lives alongside whichever
-                // catalog server is connected; with none connected there
-                // is nothing for it to cover, so the section only stays
-                // to let a leftover pairing be disconnected.
-                if (server != null || state.kosync != null) {
+                // The KOReader sync partner belongs to servers that
+                // catalog books without carrying a reading position.
+                // Where the server syncs natively, offering it too would
+                // leave one book with two sources of truth. A pairing
+                // that outlived its server still shows, so it can be
+                // disconnected rather than stranded out of sight.
+                if (server?.kind?.hostsKosyncPeer == true || state.kosync != null) {
                     KosyncSection(
                         state = state,
                         onUrlChange = onKosyncUrlChange,

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountViewModel.kt
@@ -9,7 +9,11 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.chmouel.liseur.container
 import com.chmouel.liseur.data.db.BookDao
+import com.chmouel.liseur.data.db.KosyncPeer
 import com.chmouel.liseur.data.db.WorkIdentityDao
+import com.chmouel.liseur.data.kosync.KosyncAccountRepository
+import com.chmouel.liseur.data.kosync.KosyncSetupOutcome
+import com.chmouel.liseur.data.remote.PeerPositionSync
 import com.chmouel.liseur.data.remote.RemoteAccountRepository
 import com.chmouel.liseur.data.calibre.BookDownloadRepository
 import com.chmouel.liseur.data.calibre.BulkBatch
@@ -105,6 +109,17 @@ data class ServerAccountUiState(
     val bulkEstimate: BulkDownloadEstimate? = null,
     /** True while the estimate is being worked out. */
     val estimating: Boolean = false,
+    /** The KOReader sync partner paired alongside the catalog server. */
+    val kosync: KosyncPeer? = null,
+    val kosyncUrl: String = "",
+    val kosyncUsername: String = "",
+    val kosyncPassword: String = "",
+    /** Whether connecting should create the account on the server first. */
+    val kosyncRegister: Boolean = false,
+    val kosyncConnecting: Boolean = false,
+    val kosyncError: AccountError? = null,
+    /** How the kosync partner's own last run went, apart from the summary. */
+    val kosyncStatus: PositionSyncStatus = PositionSyncStatus.Idle,
 )
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -117,6 +132,7 @@ class ServerAccountViewModel(
     private val appSettings: AppSettingsRepository,
     private val identityDao: WorkIdentityDao,
     private val bookDao: BookDao,
+    private val kosyncAccount: KosyncAccountRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(ServerAccountUiState())
@@ -124,8 +140,21 @@ class ServerAccountViewModel(
 
     init {
         viewModelScope.launch {
-            repository.server.collect { server ->
-                _state.update { it.copy(server = server) }
+            // Server and kosync peer arrive together: the Grimmory
+            // prefill below must know whether a peer exists, and two
+            // independent collectors would let it fire before the
+            // peer's first emission.
+            combine(repository.server, kosyncAccount.peer) { server, peer ->
+                server to peer
+            }.collect { (server, peer) ->
+                _state.update { state ->
+                    state.copy(
+                        server = server,
+                        kosync = peer,
+                        kosyncUrl = kosyncPrefillUrl(server, peer, state.kosyncUrl)
+                            ?: state.kosyncUrl,
+                    )
+                }
             }
         }
         viewModelScope.launch {
@@ -135,7 +164,12 @@ class ServerAccountViewModel(
         }
         viewModelScope.launch {
             reporting.status.collect { status ->
-                _state.update { it.copy(syncStatus = status) }
+                _state.update {
+                    it.copy(
+                        syncStatus = status,
+                        kosyncStatus = reporting.statusOf(PeerPositionSync.KOSYNC),
+                    )
+                }
                 // Every settled run can change who owns what and what is
                 // left over, so the answer is re-read rather than cached.
                 refreshDiagnostics()
@@ -218,6 +252,54 @@ class ServerAccountViewModel(
 
     fun setDeviceToken(value: String) =
         _state.update { it.copy(deviceToken = value.trim(), error = null) }
+
+    fun setKosyncUrl(value: String) =
+        _state.update { it.copy(kosyncUrl = value, kosyncError = null) }
+
+    fun setKosyncUsername(value: String) =
+        _state.update { it.copy(kosyncUsername = value, kosyncError = null) }
+
+    fun setKosyncPassword(value: String) =
+        _state.update { it.copy(kosyncPassword = value, kosyncError = null) }
+
+    fun setKosyncRegister(value: Boolean) =
+        _state.update { it.copy(kosyncRegister = value, kosyncError = null) }
+
+    /** Pairs the KOReader sync partner, then asks it where everything is. */
+    fun connectKosync() {
+        val current = _state.value
+        if (current.kosyncConnecting) return
+        if (current.kosyncUrl.isBlank() ||
+            current.kosyncUsername.isBlank() ||
+            current.kosyncPassword.isBlank()
+        ) {
+            return
+        }
+        _state.update { it.copy(kosyncConnecting = true, kosyncError = null) }
+        viewModelScope.launch {
+            val outcome = kosyncAccount.connect(
+                url = current.kosyncUrl,
+                username = current.kosyncUsername,
+                password = current.kosyncPassword,
+                register = current.kosyncRegister,
+            )
+            _state.update {
+                when (outcome) {
+                    KosyncSetupOutcome.Success ->
+                        it.copy(kosyncConnecting = false, kosyncPassword = "")
+                    is KosyncSetupOutcome.Failure ->
+                        it.copy(kosyncConnecting = false, kosyncError = outcome.reason.toUiError())
+                }
+            }
+            if (outcome == KosyncSetupOutcome.Success) {
+                positionSync.request(SyncScope.Full)
+            }
+        }
+    }
+
+    fun disconnectKosync() {
+        viewModelScope.launch { kosyncAccount.disconnect() }
+    }
 
     /**
      * Answers the "is this the same book?" question.
@@ -392,7 +474,14 @@ class ServerAccountViewModel(
             // books it left mid-flight would sit queued forever.
             downloads.cancelAll(BulkStopReason.ACCOUNT_CHANGED)
             repository.disconnect()
-            _state.value = ServerAccountUiState()
+            // The kosync partner stands on its own: its lifecycle is
+            // deliberately not the catalog's, and its Room flow has
+            // nothing new to re-emit after this reset.
+            val kept = _state.value
+            _state.value = ServerAccountUiState(
+                kosync = kept.kosync,
+                kosyncStatus = kept.kosyncStatus,
+            )
         }
     }
 
@@ -421,8 +510,26 @@ class ServerAccountViewModel(
                     appSettings = container.appSettings,
                     identityDao = container.database.workIdentityDao(),
                     bookDao = container.database.bookDao(),
+                    kosyncAccount = container.kosyncAccount,
                 )
             }
         }
     }
+}
+
+/**
+ * Grimmory's own kosync mount, offered once.
+ *
+ * Only while the URL field is untouched and nothing is paired, so a
+ * reader's typing is never overwritten and an existing pairing is never
+ * disturbed; null means "leave the field as it is".
+ */
+internal fun kosyncPrefillUrl(
+    server: RemoteServer?,
+    peer: KosyncPeer?,
+    currentUrl: String,
+): String? {
+    if (server?.kind != ServerKind.GRIMMORY) return null
+    if (peer != null || currentUrl.isNotBlank()) return null
+    return server.baseUrl.trimEnd('/') + "/api/koreader"
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountViewModel.kt
@@ -520,9 +520,12 @@ class ServerAccountViewModel(
 /**
  * Grimmory's own kosync mount, offered once.
  *
- * Only while the URL field is untouched and nothing is paired, so a
- * reader's typing is never overwritten and an existing pairing is never
- * disturbed; null means "leave the field as it is".
+ * Grimmory alone, and not because it is the only kind that may pair:
+ * `/api/koreader` is Grimmory's spelling of the route, so there is
+ * nothing to guess for anything else. Only while the URL field is
+ * untouched and nothing is paired, so a reader's typing is never
+ * overwritten and an existing pairing is never disturbed; null means
+ * "leave the field as it is".
  */
 internal fun kosyncPrefillUrl(
     server: RemoteServer?,

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerKindPicker.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerKindPicker.kt
@@ -172,17 +172,26 @@ private fun KindSupport(kind: ServerKind) {
     Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
         Text(stringResource(kind.taglineRes()))
         Text(
-            stringResource(kind.syncAbility.lineRes()),
+            stringResource(kind.syncLineRes()),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }
 
-private fun SyncAbility.lineRes(): Int = when (this) {
-    SyncAbility.EXACT -> R.string.server_sync_exact
-    SyncAbility.PROGRESSION -> R.string.server_sync_progression
-    SyncAbility.NONE -> R.string.server_sync_none
+/**
+ * What the picker says about keeping your place. Grimmory gets its own
+ * line rather than [SyncAbility.NONE]'s: the kind itself cannot carry a
+ * position, but a KOReader sync server paired alongside it can, and
+ * "cannot keep your place" would be false the moment one is.
+ */
+private fun ServerKind.syncLineRes(): Int = when (this) {
+    ServerKind.GRIMMORY -> R.string.server_sync_grimmory
+    else -> when (syncAbility) {
+        SyncAbility.EXACT -> R.string.server_sync_exact
+        SyncAbility.PROGRESSION -> R.string.server_sync_progression
+        SyncAbility.NONE -> R.string.server_sync_none
+    }
 }
 
 internal fun ServerKind.labelRes(): Int = when (this) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -290,7 +290,7 @@
     <string name="server_lost_to_restore">Your server account was signed out. Passwords and API keys are encrypted with a key that never leaves the phone it was made on, so one restored from a backup or moved to a new device can\'t be read. Sign in again to get it back.</string>
     <string name="server_sync_identity">Positions sync as %1$s. Reading done under another login stays on this device.</string>
     <string name="kosync_section">KOReader sync</string>
-    <string name="kosync_summary">Follow your reading position through a KOReader sync (kosync) server, alongside this catalog. It covers the books downloaded from the connected server.</string>
+    <string name="kosync_summary">Grimmory keeps your books but not your place in them. Pair a KOReader sync (kosync) server and your reading position follows you across devices, for the books you have downloaded from Grimmory.</string>
     <string name="kosync_url">Sync server address</string>
     <string name="kosync_register">Create the account on the server</string>
     <string name="kosync_register_help">For servers that take new accounts this way. Grimmory does not: its KOReader users are made in its device settings.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -296,6 +296,7 @@
     <string name="kosync_register_help">For servers that take new accounts this way. Grimmory does not: its KOReader users are made in its device settings.</string>
     <string name="kosync_connect">Connect KOReader sync</string>
     <string name="kosync_connected">Positions sync as %1$s with %2$s.</string>
+    <string name="kosync_stranded">Paired as %1$s with %2$s, but not in use: this server keeps your place itself. Disconnect the pairing, or connect Grimmory to use it.</string>
     <string name="kosync_disconnect">Disconnect KOReader sync</string>
     <string name="kosync_error_credentials">That username or password was refused by the sync server.</string>
     <string name="kosync_error_not_kosync">No KOReader sync server answered at that address. Check the address, including the path it is served from.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,7 +17,7 @@
     <string name="add_books">Add books</string>
     <string name="add_folder_hint">Point Liseur at a folder of EPUBs and it keeps watching it for new ones.</string>
     <string name="add_book_hint">Pick a single EPUB from your device or your cloud storage.</string>
-    <string name="connect_server_hint">Browse a calibre-web, Komga, liseur-sync or Grimmory library, and — on all but Grimmory — keep your place across devices.</string>
+    <string name="connect_server_hint">Browse a calibre-web, Komga, liseur-sync or Grimmory library, and keep your place across devices — Grimmory through a paired KOReader sync server.</string>
     <string name="search_books">Search books</string>
     <string name="filter_menu">Filter</string>
     <string name="filter_availability">On the device</string>
@@ -174,6 +174,7 @@
     <string name="server_sync_exact">Keeps your exact place in a book across devices</string>
     <string name="server_sync_progression">Keeps how far through a book you are across devices</string>
     <string name="server_sync_none">Browsing and downloads only — it cannot keep your place</string>
+    <string name="server_sync_grimmory">Keeps your place through a paired KOReader sync server</string>
     <string name="server_link_calibre">What calibre-web is, and how to run one</string>
     <string name="server_link_komga">What Komga is, and how to run one</string>
     <string name="server_link_grimmory">What Grimmory is, and how to run one</string>
@@ -215,7 +216,7 @@
     <string name="server_token_storage_note">Your device token is kept on this device only, encrypted. It is sent to your server each time Liseur talks to it. Revoke it on the server if you lose the phone.</string>
     <string name="server_sync_on">Your reading position will follow you between devices.</string>
     <string name="server_sync_off">Reading positions are not synced. The server may have Kobo sync switched off.</string>
-    <string name="server_sync_unsupported">Reading positions stay on this device. Grimmory\'s Komga interface has no way to carry them, so there is nothing to switch on.</string>
+    <string name="server_sync_unsupported">Grimmory\'s Komga interface has no way to carry reading positions. Grimmory can still sync them over KOReader sync: create a KOReader user in Grimmory\'s device settings, then connect it in the section below.</string>
     <string name="calibre_show_advanced">Advanced</string>
     <string name="calibre_hide_advanced">Hide advanced</string>
     <string name="calibre_token">Kobo sync token or URL</string>
@@ -288,6 +289,16 @@
     </plurals>
     <string name="server_lost_to_restore">Your server account was signed out. Passwords and API keys are encrypted with a key that never leaves the phone it was made on, so one restored from a backup or moved to a new device can\'t be read. Sign in again to get it back.</string>
     <string name="server_sync_identity">Positions sync as %1$s. Reading done under another login stays on this device.</string>
+    <string name="kosync_section">KOReader sync</string>
+    <string name="kosync_summary">Follow your reading position through a KOReader sync (kosync) server, alongside this catalog. It covers the books downloaded from the connected server.</string>
+    <string name="kosync_url">Sync server address</string>
+    <string name="kosync_register">Create the account on the server</string>
+    <string name="kosync_register_help">For servers that take new accounts this way. Grimmory does not: its KOReader users are made in its device settings.</string>
+    <string name="kosync_connect">Connect KOReader sync</string>
+    <string name="kosync_connected">Positions sync as %1$s with %2$s.</string>
+    <string name="kosync_disconnect">Disconnect KOReader sync</string>
+    <string name="kosync_error_credentials">That username or password was refused by the sync server.</string>
+    <string name="kosync_error_not_kosync">No KOReader sync server answered at that address. Check the address, including the path it is served from.</string>
     <string name="server_sync_moved_both">Last sync: %1$d brought here, %2$d sent up</string>
     <plurals name="server_sync_pulled">
         <item quantity="one">Last sync: %1$d book brought here</item>
@@ -495,8 +506,8 @@
     <string name="settings_remote_library">Remote libraries</string>
     <string name="settings_export_import">Export and import</string>
     <string name="settings_library_help_title">Book servers</string>
-    <string name="settings_library_help_body" formatted="true">A book server — calibre-web, Komga, liseur-sync or Grimmory — holds your library: Liseur browses it and downloads from it, and keeps your place in step with it. Grimmory is the exception: it is reached through its Komga-compatible interface, which can do everything but carry a reading position. One server is connected at a time.\n\nliseur-sync is the one that also keeps books that came from nowhere but this phone in step: a file off an SD card syncs its position too. Run your own from %1$s.</string>
-    <string name="settings_account_detail">Browse and download from a calibre-web, Komga, liseur-sync or Grimmory server, and keep your place in step with all but Grimmory.</string>
+    <string name="settings_library_help_body" formatted="true">A book server — calibre-web, Komga, liseur-sync or Grimmory — holds your library: Liseur browses it and downloads from it, and keeps your place in step with it. Grimmory is the exception: it is reached through its Komga-compatible interface, which cannot carry a reading position itself — pair a KOReader sync server alongside it and your place follows anyway. One server is connected at a time.\n\nliseur-sync is the one that also keeps books that came from nowhere but this phone in step: a file off an SD card syncs its position too. Run your own from %1$s.</string>
+    <string name="settings_account_detail">Browse and download from a calibre-web, Komga, liseur-sync or Grimmory server, and keep your place in step — Grimmory through a paired KOReader sync server.</string>
     <string name="settings_about">About</string>
     <string name="about_title">About</string>
     <string name="about_open">About Liseur</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
@@ -846,6 +846,6 @@ class MigrationTest {
         const val TEST_DB = "migration-test.db"
 
         /** Kept in step with the `version` on [LiseurDatabase]. */
-        const val LATEST = 41
+        const val LATEST = 42
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSyncTest.kt
@@ -13,6 +13,7 @@ import com.chmouel.liseur.data.remote.PreviewOutcome
 import com.chmouel.liseur.data.remote.RemoteHttp
 import com.chmouel.liseur.data.remote.RemoteResult
 import com.chmouel.liseur.data.remote.ResolveOutcome
+import com.chmouel.liseur.data.remote.ServerKind
 import com.chmouel.liseur.data.remote.SetupFailure
 import com.chmouel.liseur.data.remote.SyncFailure
 import com.chmouel.liseur.data.remote.SyncOutcome
@@ -69,6 +70,54 @@ class KosyncPositionSyncTest {
         db.close()
         file.delete()
         CredentialCipher.keyForTesting = null
+    }
+
+    // -- Whose server it is ------------------------------------------------
+
+    /**
+     * A saved pairing is not permission to sync. An account switch
+     * interrupted halfway, a crash, or a database restored onto a phone
+     * that never made the pairing all leave a row behind, and a server
+     * that carries positions itself must not have a second, invisible
+     * source disagreeing with it.
+     */
+    @Test
+    fun `a pairing stays quiet under a server that carries positions itself`() = runTest {
+        for (kind in listOf(ServerKind.CALIBRE, ServerKind.KOMGA, ServerKind.LISEUR_SYNC)) {
+            pair()
+            db.bookDao().upsert(book())
+
+            val outcome = sync(connectedKind = kind).syncAll(null)
+
+            assertEquals(SyncOutcome.NotApplicable, outcome)
+            assertEquals("$kind must not be spoken to", 0, server.requestCount)
+        }
+    }
+
+    @Test
+    fun `a pairing with nothing connected stays quiet`() = runTest {
+        pair()
+        db.bookDao().upsert(book())
+
+        assertEquals(SyncOutcome.NotApplicable, sync(connectedKind = null).syncAll(null))
+        assertEquals(0, server.requestCount)
+    }
+
+    /**
+     * Not just the run: the answers the reader is shown come from the
+     * same test, so an ineligible pairing reports no position rather
+     * than one it has no business fetching.
+     */
+    @Test
+    fun `an ineligible pairing offers no preview and syncs no book`() = runTest {
+        pair()
+        db.bookDao().upsert(book())
+        val komga = sync(connectedKind = ServerKind.KOMGA)
+
+        assertEquals(false, komga.canSync(BOOK))
+        assertEquals(PreviewOutcome.NotSynced, komga.previewBook(BOOK))
+        assertNull(komga.identity())
+        assertEquals(0, server.requestCount)
     }
 
     // -- The credential ----------------------------------------------------
@@ -486,7 +535,10 @@ class KosyncPositionSyncTest {
 
     private suspend fun peerKey(): String = db.kosyncPeerDao().get()!!.accountKey
 
-    private fun sync(online: Boolean = true): KosyncPositionSync {
+    private fun sync(
+        online: Boolean = true,
+        connectedKind: ServerKind? = ServerKind.GRIMMORY,
+    ): KosyncPositionSync {
         val context = ApplicationProvider.getApplicationContext<android.app.Application>()
         return KosyncPositionSync(
             kosyncDao = db.kosyncPeerDao(),
@@ -496,6 +548,7 @@ class KosyncPositionSyncTest {
             fingerprints = BookFingerprintStore(context, db.workIdentityDao()) { NOW },
             device = { DeviceIdentity(id = "dev-1", name = "Test Phone") },
             finishedState = FinishedState(db.bookDao(), db.readingProgressDao()),
+            connectedKind = { connectedKind },
             networkAvailability = { online },
             now = { NOW },
         )

--- a/app/src/test/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSyncTest.kt
@@ -526,6 +526,46 @@ class KosyncPositionSyncTest {
     }
 
     @Test
+    fun `a server that lost the record is sent the position again`() = runTest {
+        // Reset, evicted, restored from an older backup: the server
+        // answers with nothing for a book it had already agreed a
+        // position for. Left alone this device sits on a position the
+        // server does not have until the reader happens to turn a page.
+        pair()
+        db.bookDao().upsert(book())
+        record(progression = 0.4)
+        server.enqueue(json("{}"))
+        server.enqueue(json("{}"))
+        sync().syncAll(null)
+        seen.clear()
+        server.enqueue(json("{}"))
+
+        sync().syncAll(null)
+
+        val put = requests().last()
+        assertEquals("PUT", put.method)
+        assertEquals(0.4, JSONObject(put.body!!.utf8()).getDouble("percentage"), 0.0001)
+    }
+
+    @Test
+    fun `a book the server never knew about is not pushed twice`() = runTest {
+        // The other half of the rule: with no agreement behind it there
+        // is nothing to conclude from silence, so a second run with
+        // nothing read in between says nothing.
+        pair()
+        db.bookDao().upsert(book())
+        server.enqueue(json("{}"))
+
+        sync().syncAll(null)
+        val after = server.requestCount
+
+        server.enqueue(json("{}"))
+        sync().syncAll(null)
+
+        assertEquals(after + 1, server.requestCount)
+    }
+
+    @Test
     fun `disconnecting forgets the agreements along with the partner`() = runTest {
         pair()
         db.bookDao().upsert(book())

--- a/app/src/test/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSyncTest.kt
@@ -1,0 +1,584 @@
+package com.chmouel.liseur.data.kosync
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.chmouel.liseur.data.calibre.CredentialCipher
+import com.chmouel.liseur.data.db.Book
+import com.chmouel.liseur.data.db.KosyncPeer
+import com.chmouel.liseur.data.db.LiseurDatabase
+import com.chmouel.liseur.data.library.BookFingerprintStore
+import com.chmouel.liseur.data.library.FinishedState
+import com.chmouel.liseur.data.remote.DeviceIdentity
+import com.chmouel.liseur.data.remote.PreviewOutcome
+import com.chmouel.liseur.data.remote.RemoteHttp
+import com.chmouel.liseur.data.remote.RemoteResult
+import com.chmouel.liseur.data.remote.ResolveOutcome
+import com.chmouel.liseur.data.remote.SetupFailure
+import com.chmouel.liseur.data.remote.SyncFailure
+import com.chmouel.liseur.data.remote.SyncOutcome
+import java.io.File
+import java.net.InetAddress
+import javax.crypto.KeyGenerator
+import kotlinx.coroutines.test.runTest
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import mockwebserver3.RecordedRequest
+import okhttp3.tls.HandshakeCertificates
+import okhttp3.tls.HeldCertificate
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Keeping a reader's place in step with a KOReader kosync server.
+ *
+ * kosync names a book by KOReader's partial MD5 of its bytes and speaks
+ * only in percentages, so the tests watch two things above all: the
+ * document addressed on the wire is the file's hash, and every decision
+ * about whose position wins goes through the one shared merge.
+ */
+@Config(sdk = [35], application = android.app.Application::class)
+@RunWith(RobolectricTestRunner::class)
+class KosyncPositionSyncTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var db: LiseurDatabase
+    private lateinit var file: File
+
+    @Before
+    fun open() {
+        CredentialCipher.keyForTesting =
+            KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
+        server = MockWebServer()
+        server.start(InetAddress.getByName("127.0.0.1"), 0)
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        db = Room.inMemoryDatabaseBuilder(context, LiseurDatabase::class.java).build()
+        file = File.createTempFile("book", ".epub").apply { writeBytes(ByteArray(4096) { 3 }) }
+    }
+
+    @After
+    fun close() {
+        server.close()
+        db.close()
+        file.delete()
+        CredentialCipher.keyForTesting = null
+    }
+
+    // -- The credential ----------------------------------------------------
+
+    @Test
+    fun `the auth key is the hex MD5 of the password, as KOReader derives it`() {
+        // md5("secret") — a fixed vector, not a computed one.
+        assertEquals("5ebe2294ecd0e0f08eab7690d2a6ee69", KosyncCredentials.keyFor("secret"))
+    }
+
+    // -- The wire ----------------------------------------------------------
+
+    @Test
+    fun `every request carries the kosync auth headers`() = runTest {
+        pair()
+        db.bookDao().upsert(book())
+        server.enqueue(json("{}"))
+
+        sync().syncAll(null)
+
+        val request = requests().single()
+        assertEquals("ada", request.headers["x-auth-user"])
+        assertEquals(KosyncCredentials.keyFor("pw"), request.headers["x-auth-key"])
+    }
+
+    @Test
+    fun `a document that is not a hex hash is refused rather than addressed`() = runTest {
+        val client = KosyncClient()
+        // `..` would resolve in the URL before the server saw it; the
+        // rest are not KOReader's partial-MD5 shape: too short, too
+        // long, a sha-length value, uppercase.
+        for (
+            document in listOf(
+                "../users/auth",
+                "a".repeat(31),
+                "a".repeat(33),
+                "a".repeat(64),
+                "A".repeat(32),
+            )
+        ) {
+            val result = client.getProgress(
+                "http://127.0.0.1:${server.port}",
+                KosyncCredentials("ada", KosyncCredentials.keyFor("pw")),
+                document,
+            )
+            assertEquals(SyncFailure.Malformed, (result as RemoteResult.Failed).reason)
+        }
+        assertEquals(0, server.requestCount)
+    }
+
+    // -- Redirects ---------------------------------------------------------
+
+    @Test
+    fun `a redirect is refused, and the auth headers never reach the other host`() = runTest {
+        val elsewhere = MockWebServer()
+        elsewhere.start(InetAddress.getByName("127.0.0.1"), 0)
+        try {
+            server.enqueue(
+                MockResponse(
+                    code = 301,
+                    headers = okhttp3.Headers.headersOf(
+                        "Location",
+                        "http://127.0.0.1:${elsewhere.port}/users/auth",
+                    ),
+                ),
+            )
+            val result = KosyncClient().authorize(
+                "http://127.0.0.1:${server.port}",
+                KosyncCredentials("ada", KosyncCredentials.keyFor("pw")),
+            )
+            assertEquals(SyncFailure.Malformed, (result as RemoteResult.Failed).reason)
+            assertEquals(0, elsewhere.requestCount)
+        } finally {
+            elsewhere.close()
+        }
+    }
+
+    @Test
+    fun `a redirected registration never carries the password onward`() = runTest {
+        val elsewhere = MockWebServer()
+        elsewhere.start(InetAddress.getByName("127.0.0.1"), 0)
+        try {
+            // 307 preserves the method and body — exactly the redirect
+            // that would replay the raw password if it were followed.
+            server.enqueue(
+                MockResponse(
+                    code = 307,
+                    headers = okhttp3.Headers.headersOf(
+                        "Location",
+                        "http://127.0.0.1:${elsewhere.port}/users/create",
+                    ),
+                ),
+            )
+            val result = KosyncClient().register(
+                "http://127.0.0.1:${server.port}",
+                "ada",
+                "raw-pairing-code",
+            )
+            assertEquals(SyncFailure.Malformed, (result as RemoteResult.Failed).reason)
+            assertEquals(0, elsewhere.requestCount)
+        } finally {
+            elsewhere.close()
+        }
+    }
+
+    // -- Push --------------------------------------------------------------
+
+    @Test
+    fun `reading done here is pushed as a percentage under the file's hash`() = runTest {
+        pair()
+        db.bookDao().upsert(book())
+        record(progression = 0.4)
+        server.enqueue(json("{}"))
+        server.enqueue(json("""{"document":"x"}"""))
+
+        assertEquals(SyncOutcome.Success, sync().syncAll(null))
+
+        val put = requests().last()
+        assertEquals("PUT", put.method)
+        assertTrue(put.target.endsWith("/syncs/progress"))
+        val sent = JSONObject(put.body!!.utf8())
+        val document = requests().first().target.substringAfterLast("/")
+        assertEquals(document, sent.getString("document"))
+        assertEquals(0.4, sent.getDouble("percentage"), 0.0)
+        assertEquals("0.4", sent.getString("progress"))
+        assertEquals(NOW / 1000, sent.getLong("timestamp"))
+        assertEquals("Test Phone", sent.getString("device"))
+        assertEquals("dev-1", sent.getString("device_id"))
+        // Settled at the revision that was compared.
+        assertEquals(1L, db.syncPeerStateDao().get(BOOK, peerKey())?.ackedRevision)
+    }
+
+    @Test
+    fun `an agreed position is not pushed again`() = runTest {
+        pair()
+        db.bookDao().upsert(book())
+        record(progression = 0.4)
+        server.enqueue(json("{}"))
+        server.enqueue(json("{}"))
+        sync().syncAll(null)
+        val before = requests().count { it.method == "PUT" }
+
+        // Nothing moved on either side since.
+        server.enqueue(progress(0.4))
+        assertEquals(SyncOutcome.Success, sync().syncAll(null))
+
+        assertEquals(before, requests().count { it.method == "PUT" })
+    }
+
+    // -- Pull --------------------------------------------------------------
+
+    @Test
+    fun `a position read elsewhere lands here`() = runTest {
+        pair()
+        db.bookDao().upsert(book())
+        server.enqueue(progress(0.6))
+
+        assertEquals(SyncOutcome.Success, sync().syncAll(null))
+
+        val stored = db.readingProgressDao().get(BOOK)
+        assertEquals(0.6, stored?.totalProgression ?: 0.0, 0.0001)
+        assertEquals("Reading", stored?.status)
+    }
+
+    // -- Conflict ------------------------------------------------------------
+
+    @Test
+    fun `both sides having moved is preserved, not decided`() = runTest {
+        pair()
+        db.bookDao().upsert(book())
+        record(progression = 0.4)
+        server.enqueue(progress(0.9))
+
+        assertEquals(SyncOutcome.Success, sync().syncAll(null))
+
+        // Neither side changed; the disagreement is on disk for the reader.
+        assertEquals(0.4, db.readingProgressDao().get(BOOK)?.totalProgression ?: 0.0, 0.0001)
+        val state = db.syncPeerStateDao().get(BOOK, peerKey())
+        assertEquals(true, state?.hasPending)
+        assertEquals(0.9, state?.pendingProgression ?: 0.0, 0.0001)
+        assertTrue(requests().none { it.method == "PUT" })
+    }
+
+    @Test
+    fun `taking the remote side of a conflict lands it`() = runTest {
+        pair()
+        db.bookDao().upsert(book())
+        record(progression = 0.4)
+        server.enqueue(progress(0.9))
+        sync().syncAll(null)
+
+        val revision = db.readingProgressDao().get(BOOK)!!.localRevision
+        assertEquals(ResolveOutcome.Done, sync().takeRemotePosition(BOOK, revision))
+        assertEquals(0.9, db.readingProgressDao().get(BOOK)?.totalProgression ?: 0.0, 0.0001)
+        assertEquals(false, db.syncPeerStateDao().get(BOOK, peerKey())?.hasPending)
+    }
+
+    @Test
+    fun `keeping the local side clears the question and pushes next run`() = runTest {
+        pair()
+        db.bookDao().upsert(book())
+        record(progression = 0.4)
+        server.enqueue(progress(0.9))
+        sync().syncAll(null)
+
+        assertEquals(ResolveOutcome.Done, sync().keepLocalPosition(BOOK))
+        assertEquals(false, db.syncPeerStateDao().get(BOOK, peerKey())?.hasPending)
+
+        // Still dirty, so the next run sends the page that is actually open.
+        server.enqueue(json("{}"))
+        server.enqueue(json("{}"))
+        sync().syncAll(null)
+        assertTrue(requests().any { it.method == "PUT" })
+    }
+
+    // -- Who is spoken about -------------------------------------------------
+
+    @Test
+    fun `a book that never came from the catalog server is not asked about`() = runTest {
+        pair()
+        db.bookDao().upsert(book(url = BOOK, remoteUuid = null))
+        record(progression = 0.4)
+
+        assertEquals(SyncOutcome.Success, sync().syncAll(null))
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `a local book adopted after an upload keeps out of kosync`() = runTest {
+        // Adoption writes a remote_uuid onto a book whose url stays
+        // local, deliberately — its positions travel natively through
+        // liseur-sync, and kosync speaking about it too would have two
+        // partners disagreeing over one book.
+        pair()
+        val local = "content://downloads/adopted.epub"
+        db.bookDao().upsert(book(url = local, remoteUuid = "uuid-adopted"))
+        db.readingProgressDao().recordLocal(
+            bookUrl = local,
+            locatorJson = LOCATOR,
+            progression = 0.4,
+            readingSpeed = null,
+            status = "Reading",
+            updatedAt = NOW,
+        )
+
+        assertEquals(SyncOutcome.Success, sync().syncAll(null))
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `a book whose file is gone has no name here and is skipped in silence`() = runTest {
+        pair()
+        db.bookDao().upsert(book(localUri = "file:///nowhere/gone.epub"))
+        record(progression = 0.4)
+
+        assertEquals(SyncOutcome.Success, sync().syncAll(null))
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `with no partner paired there is nothing to do`() = runTest {
+        db.bookDao().upsert(book())
+        record(progression = 0.4)
+        assertEquals(SyncOutcome.NotApplicable, sync().syncAll(null))
+    }
+
+    // -- The account ---------------------------------------------------------
+
+    @Test
+    fun `signing into a different kosync account strands the old agreements`() = runTest {
+        pair()
+        db.bookDao().upsert(book())
+        record(progression = 0.4)
+        server.enqueue(json("{}"))
+        server.enqueue(json("{}"))
+        sync().syncAll(null)
+        val oldKey = peerKey()
+
+        // Pairing as somebody else goes through the repository's one door.
+        server.enqueue(json("""{"authorized":"OK"}"""))
+        val outcome = repository().connect(
+            url = "http://127.0.0.1:${server.port}",
+            username = "grace",
+            password = "other",
+        )
+        assertEquals(KosyncSetupOutcome.Success, outcome)
+        assertNull(db.syncPeerStateDao().get(BOOK, oldKey))
+        assertEquals("grace", db.kosyncPeerDao().get()?.username)
+    }
+
+    @Test
+    fun `refused credentials pair nothing`() = runTest {
+        server.enqueue(MockResponse(code = 401, body = ""))
+        val outcome = repository().connect(
+            url = "http://127.0.0.1:${server.port}",
+            username = "ada",
+            password = "wrong",
+        )
+        assertTrue(outcome is KosyncSetupOutcome.Failure)
+        assertNull(db.kosyncPeerDao().get())
+    }
+
+    @Test
+    fun `only the derived key is stored, never the password`() = runTest {
+        server.enqueue(json("""{"authorized":"OK"}"""))
+        repository().connect(
+            url = "http://127.0.0.1:${server.port}",
+            username = "ada",
+            password = "pw",
+        )
+        val peer = db.kosyncPeerDao().get()!!
+        assertEquals(KosyncCredentials.keyFor("pw"), peer.credentials?.key)
+        val auth = requests().single()
+        assertTrue(auth.target.endsWith("/users/auth"))
+    }
+
+    @Test
+    fun `registering sends the password as typed, then proves the key works`() = runTest {
+        val (https, client) = httpsServer()
+        try {
+            https.enqueue(MockResponse(code = 201, body = """{"username":"ada"}"""))
+            https.enqueue(json("""{"authorized":"OK"}"""))
+            val outcome = repository(client).connect(
+                url = "https://localhost:${https.port}",
+                username = "ada",
+                password = "raw-pairing-code",
+                register = true,
+            )
+            assertEquals(KosyncSetupOutcome.Success, outcome)
+            val create = https.takeRequest()
+            assertTrue(create.target.endsWith("/users/create"))
+            assertEquals(
+                "raw-pairing-code",
+                JSONObject(create.body!!.utf8()).getString("password"),
+            )
+            val auth = https.takeRequest()
+            assertEquals(KosyncCredentials.keyFor("raw-pairing-code"), auth.headers["x-auth-key"])
+            assertEquals("ada", db.kosyncPeerDao().get()?.username)
+        } finally {
+            https.close()
+        }
+    }
+
+    @Test
+    fun `registering over plain http is refused before the password leaves`() = runTest {
+        val outcome = repository().connect(
+            url = "http://127.0.0.1:${server.port}",
+            username = "ada",
+            password = "raw-pairing-code",
+            register = true,
+        )
+        assertEquals(
+            KosyncSetupOutcome.Failure(SetupFailure.InsecureTransport),
+            outcome,
+        )
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `a root nothing could address is refused before networking`() = runTest {
+        // Scheme with no host, a host with a space in it, scheme only:
+        // OkHttp would throw on each outside the client's error mapping.
+        for (root in listOf("https://", "https://exa mple.com", "http://")) {
+            val outcome = repository().connect(root, "ada", "pw")
+            assertEquals(KosyncSetupOutcome.Failure(SetupFailure.WrongServer), outcome)
+        }
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `disconnecting forgets the agreements along with the partner`() = runTest {
+        pair()
+        db.bookDao().upsert(book())
+        record(progression = 0.4)
+        server.enqueue(json("{}"))
+        server.enqueue(json("{}"))
+        sync().syncAll(null)
+        val key = peerKey()
+
+        repository().disconnect()
+
+        assertNull(db.kosyncPeerDao().get())
+        assertNull(db.syncPeerStateDao().get(BOOK, key))
+    }
+
+    // -- Preview ---------------------------------------------------------------
+
+    @Test
+    fun `a preview says where both sides are without moving either`() = runTest {
+        pair()
+        db.bookDao().upsert(book())
+        record(progression = 0.4)
+        server.enqueue(progress(0.6))
+
+        val outcome = sync().previewBook(BOOK)
+
+        val preview = (outcome as PreviewOutcome.Ready).preview
+        assertEquals(0.4, preview.local ?: 0.0, 0.0001)
+        assertEquals(0.6, preview.remote ?: 0.0, 0.0001)
+        assertEquals(0.4, db.readingProgressDao().get(BOOK)?.totalProgression ?: 0.0, 0.0001)
+    }
+
+    // -- Helpers -----------------------------------------------------------
+
+    private suspend fun pair(baseUrl: String = "http://127.0.0.1:${server.port}") {
+        db.kosyncPeerDao().upsert(
+            KosyncPeer(
+                baseUrl = baseUrl,
+                username = "ada",
+                keyCipher = KosyncPeer.seal(KosyncCredentials.keyFor("pw")),
+                addedAt = NOW,
+            ),
+        )
+    }
+
+    private suspend fun peerKey(): String = db.kosyncPeerDao().get()!!.accountKey
+
+    private fun sync(online: Boolean = true): KosyncPositionSync {
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        return KosyncPositionSync(
+            kosyncDao = db.kosyncPeerDao(),
+            bookDao = db.bookDao(),
+            progressDao = db.readingProgressDao(),
+            peerStateDao = db.syncPeerStateDao(),
+            fingerprints = BookFingerprintStore(context, db.workIdentityDao()) { NOW },
+            device = { DeviceIdentity(id = "dev-1", name = "Test Phone") },
+            finishedState = FinishedState(db.bookDao(), db.readingProgressDao()),
+            networkAvailability = { online },
+            now = { NOW },
+        )
+    }
+
+    private fun repository(client: KosyncClient = KosyncClient()) = KosyncAccountRepository(
+        dao = db.kosyncPeerDao(),
+        peerStateDao = db.syncPeerStateDao(),
+        client = client,
+        now = { NOW },
+    )
+
+    /**
+     * A TLS MockWebServer and a client that trusts it — registration
+     * refuses plain http, so its happy path needs a real https server.
+     */
+    private fun httpsServer(): Pair<MockWebServer, KosyncClient> {
+        val certificate = HeldCertificate.Builder()
+            .addSubjectAlternativeName("localhost")
+            .build()
+        val serverSide = HandshakeCertificates.Builder()
+            .heldCertificate(certificate)
+            .build()
+        val clientSide = HandshakeCertificates.Builder()
+            .addTrustedCertificate(certificate.certificate)
+            .build()
+        val https = MockWebServer()
+        https.useHttps(serverSide.sslSocketFactory())
+        https.start(InetAddress.getByName("127.0.0.1"), 0)
+        val ok = RemoteHttp.default().newBuilder()
+            .sslSocketFactory(clientSide.sslSocketFactory(), clientSide.trustManager)
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .build()
+        return https to KosyncClient(RemoteHttp(ok))
+    }
+
+    private suspend fun record(progression: Double) {
+        db.readingProgressDao().recordLocal(
+            bookUrl = BOOK,
+            locatorJson = LOCATOR,
+            progression = progression,
+            readingSpeed = null,
+            status = "Reading",
+            updatedAt = NOW,
+        )
+    }
+
+    private fun book(
+        url: String = BOOK,
+        remoteUuid: String? = "uuid-1",
+        localUri: String? = file.toURI().toString(),
+    ) = Book(
+        url = url,
+        title = "A Memory Called Empire",
+        author = "Arkady Martine",
+        coverPath = null,
+        source = null,
+        addedAt = NOW,
+        lastOpenedAt = NOW,
+        localUri = localUri,
+        fileModifiedAt = NOW,
+        remoteUuid = remoteUuid,
+    )
+
+    private fun progress(percentage: Double) = json(
+        """{"document":"d","progress":"$percentage","percentage":$percentage,
+            "device":"other","device_id":"dev-2","timestamp":${NOW / 1000}}
+        """.trimIndent(),
+    )
+
+    private fun json(body: String) = MockResponse(code = 200, body = body)
+
+    private fun requests(): List<RecordedRequest> {
+        while (seen.size < server.requestCount) seen += server.takeRequest()
+        return seen.toList()
+    }
+
+    private val seen = mutableListOf<RecordedRequest>()
+
+    private companion object {
+        const val NOW = 1_700_000_000_000L
+        const val BOOK = "calibre://books.example/12"
+        const val LOCATOR = """{"href":"/c1.xhtml"}"""
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSyncTest.kt
@@ -29,6 +29,7 @@ import okhttp3.tls.HeldCertificate
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -331,6 +332,30 @@ class KosyncPositionSyncTest {
         server.enqueue(json("{}"))
         sync().syncAll(null)
         assertTrue(requests().any { it.method == "PUT" })
+    }
+
+    @Test
+    fun `keeping the local side is not asked again by a server that has not moved`() = runTest {
+        // kosync has no feed, so the next run asks outright and gets the
+        // same answer back. With the old agreement still standing both
+        // sides read as moved, and the reader is asked the same question
+        // on every sync until they happen to turn a page.
+        pair()
+        db.bookDao().upsert(book())
+        record(progression = 0.4)
+        server.enqueue(progress(0.9))
+        sync().syncAll(null)
+        sync().keepLocalPosition(BOOK)
+        seen.clear()
+
+        server.enqueue(progress(0.9))
+        server.enqueue(json("{}"))
+        sync().syncAll(null)
+
+        val put = requests().singleOrNull { it.method == "PUT" }
+        assertNotNull(put)
+        assertEquals(0.4, JSONObject(put!!.body!!.utf8()).getDouble("percentage"), 0.0001)
+        assertEquals(0, db.syncPeerStateDao().countPending(peerKey()))
     }
 
     // -- Who is spoken about -------------------------------------------------

--- a/app/src/test/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSyncTest.kt
@@ -477,6 +477,44 @@ class KosyncPositionSyncTest {
     }
 
     @Test
+    fun `a root pasted with a query is stored without it`() = runTest {
+        // Endpoints are built by appending, so a query left on the root
+        // would produce `…/koreader?x=1/users/auth`, which addresses
+        // nothing.
+        server.enqueue(json("""{"authorized":"OK"}"""))
+
+        repository().connect(
+            url = "http://127.0.0.1:${server.port}/koreader?x=1#top",
+            username = "ada",
+            password = "pw",
+        )
+
+        assertEquals(
+            "http://127.0.0.1:${server.port}/koreader",
+            db.kosyncPeerDao().get()?.baseUrl,
+        )
+        assertTrue(requests().single().target.endsWith("/koreader/users/auth"))
+    }
+
+    @Test
+    fun `an upper case scheme is read as the scheme it is`() = runTest {
+        // Not a bypass today, because normalise refused the whole
+        // address, but "wrong server" is the wrong thing to tell someone
+        // who typed HTTP:// and needs to hear why it will not be used.
+        val outcome = repository().connect(
+            url = "HTTP://sync.example.com",
+            username = "ada",
+            password = "pw",
+            register = true,
+        )
+
+        assertEquals(
+            KosyncSetupOutcome.Failure(SetupFailure.InsecureTransport),
+            outcome,
+        )
+    }
+
+    @Test
     fun `a root nothing could address is refused before networking`() = runTest {
         // Scheme with no host, a host with a space in it, scheme only:
         // OkHttp would throw on each outside the client's error mapping.

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepositoryTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepositoryTest.kt
@@ -3,9 +3,12 @@ package com.chmouel.liseur.data.remote
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import com.chmouel.liseur.data.calibre.CredentialCipher
+import com.chmouel.liseur.data.db.KosyncPeer
 import com.chmouel.liseur.data.db.LiseurDatabase
 import com.chmouel.liseur.data.db.RemoteServer
 import com.chmouel.liseur.data.db.RemoteServerDao
+import com.chmouel.liseur.data.kosync.KosyncAccountRepository
+import com.chmouel.liseur.data.kosync.KosyncCredentials
 import com.chmouel.liseur.data.library.BookRemoval
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -253,11 +256,81 @@ class RemoteAccountRepositoryTest {
             db.annotationSyncDao(),
         ),
         seriesExtraDao = db.seriesExtraDao(),
+        peerStateDao = db.syncPeerStateDao(),
+        forgetKosyncPeer = { kosync().disconnect() },
         setups = mapOf(
             ServerKind.KOMGA to setup,
             ServerKind.GRIMMORY to setup,
         ),
     )
+
+    private fun kosync() = KosyncAccountRepository(
+        dao = db.kosyncPeerDao(),
+        peerStateDao = db.syncPeerStateDao(),
+    )
+
+    private suspend fun pairKosync() {
+        db.kosyncPeerDao().upsert(
+            KosyncPeer(
+                baseUrl = "https://books.example/api/koreader",
+                username = "ada",
+                keyCipher = KosyncPeer.seal(KosyncCredentials.keyFor("pw")),
+                addedAt = 0L,
+            ),
+        )
+    }
+
+    /**
+     * The pairing belongs to the server it was made next to. Connecting
+     * one that carries positions itself would otherwise leave it running
+     * out of sight, against a library it knows nothing about.
+     */
+    @Test
+    fun `connecting a server that cannot host the pairing puts it down`() = runTest {
+        account.connectGrimmory(BASE, "ada", "pw")
+        pairKosync()
+
+        connectKomga()
+
+        assertNull(db.kosyncPeerDao().get())
+    }
+
+    /**
+     * Only once a connection has landed. An attempt that fails leaves
+     * the old server standing, and taking the pairing with it would
+     * strand a working Grimmory setup on a typo.
+     */
+    @Test
+    fun `a failed connection leaves the pairing alone`() = runTest {
+        account.connectGrimmory(BASE, "ada", "pw")
+        pairKosync()
+
+        val refusing = repositoryUsing(db.remoteServerDao(), NeverConnects)
+        val result = refusing.connectKomga(BASE, KEY)
+
+        assertTrue(result is SetupResult.Failure)
+        assertEquals("ada", db.kosyncPeerDao().get()?.username)
+        assertEquals(ServerKind.GRIMMORY, db.remoteServerDao().get()?.kind)
+    }
+
+    @Test
+    fun `reconnecting grimmory keeps the pairing`() = runTest {
+        account.connectGrimmory(BASE, "ada", "pw")
+        pairKosync()
+
+        account.connectGrimmory(BASE, "ada", "pw")
+
+        assertEquals("ada", db.kosyncPeerDao().get()?.username)
+    }
+
+    /** A server that refuses, so a connection can be seen not to land. */
+    private object NeverConnects : ServerSetup {
+        override suspend fun connect(
+            rawUrl: String,
+            credentials: RemoteCredentials,
+            allowHttp: Boolean,
+        ): SetupResult = SetupResult.Failure(SetupFailure.BadCredentials)
+    }
 
     /** A server that is always there, so the tests are about the account. */
     private object AlwaysConnects : ServerSetup {

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/ServerKindTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/ServerKindTest.kt
@@ -89,6 +89,30 @@ class ServerKindTest {
         }
     }
 
+    /**
+     * The pairing exists for a server that catalogs books without
+     * carrying a place in them. Where the server syncs natively, a
+     * second source for the same book is a disagreement the reader can
+     * neither see nor resolve — so the two answers are pinned against
+     * each other here rather than drifting apart in a `when` somewhere.
+     */
+    @Test
+    fun `only a kind that cannot sync natively may host a kosync pairing`() {
+        ServerKind.entries.forEach { kind ->
+            if (kind.hostsKosyncPeer) {
+                assertEquals(
+                    "${kind.name} hosts a kosync pairing yet syncs natively",
+                    SyncAbility.NONE,
+                    kind.syncAbility,
+                )
+            }
+        }
+        assertEquals(true, ServerKind.GRIMMORY.hostsKosyncPeer)
+        listOf(ServerKind.CALIBRE, ServerKind.KOMGA, ServerKind.LISEUR_SYNC).forEach {
+            assertEquals("${it.name} must not host a kosync pairing", false, it.hostsKosyncPeer)
+        }
+    }
+
     /** An account of [kind] that has finished every setup step it has. */
     private fun fullyCredentialed(kind: ServerKind) = RemoteServer(
         kind = kind,

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/ForegroundSyncPolicyTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/ForegroundSyncPolicyTest.kt
@@ -1,5 +1,6 @@
 package com.chmouel.liseur.domain
 
+import com.chmouel.liseur.data.db.KosyncPeer
 import com.chmouel.liseur.data.db.RemoteServer
 import com.chmouel.liseur.data.remote.ServerKind
 import org.junit.Assert.assertEquals
@@ -102,6 +103,46 @@ class ForegroundSyncPolicyTest {
                 server(kind = ServerKind.LISEUR_SYNC, syncedAt = now - 5 * 60 * 1000),
                 now,
             ),
+        )
+    }
+
+    private fun kosync(syncedAt: Long?) = KosyncPeer(
+        baseUrl = "https://books.example/api/koreader",
+        username = "reader",
+        keyCipher = "sealed",
+        addedAt = 0L,
+        positionSyncedAt = syncedAt,
+    )
+
+    /**
+     * The kosync partner is exactly what a Grimmory account pairs with,
+     * and Grimmory itself can never sync — so the partner is asked about
+     * on its own terms rather than through `canSync`.
+     */
+    @Test
+    fun `a kosync partner makes sync due even when the server cannot sync itself`() {
+        val grimmory = server(kind = ServerKind.GRIMMORY, koboToken = null, syncedAt = null)
+        assertEquals(false, shouldSyncOnForeground(grimmory, now))
+        assertEquals(
+            true,
+            shouldSyncOnForeground(grimmory, now, kosync = kosync(syncedAt = null)),
+        )
+    }
+
+    @Test
+    fun `a kosync partner that synced minutes ago is left alone`() {
+        assertEquals(
+            false,
+            shouldSyncOnForeground(null, now, kosync = kosync(syncedAt = now - 5 * 60 * 1000)),
+        )
+    }
+
+    @Test
+    fun `either partner being stale is enough to ask`() {
+        val fresh = server(syncedAt = now - 5 * 60 * 1000)
+        assertEquals(
+            true,
+            shouldSyncOnForeground(fresh, now, kosync = kosync(syncedAt = now - 2 * 60 * 60 * 1000)),
         )
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/ForegroundSyncPolicyTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/ForegroundSyncPolicyTest.kt
@@ -131,18 +131,47 @@ class ForegroundSyncPolicyTest {
 
     @Test
     fun `a kosync partner that synced minutes ago is left alone`() {
+        val grimmory = server(kind = ServerKind.GRIMMORY, syncedAt = null)
         assertEquals(
             false,
-            shouldSyncOnForeground(null, now, kosync = kosync(syncedAt = now - 5 * 60 * 1000)),
+            shouldSyncOnForeground(grimmory, now, kosync = kosync(syncedAt = now - 5 * 60 * 1000)),
         )
     }
 
     @Test
     fun `either partner being stale is enough to ask`() {
-        val fresh = server(syncedAt = now - 5 * 60 * 1000)
+        val fresh = server(kind = ServerKind.GRIMMORY, syncedAt = now - 5 * 60 * 1000)
         assertEquals(
             true,
             shouldSyncOnForeground(fresh, now, kosync = kosync(syncedAt = now - 2 * 60 * 60 * 1000)),
+        )
+    }
+
+    /**
+     * A pairing outlives the server it was made for: an account switch
+     * interrupted halfway, a crash, a database restored onto another
+     * phone. Waking a sync for it would have it talk to a server on
+     * behalf of a library nobody paired it with.
+     */
+    @Test
+    fun `a pairing left behind by a server that cannot host one is not woken`() {
+        val stale = kosync(syncedAt = now - 2 * 60 * 60 * 1000)
+        for (kind in listOf(ServerKind.CALIBRE, ServerKind.KOMGA, ServerKind.LISEUR_SYNC)) {
+            val fresh = server(kind = kind, syncedAt = now - 5 * 60 * 1000)
+            assertEquals(
+                "$kind must not wake a kosync pairing",
+                false,
+                shouldSyncOnForeground(fresh, now, kosync = stale),
+            )
+        }
+    }
+
+    /** With nothing connected there is no library for a pairing to cover. */
+    @Test
+    fun `a pairing with no server connected is not woken`() {
+        assertEquals(
+            false,
+            shouldSyncOnForeground(null, now, kosync = kosync(syncedAt = null)),
         )
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/settings/KosyncPrefillTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/settings/KosyncPrefillTest.kt
@@ -1,0 +1,86 @@
+package com.chmouel.liseur.ui.settings
+
+import com.chmouel.liseur.data.db.KosyncPeer
+import com.chmouel.liseur.data.db.RemoteServer
+import com.chmouel.liseur.data.remote.ServerKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Grimmory's kosync mount is offered before it is asked for — and only
+ * then. The prefill must never overwrite what a reader typed, never
+ * disturb an existing pairing, and never speak for another kind of
+ * server, whose kosync mount (if any) is not at `/api/koreader`.
+ */
+class KosyncPrefillTest {
+
+    @Test
+    fun `a fresh grimmory connection offers its koreader mount`() {
+        assertEquals(
+            "https://books.example/api/koreader",
+            kosyncPrefillUrl(server(ServerKind.GRIMMORY), peer = null, currentUrl = ""),
+        )
+    }
+
+    @Test
+    fun `a trailing slash on the server does not double up`() {
+        assertEquals(
+            "https://books.example/api/koreader",
+            kosyncPrefillUrl(
+                server(ServerKind.GRIMMORY, baseUrl = "https://books.example/"),
+                peer = null,
+                currentUrl = "",
+            ),
+        )
+    }
+
+    @Test
+    fun `nothing is offered for the kinds that sync on their own`() {
+        for (kind in listOf(ServerKind.CALIBRE, ServerKind.KOMGA, ServerKind.LISEUR_SYNC)) {
+            assertNull(kosyncPrefillUrl(server(kind), peer = null, currentUrl = ""))
+        }
+        assertNull(kosyncPrefillUrl(null, peer = null, currentUrl = ""))
+    }
+
+    @Test
+    fun `what the reader typed is never overwritten`() {
+        assertNull(
+            kosyncPrefillUrl(
+                server(ServerKind.GRIMMORY),
+                peer = null,
+                currentUrl = "https://sync.example",
+            ),
+        )
+    }
+
+    @Test
+    fun `an existing pairing is never disturbed`() {
+        val peer = KosyncPeer(
+            baseUrl = "https://sync.example",
+            username = "ada",
+            keyCipher = "sealed",
+            addedAt = 0L,
+        )
+        assertNull(kosyncPrefillUrl(server(ServerKind.GRIMMORY), peer = peer, currentUrl = ""))
+    }
+
+    private fun server(
+        kind: ServerKind,
+        baseUrl: String = "https://books.example",
+    ) = RemoteServer(
+        kind = kind,
+        baseUrl = baseUrl,
+        username = "ada",
+        passwordCipher = null,
+        apiKeyCipher = null,
+        accountId = null,
+        userId = null,
+        koboTokenCipher = null,
+        canDownload = true,
+        addedAt = 0L,
+        catalogSyncedAt = null,
+        positionSyncedAt = null,
+        syncToken = null,
+    )
+}

--- a/docs/SERVER_CAPABILITIES.md
+++ b/docs/SERVER_CAPABILITIES.md
@@ -11,7 +11,7 @@ side.
 | Catalog browse | Implemented          | Implemented         | Implemented          | Implemented          |
 | Search         | Implemented          | Implemented         | Implemented          | Local only           |
 | File download  | Implemented          | Implemented         | Implemented          | Implemented          |
-| Position sync  | Implemented (full)   | Implemented (%)     | Implemented (full)   | Not possible         |
+| Position sync  | Implemented (full)   | Implemented (%)     | Implemented (full)   | Implemented (%, kosync) |
 | Book upload    | Not possible          | Not feasible        | Implemented          | Not implemented      |
 | Book delete    | Not possible          | Implemented         | Implemented          | Not implemented      |
 | Series claims  | N/A                   | N/A                 | Implemented          | N/A                  |
@@ -105,7 +105,7 @@ which.
 | Catalog browse | `GET /komga/api/v1/books?page=&size=` (paginated) | `GrimmoryCatalogClient` | Komga's `POST /v1/books/list` is explicitly not implemented and answers 501, so the plain paged route is used instead. Filtered client-side on `media.mediaType`, since Grimmory reports MOBI and AZW3 under `mediaProfile: "EPUB"` |
 | Search | None on the compatibility API | Returns nothing | Liseur's library search is local and covers the whole catalog, which is walked into the database anyway. Grimmory's OPDS `catalog?q=` is the way in if remote search is ever wired to the UI |
 | File download | `GET /komga/api/v1/books/{id}/file` | `GrimmoryFileSource` | Serves the book's primary file. Open to any authenticated OPDS user the library is shared with |
-| Position sync | None. `/progression`, `/read-progress` and `/positions` all fall through to a 404, and `readProgress` is never populated on a book | Not implemented | No entry in `AppContainer.positions`, so sync is never offered rather than offered and failed. Grimmory does speak KOReader's kosync at `/api/koreader`, behind a third credential set and matched by file hash — the way in if this is ever wanted |
+| Position sync | None on the compatibility API. `/progression`, `/read-progress` and `/positions` all fall through to a 404, and `readProgress` is never populated on a book | `KosyncPositionSync`, paired separately | Grimmory speaks KOReader's kosync at `/api/koreader`, behind a third credential set (a KOReader user created in its device settings) and matched by file hash. Liseur pairs it from the KOReader sync section on the server screen; percentages only. See [`adr/0014-kosync.md`](adr/0014-kosync.md) |
 | Series metadata | Ids are synthetic (`{libraryId}-{slug}`) and change when a series is renamed | Not implemented | `SeriesExtrasRepository` is gated on Komga and never fires here. The id still arrives on the book and groups the shelf, so a rename regroups rather than corrupts |
 | Book upload / delete | Not exposed by the compatibility API | Not implemented | |
 
@@ -175,7 +175,13 @@ per-server capability detection.
 | Komga | Exact position in chapter | Full Readium locator, with position snapping |
 | calibre-web | Page-level at best | Percentage (`totalProgression`) via the Kobo protocol |
 | liseur-sync | Exact position in chapter | Full Readium locator via the op log |
-| Grimmory | None | No route carries one; position stays on the device |
+| Grimmory | Page-level at best | Percentage via KOReader's kosync, paired alongside the catalog |
+| Any kosync server | Page-level at best | Same partner: it speaks the generic protocol, so a stock kosync server pairs the same way |
 
-The three that sync go through the shared `reconcileReadingState` merge
+Every sync goes through the shared `reconcileReadingState` merge
 logic in `domain/ReadingStateMerge.kt`.
+
+The kosync partner is not a kind of server: it is paired *alongside*
+whichever catalog server is connected, covers that server's downloaded
+books (matched by KOReader's partial MD5 of the file), and has its own
+lifecycle. See [`adr/0014-kosync.md`](adr/0014-kosync.md).

--- a/docs/SERVER_CAPABILITIES.md
+++ b/docs/SERVER_CAPABILITIES.md
@@ -181,7 +181,13 @@ per-server capability detection.
 Every sync goes through the shared `reconcileReadingState` merge
 logic in `domain/ReadingStateMerge.kt`.
 
-The kosync partner is not a kind of server: it is paired *alongside*
-whichever catalog server is connected, covers that server's downloaded
-books (matched by KOReader's partial MD5 of the file), and has its own
-lifecycle. See [`adr/0014-kosync.md`](adr/0014-kosync.md).
+The kosync partner is not a kind of server: it is paired *alongside* a
+connected one, covers that server's downloaded books (matched by
+KOReader's partial MD5 of the file), and has its own lifecycle.
+
+It is offered only where the connected server carries no position of its
+own, which today means Grimmory. calibre-web, Komga and liseur-sync sync
+positions natively, and a second source for the same book is a conflict
+the reader can neither see nor resolve. `ServerKind.hostsKosyncPeer` is
+the single answer to that question, and where a future kind states its
+own. See [`adr/0014-kosync.md`](adr/0014-kosync.md).

--- a/docs/adr/0014-kosync.md
+++ b/docs/adr/0014-kosync.md
@@ -1,0 +1,119 @@
+# 14. Position sync over KOReader's kosync protocol
+
+Status: accepted
+
+## Context
+
+[Issue #95](https://github.com/chmouel/liseur/issues/95). Grimmory is
+browsed through its Komga shim (ADR-0012), and the shim carries no
+reading position: `canSync` is false, and the settings screen says
+positions stay on this device. But Grimmory does hold positions — behind
+KOReader's kosync protocol at `{base}/api/koreader`, under a third
+credential set created in its device settings.
+
+kosync is not Grimmory's. It is KOReader's own sync protocol, spoken by
+kosync.koreader.rocks, by every self-hosted kosync server, by
+calibre-web plugins, and by liseur-sync at `/adapter/kosync`.
+Implementing Grimmory's flavour of it would have been implementing all
+of it while pretending otherwise.
+
+The protocol is small: `GET /users/auth` proves a credential,
+`GET /syncs/progress/{document}` asks where a book stands,
+`PUT /syncs/progress` says where it stands here. A book is named by
+KOReader's partial MD5 of its file bytes — which
+`BookFingerprint.partialMd5` already reproduces, because liseur-sync
+resolution needed it first. Auth is two headers: `x-auth-user` and
+`x-auth-key`, the hex MD5 of the password.
+
+## Decision
+
+**A kosync server is a second sync partner, not a fifth kind of
+server.** It is paired *alongside* whatever catalog server is connected,
+from a section on the same settings screen, and lives in its own
+single-row table (`kosync_peer`) with its own lifecycle: disconnecting
+the catalog server leaves it standing, and vice versa. The architecture
+was already shaped for this — `CompositePositionSync` runs a list of
+`PeerPositionSync`s in turn, and `sync_peer_state` keys agreements by
+`(book_url, peer_id)`, so the kosync partner's baselines and the catalog
+server's cannot overwrite each other. Merging goes through
+`domain/ReadingStateMerge.kt` unchanged: a fourth partner is not a
+fourth set of rules.
+
+**Coverage is the connected catalog server's downloaded books**
+(`remote_uuid` set, a remote-scheme `books.url`, bytes on device).
+kosync needs the file's hash, so only a downloaded book can be spoken
+about at all; restricting to server books keeps the run bounded and
+matches the reason the partner exists — Grimmory's own books, positions
+held next door. The URL check matters: a locally added book *adopted*
+after an upload to liseur-sync also carries a `remote_uuid` but keeps
+its local `url` by design, and its positions already travel natively —
+kosync leaves it alone. kosync has no list endpoint, so a run is one GET
+per candidate — every candidate, deliberately, because a position that
+exists only on the server can be found no other way — stopped early
+when the server stops answering.
+
+**Percentage-only fidelity.** The protocol's `progress` field is an
+engine-specific position (a CRe xpointer, a page number) that means
+nothing to Readium. On the way out it carries the percentage as a bare
+string — the shape KOReader itself accepts for engines without an
+xpointer, and the one liseur-sync answers with (verified against its
+kosync adapter and tests). A pull therefore lands at roughly the right
+page, exactly as calibre-web's Kobo sync does, and
+`SyncPreview.exactPositionAgreement` stays null. Timestamps on the wire
+are unix seconds, from stored state rather than the clock.
+
+**Only the derived key is stored.** The password is hashed to the MD5
+auth key the moment it is typed; the key is sealed with
+`CredentialCipher` and the password never touches disk. What a database
+leak exposes is a credential for this one protocol, not a password the
+reader may have reused. The key is still a replayable credential, and a
+cleartext connection exposes it to the network path: the scheme
+defaults to https, and an unreachable https root is never retried over
+http — the downgrade the catalog kinds offer behind a confirmation is
+not offered here at all.
+
+**Redirects are not followed.** OkHttp strips `Authorization` when a
+redirect changes host, which protects the catalog kinds — but kosync
+signs with custom `x-auth-*` headers that would be forwarded wholesale,
+and a register body even carries the raw password. No kosync endpoint
+legitimately redirects (the mount root is typed by the reader), so a
+3xx is read as the wrong address and refused.
+
+**Registering is an explicit ask, never a fallback.** liseur-sync
+redeems a pairing code through `POST /users/create` with the password as
+typed; Grimmory forbids the route outright. Retrying a failed sign-in as
+a registration would turn a typo into a fresh junk account on a stock
+kosync server, so the toggle is off unless the reader flips it. And
+because register is the one call that carries the password as typed
+rather than the derived key, it is refused outright over a plain-http
+root.
+
+**The account key is `kosync|{url}|{username}`.** Signing in as a
+different kosync user strands the old agreements rather than adopting
+them — the rule every other kind follows — and all per-account state is
+cleared through one repository door, the `forgetSyncPeer()` precedent.
+
+**A document name is validated before it is addressed.**
+`^[0-9a-f]{32}$` — exactly KOReader's partial-MD5 shape, the only
+document this client ever computes — or the request is refused as
+malformed. The `GrimmoryId` rule: opaque to carry, checked before put
+in a URL path.
+
+A `ServerKind.CUSTOM` (generic OPDS catalog + optional kosync) stands on
+top of this and is deliberately a separate change: position sync for it
+flows through this same partner, so the rules exist once.
+
+## Consequences
+
+- Grimmory gets position sync: browse through the shim, sync through
+  kosync, with `{base}/api/koreader` prefilled and the "positions are
+  not synced here" notice replaced by directions to the section below.
+- Any stock kosync server works the same way, which is tested end to end
+  against liseur-sync's `/adapter/kosync`.
+- A book downloaded from elsewhere has different bytes, a different
+  hash, and therefore a different kosync document — two copies of one
+  work do not exchange positions. That is the protocol's nature, not a
+  bug to fix here.
+- `shouldSyncOnForeground` now asks about the kosync partner on its own
+  terms, because the account it is most useful next to (Grimmory) is
+  exactly the one whose `canSync` is false.

--- a/docs/adr/0014-kosync.md
+++ b/docs/adr/0014-kosync.md
@@ -27,6 +27,31 @@ resolution needed it first. Auth is two headers: `x-auth-user` and
 
 ## Decision
 
+**The pairing is offered where a server has no positions of its own,
+which today means Grimmory.** calibre-web, Komga and liseur-sync all
+carry a reading position themselves, and pairing kosync next to one of
+them would leave a single book with two sources of truth, silently
+disagreeing on a device the reader is not looking at. That is a conflict
+they can neither see nor resolve, so it is not offered.
+
+`ServerKind.hostsKosyncPeer` is the one place that answers, and it is
+asked in three: the settings section, so it is not shown; the sync
+itself, so it stays quiet; and the foreground policy, so nothing wakes
+it. The last two are what make the rule true rather than merely
+presented. A saved pairing is not permission to sync — an account switch
+interrupted halfway, a crash, or a database restored onto a phone that
+never made the pairing all leave a `kosync_peer` row behind a server
+that knows nothing about it — so the peer asks what is connected on
+every run instead of trusting the row's existence.
+
+A pairing the newly connected server cannot host is dropped, in the
+transaction that stores the new server rather than when the reader
+starts connecting: an attempt that fails leaves the old server standing,
+and putting the pairing down on the attempt would take a working
+Grimmory setup with it. It goes through
+`KosyncAccountRepository.disconnect`, the same door a reader's own
+disconnect uses.
+
 **A kosync server is a second sync partner, not a fifth kind of
 server.** It is paired *alongside* whatever catalog server is connected,
 from a section on the same settings screen, and lives in its own

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,7 @@ jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 junit = { module = "junit:junit", version.ref = "junit" }
 mockwebserver = { module = "com.squareup.okhttp3:mockwebserver3-junit4", version.ref = "okhttp" }
+okhttp-tls = { module = "com.squareup.okhttp3:okhttp-tls", version.ref = "okhttp" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

Closes #95.

Grimmory keeps your books but not your place in them: Liseur browses it through its Komga endpoint, and that endpoint carries no reading position. Grimmory has a KOReader sync (kosync) endpoint that does. You can now pair one, and your reading position follows you across devices. Connecting a Grimmory server fills the sync address in for you, and any kosync server works: kosync.koreader.rocks, liseur-sync, or one you host yourself.

The pairing is offered for Grimmory and nowhere else. calibre-web, Komga and liseur-sync each keep your place themselves, and a second source for the same book would disagree with the first on a device you are not looking at, with no way for you to see it or settle it.

## Changes

- A new "KOReader sync" section on the Book server screen, shown when Grimmory is connected. Enter the sync server address, a username and a password. Disconnecting it is one button.
- It covers the books you downloaded from Grimmory. Positions are exchanged as a percentage, the same fidelity calibre-web gives.
- Your password is not stored. Liseur keeps only the encrypted key the protocol uses on the wire, and creating a new account on a sync server is refused over an unencrypted connection so the password never travels in the clear.
- Connect a server that keeps positions itself and the pairing is put down with it, so nothing is left running out of sight. A connection that fails leaves it alone, so a typo cannot cost you a working setup.
- A pairing that outlives the server it was made for still shows, and says it is not in use rather than claiming to sync, so you can disconnect it instead of wondering.
- The app no longer claims Grimmory cannot keep your place. Four screens said so; they now explain the pairing instead.
- 44 new unit tests, and a design note in `docs/adr/0014-kosync.md` for the details this description leaves out.

A "Custom" connection type, holding a plain OPDS catalog address and a kosync address, is #102 and its own pull request.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

On an emulator, against liseur-sync's kosync endpoint. The book server and the sync server were connected under two different accounts, so a position landing under the second account could only have travelled through the new pairing.

- Read The Time Machine to 13% in the app, synced, and found the position on the server under the sync account.
- Set the position to 42% on the server directly, synced in the app, and the app moved to exactly 42%.
- Paired a sync server under Grimmory, then connected Komga. The section went, the pairing went with it, and nothing was left in the database. A Komga connection that failed first left the pairing where it was.

## Screenshots or recordings

Settings, then Book server. The section appears under Grimmory and nowhere else.

| Grimmory: the pairing | Komga: no pairing |
|---|---|
| ![The KOReader sync section under a Grimmory connection](https://github.com/user-attachments/assets/54c37462-b805-41ab-b80c-c7d18165a9c7) | ![The same screen under Komga, with no KOReader sync section](https://github.com/user-attachments/assets/9c8b4ebb-922e-4986-a8ac-0e480c253852) |

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

