### PR TITLE
fix(download): pace and lengthen bulk book downloads

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/data/calibre/BookDownloadRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/calibre/BookDownloadRepository.kt
@@ -76,6 +76,14 @@ data class StorageUse(val count: Int, val bytes: Long)
  * tested without standing up WorkManager and a database.
  */
 class BulkTransferGate(maxConcurrent: Int = DEFAULT_MAX_CONCURRENT) {
+    init {
+        // Semaphore(0) or a negative count would wait forever rather
+        // than throw, and that wait looks identical to a slow server
+        // from everywhere else in the app. Caught here, once, rather
+        // than as a batch that never starts.
+        require(maxConcurrent >= 1) { "maxConcurrent must be at least 1, was $maxConcurrent" }
+    }
+
     private val slots = Semaphore(maxConcurrent)
 
     /** Runs [block] once a transfer slot is free. */

--- a/app/src/main/kotlin/com/chmouel/liseur/data/calibre/BookDownloadRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/calibre/BookDownloadRepository.kt
@@ -35,6 +35,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 
@@ -56,6 +58,41 @@ data class DownloadProgress(
 /** What downloaded books are costing in device storage. */
 data class StorageUse(val count: Int, val bytes: Long)
 
+/**
+ * Limits how many bulk-download transfers may pull bytes over the
+ * network at once.
+ *
+ * WorkManager's own executor is happy to start many [BookDownloadWorker]s
+ * in parallel once their constraints are met, which for "download
+ * everything" is at once. That is fine for the bookkeeping each does
+ * before and after, but every one of them opens its own connection to
+ * the same server for the transfer itself, and a modest self-hosted
+ * instance answering four or more of those at once is exactly what
+ * turns a slow response into a dropped one (#89). A single download the
+ * reader asked for by name never touches this: it has no batch to share
+ * a server with.
+ *
+ * Plain Kotlin, not a repository method, so the limit itself can be
+ * tested without standing up WorkManager and a database.
+ */
+class BulkTransferGate(maxConcurrent: Int = DEFAULT_MAX_CONCURRENT) {
+    private val slots = Semaphore(maxConcurrent)
+
+    /** Runs [block] once a transfer slot is free. */
+    suspend fun <T> withSlot(block: suspend () -> T): T = slots.withPermit { block() }
+
+    companion object {
+        /**
+         * Kept low on purpose: this is a courtesy to whatever the reader
+         * is self-hosting, not a limit the device needs. Two lets a
+         * finished transfer's teardown overlap with the next one
+         * starting, without asking a small server to answer a handful of
+         * large requests in parallel.
+         */
+        const val DEFAULT_MAX_CONCURRENT = 2
+    }
+}
+
 /** Starts, watches and undoes book downloads. */
 @OptIn(ExperimentalCoroutinesApi::class)
 class BookDownloadRepository(
@@ -64,8 +101,13 @@ class BookDownloadRepository(
     private val bookRemoval: BookRemoval,
     private val scope: CoroutineScope,
     private val bulkStore: BulkDownloadStore = BulkDownloadStore(context),
+    private val bulkTransferGate: BulkTransferGate = BulkTransferGate(),
 ) {
     private val workManager get() = WorkManager.getInstance(context)
+
+    /** Runs [block] once a bulk-download transfer slot is free. */
+    suspend fun <T> withBulkTransferSlot(block: suspend () -> T): T =
+        bulkTransferGate.withSlot(block)
 
     val downloaded: Flow<List<Book>> = bookDao.observeDownloaded()
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/calibre/BookDownloadWorker.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/calibre/BookDownloadWorker.kt
@@ -7,6 +7,7 @@ import androidx.work.Data
 import androidx.work.WorkerParameters
 import com.chmouel.liseur.container
 import com.chmouel.liseur.data.db.DownloadState
+import com.chmouel.liseur.data.remote.RemoteHttp
 import org.readium.r2.shared.util.AbsoluteUrl
 
 /**
@@ -66,18 +67,30 @@ class BookDownloadWorker(
         setProgress(progressData(bookUrl, null))
 
         val downloads = container.bookDownloads
-        val outcome = BookDownloader(
+        val downloader = BookDownloader(
+            http = RemoteHttp(RemoteHttp.forDownloads()),
             // Bulk work is the only thing that can fill a device on its
             // own, so it is the only thing asked to leave room behind. A
             // single download the reader asked for by name keeps the
             // behaviour it has always had.
             freeSpace = if (batchId != null) downloads::freeBytes else null,
-        ).download(
-            request = request,
-            target = downloads.fileFor(uuid),
-        ) { downloaded, total ->
-            val fraction = total?.takeIf { it > 0 }?.let { downloaded.toFloat() / it }
-            setProgress(progressData(bookUrl, fraction))
+        )
+        val runDownload = suspend {
+            downloader.download(
+                request = request,
+                target = downloads.fileFor(uuid),
+            ) { downloaded, total ->
+                val fraction = total?.takeIf { it > 0 }?.let { downloaded.toFloat() / it }
+                setProgress(progressData(bookUrl, fraction))
+            }
+        }
+        // Only a batch shares a server with siblings worth pacing
+        // against; a download the reader asked for by name runs at
+        // once, same as it always has.
+        val outcome = if (batchId != null) {
+            downloads.withBulkTransferSlot(runDownload)
+        } else {
+            runDownload()
         }
 
         return when (outcome) {

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteHttp.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteHttp.kt
@@ -26,5 +26,24 @@ class RemoteHttp(val client: OkHttpClient = default()) {
             .connectTimeout(15, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .build()
+
+        /**
+         * A client sized for fetching whole books rather than answering
+         * API calls.
+         *
+         * [default]'s 30-second read timeout is generous for a catalog
+         * page but not for a slow or loaded calibre-web instance moving
+         * megabytes: any stall between two chunks over that long aborts
+         * the transfer client-side, which a modest self-hosted server
+         * sees as the client hanging up mid-write ("broken pipe") rather
+         * than as a timeout of its own. `BookDownloader` already retries
+         * a dropped transfer by resuming from where it left off, so the
+         * fix here is to make a genuinely stalled connection wait longer
+         * before it is treated as one.
+         */
+        fun forDownloads(): OkHttpClient = default().newBuilder()
+            .readTimeout(90, TimeUnit.SECONDS)
+            .retryOnConnectionFailure(true)
+            .build()
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/calibre/BulkTransferGateTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/calibre/BulkTransferGateTest.kt
@@ -4,9 +4,9 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -30,8 +30,9 @@ class BulkTransferGateTest {
         val peak = AtomicInteger(0)
         val release = CompletableDeferred<Unit>()
 
-        // Five callers all ask for a slot at once; only two should be
-        // inside the block together, the rest waiting on the semaphore.
+        // Five callers all ask for a slot at once; only two should ever
+        // be inside the block together, the rest waiting on the
+        // semaphore.
         val jobs = (1..5).map {
             async {
                 gate.withSlot {
@@ -42,9 +43,20 @@ class BulkTransferGateTest {
                 }
             }
         }
-        // Let every job reach the semaphore before checking the peak.
-        repeat(5) { yield() }
-        assertTrue("no more than 2 should run at once, was ${peak.get()}", peak.get() <= 2)
+
+        // Wait for the actual condition -- two callers inside the gated
+        // section -- rather than a fixed number of yields, which proves
+        // nothing about how many coroutines the scheduler chose to run.
+        withTimeout(5_000) {
+            while (concurrent.get() < 2) yield()
+        }
+        assertEquals(2, concurrent.get())
+
+        // Give the remaining three every chance to sneak past the cap
+        // while the first two are still held open.
+        repeat(50) { yield() }
+        assertEquals("a third caller got in while two were still running", 2, concurrent.get())
+        assertEquals(2, peak.get())
 
         release.complete(Unit)
         jobs.forEach { it.await() }
@@ -63,4 +75,21 @@ class BulkTransferGateTest {
 
         assertEquals(4, completed.get())
     }
+
+    @Test
+    fun `refuses a gate that could never let anything through`() {
+        assertThrows(IllegalArgumentException::class.java) { BulkTransferGate(maxConcurrent = 0) }
+        assertThrows(IllegalArgumentException::class.java) { BulkTransferGate(maxConcurrent = -1) }
+    }
+
+    private fun assertThrows(expected: Class<out Throwable>, block: () -> Unit) {
+        try {
+            block()
+        } catch (e: Throwable) {
+            if (expected.isInstance(e)) return
+            throw e
+        }
+        throw AssertionError("Expected ${expected.simpleName} but nothing was thrown")
+    }
 }
+

--- a/app/src/test/kotlin/com/chmouel/liseur/data/calibre/BulkTransferGateTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/calibre/BulkTransferGateTest.kt
@@ -3,6 +3,7 @@ package com.chmouel.liseur.data.calibre
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.yield
@@ -28,6 +29,7 @@ class BulkTransferGateTest {
         val gate = BulkTransferGate(maxConcurrent = 2)
         val concurrent = AtomicInteger(0)
         val peak = AtomicInteger(0)
+        val entered = Channel<Unit>(capacity = Channel.UNLIMITED)
         val release = CompletableDeferred<Unit>()
 
         // Five callers all ask for a slot at once; only two should ever
@@ -38,23 +40,30 @@ class BulkTransferGateTest {
                 gate.withSlot {
                     val now = concurrent.incrementAndGet()
                     peak.updateAndGet { prev -> maxOf(prev, now) }
+                    entered.trySend(Unit)
                     release.await()
                     concurrent.decrementAndGet()
                 }
             }
         }
 
-        // Wait for the actual condition -- two callers inside the gated
-        // section -- rather than a fixed number of yields, which proves
-        // nothing about how many coroutines the scheduler chose to run.
+        // Wait, through a real suspension rather than a busy loop, for
+        // exactly as many callers as the gate should ever admit. A busy
+        // `while (condition) yield()` spins the test's virtual clock in
+        // place: if the gate were ever broken and never let two through,
+        // that loop would never idle long enough for `withTimeout`'s
+        // virtual-time deadline to fire, hanging the test instead of
+        // failing it. Receiving from a channel suspends for real, so a
+        // broken gate times out here instead.
         withTimeout(5_000) {
-            while (concurrent.get() < 2) yield()
+            entered.receive()
+            entered.receive()
         }
         assertEquals(2, concurrent.get())
 
         // Give the remaining three every chance to sneak past the cap
         // while the first two are still held open.
-        repeat(50) { yield() }
+        yield()
         assertEquals("a third caller got in while two were still running", 2, concurrent.get())
         assertEquals(2, peak.get())
 
@@ -92,4 +101,5 @@ class BulkTransferGateTest {
         throw AssertionError("Expected ${expected.simpleName} but nothing was thrown")
     }
 }
+
 

--- a/app/src/test/kotlin/com/chmouel/liseur/data/calibre/BulkTransferGateTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/calibre/BulkTransferGateTest.kt
@@ -1,0 +1,66 @@
+package com.chmouel.liseur.data.calibre
+
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * How many bulk-download transfers a [BulkTransferGate] lets run at
+ * once.
+ *
+ * Reported against #89: a "download everything" run opened as many
+ * connections to a self-hosted calibre-web instance as WorkManager was
+ * willing to start workers, and a modest server answered a handful of
+ * large requests in parallel by dropping some of them ("broken pipe" in
+ * its own logs). The gate is the fix -- whatever WorkManager starts,
+ * only a small, fixed number of transfers are ever pulling bytes at the
+ * same time.
+ */
+class BulkTransferGateTest {
+
+    @Test
+    fun `never lets more than the limit run at once`() = runTest {
+        val gate = BulkTransferGate(maxConcurrent = 2)
+        val concurrent = AtomicInteger(0)
+        val peak = AtomicInteger(0)
+        val release = CompletableDeferred<Unit>()
+
+        // Five callers all ask for a slot at once; only two should be
+        // inside the block together, the rest waiting on the semaphore.
+        val jobs = (1..5).map {
+            async {
+                gate.withSlot {
+                    val now = concurrent.incrementAndGet()
+                    peak.updateAndGet { prev -> maxOf(prev, now) }
+                    release.await()
+                    concurrent.decrementAndGet()
+                }
+            }
+        }
+        // Let every job reach the semaphore before checking the peak.
+        repeat(5) { yield() }
+        assertTrue("no more than 2 should run at once, was ${peak.get()}", peak.get() <= 2)
+
+        release.complete(Unit)
+        jobs.forEach { it.await() }
+        assertEquals(0, concurrent.get())
+    }
+
+    @Test
+    fun `lets every caller through eventually`() = runTest {
+        val gate = BulkTransferGate(maxConcurrent = 1)
+        val completed = AtomicInteger(0)
+
+        val jobs = (1..4).map {
+            async { gate.withSlot { completed.incrementAndGet() } }
+        }
+        jobs.forEach { it.await() }
+
+        assertEquals(4, completed.get())
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteHttpTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteHttpTest.kt
@@ -1,0 +1,41 @@
+package com.chmouel.liseur.data.remote
+
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The download client's read timeout, against #89: 30 seconds -- fine
+ * for an API call -- was aborting book transfers the moment a modest
+ * self-hosted server paused for breath, which the server then logged as
+ * the client hanging up mid-write rather than as a timeout of its own.
+ * [RemoteHttp.forDownloads] gives transfers longer to stall before that
+ * happens, without touching the timeout every other call still uses.
+ */
+class RemoteHttpTest {
+
+    @Test
+    fun `download client tolerates a longer stall than the default one`() {
+        val default = RemoteHttp.default()
+        val downloads = RemoteHttp.forDownloads()
+
+        assertTrue(
+            "download read timeout (${downloads.readTimeoutMillis}) should exceed " +
+                "the default (${default.readTimeoutMillis})",
+            downloads.readTimeoutMillis > default.readTimeoutMillis,
+        )
+        assertEquals(
+            TimeUnit.SECONDS.toMillis(90).toInt(),
+            downloads.readTimeoutMillis,
+        )
+    }
+
+    @Test
+    fun `download client keeps the same connect timeout`() {
+        assertEquals(
+            RemoteHttp.default().connectTimeoutMillis,
+            RemoteHttp.forDownloads().connectTimeoutMillis,
+        )
+    }
+}


### PR DESCRIPTION
## What

Fixes the "download all" connection-drop issue reported in #89: fetching an entire library from a self-hosted calibre-web/Grimmroy instance dropped connections ("broken pipe" in server logs) and required multiple manual restarts to finish.

## Why it happened

Two causes, both about a bulk run overwhelming a modest self-hosted server, not about the resume logic (which was already sound — `.part` file + Range/If-Range resume, retry on network failure, per-book unique WorkManager names):

1. `RemoteHttp`'s shared OkHttp client used a 30-second read timeout, tuned for short API calls. Any pause between two chunks longer than that aborted the transfer client-side — which the server logs as the client hanging up mid-write.
2. `BookDownloadRepository.enqueueAll` enqueued one `BookDownloadWorker` per book with no cap on how many could run their network transfer at the same time. WorkManager happily starts several in parallel, each opening its own connection to the same server.

## What changed

- `RemoteHttp.forDownloads()`: a new client, derived from the default, with the read timeout raised to 90s. Only used for book downloads — every other API call keeps its existing 30s timeout.
- `BulkTransferGate`: a small, plain-Kotlin semaphore wrapper capping concurrent *transfers* during a bulk "download all" run at 2. A single download started by tapping a book cover is unaffected — it has no batch to share a server with.
- `BookDownloadWorker` now builds its downloader with the longer-timeout client and, when it belongs to a batch, acquires a transfer slot before starting the transfer.

## Testing

- Added `RemoteHttpTest` (timeout values) and `BulkTransferGateTest` (never exceeds the cap, no starvation/deadlock).
- `./gradlew testDebugUnitTest lintDebug assembleDebug` all pass.

Closes #89.