### PR TITLE
fix(reader): stop a layout fit settling over a page the reader chose

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/reader/IssuedMoves.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/IssuedMoves.kt
@@ -1,0 +1,262 @@
+package com.chmouel.liseur.reader
+
+import com.chmouel.liseur.reader.progress.RestorePoint
+import kotlin.math.abs
+
+/**
+ * The moves the reader has been sent on, and whether they have arrived.
+ *
+ * Readium says it has moved only once it has moved, and it lays a
+ * resource out and puts it on screen before it says even that. A `go`
+ * that has been issued and not yet landed is therefore invisible to
+ * every question that can be asked about the page: the navigator's
+ * position still names where the reader was, and the web view under the
+ * middle of the screen is still the one they were reading.
+ *
+ * That is the blind spot of anything which captures a place, does
+ * something slow to the document, and then puts the reader back — the
+ * wide-content fit and a run of preference changes both do. Between the
+ * capture and the restore the reader can tap a contents entry or turn a
+ * page, and neither the position nor the views on screen will admit it
+ * for another moment; the restore then carries them back to the page
+ * they just asked to leave, which is a book that changes page by
+ * itself.
+ *
+ * Two orderings do that, and counting moves alone answers only the
+ * first:
+ *
+ *  - the move is asked for *after* the restore took its bearings, which
+ *    a count catches, because the count has moved on; and
+ *  - the move is asked for *before*, and is still in the air when the
+ *    restore looks — which no count catches, since nothing has been
+ *    issued since. This is the one a table of contents pointing at
+ *    fragments of a single resource produces: the resource never
+ *    changes, so every guard written in terms of the resource on screen
+ *    agrees the reader is where they were.
+ *
+ * So a move is remembered along with where it was going and stays
+ * outstanding until the navigator reports being there. A restore takes
+ * a [mark] before it starts, which is [NONE] while anything is
+ * outstanding and is retired by anything asked for after it. Refusing
+ * is always the safe answer: a fit left unrestored moves the text by a
+ * line, a restore that should have been refused moves the reader out of
+ * the chapter they chose.
+ *
+ * What arrival can be recognised from depends on how much the caller
+ * knew:
+ *
+ *  - a move with a destination is answered by the navigator reporting
+ *    that destination, unless a fragment was asked for, which nothing
+ *    reports back and only the clock ends;
+ *  - one move with no destination, and nothing else in the air — a
+ *    single page turn — is answered by any position other than the one
+ *    it started from;
+ *  - anything overlapping is not answered at all. Readium publishes a
+ *    resource's own idea of where it is and then the real position, so
+ *    emissions and moves do not pair off, and guessing which arrival
+ *    belongs to which move would let one of them stand for both. They
+ *    are held together until the reader stops and the clock runs out.
+ *
+ * Nothing here is synchronised, and nothing here needs to be: moves are
+ * issued and positions read on the main thread, as `chrome/HeldPlace`
+ * is.
+ */
+class IssuedMoves(
+    private val settleTimeoutMs: Long = SETTLE_TIMEOUT_MS,
+    private val restlessMs: Long = RESTLESS_MS,
+) {
+
+    /**
+     * Where a move is going, in the terms that can be checked against
+     * what the navigator later reports.
+     *
+     * Not a Readium `Locator` on purpose: the decision below is worth
+     * testing without a navigator to ask.
+     */
+    data class Destination(
+        val href: String,
+        /** Whole-book, as `Locator.locations.totalProgression`. */
+        val progression: Double?,
+        /** The `#fragment` a link asked for, if it named one. */
+        val fragment: String?,
+    )
+
+    private var issued = 0
+
+    private var target: Destination? = null
+    private var targetDeadline = 0L
+    private var targetToken = NONE
+
+    private var restless = false
+    private var restlessFrom: RestorePoint? = null
+    private var attributable = false
+    private var restlessDeadline = 0L
+    private var restlessToken = NONE
+
+    /**
+     * The reader is being sent somewhere.
+     *
+     * [from] is where they are as it is asked for and [to] where they
+     * are being sent. A page turn knows no destination, and is held
+     * against [from] instead — until a second one joins it, at which
+     * point neither can be told from the other and both wait for the
+     * clock.
+     *
+     * Answers a token to hand back to [cancel] if the move turns out
+     * not to be happening.
+     */
+    fun issue(from: RestorePoint? = null, to: Destination? = null, nowMs: Long = 0L): Int {
+        issued++
+        if (to != null) {
+            // The newest destination is what the reader asked for last,
+            // and reaching it accounts for whatever was asked before.
+            target = to
+            targetDeadline = nowMs + settleTimeoutMs
+            // A turn waiting alongside it can no longer be recognised
+            // by a position that differs, because the arrival of this
+            // one differs too.
+            attributable = false
+            restlessFrom = null
+            targetToken = issued
+            return issued
+        }
+        attributable = !restless && target == null
+        restlessFrom = from.takeIf { attributable }
+        restless = true
+        restlessDeadline = nowMs + restlessMs
+        restlessToken = issued
+        return issued
+    }
+
+    /**
+     * The reader is moving a scrolled page with their finger.
+     *
+     * No `go` is issued for this and no arrival is reported, so it is
+     * held open for as long as the dragging goes on and let go of a
+     * moment after it stops. A fit settling over a page being dragged
+     * pulls it back under the finger.
+     */
+    fun scrolled(nowMs: Long = 0L) {
+        issued++
+        attributable = false
+        restlessFrom = null
+        restless = true
+        restlessDeadline = nowMs + restlessMs
+        restlessToken = issued
+    }
+
+    /**
+     * What was announced is not happening: a `go` the navigator
+     * declined, a probe that came back to find the page already gone.
+     * Said so that a turn which moved nothing does not keep every later
+     * restore waiting for an arrival that was never on its way.
+     *
+     * The [token] the announcement answered with is required, and ends
+     * only the wait that token opened. A page turn giving up must not
+     * take a jump's wait with it, and an answer that arrives late must
+     * not end a wait opened since — an asynchronous probe finding the
+     * page gone is exactly the case where both are true at once.
+     *
+     * The count is not wound back. A restore that took its bearings
+     * before the reader asked for anything at all stays refused,
+     * because the asking is what makes those bearings suspect, not the
+     * outcome.
+     */
+    fun cancel(token: Int) {
+        if (token == NONE) return
+        if (token == targetToken) {
+            target = null
+            targetToken = NONE
+            return
+        }
+        if (token == restlessToken) stopRestless()
+    }
+
+    /** A position the navigator reported. */
+    fun onPosition(here: RestorePoint, nowMs: Long = 0L) {
+        expire(nowMs)
+        target?.let {
+            if (it.arrived(here)) {
+                target = null
+                targetToken = NONE
+            }
+        }
+        if (restless && attributable && here != restlessFrom) stopRestless()
+    }
+
+    /**
+     * The state to hold a later restore against, or [NONE] while a move
+     * is still in the air — a restore that begins then has taken its
+     * bearings from a page the reader is already leaving.
+     */
+    fun mark(nowMs: Long = 0L): Int {
+        expire(nowMs)
+        return if (target == null && !restless) issued else NONE
+    }
+
+    /** Whether nothing has been asked for since [mark] answered [since]. */
+    fun unchangedSince(since: Int): Boolean = since != NONE && since == issued
+
+    private fun stopRestless() {
+        restless = false
+        attributable = false
+        restlessFrom = null
+        restlessToken = NONE
+    }
+
+    /**
+     * Stop waiting.
+     *
+     * A `go` to where the reader already is publishes nothing to say so,
+     * a fragment jump is never reported as arriving, and turns in a
+     * flurry cannot be told apart. Waiting forever would leave the book
+     * with no restores for the rest of the session, so both waits are
+     * bounded — the one for a destination widely enough to outlast a
+     * resource loading and being scrolled to a fragment on a slow
+     * phone, the one for a hand on the page only long enough to see
+     * that it has come off.
+     */
+    private fun expire(nowMs: Long) {
+        if (target != null && nowMs - targetDeadline >= 0) {
+            target = null
+            targetToken = NONE
+        }
+        if (restless && nowMs - restlessDeadline >= 0) stopRestless()
+    }
+
+    private fun Destination.arrived(here: RestorePoint): Boolean {
+        // A fragment is asked for and never reported back: Readium
+        // publishes the resource's own idea of where it is, which as it
+        // loads is the top of it. Taking that for the arrival is the
+        // reported bug exactly — the reader asks for a section and a
+        // restore puts them back at the start of the file it lives in.
+        if (fragment != null) return false
+        if (here.href != href) return false
+        val wanted = progression ?: return true
+        val reached = here.progression ?: return false
+        return abs(reached - wanted) <= TOLERANCE
+    }
+
+    companion object {
+        /**
+         * No mark: a restore that asked while a move was in the air.
+         * Also the token of nothing, since a move's token is the count
+         * it was announced at and counting starts at one.
+         */
+        const val NONE = -1
+
+        /**
+         * How close to where it was sent a move has to land to count as
+         * having landed. The same tolerance the opening gate uses, and
+         * for the same reason: this asks whether the navigator went
+         * roughly where it was told, not whether two devices agree.
+         */
+        const val TOLERANCE = 0.01
+
+        /** How long to wait for a move that named where it was going. */
+        const val SETTLE_TIMEOUT_MS = 3_000L
+
+        /** How long a page that was being moved by hand stays moving. */
+        const val RESTLESS_MS = 1_000L
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
@@ -3,6 +3,7 @@ package com.chmouel.liseur.reader
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.os.SystemClock
 import android.view.KeyEvent
 import android.widget.Toast
 import androidx.activity.compose.setContent
@@ -218,6 +219,13 @@ class ReaderActivity : FragmentActivity() {
                                 ) {
                                     viewModel.lastLocator ?: s.initialLocator
                                 }
+                                // Every move the reader is sent on, counted
+                                // where both the screen and the link listener
+                                // below can say so. A tapped link is a jump
+                                // like any other, and a layout change settling
+                                // over it takes the reader back off the page
+                                // they asked for. See IssuedMoves.
+                                val moves = remember { IssuedMoves() }
                                 remember(s.navigatorFactory, columnMode, scrollMode) {
                                     s.navigatorFactory.createFragmentFactory(
                                         initialLocator = restoreTarget,
@@ -235,7 +243,19 @@ class ReaderActivity : FragmentActivity() {
                                             onFootnote = viewModel::showFootnote,
                                             onFollow = { link ->
                                                 viewModel.onJump()
-                                                navigator?.go(link, animated = false)
+                                                navigator?.let { nav ->
+                                                    val token = moves.issue(
+                                                        from = nav.currentLocator.value
+                                                            .restorePoint(),
+                                                        to = s.publication
+                                                            .locatorFromLink(link)
+                                                            ?.destination(),
+                                                        nowMs = SystemClock.elapsedRealtime(),
+                                                    )
+                                                    if (!nav.go(link, animated = false)) {
+                                                        moves.cancel(token)
+                                                    }
+                                                }
                                             },
                                             onExternal = { pendingExternalLink = it },
                                         ),
@@ -272,6 +292,7 @@ class ReaderActivity : FragmentActivity() {
                                 ReaderScreen(
                                     publication = s.publication,
                                     restoreTarget = restoreTarget,
+                                    moves = moves,
                                     prefsFlow = viewModel.prefs,
                                     readingTheme = readingTheme,
                                     typographyIsOwnFlow = viewModel.typographyIsOwn,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -814,11 +814,14 @@ fun ReaderScreen(
                     // change in the run the very position this one
                     // refused.
                     val since = moves.mark(SystemClock.elapsedRealtime())
-                    if (since == IssuedMoves.NONE) reflowAnchor = null
-                    val anchor = reflowAnchor ?: capture(nav, nav.currentLocator.value)
-                    if (since != IssuedMoves.NONE) {
-                        reflowAnchor = anchor
-                        onLocatorChanged(anchor, NavigatorPositionEvent.PREFERENCE_REFLOW)
+                    val anchor = if (since == IssuedMoves.NONE) {
+                        reflowAnchor = null
+                        null
+                    } else {
+                        (reflowAnchor ?: capture(nav, nav.currentLocator.value)).also {
+                            reflowAnchor = it
+                            onLocatorChanged(it, NavigatorPositionEvent.PREFERENCE_REFLOW)
+                        }
                     }
                     val before = ExactLocatorAnchor.layoutSignature(nav)
                     nav.submitPreferences(it)
@@ -838,7 +841,7 @@ fun ReaderScreen(
                     // again. The preferences are still submitted — they
                     // are what the reader asked for — and only the
                     // reader's place is left where they put it.
-                    if (moves.unchangedSince(since)) {
+                    if (anchor != null && moves.unchangedSince(since)) {
                         navigate(
                             nav = nav,
                             locator = anchor,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -239,6 +239,13 @@ fun ReaderScreen(
      * built. Null for a book with no saved position.
      */
     restoreTarget: Locator?,
+    /**
+     * The moves the reader is sent on, counted as they are asked for.
+     * Owned above this screen because a link tapped in the book is
+     * followed by the activity's own navigator listener. See
+     * [IssuedMoves].
+     */
+    moves: IssuedMoves,
     prefsFlow: StateFlow<ReaderPrefs>,
     readingTheme: ReaderTheme,
     typographyIsOwnFlow: StateFlow<Boolean>,
@@ -504,7 +511,12 @@ fun ReaderScreen(
         // otherwise take that marker and be saved as the move.
         retargetGate(locator)
         pendingPositionEvent = event
-        nav.go(locator, animated = false)
+        val token = moves.issue(
+            from = nav.currentLocator.value.restorePoint(),
+            to = locator.destination(),
+            nowMs = SystemClock.elapsedRealtime(),
+        )
+        if (!nav.go(locator, animated = false)) moves.cancel(token)
         if (!verify || !ExactLocatorAnchor.isExact(locator)) return
         // The go above is carried out by a script the WebView runs when
         // it gets to it; asking too early answers for the page it is
@@ -517,7 +529,12 @@ fun ReaderScreen(
         val fallback = onProgressAction.locatorAtOrBeforeProgression(progression) ?: return
         retargetGate(fallback)
         pendingPositionEvent = event
-        nav.go(fallback, animated = false)
+        val fallbackToken = moves.issue(
+            from = nav.currentLocator.value.restorePoint(),
+            to = fallback.destination(),
+            nowMs = SystemClock.elapsedRealtime(),
+        )
+        if (!nav.go(fallback, animated = false)) moves.cancel(fallbackToken)
         onProgressAction.onApproximateResume()
     }
 
@@ -594,6 +611,14 @@ fun ReaderScreen(
                 showingEnd = false
                 onLeftEndpaper()
             },
+            onMoveIssued = { from, to ->
+                moves.issue(
+                    from = from?.restorePoint(),
+                    to = to?.destination(),
+                    nowMs = SystemClock.elapsedRealtime(),
+                )
+            },
+            onMoveDropped = moves::cancel,
         )
     }
 
@@ -671,6 +696,20 @@ fun ReaderScreen(
         }
     }
 
+    // Where the navigator says it is, told to the record of moves so a
+    // move can be seen to have landed.
+    //
+    // Its own subscription rather than a line in the collector above:
+    // that one drops its first emission and is torn down with every
+    // pause, and the emission a restore is waiting on is exactly the
+    // one it would drop.
+    LaunchedEffect(navigator) {
+        val nav = navigator ?: return@LaunchedEffect
+        nav.currentLocator.collect {
+            moves.onPosition(it.restorePoint(), SystemClock.elapsedRealtime())
+        }
+    }
+
     // Asking the maker's screen controller to repaint the page the way
     // it repaints text.
     //
@@ -721,7 +760,12 @@ fun ReaderScreen(
         // looking like a page turn. Telling the gate where the reader is
         // now being sent keeps it closed until they get there.
         retargetGate(fallback)
-        nav.go(fallback, animated = false)
+        val fallbackToken = moves.issue(
+            from = nav.currentLocator.value.restorePoint(),
+            to = fallback.destination(),
+            nowMs = SystemClock.elapsedRealtime(),
+        )
+        if (!nav.go(fallback, animated = false)) moves.cancel(fallbackToken)
         onProgressAction.onApproximateResume()
     }
 
@@ -757,9 +801,25 @@ fun ReaderScreen(
             .distinctUntilChanged()
             .collect {
                 reflow.within {
+                    // Taken before the anchor rather than with the
+                    // restore. The capture below reads the document,
+                    // and a move still in the air has not reached it
+                    // either, so an anchor taken then names a page the
+                    // reader is already leaving — restoring it later is
+                    // only the second half of the same mistake.
+                    //
+                    // A held anchor is dropped along with it. It was
+                    // measured against a page a move has since been
+                    // asked for, and keeping it would hand the next
+                    // change in the run the very position this one
+                    // refused.
+                    val since = moves.mark(SystemClock.elapsedRealtime())
+                    if (since == IssuedMoves.NONE) reflowAnchor = null
                     val anchor = reflowAnchor ?: capture(nav, nav.currentLocator.value)
-                    reflowAnchor = anchor
-                    onLocatorChanged(anchor, NavigatorPositionEvent.PREFERENCE_REFLOW)
+                    if (since != IssuedMoves.NONE) {
+                        reflowAnchor = anchor
+                        onLocatorChanged(anchor, NavigatorPositionEvent.PREFERENCE_REFLOW)
+                    }
                     val before = ExactLocatorAnchor.layoutSignature(nav)
                     nav.submitPreferences(it)
                     awaitReflowSettled(nav, before)
@@ -772,12 +832,20 @@ fun ReaderScreen(
                     ) {
                         awaitReflowSettled(nav, before)
                     }
-                    navigate(
-                        nav = nav,
-                        locator = anchor,
-                        event = NavigatorPositionEvent.PREFERENCE_REFLOW,
-                        verify = true,
-                    )
+                    // A reader who tapped a contents entry while the
+                    // text was still moving has chosen a page; putting
+                    // the settings back over it would take it away
+                    // again. The preferences are still submitted — they
+                    // are what the reader asked for — and only the
+                    // reader's place is left where they put it.
+                    if (moves.unchangedSince(since)) {
+                        navigate(
+                            nav = nav,
+                            locator = anchor,
+                            event = NavigatorPositionEvent.PREFERENCE_REFLOW,
+                            verify = true,
+                        )
+                    }
                 }
             }
     }
@@ -827,17 +895,33 @@ fun ReaderScreen(
                     ResourceAddress.shows(web.url, it.href.toString())
                 }
             }
+            // Taken here rather than at the top of the run, because
+            // the wait above is itself the arrival of whatever move
+            // brought this resource in: marking before it would refuse
+            // the restore after every chapter turn, which is most of
+            // the times a resource is laid out at all.
+            //
+            // It is still [IssuedMoves.NONE] when the reader is being
+            // sent somewhere within this resource — a contents entry
+            // pointing at a fragment of it — because the position the
+            // wait settled for is the one published as the resource
+            // loaded, not the one they asked for.
+            val since = moves.mark(SystemClock.elapsedRealtime())
             // Whether the resource this run is for is still the one on
-            // screen and the one the navigator names. Waiting above and
-            // taking the scope below are both places the reader can
+            // screen, the one the navigator names, and the one the
+            // reader has not since been sent away from. Waiting above
+            // and taking the scope below are both places the reader can
             // turn a page, and everything after them speaks to the
             // document in front of them: a capture takes its words from
             // it, a restore puts the reader back into it. Asked again
             // rather than assumed, at each point where the answer could
-            // have changed.
+            // have changed — and asked of the moves issued as well,
+            // because a jump the reader has just made shows in neither
+            // the position nor the views for a moment yet.
             fun stillFitting(): Boolean =
                 web === visibleWebView(root) &&
-                    ResourceAddress.shows(web.url, nav.currentLocator.value.href.toString())
+                    ResourceAddress.shows(web.url, nav.currentLocator.value.href.toString()) &&
+                    moves.unchangedSince(since)
             reflow.within {
                 val anchor = here?.takeIf { stillFitting() }?.let { capture(nav, it) }
                 val before = ExactLocatorAnchor.layoutSignature(nav)
@@ -1207,6 +1291,13 @@ fun ReaderScreen(
                 // read, so that whatever it has reached while the loop
                 // ran is the baseline the moment it stops.
                 if (moved && !autoScrollRunning) {
+                    // A finger on a scrolled page moves the reader
+                    // without a `go` for anything to count, so the one
+                    // place that notices says so. Held open for as long
+                    // as the dragging lasts and let go of a moment
+                    // after it stops: a layout fit settling over a page
+                    // being dragged pulls it back under the finger.
+                    moves.scrolled(SystemClock.elapsedRealtime())
                     // A place that cannot be had leaves the last one
                     // standing: it is behind the reader by a tick, where
                     // the alternative is nothing at all.
@@ -1661,7 +1752,14 @@ fun ReaderScreen(
                 onGoToNote = {
                     onDismissFootnote()
                     onProgressAction.onJump()
-                    navigator?.go(note.link, animated = false)
+                    navigator?.let { nav ->
+                        val noteToken = moves.issue(
+                            from = nav.currentLocator.value.restorePoint(),
+                            to = publication.locatorFromLink(note.link)?.destination(),
+                            nowMs = SystemClock.elapsedRealtime(),
+                        )
+                        if (!nav.go(note.link, animated = false)) moves.cancel(noteToken)
+                    }
                 },
                 onDismiss = onDismissFootnote,
             )
@@ -2233,7 +2331,19 @@ private fun consumeInsetsForReadium(view: View) {
  * Nothing here is Readium-shaped on purpose: the decision the gate makes
  * is worth testing on its own, without a navigator to ask.
  */
-private fun Locator.restorePoint(exact: Boolean = false) = RestorePoint(
+/**
+ * Where a move is going, in the terms [IssuedMoves] can check against
+ * what the navigator later reports. The fragment is carried because a
+ * contents entry pointing inside a resource is the one destination
+ * nothing else tells apart from the resource merely having loaded.
+ */
+internal fun Locator.destination() = IssuedMoves.Destination(
+    href = href.toString(),
+    progression = locations.totalProgression,
+    fragment = locations.fragments.firstOrNull(),
+)
+
+internal fun Locator.restorePoint(exact: Boolean = false) = RestorePoint(
     href = href.toString(),
     progression = locations.totalProgression,
     exact = exact,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnEffect.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnEffect.kt
@@ -330,7 +330,14 @@ class PageTurner(
         )
         web.evaluateJavascript(script) { result ->
             if (generation != probeGeneration || navigator !== nav) return@evaluateJavascript
-            if (result?.contains(AT_END) == true) stepChapter(forward)
+            if (result?.contains(AT_END) != true) return@evaluateJavascript
+            // The page was already against its edge, so the screenful
+            // this turn announced never moved. Dropped before stepping,
+            // because the step announces the move that does happen and
+            // leaving both open holds every restore for the wait of the
+            // one that did not.
+            onMoveDropped(token)
+            stepChapter(forward)
         }
     }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnEffect.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnEffect.kt
@@ -105,6 +105,24 @@ class PageTurner(
     private val showingEnd: () -> Boolean = { false },
     private val onReachedEnd: () -> Unit = {},
     private val onLeaveEnd: () -> Unit = {},
+    /**
+     * Said as a turn is asked for, before the page has moved and long
+     * before Readium says it has, carrying the position being left so
+     * the arrival can be told from Readium republishing it. What is
+     * listening is the screen's record of the moves the reader has been
+     * sent on, which is what stops a layout change settling over the
+     * page they turned to.
+     */
+    private val onMoveIssued: (from: Locator?, to: Locator?) -> Int = { _, _ -> 0 },
+    /**
+     * Said when a turn that was announced turns out to move nothing —
+     * the navigator declining a `go`, the last page turning out to be
+     * the last. Without it the screen would go on waiting for an
+     * arrival that was never on its way, and refuse restores until it
+     * gave up. Given the token the announcement answered with, so that
+     * a probe coming back late cannot end a wait opened since.
+     */
+    private val onMoveDropped: (token: Int) -> Unit = {},
 ) {
     var navigator: OverflowableNavigator? = null
     var window: Window? = null
@@ -132,24 +150,33 @@ class PageTurner(
         }
         val generation = ++probeGeneration
         val nav = navigator ?: return
+        val token = onMoveIssued(nav.currentLocator.value, null)
         if (isScrolling()) {
-            scrollScreenful(nav, forward, generation)
+            scrollScreenful(nav, forward, generation, token)
             return
         }
         if (forward && isOnLastResource(nav)) {
             val probed = nav.currentLocator.value
             askIfLastContentVisible(nav) { atEnd ->
-                if (!probeStillHolds(generation, nav, probed)) return@askIfLastContentVisible
-                if (atEnd) revealEnd() else turnPaginated(nav, forward = true)
+                if (!probeStillHolds(generation, nav, probed)) {
+                    onMoveDropped(token)
+                    return@askIfLastContentVisible
+                }
+                if (atEnd) {
+                    onMoveDropped(token)
+                    revealEnd()
+                } else {
+                    turnPaginated(nav, forward = true, token = token)
+                }
             }
             return
         }
-        turnPaginated(nav, forward)
+        turnPaginated(nav, forward, token)
     }
 
-    private fun turnPaginated(nav: OverflowableNavigator, forward: Boolean) {
+    private fun turnPaginated(nav: OverflowableNavigator, forward: Boolean, token: Int) {
         if (!isAnimated()) {
-            navigate(nav, forward, animated = false)
+            navigate(nav, forward, animated = false, token = token)
             return
         }
         val win = window
@@ -159,11 +186,11 @@ class PageTurner(
         ) {
             // Rapid taps while a turn is animating jump instantly to
             // keep up with the reader's pace.
-            navigate(nav, forward, animated = !effect.isRunning)
+            navigate(nav, forward, animated = !effect.isRunning, token = token)
             return
         }
         copyPage(win, view) { bitmap ->
-            val moved = navigate(nav, forward, animated = false)
+            val moved = navigate(nav, forward, animated = false, token = token)
             val rtl = nav.overflow.value.readingProgression == ReadingProgression.RTL
             if (moved && bitmap != null) {
                 effect.start(bitmap, slideLeft = forward != rtl)
@@ -223,8 +250,10 @@ class PageTurner(
         nav: OverflowableNavigator,
         forward: Boolean,
         animated: Boolean,
+        token: Int,
     ): Boolean {
         val moved = if (forward) nav.goForward(animated) else nav.goBackward(animated)
+        if (!moved) onMoveDropped(token)
         // The last resource can still refuse to move even when the page
         // itself was not sure it was finished; that refusal is the end.
         if (forward && !moved && isOnLastResource(nav)) revealEnd()
@@ -288,9 +317,10 @@ class PageTurner(
         nav: OverflowableNavigator,
         forward: Boolean,
         generation: Long,
+        token: Int,
     ) {
         val web = visibleWebView(nav.publicationView) ?: run {
-            navigate(nav, forward, animated = false)
+            navigate(nav, forward, animated = false, token = token)
             return
         }
         val script = scrollScreenfulScript(
@@ -323,17 +353,23 @@ class PageTurner(
         val nav = navigator ?: return false
         val pub = publication ?: return false
         val readingOrder = pub.readingOrder
-        val index = readingOrder.indexOfFirstWithHref(nav.currentLocator.value.href)
-            ?: return false
+        val here = nav.currentLocator.value
+        val index = readingOrder.indexOfFirstWithHref(here.href) ?: return false
         val next = readingOrder.getOrNull(index + if (forward) 1 else -1) ?: run {
             if (forward) revealEnd()
             return false
         }
-        val locator = pub.locatorFromLink(next) ?: return nav.go(next, animated = false)
-        return nav.go(
-            if (forward) locator else locator.copyWithLocations(progression = 1.0),
-            animated = false,
-        )
+        // Announced where the chapter is known and not before: the
+        // returns above move nobody, and a step announced for one of
+        // them would have the screen waiting on an arrival that is not
+        // coming.
+        val locator = pub.locatorFromLink(next) ?: run {
+            val stepToken = onMoveIssued(here, null)
+            return nav.go(next, animated = false).also { if (!it) onMoveDropped(stepToken) }
+        }
+        val target = if (forward) locator else locator.copyWithLocations(progression = 1.0)
+        val stepToken = onMoveIssued(here, target)
+        return nav.go(target, animated = false).also { if (!it) onMoveDropped(stepToken) }
     }
 }
 

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/IssuedMovesTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/IssuedMovesTest.kt
@@ -258,8 +258,12 @@ class IssuedMovesTest {
         val moves = IssuedMoves(settleTimeoutMs = 3_000L)
         moves.issue(from = cover, to = section, nowMs = 0L)
         val since = moves.mark(nowMs = 0L)
+        // The deadline lets go of the move, so a restore beginning
+        // after it has bearings again. The one that began without them
+        // does not acquire them.
+        val afterwards = moves.mark(nowMs = 3_000L)
         assertFalse(moves.unchangedSince(since))
-        assertFalse(moves.unchangedSince(since))
+        assertTrue(moves.unchangedSince(afterwards))
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/IssuedMovesTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/IssuedMovesTest.kt
@@ -1,0 +1,292 @@
+package com.chmouel.liseur.reader
+
+import com.chmouel.liseur.reader.progress.RestorePoint
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IssuedMovesTest {
+
+    private fun at(href: String, progression: Double?) =
+        RestorePoint(href = href, progression = progression, exact = false)
+
+    private fun to(href: String, progression: Double? = null, fragment: String? = null) =
+        IssuedMoves.Destination(href = href, progression = progression, fragment = fragment)
+
+    private val cover = at("EPUB/cover.xhtml", 0.0)
+    private val bodyTop = at("EPUB/body.xhtml", 0.05)
+    private val bodySection = at("EPUB/body.xhtml", 0.60)
+    private val section = to("EPUB/body.xhtml", progression = 0.60)
+
+    @Test
+    fun `a mark holds while nothing is asked for`() {
+        val moves = IssuedMoves()
+        val since = moves.mark()
+        assertTrue(moves.unchangedSince(since))
+    }
+
+    @Test
+    fun `a move asked for after a mark retires it`() {
+        val moves = IssuedMoves()
+        val fit = moves.mark()
+        val reflow = moves.mark()
+        moves.issue(from = cover, to = section)
+        assertFalse(moves.unchangedSince(fit))
+        assertFalse(moves.unchangedSince(reflow))
+    }
+
+    @Test
+    fun `a mark stays retired however many moves follow`() {
+        val moves = IssuedMoves()
+        val since = moves.mark()
+        repeat(3) { moves.issue(from = cover) }
+        assertFalse(moves.unchangedSince(since))
+    }
+
+    @Test
+    fun `a move still in the air refuses a mark outright`() {
+        val moves = IssuedMoves()
+        moves.issue(from = cover, to = section)
+        assertEquals(IssuedMoves.NONE, moves.mark())
+        assertFalse(moves.unchangedSince(IssuedMoves.NONE))
+    }
+
+    @Test
+    fun `a move that landed lets a mark be taken`() {
+        val moves = IssuedMoves()
+        moves.issue(from = cover, to = section)
+        moves.onPosition(bodySection)
+        assertTrue(moves.unchangedSince(moves.mark()))
+    }
+
+    @Test
+    fun `the position published as a resource loads is not the arrival`() {
+        val moves = IssuedMoves()
+        moves.issue(from = cover, to = section)
+        moves.onPosition(bodyTop)
+        assertEquals(IssuedMoves.NONE, moves.mark())
+        moves.onPosition(bodySection)
+        assertTrue(moves.unchangedSince(moves.mark()))
+    }
+
+    @Test
+    fun `a fragment jump is not answered by its resource appearing`() {
+        // The reported shape. `Publication.locatorFromLink` answers a
+        // contents entry like `body.xhtml#sec-18` with the fragment and
+        // no whole-book progression at all, so nothing the navigator
+        // publishes says the jump landed — and the first thing it
+        // publishes is the top of the file the section lives in. Only
+        // the clock ends this wait.
+        val moves = IssuedMoves(settleTimeoutMs = 3_000L)
+        moves.issue(from = cover, to = to("EPUB/body.xhtml", fragment = "sec-18"), nowMs = 0L)
+        moves.onPosition(bodyTop, nowMs = 10L)
+        assertEquals(IssuedMoves.NONE, moves.mark(nowMs = 20L))
+        moves.onPosition(bodySection, nowMs = 30L)
+        assertEquals(IssuedMoves.NONE, moves.mark(nowMs = 40L))
+        assertTrue(moves.unchangedSince(moves.mark(nowMs = 3_000L)))
+    }
+
+    @Test
+    fun `landing near enough counts as landing`() {
+        val moves = IssuedMoves()
+        moves.issue(from = cover, to = section)
+        moves.onPosition(at("EPUB/body.xhtml", 0.60 + IssuedMoves.TOLERANCE / 2))
+        assertTrue(moves.unchangedSince(moves.mark()))
+    }
+
+    @Test
+    fun `a chapter destination with no progression lands on its resource`() {
+        val moves = IssuedMoves()
+        moves.issue(from = cover, to = to("EPUB/body.xhtml"))
+        moves.onPosition(cover)
+        assertEquals(IssuedMoves.NONE, moves.mark())
+        moves.onPosition(bodyTop)
+        assertTrue(moves.unchangedSince(moves.mark()))
+    }
+
+    @Test
+    fun `one turn lands on the first position that differs`() {
+        val moves = IssuedMoves()
+        moves.issue(from = cover)
+        moves.onPosition(cover)
+        assertEquals(IssuedMoves.NONE, moves.mark())
+        moves.onPosition(bodyTop)
+        assertTrue(moves.unchangedSince(moves.mark()))
+    }
+
+    @Test
+    fun `turns in a flurry are not told apart by their arrivals`() {
+        // Readium publishes a resource's own idea of where it is and
+        // then the real position, so emissions and turns do not pair
+        // off. Two taps in the air at once wait for the clock rather
+        // than let one arrival — or two — stand for both.
+        val moves = IssuedMoves(restlessMs = 1_000L)
+        moves.issue(from = cover, nowMs = 0L)
+        moves.issue(from = cover, nowMs = 10L)
+        moves.onPosition(bodyTop, nowMs = 20L)
+        moves.onPosition(bodySection, nowMs = 30L)
+        assertEquals(IssuedMoves.NONE, moves.mark(nowMs = 40L))
+        assertTrue(moves.unchangedSince(moves.mark(nowMs = 1_010L)))
+    }
+
+    @Test
+    fun `a second position for one turn does not open the door early`() {
+        // The same emissions, but for a single turn: the first one that
+        // differs is its arrival, and the second changes nothing.
+        val moves = IssuedMoves()
+        moves.issue(from = cover)
+        moves.onPosition(bodyTop)
+        val since = moves.mark()
+        moves.onPosition(bodySection)
+        assertTrue(moves.unchangedSince(since))
+    }
+
+    @Test
+    fun `a turn that moved nothing is not waited for`() {
+        val moves = IssuedMoves()
+        val token = moves.issue(from = cover)
+        assertEquals(IssuedMoves.NONE, moves.mark())
+        moves.cancel(token)
+        assertTrue(moves.unchangedSince(moves.mark()))
+    }
+
+    @Test
+    fun `a cancelled move still retires a mark taken before it`() {
+        val moves = IssuedMoves()
+        val since = moves.mark()
+        val token = moves.issue(from = cover)
+        moves.cancel(token)
+        assertFalse(moves.unchangedSince(since))
+    }
+
+    @Test
+    fun `a cancelled chapter step leaves a turn still outstanding`() {
+        // `turn()` in a scrolled book announces, then hands over to
+        // `stepChapter()` at the edge; the step declining is not the
+        // turn having landed.
+        val moves = IssuedMoves(restlessMs = 1_000L)
+        moves.issue(from = cover, nowMs = 0L)
+        val step = moves.issue(from = cover, to = to("EPUB/body.xhtml"), nowMs = 10L)
+        moves.cancel(step)
+        assertEquals(IssuedMoves.NONE, moves.mark(nowMs = 20L))
+        assertTrue(moves.unchangedSince(moves.mark(nowMs = 1_010L)))
+    }
+
+    @Test
+    fun `a cancelled turn leaves a jump still outstanding`() {
+        // The mirror of the case above, and the one that costs a reader
+        // their page: a jump is in the air, a turn is announced behind
+        // it, and the turn's last-page probe comes back to find the
+        // page gone. Giving up on the turn must not be read as the jump
+        // having landed.
+        val moves = IssuedMoves(settleTimeoutMs = 3_000L, restlessMs = 1_000L)
+        val jump = moves.issue(
+            from = cover,
+            to = to("EPUB/body.xhtml", fragment = "sec18"),
+            nowMs = 0L,
+        )
+        val turn = moves.issue(from = cover, nowMs = 10L)
+        moves.cancel(turn)
+        assertEquals(IssuedMoves.NONE, moves.mark(nowMs = 1_020L))
+        // Only the jump's own deadline lets go of it.
+        assertTrue(moves.unchangedSince(moves.mark(nowMs = 3_000L)))
+        assertNotEquals(IssuedMoves.NONE, jump)
+    }
+
+    @Test
+    fun `an answer arriving late cannot end a wait opened since`() {
+        // A probe abandoned by one turn reports back after the reader
+        // has already asked for another.
+        val moves = IssuedMoves(restlessMs = 1_000L)
+        val stale = moves.issue(from = cover, nowMs = 0L)
+        moves.issue(from = cover, nowMs = 900L)
+        moves.cancel(stale)
+        assertEquals(IssuedMoves.NONE, moves.mark(nowMs = 950L))
+    }
+
+    @Test
+    fun `a jump arriving does not leave its token able to end another`() {
+        val moves = IssuedMoves(restlessMs = 1_000L)
+        val jump = moves.issue(from = cover, to = to("EPUB/body.xhtml", 0.5), nowMs = 0L)
+        moves.onPosition(at("EPUB/body.xhtml", 0.5), nowMs = 10L)
+        moves.issue(from = at("EPUB/body.xhtml", 0.5), nowMs = 20L)
+        moves.cancel(jump)
+        assertEquals(IssuedMoves.NONE, moves.mark(nowMs = 30L))
+    }
+
+    @Test
+    fun `a hand on the page holds for as long as it keeps moving`() {
+        val moves = IssuedMoves(restlessMs = 1_000L)
+        moves.scrolled(nowMs = 0L)
+        moves.scrolled(nowMs = 800L)
+        moves.scrolled(nowMs = 1_600L)
+        assertEquals(IssuedMoves.NONE, moves.mark(nowMs = 2_000L))
+        assertTrue(moves.unchangedSince(moves.mark(nowMs = 2_600L)))
+    }
+
+    @Test
+    fun `a hand on the page is not let go of by a position`() {
+        val moves = IssuedMoves(restlessMs = 1_000L)
+        moves.scrolled(nowMs = 0L)
+        moves.onPosition(bodySection, nowMs = 10L)
+        assertEquals(IssuedMoves.NONE, moves.mark(nowMs = 20L))
+    }
+
+    @Test
+    fun `a move that never lands is given up on rather than held forever`() {
+        val moves = IssuedMoves(settleTimeoutMs = 3_000L)
+        moves.issue(from = cover, to = section, nowMs = 1_000L)
+        assertEquals(IssuedMoves.NONE, moves.mark(nowMs = 3_999L))
+        assertTrue(moves.unchangedSince(moves.mark(nowMs = 4_000L)))
+    }
+
+    @Test
+    fun `a mark taken while a move was in the air is refused even once it lands`() {
+        // A restore that began with no bearings does not acquire them by
+        // waiting: the anchor it took names the page the reader left.
+        val moves = IssuedMoves()
+        moves.issue(from = cover, to = section)
+        val since = moves.mark()
+        moves.onPosition(bodySection)
+        assertFalse(moves.unchangedSince(since))
+    }
+
+    @Test
+    fun `a mark taken while a move was in the air is refused even once it expires`() {
+        val moves = IssuedMoves(settleTimeoutMs = 3_000L)
+        moves.issue(from = cover, to = section, nowMs = 0L)
+        val since = moves.mark(nowMs = 0L)
+        assertFalse(moves.unchangedSince(since))
+        assertFalse(moves.unchangedSince(since))
+    }
+
+    @Test
+    fun `a second move in a run is outstanding again`() {
+        val moves = IssuedMoves()
+        moves.issue(from = cover, to = to("EPUB/body.xhtml", progression = 0.05))
+        moves.onPosition(bodyTop)
+        assertTrue(moves.unchangedSince(moves.mark()))
+        moves.issue(from = bodyTop, to = section)
+        assertEquals(IssuedMoves.NONE, moves.mark())
+    }
+
+    @Test
+    fun `a turn while a jump is in the air waits for both`() {
+        val moves = IssuedMoves(settleTimeoutMs = 3_000L, restlessMs = 1_000L)
+        moves.issue(from = cover, to = section, nowMs = 0L)
+        moves.issue(from = cover, nowMs = 10L)
+        moves.onPosition(bodySection, nowMs = 20L)
+        assertEquals(IssuedMoves.NONE, moves.mark(nowMs = 30L))
+        assertTrue(moves.unchangedSince(moves.mark(nowMs = 1_010L)))
+    }
+
+    @Test
+    fun `a position reported with no move outstanding changes nothing`() {
+        val moves = IssuedMoves()
+        val since = moves.mark()
+        moves.onPosition(bodySection)
+        assertTrue(moves.unchangedSince(since))
+    }
+}


### PR DESCRIPTION
## Summary

A tap on a contents entry could land on the section and then, a moment later, put the reader back where they had been. Reported in #106 against 0.11.0, with a recording: the book opens on the cover, the reader picks "SECTION EIGHTEEN: ESTATE PLANNING", the section renders, and the screen returns to the cover.

Two flows in `ReaderScreen` capture a place, do something slow to the document and put the reader back — the wide-content fit and a run of preference changes. Both ask the navigator where the reader is, and Readium answers only once a move has landed; it lays a resource out and puts it on screen before it says even that. A `go` that has been issued and not yet landed is therefore invisible to the navigator's position *and* to the web views on screen, so a restore beginning in that window takes its bearings from the page the reader is leaving and carries them back to it.

#86 guarded both flows by the resource on screen, which covers a jump into another file and shipped in 0.12.0. It cannot cover a book whose table of contents points at fragments of one large resource: the resource never changes, so every guard written in terms of it agrees the reader has not moved. That is the shape of the book in the report.

Closes #106

## Changes

- New `reader/IssuedMoves.kt`. Moves are recorded as they are *asked for* and stay outstanding until the navigator reports arriving. A restore takes a `mark()` before it starts, which is `NONE` while anything is in the air and is retired by anything asked for since.
  - A move with a destination is answered by reaching it; a lone page turn by any position other than the one it left; anything overlapping only by the clock, because Readium publishes a resource's own idea of where it is before the real one, so emissions and moves do not pair off.
  - A **fragment** is never reported as arriving and only its deadline ends it. `Publication.locatorFromLink` gives fragment locators no `totalProgression`, and the position published as the file loads is the top of it — taking that for the arrival is the reported bug exactly.
- Every path that moves the reader announces: the `navigate` helpers, the opening-restoration fallback, footnote and internal-link taps, and `PageTurner`'s turns and chapter steps, which also say when a move they announced was declined.
- An announcement answers with a token and a cancellation ends only the wait that token opened, so a turn giving up — an asynchronous last-page probe coming back to find the page gone — cannot release a jump still in flight.
- Manual scrolling holds the same wait through `scrolled()`, since dragging reports no arrival and a fit settling mid-drag pulls the page back under the finger.
- `IssuedMovesTest`: 26 cases, pure JVM.

### Deliberate behaviour changes

- A preference change made while a jump is in the air leaves that reflow unrestored. Refusing is the cheap side: a fit left unrestored moves the text by a line, a restore that should have been refused moves the reader out of the chapter they chose.
- Auto-scroll is excluded from `scrolled()` — issuing on every tick of a loop that never stops would keep a move outstanding for the whole session. Its resource changes go through `stepChapter()`, which does announce.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on an emulator

Reproduced on `liseur_phone_api36` with a synthetic EPUB built the way the reported book appears to be: one large resource with fragment-anchored sections. With a temporary sleep widening the window, jumping from section 8 to section 12 logged

```
go event=LOCAL_JUMP to=Destination(href=EPUB/body.xhtml, progression=null, fragment=sec-12) token=1
fit: clauses view=true res=true unmoved=false since=0
fit: restore? anchor=false fitting=false
```

Both pre-existing guards said the restore was still fine (`view=true res=true`); only the new one refused it. On `main` that restore fires and the reader is thrown back. The screenshot is two minutes after the jump.

## Screenshots or recordings

![stayed-on-section-12.png](https://github.com/user-attachments/assets/0cce2f47-cb18-4225-bfca-61b56fac2f59)

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
