### PR TITLE
feat(reader): import your own TTF and OTF fonts

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -26,6 +26,7 @@ import com.chmouel.liseur.data.library.ReadingSessionManager
 import com.chmouel.liseur.data.settings.AppSettingsRepository
 import com.chmouel.liseur.data.settings.ReaderPreferencesRepository
 import com.chmouel.liseur.data.settings.ReadingPaceRepository
+import com.chmouel.liseur.data.settings.UserFontRepository
 import com.chmouel.liseur.data.remote.DeviceIdentityRepository
 import com.chmouel.liseur.data.remote.BookUploadRepository
 import com.chmouel.liseur.data.remote.UploadPrompts
@@ -139,6 +140,8 @@ class AppContainer(context: Context) {
     )
 
     val readerPreferences = ReaderPreferencesRepository(context.applicationContext)
+
+    val userFonts = UserFontRepository(context.applicationContext, applicationScope)
 
     /** What the app has learned about how fast this reader reads. */
     val readingPace = ReadingPaceRepository(context.applicationContext)

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/BookTypography.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/BookTypography.kt
@@ -6,7 +6,7 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import androidx.room.Query
 import androidx.room.Upsert
-import com.chmouel.liseur.data.settings.ReaderFont
+import com.chmouel.liseur.data.settings.ReadingFont
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import kotlinx.coroutines.flow.Flow
 
@@ -33,7 +33,15 @@ data class BookTypography(
     @ColumnInfo(name = "page_margins") val pageMargins: Double?,
 ) {
     companion object {
-        /** Sets a book apart starting from how it reads right now. */
+        /**
+         * Sets a book apart starting from how it reads right now.
+         *
+         * Records the *raw* font id, which for an imported font may name
+         * one whose file is currently missing. Writing the fallback here
+         * instead would quietly destroy the choice: set a book apart while
+         * its font happens to be gone, and re-importing the file would no
+         * longer bring it back.
+         */
         fun from(bookUrl: String, prefs: ReaderPrefs) = BookTypography(
             bookUrl = bookUrl,
             font = prefs.font.id,
@@ -53,7 +61,7 @@ fun ReaderPrefs.withTypographyOf(own: BookTypography?): ReaderPrefs =
         this
     } else {
         copy(
-            font = ReaderFont.fromId(own.font),
+            font = ReadingFont.fromId(own.font),
             fontSize = own.fontSize,
             lineHeight = own.lineHeight,
             pageMargins = own.pageMargins,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPreferencesRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPreferencesRepository.kt
@@ -34,7 +34,7 @@ class ReaderPreferencesRepository(private val context: Context) {
 
     val prefs: Flow<ReaderPrefs> = context.readerPrefsStore.data.map { p ->
         ReaderPrefs(
-            font = ReaderFont.fromId(p[Keys.FONT]),
+            font = ReadingFont.fromId(p[Keys.FONT]),
             fontSize = p[Keys.FONT_SIZE] ?: 1.0,
             themeChoice = ReaderThemeChoice.fromId(p[Keys.THEME]),
             lineHeight = p[Keys.LINE_HEIGHT],
@@ -49,7 +49,7 @@ class ReaderPreferencesRepository(private val context: Context) {
         )
     }
 
-    suspend fun setFont(font: ReaderFont) {
+    suspend fun setFont(font: ReadingFont) {
         context.readerPrefsStore.edit { it[Keys.FONT] = font.id }
     }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPrefs.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPrefs.kt
@@ -1,6 +1,7 @@
 package com.chmouel.liseur.data.settings
 
 import androidx.compose.ui.graphics.Color
+import com.chmouel.liseur.data.settings.fonts.UserFont
 import kotlin.math.roundToInt
 
 /**
@@ -20,6 +21,79 @@ enum class ReaderFont(val id: String, val displayName: String, val cssName: Stri
         val Default = LITERATA
 
         fun fromId(id: String?): ReaderFont = entries.firstOrNull { it.id == id } ?: Default
+    }
+}
+
+/**
+ * The font a book is read in: one Liseur ships, or one the reader brought.
+ *
+ * [ReaderFont] stays the closed list of bundled families it always was.
+ * This is the wider question the rest of the app now asks, and the two
+ * are deliberately separate — an imported font has no `displayName` worth
+ * hard-coding and no asset path, and folding it into the enum would mean
+ * every `when` over the bundled four grew a branch that cannot be
+ * exhaustive.
+ *
+ * [cssName] is derivable from the id alone, without consulting the
+ * registry of imported fonts, so mapping a preference to Readium's
+ * [org.readium.r2.navigator.preferences.FontFamily] needs no lookup and
+ * cannot fail.
+ */
+sealed interface ReadingFont {
+    val id: String
+
+    /** The declared family, or null for the publisher's own font. */
+    val cssName: String?
+
+    data class Bundled(val font: ReaderFont) : ReadingFont {
+        override val id: String get() = font.id
+        override val cssName: String? get() = font.cssName
+    }
+
+    /**
+     * A font the reader imported, named by the SHA-256 of its file.
+     *
+     * [cssName] is namespaced rather than the family's own name: an
+     * imported font is perfectly entitled to call itself Literata, and
+     * unprefixed it would silently take over the bundled declaration or
+     * a publisher's embedded face.
+     */
+    data class Imported(val digest: String) : ReadingFont {
+        override val id: String get() = UserFont.ID_PREFIX + digest
+        override val cssName: String get() = "LiseurUser-$digest"
+    }
+
+    /**
+     * This font if its file is still there, otherwise the default.
+     *
+     * The distinction between the *raw* choice and the *effective* one is
+     * the whole reason a deleted font is not a lost setting. DataStore and
+     * `book_typography` keep the raw value untouched; only this resolved
+     * one reaches the navigator, the preview and the rendered selection.
+     * Re-import the same file and the digest, the id and every book's
+     * choice come back.
+     */
+    fun effective(registry: Set<String>): ReadingFont =
+        if (this is Imported && id !in registry) Default else this
+
+    companion object {
+        val Default: ReadingFont = Bundled(ReaderFont.Default)
+
+        /**
+         * The font a stored id names, or the default.
+         *
+         * Bundled ids are matched first, then the reserved `user:`
+         * namespace, and **only** in its canonical shape. Anything else —
+         * null, blank, corrupt, or an id from a version that has not been
+         * written yet — falls back, exactly as [ReaderFont.fromId] already
+         * did. An unknown id is never guessed to be an import, so a
+         * bundled font added later cannot be mistaken for one.
+         */
+        fun fromId(id: String?): ReadingFont {
+            if (id == null) return Default
+            ReaderFont.entries.firstOrNull { it.id == id }?.let { return Bundled(it) }
+            return UserFont.digestOf(id)?.let(::Imported) ?: Default
+        }
     }
 }
 
@@ -216,7 +290,7 @@ object AutoScrollPreference {
  *   text has further to travel to show the same words.
  */
 data class ReaderPrefs(
-    val font: ReaderFont = ReaderFont.Default,
+    val font: ReadingFont = ReadingFont.Default,
     val fontSize: Double = 1.0,
     val themeChoice: ReaderThemeChoice = ReaderThemeChoice.Default,
     val lineHeight: Double? = null,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/UserFontRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/UserFontRepository.kt
@@ -1,0 +1,386 @@
+package com.chmouel.liseur.data.settings
+
+import android.content.Context
+import android.graphics.Typeface
+import android.net.Uri
+import android.util.AtomicFile
+import android.util.Log
+import com.chmouel.liseur.data.settings.fonts.FontNames
+import com.chmouel.liseur.data.settings.fonts.SfntFont
+import com.chmouel.liseur.data.settings.fonts.UserFont
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import org.json.JSONException
+import org.json.JSONObject
+import java.io.File
+import java.io.IOException
+import java.security.MessageDigest
+import java.util.UUID
+
+/** What became of an attempt to bring a font in. */
+sealed interface ImportResult {
+    data class Imported(val id: String) : ImportResult
+    data class AlreadyPresent(val id: String) : ImportResult
+    data object NotAFont : ImportResult
+    data object TooLarge : ImportResult
+    data object TooMany : ImportResult
+    data object Unreadable : ImportResult
+    data object StorageFailed : ImportResult
+}
+
+/** What became of an attempt to take one away. */
+sealed interface RemovalResult {
+    data object Removed : RemovalResult
+    data object InvalidId : RemovalResult
+    data object NotFound : RemovalResult
+    data object DeleteFailed : RemovalResult
+    data object IndexFailed : RemovalResult
+}
+
+/**
+ * The fonts the reader has imported.
+ *
+ * Content-addressed: a font is stored as `<sha256>.<ext>` and known by
+ * `user:<sha256>`. That is what lets a font be deleted, and the same file
+ * imported again months later, and every book that was reading in it pick
+ * it straight back up — the id was never a handle into a table, it was
+ * always the bytes.
+ *
+ * **The files are authoritative.** [index] caches only the display name,
+ * because that is the one thing a font with no `name` table cannot tell us
+ * a second time. Everything else is re-parsed on every scan, so a lost or
+ * corrupted index costs a name and never a font.
+ */
+class UserFontRepository(
+    context: Context,
+    scope: CoroutineScope,
+    /**
+     * Injectable so tests can exercise a failing store without a mock
+     * filesystem: a `renameTo` that returns false is a real branch with a
+     * real recovery, and it needs to be reachable.
+     */
+    private val loadCheck: (File) -> Boolean = ::canBeLoaded,
+) {
+    private val resolver = context.applicationContext.contentResolver
+    private val dir = File(context.applicationContext.filesDir, DIR)
+    private val index = AtomicFile(File(dir, INDEX))
+
+    private val _fonts = MutableStateFlow(emptyList<UserFont>())
+    val fonts: StateFlow<List<UserFont>> = _fonts.asStateFlow()
+
+    /**
+     * One lock over the scan as well as the mutations.
+     *
+     * Without it covering the startup scan, a reader quick enough to
+     * import a font before the scan finished would watch it disappear:
+     * the scan would publish a directory listing taken before the import
+     * over the top of it.
+     */
+    private val lock = Mutex()
+
+    private val _ready = MutableStateFlow(false)
+
+    init {
+        scope.launch { lock.withLock { rescanLocked() }; _ready.value = true }
+    }
+
+    /**
+     * Suspends until the first scan has published.
+     *
+     * The reader calls this before taking its first font snapshot. A book
+     * already set to an imported font would otherwise open in the default
+     * for a beat and then rebuild its navigator when the scan landed — a
+     * reflow, unasked for, on the screen someone was trying to read.
+     */
+    suspend fun awaitReady() {
+        if (_ready.value) return
+        _ready.first { it }
+    }
+
+    /** The ids currently backed by a file, for resolving a stored preference. */
+    fun registry(): Set<String> = _fonts.value.mapTo(HashSet()) { it.id }
+
+    // -- import -------------------------------------------------------------
+
+    suspend fun import(uri: Uri, pickedName: String?): ImportResult = withContext(Dispatchers.IO) {
+        lock.withLock { importLocked(uri, pickedName) }
+    }
+
+    private fun importLocked(uri: Uri, pickedName: String?): ImportResult {
+        if (!dir.exists() && !dir.mkdirs()) return ImportResult.StorageFailed
+
+        val temp = File(dir, "${UUID.randomUUID()}$TEMP")
+        val staged = try {
+            stage(uri, temp)
+        } catch (e: IOException) {
+            Log.w(TAG, "could not read the picked font", e)
+            temp.delete()
+            return ImportResult.Unreadable
+        } catch (e: SecurityException) {
+            // A provider can withdraw a grant between the pick and the read.
+            Log.w(TAG, "no longer permitted to read the picked font", e)
+            temp.delete()
+            return ImportResult.Unreadable
+        }
+
+        val outcome = when (staged) {
+            is Staged.Hashed -> staged
+            is Staged.Refused -> {
+                temp.delete()
+                return staged.result
+            }
+        }
+
+        val metadata = SfntFont.parse(temp.readBytes())
+        if (metadata == null || !loadCheck(temp)) {
+            // Plausible sfnt tables are not the same thing as a font this
+            // device can actually render, and one that fails to load would
+            // otherwise reach the dropdown's preview and throw inside
+            // composition.
+            temp.delete()
+            return ImportResult.NotAFont
+        }
+
+        val target = File(dir, "${outcome.digest}.${metadata.format.extension}")
+        val id = UserFont.ID_PREFIX + outcome.digest
+
+        // Dedupe before the cap, deliberately: re-picking a font already
+        // imported must land on it, never be refused for a limit it does
+        // not push against.
+        if (target.exists()) {
+            temp.delete()
+            return ImportResult.AlreadyPresent(id)
+        }
+        if (_fonts.value.size >= MAX_FONTS) {
+            temp.delete()
+            return ImportResult.TooMany
+        }
+
+        if (!temp.renameTo(target)) {
+            temp.delete()
+            return ImportResult.StorageFailed
+        }
+
+        val name = metadata.familyName
+            ?: pickedName?.substringBeforeLast('.')?.let(FontNames::sanitize)
+            ?: FontNames.fallbackName(outcome.digest)
+
+        return try {
+            writeIndex(readIndex() + (id to name))
+            rescanLocked()
+            ImportResult.Imported(id)
+        } catch (e: IOException) {
+            Log.w(TAG, "font stored but the name index could not be written", e)
+            // The file is there and must be published as there. It comes
+            // back with a name derived from its own tables or its digest;
+            // the list never disagrees with the directory.
+            rescanLocked()
+            ImportResult.Imported(id)
+        }
+    }
+
+    private sealed interface Staged {
+        data class Hashed(val digest: String) : Staged
+        data class Refused(val result: ImportResult) : Staged
+    }
+
+    /**
+     * Copies [uri] into [temp], hashing as it goes.
+     *
+     * The size cap is enforced *while* streaming rather than by asking the
+     * provider how big the file is: the answer is optional, and a
+     * mis-picked 2 GB video should be abandoned in the first megabyte
+     * rather than after it has been copied into private storage.
+     */
+    private fun stage(uri: Uri, temp: File): Staged {
+        val digest = MessageDigest.getInstance("SHA-256")
+        var total = 0L
+        val input = resolver.openInputStream(uri)
+            ?: return Staged.Refused(ImportResult.Unreadable)
+        input.use { source ->
+            temp.outputStream().use { sink ->
+                val buffer = ByteArray(BUFFER)
+                while (true) {
+                    val read = source.read(buffer)
+                    if (read < 0) break
+                    total += read
+                    if (total > MAX_BYTES) return Staged.Refused(ImportResult.TooLarge)
+                    digest.update(buffer, 0, read)
+                    sink.write(buffer, 0, read)
+                }
+            }
+        }
+        if (total == 0L) return Staged.Refused(ImportResult.NotAFont)
+        return Staged.Hashed(digest.digest().joinToString("") { "%02x".format(it) })
+    }
+
+    // -- removal ------------------------------------------------------------
+
+    suspend fun remove(id: String): RemovalResult = withContext(Dispatchers.IO) {
+        lock.withLock { removeLocked(id) }
+    }
+
+    private fun removeLocked(id: String): RemovalResult {
+        if (UserFont.digestOf(id) == null) return RemovalResult.InvalidId
+        // Resolved through the registry, never by building a path out of
+        // what the caller passed in.
+        val font = _fonts.value.firstOrNull { it.id == id } ?: return RemovalResult.NotFound
+
+        if (font.file.exists() && !font.file.delete()) return RemovalResult.DeleteFailed
+
+        return try {
+            writeIndex(readIndex() - id)
+            rescanLocked()
+            RemovalResult.Removed
+        } catch (e: IOException) {
+            Log.w(TAG, "font deleted but the name index could not be written", e)
+            // The file is gone; the list has to say so even though the
+            // index still names it. The scan drops entries with no file.
+            rescanLocked()
+            RemovalResult.IndexFailed
+        }
+    }
+
+    // -- scanning -----------------------------------------------------------
+
+    private fun rescanLocked() {
+        val names = try {
+            readIndex()
+        } catch (e: IOException) {
+            Log.w(TAG, "name index unreadable; falling back to what the files say", e)
+            emptyMap()
+        }
+
+        val files = dir.listFiles().orEmpty()
+        val found = ArrayList<UserFont>(files.size)
+
+        for (file in files) {
+            if (file.name.startsWith(INDEX)) continue
+            if (file.name.endsWith(TEMP)) {
+                // A staged import that died before its rename. Nothing
+                // refers to it and nothing ever will.
+                file.delete()
+                continue
+            }
+
+            val digest = file.nameWithoutExtension
+            val extension = file.extension.lowercase()
+            if (UserFont.fileNameFor(digest, extension) != file.name) continue
+
+            // A font that has become unreadable — storage detached, a
+            // directory where a file was — costs itself and not the scan.
+            // This runs from `init`, where a throw would take the whole
+            // shelf down and never come back.
+            val bytes = try {
+                file.readBytes()
+            } catch (e: IOException) {
+                Log.w(TAG, "could not read ${file.name}; leaving it out", e)
+                continue
+            }
+            val metadata = SfntFont.parse(bytes) ?: continue
+            // A file whose magic disagrees with the name Liseur gave it is
+            // not one Liseur wrote.
+            if (metadata.format.extension != extension) continue
+
+            val id = UserFont.ID_PREFIX + digest
+            found += UserFont(
+                digest = digest,
+                displayName = names[id]
+                    ?: metadata.familyName
+                    ?: FontNames.fallbackName(digest),
+                file = file,
+                extension = extension,
+                italic = metadata.italic,
+                staticWeight = metadata.weight,
+                weightRange = metadata.weightRange,
+            )
+        }
+
+        _fonts.value = found.sortedBy { it.displayName.lowercase() }
+    }
+
+    // -- the index ----------------------------------------------------------
+
+    private fun readIndex(): Map<String, String> {
+        if (!index.baseFile.exists()) return emptyMap()
+        val text = index.readFully().toString(Charsets.UTF_8)
+        return try {
+            val json = JSONObject(text)
+            buildMap {
+                for (key in json.keys()) {
+                    val name = json.optString(key).takeIf { it.isNotEmpty() } ?: continue
+                    // Sanitised on the way back in as well as on the way
+                    // out: the file is only as trustworthy as whatever
+                    // last wrote it, and a restore could have brought it
+                    // from another install.
+                    FontNames.sanitize(name)?.let { put(key, it) }
+                }
+            }
+        } catch (e: JSONException) {
+            Log.w(TAG, "name index is not readable JSON; ignoring it", e)
+            emptyMap()
+        }
+    }
+
+    /**
+     * Writes through [AtomicFile] rather than a bare rename.
+     *
+     * `File.renameTo` says nothing about replacing an existing target, and
+     * a half-written index read back as JSON would lose every name at
+     * once.
+     */
+    private fun writeIndex(names: Map<String, String>) {
+        if (!dir.exists() && !dir.mkdirs()) throw IOException("no font directory")
+        val json = JSONObject()
+        names.forEach { (id, name) -> json.put(id, name) }
+        val stream = index.startWrite()
+        try {
+            stream.write(json.toString().toByteArray(Charsets.UTF_8))
+            index.finishWrite(stream)
+        } catch (e: IOException) {
+            index.failWrite(stream)
+            throw e
+        }
+    }
+
+    companion object {
+        private const val TAG = "UserFonts"
+
+        const val DIR = "fonts"
+
+        /**
+         * `AtomicFile` writes alongside the base name, so its working
+         * files share this prefix. Skipping by prefix rather than naming
+         * each suffix means a platform that adds another one does not
+         * quietly put a stray file in front of the parser.
+         */
+        private const val INDEX = "index.json"
+        private const val TEMP = ".tmp"
+
+        private const val BUFFER = 64 * 1024
+        private const val MAX_BYTES = 16L * 1024 * 1024
+        private const val MAX_FONTS = 32
+
+        /**
+         * Whether Android itself can make a [Typeface] of this file.
+         *
+         * The WebView and the Compose preview both go through the same
+         * loader, so a file that fails here would fail on the page and in
+         * the dropdown, and the dropdown's failure is inside composition.
+         */
+        private fun canBeLoaded(file: File): Boolean = try {
+            Typeface.Builder(file).build() != null
+        } catch (e: RuntimeException) {
+            Log.w(TAG, "the platform refused to load the picked font", e)
+            false
+        }
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/UserFontRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/UserFontRepository.kt
@@ -23,6 +23,7 @@ import org.json.JSONObject
 import java.io.File
 import java.io.IOException
 import java.security.MessageDigest
+import java.util.Locale
 import java.util.UUID
 
 /** What became of an attempt to bring a font in. */
@@ -139,7 +140,18 @@ class UserFontRepository(
             }
         }
 
-        val metadata = SfntFont.parse(temp.readBytes())
+        // The staged file was written a moment ago, but the storage it went
+        // to can still fail underneath us, and a throw here would escape the
+        // import as a crash rather than a message.
+        val bytes = try {
+            temp.readBytes()
+        } catch (e: IOException) {
+            Log.w(TAG, "could not read back the staged font", e)
+            temp.delete()
+            return ImportResult.Unreadable
+        }
+
+        val metadata = SfntFont.parse(bytes)
         if (metadata == null || !loadCheck(temp)) {
             // Plausible sfnt tables are not the same thing as a font this
             // device can actually render, and one that fails to load would
@@ -272,7 +284,7 @@ class UserFontRepository(
             }
 
             val digest = file.nameWithoutExtension
-            val extension = file.extension.lowercase()
+            val extension = file.extension.lowercase(Locale.ROOT)
             if (UserFont.fileNameFor(digest, extension) != file.name) continue
 
             // A font that has become unreadable — storage detached, a
@@ -304,7 +316,10 @@ class UserFontRepository(
             )
         }
 
-        _fonts.value = found.sortedBy { it.displayName.lowercase() }
+        // Locale.ROOT, not the device's: a Turkish reader's dotted and
+        // dotless i would otherwise order their shelf differently from
+        // everyone else's, and this fold exists only to sort.
+        _fonts.value = found.sortedBy { it.displayName.lowercase(Locale.ROOT) }
     }
 
     // -- the index ----------------------------------------------------------

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/fonts/FontNames.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/fonts/FontNames.kt
@@ -1,0 +1,68 @@
+package com.chmouel.liseur.data.settings.fonts
+
+/**
+ * Cleans up a name that came from outside the app.
+ *
+ * Both names Liseur can end up showing for an imported font are supplied by
+ * something it does not control: the `name` table of a file the reader
+ * picked, and the display name a DocumentsProvider reports for it. Neither
+ * is trustworthy, and a font called
+ * `"Literata\u202E gnitteS"` would render in a settings list as a line that
+ * reads backwards. One sanitiser, applied to both, so there is no second
+ * path where somebody forgot.
+ */
+object FontNames {
+
+    private const val MAX_LENGTH = 64
+
+    /**
+     * Bidirectional overrides and isolates. These have legitimate uses in
+     * running text and none at all in a font's name, where their only
+     * effect is to reorder the row they are drawn in — and, worse, the rows
+     * around it, since an unterminated override runs on.
+     */
+    private val BIDI = setOf(
+        '\u200E', '\u200F',                               // LRM, RLM
+        '\u202A', '\u202B', '\u202C', '\u202D', '\u202E', // embeddings, override
+        '\u2066', '\u2067', '\u2068', '\u2069',           // isolates
+    )
+
+    /**
+     * Returns a name safe to show, or null when nothing usable is left.
+     *
+     * Null rather than a placeholder: only the caller knows what to fall
+     * back to, and a font with an unreadable `name` table should get the
+     * name of the file it arrived in before it gets a digest.
+     */
+    fun sanitize(raw: String): String? {
+        val cleaned = buildString(raw.length) {
+            for (c in raw) {
+                when {
+                    c in BIDI -> Unit
+                    // Includes NUL, which a fixed-length name record is
+                    // padded with, and the line separators that would let
+                    // one name occupy two rows.
+                    c.isISOControl() -> append(' ')
+                    c.isWhitespace() -> append(' ')
+                    else -> append(c)
+                }
+            }
+        }
+        val collapsed = cleaned.trim().replace(WHITESPACE, " ")
+        if (collapsed.isEmpty()) return null
+        return if (collapsed.length <= MAX_LENGTH) {
+            collapsed
+        } else {
+            // Trimmed again: the cut may have landed just after a space.
+            collapsed.take(MAX_LENGTH).trimEnd()
+        }
+    }
+
+    /**
+     * The name a font gets when it has told us nothing and its file was
+     * called something unusable either.
+     */
+    fun fallbackName(digest: String): String = "Imported font ${digest.take(8)}"
+
+    private val WHITESPACE = Regex(" {2,}")
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/fonts/SfntFont.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/fonts/SfntFont.kt
@@ -1,0 +1,303 @@
+package com.chmouel.liseur.data.settings.fonts
+
+/**
+ * What Liseur needs to know about a font file it has been handed.
+ *
+ * @param format decided by the file's magic, and the only thing allowed to
+ *   decide the stored extension — a reader can name a file anything.
+ * @param familyName the font's own name for itself, or null when it has no
+ *   usable name record and the caller has to fall back to the picked
+ *   filename.
+ * @param weightRange the `wght` axis of a variable font, already clamped
+ *   into the range CSS and Readium accept.
+ */
+data class SfntMetadata(
+    val format: SfntFormat,
+    val familyName: String?,
+    val italic: Boolean,
+    val weight: Int,
+    val weightRange: IntRange?,
+)
+
+enum class SfntFormat(val extension: String) {
+    TRUE_TYPE("ttf"),
+    OPEN_TYPE("otf"),
+}
+
+/**
+ * Just enough OpenType to answer "is this a font, and what is it called".
+ *
+ * Reads the `name`, `head`, `OS/2` and `fvar` tables and nothing else.
+ * Deliberately pure Kotlin over a [ByteArray]: it is fed a file the reader
+ * picked out of a file manager, which is to say a hostile byte string, and
+ * being testable off a device is what makes it possible to say so with
+ * confidence.
+ *
+ * Every read is bounds-checked and every malformed input returns null. It
+ * never throws — the caller is a file picker callback, and a
+ * [ArrayIndexOutOfBoundsException] there would take down the reader
+ * because someone chose the wrong file.
+ */
+object SfntFont {
+
+    /** Collections, WOFF and WOFF2 are recognised only so they can be refused. */
+    fun parse(bytes: ByteArray): SfntMetadata? {
+        val format = formatOf(bytes) ?: return null
+
+        val numTables = bytes.u16(4) ?: return null
+        if (numTables == 0 || numTables > MAX_TABLES) return null
+
+        val tables = HashMap<String, IntRange>(numTables)
+        for (i in 0 until numTables) {
+            val record = TABLE_DIRECTORY + i * TABLE_RECORD
+            val tag = bytes.ascii(record, 4) ?: return null
+            val offset = bytes.u32(record + 8) ?: return null
+            val length = bytes.u32(record + 12) ?: return null
+            // Not a failure: a font is allowed tables Liseur has no use
+            // for, and one of those being out of bounds says nothing about
+            // the ones it does read. The tables that matter are checked
+            // where they are used.
+            if (!bytes.holds(offset, length)) continue
+            tables.putIfAbsent(tag, offset until offset + length)
+        }
+
+        val head = tables["head"]?.let { readHead(bytes, it) }
+        val os2 = tables["OS/2"]?.let { readOs2(bytes, it) }
+        val fvar = tables["fvar"]?.let { readWeightAxis(bytes, it) }
+
+        // A font with no readable name table is still a usable font; it
+        // just has to borrow the name of the file it came in.
+        val family = tables["name"]?.let { readFamilyName(bytes, it) }
+
+        val italic = os2?.italic ?: head?.italic ?: false
+        val bold = os2?.bold ?: head?.bold ?: false
+        val weight = os2?.weightClass?.takeIf { it in CSS_WEIGHTS }
+            ?: if (bold) BOLD_WEIGHT else NORMAL_WEIGHT
+
+        return SfntMetadata(
+            format = format,
+            familyName = family,
+            italic = italic,
+            weight = weight,
+            weightRange = fvar,
+        )
+    }
+
+    private fun formatOf(bytes: ByteArray): SfntFormat? = when (bytes.u32(0)) {
+        0x00010000, TAG_TRUE -> SfntFormat.TRUE_TYPE
+        TAG_OTTO -> SfntFormat.OPEN_TYPE
+        else -> null
+    }
+
+    // -- name ---------------------------------------------------------------
+
+    /**
+     * The family name, preferring the typographic one.
+     *
+     * A font whose four styles are one family to a typographer but four
+     * families to Windows carries both names: nameID 16 is the one a
+     * reader would recognise, nameID 1 the compatibility spelling. Take 16
+     * where it exists.
+     */
+    private fun readFamilyName(bytes: ByteArray, table: IntRange): String? {
+        val base = table.first
+        val count = bytes.u16(base + 2) ?: return null
+        val storage = bytes.u16(base + 4)?.let { base + it } ?: return null
+        if (count > MAX_NAME_RECORDS) return null
+
+        var best: Candidate? = null
+        for (i in 0 until count) {
+            val record = base + NAME_RECORD_START + i * NAME_RECORD
+            if (record + NAME_RECORD > table.last + 1) break
+
+            val platform = bytes.u16(record) ?: break
+            val encoding = bytes.u16(record + 2) ?: break
+            val language = bytes.u16(record + 4) ?: break
+            val nameId = bytes.u16(record + 6) ?: break
+            if (nameId != NAME_TYPOGRAPHIC_FAMILY && nameId != NAME_FAMILY) continue
+
+            val rank = rank(platform, encoding, language, nameId) ?: continue
+            if (best != null && rank >= best.rank) continue
+
+            val length = bytes.u16(record + 8) ?: break
+            val offset = bytes.u16(record + 10) ?: break
+            val value = decode(bytes, storage + offset, length, platform, encoding) ?: continue
+            best = Candidate(rank, value)
+        }
+        return best?.value
+    }
+
+    private data class Candidate(val rank: Int, val value: String)
+
+    /**
+     * How much a name record is wanted, lower being better.
+     *
+     * nameID 16 outranks nameID 1 outright; within a nameID, the English
+     * Windows record is the one nearly every font gets right, then any
+     * Windows record, then the platform-independent Unicode one, and Mac
+     * last because MacRoman can only be decoded for Latin.
+     */
+    private fun rank(platform: Int, encoding: Int, language: Int, nameId: Int): Int? {
+        val nameRank = if (nameId == NAME_TYPOGRAPHIC_FAMILY) 0 else 100
+        val platformRank = when {
+            platform == PLATFORM_WINDOWS && encoding in WINDOWS_UNICODE && language == LANG_EN_US -> 0
+            platform == PLATFORM_WINDOWS && encoding in WINDOWS_UNICODE -> 1
+            platform == PLATFORM_UNICODE -> 2
+            platform == PLATFORM_MAC && encoding == MAC_ROMAN -> 3
+            else -> return null
+        }
+        return nameRank + platformRank
+    }
+
+    private fun decode(
+        bytes: ByteArray,
+        offset: Int,
+        length: Int,
+        platform: Int,
+        encoding: Int,
+    ): String? {
+        if (length == 0 || length > MAX_NAME_BYTES) return null
+        if (!bytes.holds(offset, length)) return null
+        val slice = bytes.copyOfRange(offset, offset + length)
+        val text = when {
+            platform == PLATFORM_MAC && encoding == MAC_ROMAN ->
+                // Latin-1 is not MacRoman, but they agree on ASCII, which
+                // is all a Mac-only family name is ever going to be here.
+                String(slice, Charsets.ISO_8859_1)
+            encoding == WINDOWS_UCS4 -> String(slice, Charsets.UTF_32BE)
+            else -> String(slice, Charsets.UTF_16BE)
+        }
+        return FontNames.sanitize(text)
+    }
+
+    // -- head, OS/2, fvar ---------------------------------------------------
+
+    private data class Style(val italic: Boolean, val bold: Boolean)
+
+    private fun readHead(bytes: ByteArray, table: IntRange): Style? {
+        val macStyle = bytes.u16(table.first + HEAD_MAC_STYLE) ?: return null
+        if (table.first + HEAD_MAC_STYLE + 2 > table.last + 1) return null
+        return Style(italic = macStyle and 0b10 != 0, bold = macStyle and 0b1 != 0)
+    }
+
+    private data class Os2(val italic: Boolean, val bold: Boolean, val weightClass: Int)
+
+    private fun readOs2(bytes: ByteArray, table: IntRange): Os2? {
+        if (table.last + 1 - table.first < OS2_MIN_LENGTH) return null
+        val weightClass = bytes.u16(table.first + OS2_WEIGHT_CLASS) ?: return null
+        val selection = bytes.u16(table.first + OS2_SELECTION) ?: return null
+        return Os2(
+            italic = selection and OS2_ITALIC != 0,
+            bold = selection and OS2_BOLD != 0,
+            weightClass = weightClass,
+        )
+    }
+
+    /**
+     * The `wght` axis of a variable font, clamped into what CSS allows.
+     *
+     * Readium's `setFontWeight(ClosedRange<Int>)` asserts `1..1000`, so an
+     * unclamped range out of a font with a nonsense `fvar` would throw
+     * while the navigator was being configured — the reader would lose the
+     * book, not the font. Clamping here means the assertion can never be
+     * reached from a file a reader picked.
+     */
+    private fun readWeightAxis(bytes: ByteArray, table: IntRange): IntRange? {
+        val base = table.first
+        val axesOffset = bytes.u16(base + 4) ?: return null
+        val axisCount = bytes.u16(base + 8) ?: return null
+        val axisSize = bytes.u16(base + 10) ?: return null
+        if (axisCount == 0 || axisCount > MAX_AXES || axisSize < FVAR_AXIS) return null
+
+        for (i in 0 until axisCount) {
+            val axis = base + axesOffset + i * axisSize
+            if (!bytes.holds(axis, FVAR_AXIS)) return null
+            if (bytes.ascii(axis, 4) != "wght") continue
+
+            val min = bytes.fixed(axis + 4) ?: return null
+            val max = bytes.fixed(axis + 12) ?: return null
+            val low = min.coerceIn(CSS_WEIGHTS)
+            val high = max.coerceIn(CSS_WEIGHTS)
+            // A font claiming a maximum below its minimum has told us
+            // nothing usable. Better a static weight than a range Readium
+            // will refuse.
+            return if (low <= high) low..high else null
+        }
+        return null
+    }
+
+    // -- bounds-checked reads -----------------------------------------------
+
+    private fun ByteArray.holds(offset: Int, length: Int): Boolean =
+        offset >= 0 && length >= 0 && offset <= size && length <= size - offset
+
+    private fun ByteArray.u8(index: Int): Int? =
+        if (index in indices) this[index].toInt() and 0xFF else null
+
+    private fun ByteArray.u16(index: Int): Int? {
+        if (!holds(index, 2)) return null
+        return (u8(index)!! shl 8) or u8(index + 1)!!
+    }
+
+    private fun ByteArray.u32(index: Int): Int? {
+        if (!holds(index, 4)) return null
+        val value = (u8(index)!!.toLong() shl 24) or
+            (u8(index + 1)!!.toLong() shl 16) or
+            (u8(index + 2)!!.toLong() shl 8) or
+            u8(index + 3)!!.toLong()
+        // Offsets are unsigned 32-bit in the spec but no font Liseur will
+        // ever open is 2 GB, and an Int keeps every later comparison free
+        // of overflow.
+        return if (value > Int.MAX_VALUE) null else value.toInt()
+    }
+
+    /** A 16.16 fixed-point number, rounded — `fvar` states weights this way. */
+    private fun ByteArray.fixed(index: Int): Int? {
+        if (!holds(index, 4)) return null
+        val whole = ((u8(index)!! shl 8) or u8(index + 1)!!).toShort().toInt()
+        val fraction = ((u16(index + 2)!!).toDouble() / 65536.0)
+        return Math.round(whole + fraction).toInt()
+    }
+
+    private fun ByteArray.ascii(index: Int, length: Int): String? {
+        if (!holds(index, length)) return null
+        return String(copyOfRange(index, index + length), Charsets.US_ASCII)
+    }
+
+    private const val TAG_OTTO = 0x4F54544F      // 'OTTO'
+    private const val TAG_TRUE = 0x74727565      // 'true'
+
+    private const val TABLE_DIRECTORY = 12
+    private const val TABLE_RECORD = 16
+    private const val MAX_TABLES = 512
+
+    private const val NAME_RECORD_START = 6
+    private const val NAME_RECORD = 12
+    private const val MAX_NAME_RECORDS = 4096
+    private const val MAX_NAME_BYTES = 1024
+    private const val NAME_FAMILY = 1
+    private const val NAME_TYPOGRAPHIC_FAMILY = 16
+
+    private const val PLATFORM_UNICODE = 0
+    private const val PLATFORM_MAC = 1
+    private const val PLATFORM_WINDOWS = 3
+    private const val MAC_ROMAN = 0
+    private const val WINDOWS_UCS4 = 10
+    private val WINDOWS_UNICODE = setOf(1, WINDOWS_UCS4)
+    private const val LANG_EN_US = 0x0409
+
+    private const val HEAD_MAC_STYLE = 44
+
+    private const val OS2_WEIGHT_CLASS = 4
+    private const val OS2_SELECTION = 62
+    private const val OS2_MIN_LENGTH = 64
+    private const val OS2_ITALIC = 0x01
+    private const val OS2_BOLD = 0x20
+
+    private const val FVAR_AXIS = 20
+    private const val MAX_AXES = 64
+
+    private const val NORMAL_WEIGHT = 400
+    private const val BOLD_WEIGHT = 700
+    private val CSS_WEIGHTS = 1..1000
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/fonts/UserFont.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/fonts/UserFont.kt
@@ -1,0 +1,61 @@
+package com.chmouel.liseur.data.settings.fonts
+
+import java.io.File
+
+/**
+ * A font the reader brought in themselves.
+ *
+ * Identity is the SHA-256 of the file, so the same file imported twice is
+ * the same font, and — the part that matters — a font deleted and later
+ * imported again comes back under the id every book already remembers.
+ * Nothing about the name the file arrived with is load-bearing.
+ *
+ * [cssName] is namespaced rather than being the family's own name. An
+ * imported font is free to call itself Literata, and without the prefix
+ * it would quietly take over the bundled declaration, or a publisher's
+ * own embedded face.
+ */
+data class UserFont(
+    val digest: String,
+    val displayName: String,
+    val file: File,
+    val extension: String,
+    val italic: Boolean,
+    val staticWeight: Int,
+    val weightRange: IntRange?,
+) {
+    val id: String get() = ID_PREFIX + digest
+
+    val cssName: String get() = "LiseurUser-$digest"
+
+    val fileName: String get() = "$digest.$extension"
+
+    companion object {
+        const val ID_PREFIX = "user:"
+
+        /** `ttf` or `otf`, decided by the file's own magic — never by its name. */
+        val EXTENSIONS = setOf("ttf", "otf")
+
+        private val DIGEST = Regex("[0-9a-f]{64}")
+
+        /** Whether [digest] is one Liseur could have written. */
+        fun isDigest(digest: String): Boolean = DIGEST.matches(digest)
+
+        /**
+         * The digest behind a stored id, or null if [id] is not one of ours.
+         *
+         * Deliberately strict: an id that is merely *unknown* has to stay
+         * distinguishable from one that is malformed, so that a preference
+         * written by some future version falls back to the default instead
+         * of being read as a font that was never imported.
+         */
+        fun digestOf(id: String?): String? {
+            if (id == null || !id.startsWith(ID_PREFIX)) return null
+            return id.removePrefix(ID_PREFIX).takeIf(::isDigest)
+        }
+
+        /** The canonical file name for a digest, or null if either part is not canonical. */
+        fun fileNameFor(digest: String, extension: String): String? =
+            if (isDigest(digest) && extension in EXTENSIONS) "$digest.$extension" else null
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
@@ -205,6 +205,16 @@ class ReaderActivity : FragmentActivity() {
                                 val readingTheme = prefs.themeChoice.resolve(appIsDark)
                                 val scrollMode by viewModel.scrollMode.collectAsStateWithLifecycle()
                                 val columnMode = prefs.columnMode.effectiveFor(widthClass())
+                                // A third key, for the same reason as the
+                                // other two: a font family is declared when
+                                // the navigator is configured, so a font
+                                // imported while the book is open only
+                                // reaches the page if the fragment is built
+                                // again. The ids in order are the whole of
+                                // what the declarations depend on.
+                                val importedFonts by viewModel.importedFonts
+                                    .collectAsStateWithLifecycle()
+                                val fontKey = importedFonts.joinToString(",") { it.id }
                                 // Read once, here, alongside the factory that is
                                 // built from it, and handed to the screen as the
                                 // point this navigator is being restored to.
@@ -216,6 +226,7 @@ class ReaderActivity : FragmentActivity() {
                                     s.navigatorFactory,
                                     columnMode,
                                     scrollMode,
+                                    fontKey,
                                 ) {
                                     viewModel.lastLocator ?: s.initialLocator
                                 }
@@ -226,14 +237,27 @@ class ReaderActivity : FragmentActivity() {
                                 // over it takes the reader back off the page
                                 // they asked for. See IssuedMoves.
                                 val moves = remember { IssuedMoves() }
-                                remember(s.navigatorFactory, columnMode, scrollMode) {
+                                // Kept as a value rather than computed
+                                // inline, because ReaderScreen has to know
+                                // exactly what this navigator was built
+                                // with to tell an already-rendered
+                                // preference from one still to submit.
+                                val initialPreferences = remember(
+                                    s.navigatorFactory,
+                                    columnMode,
+                                    scrollMode,
+                                    fontKey,
+                                ) {
+                                    prefs.toEpubPreferences(
+                                        theme = readingTheme,
+                                        columnMode = columnMode,
+                                        scroll = scrollMode,
+                                    )
+                                }
+                                remember(s.navigatorFactory, columnMode, scrollMode, fontKey) {
                                     s.navigatorFactory.createFragmentFactory(
                                         initialLocator = restoreTarget,
-                                        initialPreferences = prefs.toEpubPreferences(
-                                            theme = readingTheme,
-                                            columnMode = columnMode,
-                                            scroll = scrollMode,
-                                        ),
+                                        initialPreferences = initialPreferences,
                                         // Without a listener the navigator answers
                                         // every link the same way — go there — and
                                         // a footnote costs the reader their page.
@@ -262,6 +286,7 @@ class ReaderActivity : FragmentActivity() {
                                         configuration = epubNavigatorConfiguration(
                                             columnMode = columnMode,
                                             scroll = scrollMode,
+                                            userFonts = importedFonts,
                                             onTextSelected = viewModel::onTextSelected,
                                             onSelectionCleared = viewModel::onSelectionCleared,
                                         ),
@@ -292,6 +317,8 @@ class ReaderActivity : FragmentActivity() {
                                 ReaderScreen(
                                     publication = s.publication,
                                     restoreTarget = restoreTarget,
+                                    fontKey = fontKey,
+                                    initialPreferences = initialPreferences,
                                     moves = moves,
                                     prefsFlow = viewModel.prefs,
                                     readingTheme = readingTheme,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapper.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapper.kt
@@ -8,6 +8,7 @@ import com.chmouel.liseur.data.settings.ColumnMode
 import com.chmouel.liseur.data.settings.ReaderFont
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.ReaderTheme
+import com.chmouel.liseur.data.settings.fonts.UserFont
 import com.chmouel.liseur.ui.WidthClass
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.navigator.epub.EpubPreferences
@@ -155,6 +156,7 @@ fun ColumnMode.effectiveFor(widthClass: WidthClass): ColumnMode = when {
 fun epubNavigatorConfiguration(
     columnMode: ColumnMode = ColumnMode.Default,
     scroll: Boolean = false,
+    userFonts: List<UserFont> = emptyList(),
     onTextSelected: () -> Unit = {},
     onSelectionCleared: () -> Unit = {},
 ): EpubNavigatorFragment.Configuration =
@@ -256,6 +258,26 @@ fun epubNavigatorConfiguration(
                 addSource("fonts/Inter-Italic.ttf")
                 setFontStyle(FontStyle.ITALIC)
                 setFontWeight(100..900)
+            }
+        }
+
+        // Every imported font is declared, not just the chosen one, so
+        // switching between them is the instant change it already is for
+        // the four above — the web view only fetches the family a page
+        // actually asks for. Each is one face: a single file cannot carry
+        // a real italic or bold, and the page synthesises them.
+        //
+        // The weight range arrives already clamped to 1..1000, because
+        // setFontWeight() asserts that and a malformed `fvar` would
+        // otherwise bring the reader down while it was being configured.
+        userFonts.forEach { font ->
+            addFontFamilyDeclaration(FontFamily(font.cssName)) {
+                addFontFace {
+                    addSource(UserFontResources.url(font))
+                    setFontStyle(if (font.italic) FontStyle.ITALIC else FontStyle.NORMAL)
+                    val weight = font.weightRange ?: font.staticWeight..font.staticWeight
+                    setFontWeight(weight)
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -101,7 +101,7 @@ import com.chmouel.liseur.reader.dictionary.DefinitionSheet
 import com.chmouel.liseur.reader.dictionary.WiktionaryClient
 import com.chmouel.liseur.data.settings.FooterMode
 import com.chmouel.liseur.data.settings.ColumnMode
-import com.chmouel.liseur.data.settings.ReaderFont
+import com.chmouel.liseur.data.settings.ReadingFont
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.ReaderTheme
 import com.chmouel.liseur.data.settings.ReaderThemeChoice
@@ -155,11 +155,13 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import org.readium.r2.navigator.Decoration
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
+import org.readium.r2.navigator.epub.EpubPreferences
 import org.readium.r2.navigator.preferences.ReadingProgression
 import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.publication.Layout
@@ -239,6 +241,25 @@ fun ReaderScreen(
      * built. Null for a book with no saved position.
      */
     restoreTarget: Locator?,
+    /**
+     * The imported fonts, as an ordered list of ids.
+     *
+     * Only ever a key. The activity builds the declarations; this is how
+     * the fragment holding the old ones gets torn down.
+     */
+    fontKey: String,
+    /**
+     * The preferences the navigator in hand was actually built with.
+     *
+     * Not the same thing as "the current preferences": the factory
+     * captures them when it is rebuilt, and a font import changes the
+     * declarations and the selected font as two separate updates. Land
+     * the rebuild between them and the fragment is built with the font
+     * the reader has just replaced. This is what tells the collector
+     * below which value is already on the page and which one still has
+     * to be submitted.
+     */
+    initialPreferences: EpubPreferences,
     /**
      * The moves the reader is sent on, counted as they are asked for.
      * Owned above this screen because a link tapped in the book is
@@ -775,10 +796,18 @@ fun ReaderScreen(
     // choice made on a wide one, and the control to undo it is hidden.
     LaunchedEffect(navigator) {
         val nav = navigator ?: return@LaunchedEffect
-        // The factory already built this navigator with the current
-        // preferences. Submitting that same value once more reflows the
-        // freshly opened book and emits a second restoration locator,
-        // which must not be recorded as a page the reader turned.
+        // The factory already built this navigator with some value, and
+        // submitting that same value once more reflows the freshly
+        // opened book and emits a second restoration locator, which must
+        // not be recorded as a page the reader turned.
+        //
+        // Which value, though, is not "whichever arrives first". A font
+        // import publishes the new declarations and writes the new
+        // selection as two updates, and a rebuild landing between them
+        // builds the fragment with the font the reader has just left. So
+        // the leading emission is dropped for *being* the one already
+        // rendered, not for being first — otherwise the newly imported
+        // font is skipped and the page keeps the old one.
         //
         // The theme is combined in rather than read once because it can
         // change without the preferences changing at all: a reader on
@@ -790,7 +819,6 @@ fun ReaderScreen(
         ) { p, (theme, columns, scrolling) ->
             p.toEpubPreferences(theme, columns, scrolling)
         }
-            .drop(1)
             // What the book is rendered with, not what the reader
             // happens to be holding. Reading preferences carry answers
             // the page cannot see — the auto-scroll speed is one — and a
@@ -799,6 +827,7 @@ fun ReaderScreen(
             // anchor and restoring it, for a setting that changes not one
             // line of the text.
             .distinctUntilChanged()
+            .dropWhile { it == initialPreferences }
             .collect {
                 reflow.within {
                     // Taken before the anchor rather than with the
@@ -1454,7 +1483,9 @@ fun ReaderScreen(
         // Scrolling is keyed for the same reason: whether a sideways
         // swipe turns a page is fixed at construction too, and it has to
         // stop turning them when the pages become one long column.
-        key(columnMode, scrollMode) {
+        // And on the imported fonts, third of the three, because a
+        // font family is declared at construction as well.
+        key(columnMode, scrollMode, fontKey) {
             // Derived, not measured: the reservation must exist before
             // the page lays out, or the last line is cut in half. The
             // line height is the very style the footer draws with, and
@@ -2127,7 +2158,7 @@ private fun dwellMillis(viewportPixels: Int, pixelsPerSecond: Double): Long {
 
 /** Bundle of preference setters passed down to the reader chrome. */
 class ReaderPrefsActions(
-    val setFont: (ReaderFont) -> Unit,
+    val setFont: (ReadingFont) -> Unit,
     val setFontSize: (Double) -> Unit,
     val setTheme: (ReaderThemeChoice) -> Unit,
     val setLineHeight: (Double?) -> Unit,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -37,9 +37,11 @@ import com.chmouel.liseur.data.library.ReadingSessionManager
 import com.chmouel.liseur.data.settings.AppSettingsRepository
 import com.chmouel.liseur.data.settings.DefinitionTarget
 import com.chmouel.liseur.data.settings.FooterMode
-import com.chmouel.liseur.data.settings.ReaderFont
+import com.chmouel.liseur.data.settings.ReadingFont
 import com.chmouel.liseur.data.settings.ReaderPreferencesRepository
 import com.chmouel.liseur.data.settings.ReadingPaceRepository
+import com.chmouel.liseur.data.settings.UserFontRepository
+import com.chmouel.liseur.data.settings.fonts.UserFont
 import com.chmouel.liseur.sync.PositionSyncCoordinator
 import com.chmouel.liseur.sync.SyncScope
 import com.chmouel.liseur.sync.PositionUpdate
@@ -95,6 +97,7 @@ import org.readium.r2.shared.publication.indexOfFirstWithHref
 import org.readium.r2.shared.publication.services.search.search
 import org.readium.r2.shared.util.AbsoluteUrl
 import org.readium.r2.shared.util.asset.AssetRetriever
+import org.readium.r2.shared.util.data.CompositeContainer
 import org.readium.r2.shared.util.getOrElse
 import org.readium.r2.shared.util.use
 import org.readium.r2.streamer.PublicationOpener
@@ -125,8 +128,19 @@ class ReaderViewModel(
     private val downloads: BookDownloadRepository,
     private val seriesExtras: SeriesExtrasRepository,
     private val remoteAccount: RemoteAccountRepository,
+    private val userFonts: UserFontRepository,
     sessionManager: ReadingSessionManager,
 ) : ViewModel() {
+
+    /**
+     * The fonts the reader has imported, for the navigator to declare.
+     *
+     * All of them, not just the selected one — declaring the lot up front
+     * is what makes switching between them as instant as it already is
+     * for the bundled four. The web view only fetches the family the page
+     * actually uses.
+     */
+    val importedFonts: StateFlow<List<UserFont>> = userFonts.fonts
 
     private val sessions = sessionManager.recorder(bookId)
     private val timeSpent = sessionManager.observeTotal(bookId)
@@ -590,8 +604,24 @@ class ReaderViewModel(
         .map { it != null }
         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
-    val prefs: StateFlow<ReaderPrefs> = prefsRepo.prefs
+    /**
+     * How this book reads, exactly as it is stored.
+     *
+     * The font here may name an import whose file is no longer on the
+     * device. That is deliberate and it is what [prefs] resolves; this is
+     * the value that gets written back, so that deleting a font is a
+     * font going missing and never a setting being lost.
+     */
+    private val rawPrefs: StateFlow<ReaderPrefs> = prefsRepo.prefs
         .combine(ownTypography) { shared, own -> shared.withTypographyOf(own) }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, ReaderPrefs())
+
+    /** How this book reads, with a missing imported font resolved away. */
+    val prefs: StateFlow<ReaderPrefs> = rawPrefs
+        .combine(userFonts.fonts) { stored, available ->
+            val registry = available.mapTo(HashSet()) { it.id }
+            stored.copy(font = stored.font.effective(registry))
+        }
         .stateIn(viewModelScope, SharingStarted.Eagerly, ReaderPrefs())
 
     /**
@@ -656,11 +686,32 @@ class ReaderViewModel(
             // Make sure saved preferences are loaded before the navigator is
             // created, so the book opens directly with the user's settings.
             prefsRepo.prefs.first()
+            // And before the first font snapshot is taken. A book already
+            // set to an imported font would otherwise open in the default
+            // and rebuild its navigator the moment the scan landed — a
+            // reflow nobody asked for, on the page they were reading.
+            userFonts.awaitReady()
             val asset = assetRetriever.retrieve(bookUrl).getOrElse {
                 _state.value = UiState.Failure(it.message)
                 return@launch
             }
-            val publication = publicationOpener.open(asset, allowUserInteraction = false)
+            val publication = publicationOpener.open(
+                asset,
+                allowUserInteraction = false,
+                onCreatePublication = {
+                    // Imported fonts are served as publication resources:
+                    // Readium's asset host only ever reads the APK, so a
+                    // font in private storage has to arrive this way. Ours
+                    // goes first because it is registry-strict — it can
+                    // only answer for a digest it holds, so it cannot
+                    // shadow anything the book carries, whereas the book
+                    // could otherwise shadow a font.
+                    container = CompositeContainer(
+                        UserFontsContainer { userFonts.fonts.value },
+                        container,
+                    )
+                },
+            )
                 .getOrElse {
                     asset.close()
                     _state.value = UiState.Failure(it.message)
@@ -1266,13 +1317,13 @@ class ReaderViewModel(
      */
     fun setTypographyIsOwn(own: Boolean) = viewModelScope.launch {
         if (own) {
-            typographyDao.upsert(BookTypography.from(bookId, prefs.value))
+            typographyDao.upsert(BookTypography.from(bookId, rawPrefs.value))
         } else {
             typographyDao.clear(bookId)
         }
     }
 
-    fun setFont(font: ReaderFont) = typography(
+    fun setFont(font: ReadingFont) = typography(
         shared = { prefsRepo.setFont(font) },
         own = { it.copy(font = font.id) },
     )
@@ -1413,6 +1464,7 @@ class ReaderViewModel(
                     downloads = container.bookDownloads,
                     seriesExtras = container.seriesExtras,
                     remoteAccount = container.remoteAccount,
+                    userFonts = container.userFonts,
                     sessionManager = container.readingSessions,
                 )
             }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/UserFontResources.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/UserFontResources.kt
@@ -1,0 +1,119 @@
+package com.chmouel.liseur.reader
+
+import com.chmouel.liseur.data.settings.fonts.UserFont
+import org.readium.r2.shared.util.AbsoluteUrl
+import org.readium.r2.shared.util.Url
+import org.readium.r2.shared.util.data.Container
+import org.readium.r2.shared.util.file.FileResource
+import org.readium.r2.shared.util.resource.Resource
+
+/**
+ * Serving an imported font to the reader's web view.
+ *
+ * Readium can only serve fonts out of the APK's own assets. Its
+ * `servedAssets` setting reads like it widens that, but it is only a
+ * pattern allowlist: every path it admits is still handed to a
+ * `WebViewAssetLoader.AssetsPathHandler`, which knows nothing but
+ * `assets/`. A file in `filesDir` is unreachable through it, and no other
+ * hook exists — a `data:` URL cannot even be expressed as a Readium
+ * [Url] (`AbsoluteUrl` requires a hierarchical URI, a `data:` URI is
+ * opaque), and a `file://` subresource of an `https://` page is refused
+ * by the web view.
+ *
+ * What is reachable is the *publication*. Any request the navigator makes
+ * that is not aimed at the assets host is looked up in the publication's
+ * container, and Liseur builds that container itself. So an imported font
+ * is served as though it were part of the book: the container is wrapped
+ * at open, and the font is declared with an absolute URL on the package
+ * host, which [org.readium.r2.navigator.epub.css.ReadiumCss] passes
+ * through untouched because `Url.resolve` returns an absolute URL as it
+ * is.
+ *
+ * It lands same-origin with the page, so unlike the bundled fonts it
+ * needs no CORS header.
+ */
+internal object UserFontResources {
+
+    /**
+     * Where imported fonts appear to live inside every book.
+     *
+     * Underscored and doubled so that it cannot plausibly collide with a
+     * real EPUB entry — and if one ever does, [UserFontsContainer] is
+     * consulted first and answers only for digests it actually holds, so
+     * the book's own resource is still found.
+     */
+    const val DIR = "__liseur_fonts__"
+
+    /**
+     * Readium's package host, spelled out because `WebViewServer.PACKAGE_HOSTNAME`
+     * is `internal`.
+     *
+     * This is the one place a Readium upgrade could break imported fonts
+     * quietly: the font would 404 and the page would fall back to a
+     * default face with nothing said. If that ever happens, this constant
+     * is what to check first. See `docs/adr/0004-user-imported-fonts.md`.
+     */
+    const val PACKAGE_ORIGIN = "https://readium_package/"
+
+    /** The URL an imported font is declared and served at. */
+    fun url(font: UserFont): AbsoluteUrl =
+        checkNotNull(AbsoluteUrl(absoluteHref(font.fileName))) {
+            "Font file name is not URL-safe: ${font.fileName}"
+        }
+
+    private fun absoluteHref(fileName: String): String = "$PACKAGE_ORIGIN$DIR/$fileName"
+
+    private fun relativeHref(fileName: String): String = "$DIR/$fileName"
+
+    /**
+     * The font [url] asks for, or null.
+     *
+     * Exact string equality against an href built from a font Liseur
+     * itself stored, rather than any kind of path resolution. Nothing is
+     * ever joined onto the font directory, so there is no path for a
+     * traversal to traverse: `..`, `%2e%2e`, an encoded separator, a
+     * doubled slash or a foreign host all simply fail to equal any
+     * candidate. Requiring `https://readium_package/` as a literal prefix
+     * settles the scheme, the host, the absence of a port and the absence
+     * of user-info in one comparison.
+     *
+     * The fragment and the query are dropped first rather than refused.
+     * `Publication.get` retries a lookup with the query removed, so a
+     * rule that turned one away would break Readium's own second attempt
+     * at a request that was legitimate to begin with. They are not the
+     * boundary; the exact match against a stored font is.
+     */
+    fun match(url: Url, fonts: List<UserFont>): UserFont? {
+        val href = url.removeFragment().removeQuery().toString()
+        if (href.length > MAX_HREF) return null
+        return fonts.firstOrNull { font ->
+            href == absoluteHref(font.fileName) || href == relativeHref(font.fileName)
+        }
+    }
+
+    private const val MAX_HREF = 256
+}
+
+/**
+ * The imported fonts, offered to the navigator as part of every book.
+ *
+ * [fonts] is read on each call rather than captured once, so a font
+ * imported while a book is open is servable the moment the navigator asks
+ * for it. That is what lets an import reflow the page the reader is on
+ * instead of waiting for the next book.
+ */
+internal class UserFontsContainer(
+    private val fonts: () -> List<UserFont>,
+) : Container<Resource> {
+
+    override val entries: Set<Url>
+        get() = fonts().mapNotNullTo(mutableSetOf()) { Url("${UserFontResources.DIR}/${it.fileName}") }
+
+    override fun get(url: Url): Resource? =
+        UserFontResources.match(url, fonts())
+            ?.takeIf { it.file.isFile }
+            ?.let { FileResource(it.file) }
+
+    /** Nothing to close: every entry is opened per request and owned by the caller. */
+    override fun close() {}
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/TypographySheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/TypographySheet.kt
@@ -25,13 +25,14 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.chmouel.liseur.R
-import com.chmouel.liseur.data.settings.ReaderFont
+import com.chmouel.liseur.data.settings.ReadingFont
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.ReaderTheme
 import com.chmouel.liseur.data.settings.ReaderThemeChoice
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.reading.ReadingBrightnessSlider
 import com.chmouel.liseur.ui.reading.ReadingFontDropdown
+import com.chmouel.liseur.ui.reading.rememberFontLibrary
 import com.chmouel.liseur.ui.reading.ReadingFontSizeSlider
 import com.chmouel.liseur.ui.reading.ReadingThemeRow
 import com.chmouel.liseur.ui.windowWidth
@@ -55,7 +56,7 @@ import com.chmouel.liseur.ui.windowWidth
 fun TypographySheet(
     prefs: ReaderPrefs,
     readingTheme: ReaderTheme,
-    onFontSelected: (ReaderFont) -> Unit,
+    onFontSelected: (ReadingFont) -> Unit,
     onFontSizeChanged: (Double) -> Unit,
     onThemeSelected: (ReaderThemeChoice) -> Unit,
     onBrightnessChanged: (Float?) -> Unit,
@@ -83,7 +84,14 @@ fun TypographySheet(
             )
             ReadingFontSizeSlider(value = prefs.fontSize, onChanged = onFontSizeChanged)
             ReadingBrightnessSlider(value = prefs.brightness, onChanged = onBrightnessChanged)
-            ReadingFontDropdown(selected = prefs.font, onSelected = onFontSelected)
+            val fontLibrary = rememberFontLibrary(onSelected = onFontSelected)
+            ReadingFontDropdown(
+                selected = prefs.font,
+                imported = fontLibrary.fonts,
+                onSelected = onFontSelected,
+                onImport = fontLibrary.pick,
+                onRemove = fontLibrary.remove,
+            )
             ScrollModeToggle(
                 enabled = scrollMode,
                 onChanged = onScrollModeChanged,

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/reading/FontLibrary.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/reading/FontLibrary.kt
@@ -1,0 +1,103 @@
+package com.chmouel.liseur.ui.reading
+
+import android.widget.Toast
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.chmouel.liseur.R
+import com.chmouel.liseur.container
+import com.chmouel.liseur.data.settings.ImportResult
+import com.chmouel.liseur.data.settings.ReadingFont
+import com.chmouel.liseur.data.settings.RemovalResult
+import com.chmouel.liseur.data.settings.fonts.UserFont
+import kotlinx.coroutines.launch
+
+/** The imported fonts, and the two things a reader can do to them. */
+@Immutable
+data class FontLibraryState(
+    val fonts: List<UserFont>,
+    val pick: () -> Unit,
+    val remove: (UserFont) -> Unit,
+)
+
+/**
+ * The imported fonts, wired to the picker and to a message for every
+ * outcome.
+ *
+ * Shared by the reader's typography sheet and Settings → Reading
+ * appearance so the two cannot drift. [onSelected] is what routes a
+ * successful import to the right place — the caller already knows whether
+ * this book has been set apart — because **reloading the declarations is
+ * not choosing**: someone who has just picked a font file out of a file
+ * manager plainly means to read in it, and stopping at "it is now
+ * available" would look like nothing happened.
+ */
+@Composable
+fun rememberFontLibrary(onSelected: (ReadingFont) -> Unit): FontLibraryState {
+    val context = LocalContext.current
+    // Resources rather than the context: reading a resource value off
+    // LocalContext does not track configuration changes, and lint is
+    // right to say so.
+    val resources = LocalResources.current
+    val scope = rememberCoroutineScope()
+    val repository = remember(context) { context.container.userFonts }
+    val fonts by repository.fonts.collectAsStateWithLifecycle()
+
+    val say = { message: String ->
+        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+    }
+
+    val pick = rememberFontPicker { uri, name ->
+        scope.launch {
+            when (val result = repository.import(uri, name)) {
+                is ImportResult.Imported -> {
+                    onSelected(ReadingFont.fromId(result.id))
+                    val added = repository.fonts.value.firstOrNull { it.id == result.id }
+                    say(resources.getString(R.string.reader_font_imported, added?.displayName ?: ""))
+                }
+                // Re-picking a font already held has to land on it too, or
+                // the second attempt looks like a failure.
+                is ImportResult.AlreadyPresent -> {
+                    onSelected(ReadingFont.fromId(result.id))
+                    val held = repository.fonts.value.firstOrNull { it.id == result.id }
+                    say(
+                        resources.getString(
+                            R.string.reader_font_already_present,
+                            held?.displayName ?: "",
+                        ),
+                    )
+                }
+                ImportResult.NotAFont -> say(resources.getString(R.string.reader_font_error_not_a_font))
+                ImportResult.TooLarge -> say(resources.getString(R.string.reader_font_error_too_large))
+                ImportResult.TooMany -> say(resources.getString(R.string.reader_font_error_too_many))
+                ImportResult.Unreadable ->
+                    say(resources.getString(R.string.reader_font_error_unreadable))
+                ImportResult.StorageFailed ->
+                    say(resources.getString(R.string.reader_font_error_storage))
+            }
+        }
+    }
+
+    return FontLibraryState(
+        fonts = fonts,
+        pick = pick,
+        remove = { font ->
+            scope.launch {
+                when (repository.remove(font.id)) {
+                    // The selection is deliberately left alone. It stays
+                    // the raw id, dormant, and the reader falls back to
+                    // the default until the same file comes back.
+                    RemovalResult.Removed -> Unit
+                    RemovalResult.NotFound, RemovalResult.InvalidId -> Unit
+                    RemovalResult.DeleteFailed, RemovalResult.IndexFailed ->
+                        say(resources.getString(R.string.reader_font_error_remove))
+                }
+            }
+        },
+    )
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/reading/FontPicker.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/reading/FontPicker.kt
@@ -1,0 +1,53 @@
+package com.chmouel.liseur.ui.reading
+
+import android.net.Uri
+import android.provider.OpenableColumns
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * The types offered when picking a font.
+ *
+ * `application/octet-stream` is in the list on purpose. Android's
+ * `MimeTypeMap` has no entry for `ttf` or `otf`, so most
+ * DocumentsProviders report a font as a nameless binary, and a filter
+ * without it greys out the very files the reader came to find. Nothing is
+ * trusted on the strength of it: what the file *is* gets decided by
+ * reading its magic, never by what the provider claimed.
+ */
+private val FONT_MIME_TYPES = arrayOf(
+    "font/ttf",
+    "font/otf",
+    "font/sfnt",
+    "application/x-font-ttf",
+    "application/x-font-otf",
+    "application/font-sfnt",
+    "application/octet-stream",
+)
+
+/**
+ * Opens the system file picker and hands back what was chosen.
+ *
+ * The display name is looked up here rather than by the caller because
+ * the content URI is only readable while the grant lasts. It is a
+ * fallback for the font's name and nothing more — a font that names
+ * itself is never called after its file.
+ */
+@Composable
+fun rememberFontPicker(onPicked: (Uri, String?) -> Unit): () -> Unit {
+    val context = LocalContext.current
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument(),
+    ) { uri ->
+        if (uri == null) return@rememberLauncherForActivityResult
+        val name = runCatching {
+            context.contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+                ?.use { cursor -> if (cursor.moveToFirst()) cursor.getString(0) else null }
+        }.getOrNull()
+        onPicked(uri, name)
+    }
+    return remember(launcher) { { launcher.launch(FONT_MIME_TYPES) } }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/reading/ReadingAppearanceControls.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/reading/ReadingAppearanceControls.kt
@@ -17,6 +17,9 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.outlined.BrightnessAuto
 import androidx.compose.material.icons.outlined.BrightnessHigh
 import androidx.compose.material.icons.outlined.BrightnessLow
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -33,6 +36,7 @@ import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -57,6 +61,8 @@ import com.chmouel.liseur.data.settings.ReaderFont
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.ReaderTheme
 import com.chmouel.liseur.data.settings.ReaderThemeChoice
+import com.chmouel.liseur.data.settings.ReadingFont
+import com.chmouel.liseur.data.settings.fonts.UserFont
 import com.chmouel.liseur.ui.widthClass
 
 /*
@@ -155,9 +161,17 @@ fun ReadingThemeRow(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ReadingFontDropdown(selected: ReaderFont, onSelected: (ReaderFont) -> Unit) {
+fun ReadingFontDropdown(
+    selected: ReadingFont,
+    imported: List<UserFont>,
+    onSelected: (ReadingFont) -> Unit,
+    onImport: () -> Unit,
+    onRemove: (UserFont) -> Unit,
+) {
     val context = LocalContext.current
     var expanded by remember { mutableStateOf(false) }
+    var pendingRemoval by remember { mutableStateOf<UserFont?>(null) }
+
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         ReadingSectionLabel(stringResource(R.string.reader_font))
         ExposedDropdownMenuBox(
@@ -165,12 +179,12 @@ fun ReadingFontDropdown(selected: ReaderFont, onSelected: (ReaderFont) -> Unit) 
             onExpandedChange = { expanded = it },
         ) {
             OutlinedTextField(
-                value = stringResource(selected.label),
+                value = selected.displayName(imported),
                 onValueChange = {},
                 readOnly = true,
                 singleLine = true,
                 textStyle = LocalTextStyle.current.copy(
-                    fontFamily = remember(selected) { selected.composeFamily(context.assets) },
+                    fontFamily = selected.readingFamily(imported),
                     fontSize = 18.sp,
                 ),
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
@@ -183,6 +197,7 @@ fun ReadingFontDropdown(selected: ReaderFont, onSelected: (ReaderFont) -> Unit) 
                 onDismissRequest = { expanded = false },
             ) {
                 ReaderFont.entries.forEach { font ->
+                    val choice = ReadingFont.Bundled(font)
                     val family = remember(font) { font.composeFamily(context.assets) }
                     DropdownMenuItem(
                         text = {
@@ -192,23 +207,131 @@ fun ReadingFontDropdown(selected: ReaderFont, onSelected: (ReaderFont) -> Unit) 
                                 fontSize = 18.sp,
                             )
                         },
-                        trailingIcon = {
-                            if (font == selected) {
-                                Icon(
-                                    Icons.Default.Check,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.primary,
-                                )
-                            }
-                        },
+                        trailingIcon = { SelectedMark(choice.id == selected.id) },
                         onClick = {
-                            onSelected(font)
+                            onSelected(choice)
                             expanded = false
                         },
                     )
                 }
+
+                imported.forEach { font ->
+                    val choice = ReadingFont.Imported(font.digest)
+                    DropdownMenuItem(
+                        text = {
+                            Text(
+                                text = font.displayName,
+                                fontFamily = rememberImportedFamily(font),
+                                fontSize = 18.sp,
+                            )
+                        },
+                        trailingIcon = {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                SelectedMark(choice.id == selected.id)
+                                IconButton(onClick = { pendingRemoval = font }) {
+                                    Icon(
+                                        Icons.Outlined.Delete,
+                                        contentDescription = stringResource(
+                                            R.string.reader_font_remove,
+                                            font.displayName,
+                                        ),
+                                    )
+                                }
+                            }
+                        },
+                        onClick = {
+                            onSelected(choice)
+                            expanded = false
+                        },
+                    )
+                }
+
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.reader_font_add)) },
+                    leadingIcon = { Icon(Icons.Outlined.Add, contentDescription = null) },
+                    onClick = {
+                        expanded = false
+                        onImport()
+                    },
+                )
             }
         }
+    }
+
+    pendingRemoval?.let { font ->
+        AlertDialog(
+            onDismissRequest = { pendingRemoval = null },
+            title = { Text(stringResource(R.string.reader_font_remove_title, font.displayName)) },
+            // Says plainly what happens, because neither half is
+            // guessable: books reading in it fall back rather than break,
+            // and the choice is dormant rather than gone, so importing the
+            // same file again puts every one of them back.
+            text = { Text(stringResource(R.string.reader_font_remove_body)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    onRemove(font)
+                    pendingRemoval = null
+                }) { Text(stringResource(R.string.reader_font_remove_confirm)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingRemoval = null }) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun SelectedMark(selected: Boolean) {
+    if (!selected) return
+    Icon(
+        Icons.Default.Check,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.primary,
+    )
+}
+
+/**
+ * A preview face for an imported font, or the default if it will not load.
+ *
+ * The import path already refuses a file the platform cannot make a
+ * [android.graphics.Typeface] of, so this should never fire. It is here
+ * because the alternative is throwing inside composition — the settings
+ * screen would not fail to draw one row, it would fail to draw at all,
+ * and the reader would have no way back to the font that did it.
+ */
+@Composable
+private fun rememberImportedFamily(font: UserFont): FontFamily? = remember(font.id) {
+    runCatching { FontFamily(Font(font.file)) }.getOrNull()
+}
+
+/**
+ * The name to show for a font, resolving one that is no longer installed.
+ *
+ * An imported font whose file has gone is shown as the default, because
+ * the default is what the page is actually rendering in. The stored id is
+ * not drawn as a ghost row and, crucially, is not written over — only the
+ * reader picking something replaces it.
+ */
+@Composable
+private fun ReadingFont.displayName(imported: List<UserFont>): String =
+    when (val resolved = effective(imported.mapTo(HashSet()) { it.id })) {
+        is ReadingFont.Bundled -> stringResource(resolved.font.label)
+        is ReadingFont.Imported ->
+            imported.first { it.id == resolved.id }.displayName
+    }
+
+/** The face to preview a font in, resolving one that is no longer installed. */
+@Composable
+internal fun ReadingFont.readingFamily(imported: List<UserFont>): FontFamily? {
+    val context = LocalContext.current
+    return when (val resolved = effective(imported.mapTo(HashSet()) { it.id })) {
+        is ReadingFont.Bundled -> remember(resolved.font) {
+            resolved.font.composeFamily(context.assets)
+        }
+        is ReadingFont.Imported ->
+            rememberImportedFamily(imported.first { it.id == resolved.id })
     }
 }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
@@ -47,14 +47,17 @@ import androidx.compose.ui.unit.sp
 import com.chmouel.liseur.R
 import com.chmouel.liseur.data.settings.ColumnMode
 import com.chmouel.liseur.data.settings.FooterMode
-import com.chmouel.liseur.data.settings.ReaderFont
+import com.chmouel.liseur.data.settings.ReadingFont
 import com.chmouel.liseur.data.settings.ReaderPrefs
+import com.chmouel.liseur.data.settings.fonts.UserFont
 import com.chmouel.liseur.data.settings.ReaderTheme
 import com.chmouel.liseur.data.settings.ReaderThemeChoice
 import com.chmouel.liseur.ui.LocalEInk
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.reading.ReadingBrightnessSlider
 import com.chmouel.liseur.ui.reading.ReadingFontDropdown
+import com.chmouel.liseur.ui.reading.readingFamily
+import com.chmouel.liseur.ui.reading.rememberFontLibrary
 import com.chmouel.liseur.ui.reading.ReadingFontSizeSlider
 import com.chmouel.liseur.ui.reading.ReadingFooterModeDropdown
 import com.chmouel.liseur.ui.reading.ReadingLayoutControls
@@ -82,7 +85,7 @@ fun ReadingAppearanceScreen(
     prefs: ReaderPrefs,
     appIsDark: Boolean,
     onTheme: (ReaderThemeChoice) -> Unit,
-    onFont: (ReaderFont) -> Unit,
+    onFont: (ReadingFont) -> Unit,
     onFontSize: (Double) -> Unit,
     onLineHeight: (Double?) -> Unit,
     onPageMargins: (Double?) -> Unit,
@@ -123,7 +126,12 @@ fun ReadingAppearanceScreen(
                     .padding(bottom = 32.dp),
                 verticalArrangement = Arrangement.spacedBy(20.dp),
             ) {
-                ReadingPreview(prefs = prefs, theme = resolved)
+                val fontLibrary = rememberFontLibrary(onSelected = onFont)
+                ReadingPreview(
+                    prefs = prefs,
+                    theme = resolved,
+                    imported = fontLibrary.fonts,
+                )
                 ReadingThemeRow(
                     selected = prefs.themeChoice,
                     resolved = resolved,
@@ -131,7 +139,13 @@ fun ReadingAppearanceScreen(
                 )
                 ReadingFontSizeSlider(value = prefs.fontSize, onChanged = onFontSize)
                 ReadingBrightnessSlider(value = prefs.brightness, onChanged = onBrightness)
-                ReadingFontDropdown(selected = prefs.font, onSelected = onFont)
+                ReadingFontDropdown(
+                    selected = prefs.font,
+                    imported = fontLibrary.fonts,
+                    onSelected = onFont,
+                    onImport = fontLibrary.pick,
+                    onRemove = fontLibrary.remove,
+                )
                 AdvancedSection(
                     prefs = prefs,
                     onLineHeight = onLineHeight,
@@ -225,9 +239,12 @@ private fun AdvancedSection(
  * screen's and not the page's.
  */
 @Composable
-private fun ReadingPreview(prefs: ReaderPrefs, theme: ReaderTheme) {
-    val context = LocalContext.current
-    val family = remember(prefs.font) { prefs.font.composeFamily(context.assets) }
+private fun ReadingPreview(
+    prefs: ReaderPrefs,
+    theme: ReaderTheme,
+    imported: List<UserFont>,
+) {
+    val family = prefs.font.readingFamily(imported)
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         ReadingSectionLabel(stringResource(R.string.reader_preview_title))
         Box(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -473,6 +473,19 @@
     <string name="reader_font_atkinson" translatable="false">Atkinson Hyperlegible</string>
     <string name="reader_font_inter" translatable="false">Inter</string>
     <string name="reader_font_publisher">Publisher font</string>
+    <string name="reader_font_add">Add a font…</string>
+    <string name="reader_font_remove">Remove %1$s</string>
+    <string name="reader_font_remove_title">Remove %1$s?</string>
+    <string name="reader_font_remove_body">The font file is deleted from Liseur. Books reading in it fall back to the default for now — add the same file again and they go back to it.</string>
+    <string name="reader_font_remove_confirm">Remove</string>
+    <string name="reader_font_imported">%1$s added</string>
+    <string name="reader_font_already_present">%1$s is already in your fonts</string>
+    <string name="reader_font_error_not_a_font">That file is not a TrueType or OpenType font</string>
+    <string name="reader_font_error_too_large">That file is too large to be a font</string>
+    <string name="reader_font_error_too_many">You already have the most fonts Liseur will hold</string>
+    <string name="reader_font_error_unreadable">That file could not be read</string>
+    <string name="reader_font_error_storage">The font could not be saved</string>
+    <string name="reader_font_error_remove">The font could not be removed</string>
     <string name="reader_typography_own">Use separate settings for this book</string>
     <string name="reader_typography_own_on">Font, size and layout stay with this book.</string>
     <string name="reader_typography_own_off">Font, size and layout are shared with every book.</string>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -8,6 +8,14 @@
   or useless. Downloaded books (files/books) would blow through the 25 MB
   backup quota and can be fetched again; covers (files/covers) are built
   from the books themselves.
+
+  Imported fonts (files/fonts) do not travel here either. They are
+  user-supplied binaries, up to 32 of them, against the same 25 MB
+  quota. A restore therefore arrives with font choices whose files are
+  absent; that is a case the app already handles, falling back to the
+  default and keeping the choice, so importing the same file again puts
+  every book back where it was. They do travel on a device transfer,
+  which has no quota — see data_extraction_rules.xml.
 -->
 <full-backup-content>
     <!-- Room: library, reading positions, highlights and notes. -->

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -7,6 +7,11 @@
   arrive unreadable however they travel. The app notices that on first
   run and asks for the account again rather than pretending to be
   connected.
+
+  The one difference between the two lists is imported fonts. A device
+  transfer is the "everything is as it was" promise and is not
+  quota-limited, so the font files go with it. Cloud backup is capped at
+  25 MB and shared with the library, so they do not.
 -->
 <data-extraction-rules>
     <cloud-backup>
@@ -18,5 +23,7 @@
         <include domain="database" path="liseur.db" />
         <include domain="file" path="datastore" />
         <include domain="sharedpref" path="." />
+        <!-- Fonts the reader imported; nothing else can supply them. -->
+        <include domain="file" path="fonts" />
     </device-transfer>
 </data-extraction-rules>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/BookTypographyTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/BookTypographyTest.kt
@@ -2,6 +2,7 @@ package com.chmouel.liseur.data.db
 
 import com.chmouel.liseur.data.settings.FooterMode
 import com.chmouel.liseur.data.settings.ReaderFont
+import com.chmouel.liseur.data.settings.ReadingFont
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.ReaderThemeChoice
 import org.junit.Assert.assertEquals
@@ -17,7 +18,7 @@ import org.junit.Test
 class BookTypographyTest {
 
     private val shared = ReaderPrefs(
-        font = ReaderFont.LITERATA,
+        font = ReadingFont.Bundled(ReaderFont.LITERATA),
         fontSize = 1.0,
         themeChoice = ReaderThemeChoice.DARK,
         lineHeight = 1.4,
@@ -43,7 +44,7 @@ class BookTypographyTest {
     @Test
     fun `a book set apart is set in what it asked for`() {
         val effective = shared.withTypographyOf(own)
-        assertEquals(ReaderFont.ATKINSON, effective.font)
+        assertEquals(ReadingFont.Bundled(ReaderFont.ATKINSON), effective.font)
         assertEquals(1.6, effective.fontSize, 0.0)
         assertEquals(2.0, effective.lineHeight!!, 0.0)
         assertEquals(1.8, effective.pageMargins!!, 0.0)
@@ -77,6 +78,24 @@ class BookTypographyTest {
     @Test
     fun `a font that is no longer bundled falls back rather than failing`() {
         val effective = shared.withTypographyOf(own.copy(font = "a-font-we-removed"))
-        assertEquals(ReaderFont.Default, effective.font)
+        assertEquals(ReadingFont.Default, effective.font)
+    }
+
+    @Test
+    fun `a book set apart in an imported font keeps the import`() {
+        val digest = "a".repeat(64)
+        val effective = shared.withTypographyOf(own.copy(font = "user:" + digest))
+        assertEquals(ReadingFont.Imported(digest), effective.font)
+    }
+
+    @Test
+    fun `setting a book apart records the raw font, not the fallback`() {
+        // The point of the raw/effective split. If a book set apart while
+        // its imported font happened to be missing recorded the fallback,
+        // re-importing the very same file would no longer bring the
+        // choice back — and the reader would never learn why.
+        val digest = "b".repeat(64)
+        val missing = shared.copy(font = ReadingFont.Imported(digest))
+        assertEquals("user:" + digest, BookTypography.from("book", missing).font)
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/settings/ReadingFontTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/settings/ReadingFontTest.kt
@@ -1,0 +1,96 @@
+package com.chmouel.liseur.data.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * Which font a stored id means, and what happens when its file is gone.
+ *
+ * The raw/effective split lives here, and it is the reason deleting a
+ * font is a font going missing rather than a setting being destroyed.
+ */
+class ReadingFontTest {
+
+    private val digest = "0123456789abcdef".repeat(4)
+    private val imported = ReadingFont.Imported(digest)
+
+    @Test
+    fun `every bundled id round-trips`() {
+        ReaderFont.entries.forEach { font ->
+            assertEquals(ReadingFont.Bundled(font), ReadingFont.fromId(font.id))
+        }
+    }
+
+    @Test
+    fun `an imported id round-trips`() {
+        assertEquals(imported, ReadingFont.fromId("user:$digest"))
+        assertEquals("user:$digest", imported.id)
+    }
+
+    @Test
+    fun `nothing at all is the default`() {
+        assertEquals(ReadingFont.Default, ReadingFont.fromId(null))
+        assertEquals(ReadingFont.Default, ReadingFont.fromId(""))
+        assertEquals(ReadingFont.Default, ReadingFont.fromId("   "))
+    }
+
+    @Test
+    fun `an id from a version that does not exist yet is the default`() {
+        // Never guessed to be an import. A bundled font added later must
+        // not be readable as one, or it would resolve to a file that can
+        // never be there.
+        assertEquals(ReadingFont.Default, ReadingFont.fromId("some-future-font"))
+        assertEquals(ReadingFont.Default, ReadingFont.fromId("user"))
+        assertEquals(ReadingFont.Default, ReadingFont.fromId("user:"))
+    }
+
+    @Test
+    fun `a user id whose digest is not a digest is the default`() {
+        assertEquals(ReadingFont.Default, ReadingFont.fromId("user:short"))
+        assertEquals(ReadingFont.Default, ReadingFont.fromId("user:" + "z".repeat(64)))
+        assertEquals(ReadingFont.Default, ReadingFont.fromId("user:" + "A".repeat(64)))
+        assertEquals(ReadingFont.Default, ReadingFont.fromId("user:" + "0".repeat(63)))
+        assertEquals(ReadingFont.Default, ReadingFont.fromId("user:" + "0".repeat(65)))
+        assertEquals(ReadingFont.Default, ReadingFont.fromId("user:../../etc/passwd"))
+    }
+
+    @Test
+    fun `an imported family is namespaced so it cannot take over a bundled one`() {
+        assertNotEquals(ReaderFont.LITERATA.cssName, imported.cssName)
+        assertEquals("LiseurUser-$digest", imported.cssName)
+    }
+
+    @Test
+    fun `the publisher font declares no family at all`() {
+        assertEquals(null, ReadingFont.Bundled(ReaderFont.PUBLISHER).cssName)
+    }
+
+    @Test
+    fun `an import that is still installed resolves to itself`() {
+        assertEquals(imported, imported.effective(setOf("user:$digest")))
+    }
+
+    @Test
+    fun `an import whose file has gone resolves to the default`() {
+        assertEquals(ReadingFont.Default, imported.effective(emptySet()))
+        assertEquals(ReadingFont.Default, imported.effective(setOf("user:" + "f".repeat(64))))
+    }
+
+    @Test
+    fun `resolving never alters the value that gets stored`() {
+        // effective() answers a question; it does not change the answer to
+        // "what did the reader choose". Re-import the same bytes and the
+        // choice is simply live again.
+        val registry = emptySet<String>()
+        assertEquals(ReadingFont.Default, imported.effective(registry))
+        assertEquals("user:$digest", imported.id)
+        assertEquals(imported, imported.effective(setOf("user:$digest")))
+    }
+
+    @Test
+    fun `a bundled font is never resolved away`() {
+        val bundled = ReadingFont.Bundled(ReaderFont.VOLLKORN)
+        assertEquals(bundled, bundled.effective(emptySet()))
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/settings/UserFontRepositoryTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/settings/UserFontRepositoryTest.kt
@@ -1,0 +1,432 @@
+package com.chmouel.liseur.data.settings
+
+import android.content.Context
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import com.chmouel.liseur.data.settings.fonts.SfntFixtures
+import com.chmouel.liseur.data.settings.fonts.UserFont
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowContentResolver
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.security.MessageDigest
+
+/**
+ * The store behind the reader's imported fonts.
+ *
+ * The interesting assertions here are the ones about failure. A font
+ * arrives from a file picker, so every step of the way something can be
+ * absent, truncated, enormous, or not a font at all, and none of it may
+ * end with the published list disagreeing with what is actually on disk
+ * — a list that names a file that is not there is a dropdown row that
+ * blanks the page when it is tapped.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@Config(sdk = [35], application = android.app.Application::class)
+@RunWith(RobolectricTestRunner::class)
+class UserFontRepositoryTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val dir = File(context.filesDir, "fonts")
+    private val index = File(dir, "index.json")
+
+    private var next = 0
+
+    @Before
+    fun clean() {
+        dir.deleteRecursively()
+    }
+
+    @After
+    fun reset() {
+        ShadowContentResolver.reset()
+    }
+
+    // -- the happy path -----------------------------------------------------
+
+    @Test
+    fun `an imported font is stored under its own digest`() = test { fonts ->
+        val bytes = SfntFixtures.sfnt(names = listOf(SfntFixtures.name(1, "Fixture Text")))
+        val result = fonts.import(uriFor(bytes), "whatever-they-called-it.ttf")
+
+        val digest = sha256(bytes)
+        assertEquals(ImportResult.Imported("user:$digest"), result)
+        assertTrue(File(dir, "$digest.ttf").exists())
+        assertEquals(listOf("Fixture Text"), fonts.fonts.value.map { it.displayName })
+        assertEquals(setOf("user:$digest"), fonts.registry())
+    }
+
+    @Test
+    fun `the extension comes from the magic and not from what was picked`() = test { fonts ->
+        val bytes = SfntFixtures.sfnt(magic = SfntFixtures.OTTO)
+        fonts.import(uriFor(bytes), "definitely-a.ttf")
+
+        assertEquals("otf", fonts.fonts.value.single().extension)
+        assertTrue(File(dir, "${sha256(bytes)}.otf").exists())
+    }
+
+    @Test
+    fun `weight and italic are carried through for the declaration`() = test { fonts ->
+        val bytes = SfntFixtures.sfnt(
+            weightClass = 300,
+            fsSelection = SfntFixtures.OS2_ITALIC,
+            weightAxis = 200 to 900,
+        )
+        fonts.import(uriFor(bytes), null)
+
+        val font = fonts.fonts.value.single()
+        assertEquals(300, font.staticWeight)
+        assertTrue(font.italic)
+        assertEquals(200..900, font.weightRange)
+    }
+
+    @Test
+    fun `fonts are listed in an order the reader can scan`() = test { fonts ->
+        fonts.import(uriFor(named("Zeta")), null)
+        fonts.import(uriFor(named("alpha")), null)
+
+        assertEquals(listOf("alpha", "Zeta"), fonts.fonts.value.map { it.displayName })
+    }
+
+    // -- naming -------------------------------------------------------------
+
+    @Test
+    fun `a font with no name of its own takes the one it was picked under`() = test { fonts ->
+        fonts.import(uriFor(SfntFixtures.sfnt(names = emptyList())), "OpenDyslexic-Regular.ttf")
+
+        assertEquals("OpenDyslexic-Regular", fonts.fonts.value.single().displayName)
+    }
+
+    @Test
+    fun `a nameless font picked from nowhere still has something to show`() = test { fonts ->
+        val bytes = SfntFixtures.sfnt(names = emptyList())
+        fonts.import(uriFor(bytes), null)
+
+        val shown = fonts.fonts.value.single().displayName
+        assertTrue(shown, shown.isNotBlank())
+        assertTrue(shown, shown.contains(sha256(bytes).take(8)))
+    }
+
+    @Test
+    fun `a hostile picked name is sanitised before it is ever stored`() = test { fonts ->
+        fonts.import(uriFor(SfntFixtures.sfnt(names = emptyList())), "Bo\u202Eslim.ttf\u202C")
+
+        val shown = fonts.fonts.value.single().displayName
+        assertFalse(shown, shown.any { it == '\u202E' || it == '\u202C' })
+    }
+
+    @Test
+    fun `the picked name of a nameless font survives a restart`() = test { fonts ->
+        // The one thing a file cannot tell us twice, which is the whole
+        // reason there is an index at all.
+        fonts.import(uriFor(SfntFixtures.sfnt(names = emptyList())), "OpenDyslexic.ttf")
+
+        assertEquals("OpenDyslexic", reopened().fonts.value.single().displayName)
+    }
+
+    // -- refusals -----------------------------------------------------------
+
+    @Test
+    fun `something that is not a font is refused`() = test { fonts ->
+        val result = fonts.import(uriFor(ByteArray(4096) { (it * 31 % 251).toByte() }), "x.ttf")
+
+        assertEquals(ImportResult.NotAFont, result)
+        assertEquals(emptyList<UserFont>(), fonts.fonts.value)
+    }
+
+    @Test
+    fun `an empty file is refused`() = test { fonts ->
+        assertEquals(ImportResult.NotAFont, fonts.import(uriFor(ByteArray(0)), "empty.ttf"))
+    }
+
+    @Test
+    fun `a font the platform cannot load is refused before it reaches the preview`() {
+        // Plausible sfnt tables are not the same thing as a face Android
+        // can render, and the dropdown's preview has nowhere to put a
+        // throw.
+        test(loadCheck = { false }) { fonts ->
+            assertEquals(ImportResult.NotAFont, fonts.import(uriFor(SfntFixtures.sfnt()), null))
+            assertEquals(emptyList<UserFont>(), fonts.fonts.value)
+        }
+    }
+
+    @Test
+    fun `a provider that dies mid-read is reported rather than swallowed`() = test { fonts ->
+        // The grant can be withdrawn, or the file removed, between the
+        // tap and the read. There is nowhere for that to surface except
+        // a result the caller can show.
+        val uri = supplying {
+            object : InputStream() {
+                override fun read() = throw IOException("provider went away")
+            }
+        }
+        assertEquals(ImportResult.Unreadable, fonts.import(uri, "gone.ttf"))
+        assertEquals(emptyList<String>(), tempFiles())
+    }
+
+    @Test
+    fun `an enormous file is abandoned rather than copied in whole`() = test { fonts ->
+        val huge = ByteArray(17 * 1024 * 1024)
+        SfntFixtures.sfnt().copyInto(huge)
+
+        assertEquals(ImportResult.TooLarge, fonts.import(uriFor(huge), "video.ttf"))
+        assertEquals(emptyList<UserFont>(), fonts.fonts.value)
+    }
+
+    @Test
+    fun `nothing refused leaves a temp file behind`() = test { fonts ->
+        fonts.import(uriFor(ByteArray(4096)), "junk.ttf")
+        fonts.import(uriFor(ByteArray(17 * 1024 * 1024)), "huge.ttf")
+
+        assertEquals(emptyList<String>(), tempFiles())
+    }
+
+    // -- deduping -----------------------------------------------------------
+
+    @Test
+    fun `the same bytes picked twice are one font`() = test { fonts ->
+        val bytes = SfntFixtures.sfnt()
+        val first = fonts.import(uriFor(bytes), "Serif.ttf")
+        val again = fonts.import(uriFor(bytes), "A copy of Serif.TTF")
+
+        assertEquals(ImportResult.Imported("user:${sha256(bytes)}"), first)
+        assertEquals(ImportResult.AlreadyPresent("user:${sha256(bytes)}"), again)
+        assertEquals(1, fonts.fonts.value.size)
+    }
+
+    @Test
+    fun `re-picking a font is never refused for a limit it does not push against`() =
+        test { fonts ->
+            // Dedupe is checked before the cap, deliberately. Otherwise a
+            // full shelf turns "tap the font you already have" into
+            // "you have too many fonts", which is nonsense.
+            repeat(32) { fonts.import(uriFor(named("Filler $it")), null) }
+            assertEquals(32, fonts.fonts.value.size)
+
+            val existing = named("Filler 0")
+            assertEquals(
+                ImportResult.AlreadyPresent("user:${sha256(existing)}"),
+                fonts.import(uriFor(existing), null),
+            )
+            assertEquals(ImportResult.TooMany, fonts.import(uriFor(named("One more")), null))
+        }
+
+    // -- removal ------------------------------------------------------------
+
+    @Test
+    fun `removing a font takes the file and the name with it`() = test { fonts ->
+        val bytes = named("Doomed")
+        fonts.import(uriFor(bytes), null)
+        val id = "user:${sha256(bytes)}"
+
+        assertEquals(RemovalResult.Removed, fonts.remove(id))
+        assertEquals(emptyList<UserFont>(), fonts.fonts.value)
+        assertFalse(File(dir, "${sha256(bytes)}.ttf").exists())
+        assertFalse(index.readText().contains(id))
+    }
+
+    @Test
+    fun `an id that was never a font is refused without touching anything`() = test { fonts ->
+        fonts.import(uriFor(named("Kept")), null)
+
+        assertEquals(RemovalResult.InvalidId, fonts.remove("literata"))
+        assertEquals(RemovalResult.InvalidId, fonts.remove("user:../../databases/liseur.db"))
+        assertEquals(RemovalResult.InvalidId, fonts.remove("user:nothexatall"))
+        assertEquals(RemovalResult.NotFound, fonts.remove("user:" + "f".repeat(64)))
+        assertEquals(1, fonts.fonts.value.size)
+    }
+
+    // -- what survives a restart --------------------------------------------
+
+    @Test
+    fun `the shelf comes back`() = test { fonts ->
+        fonts.import(uriFor(named("One")), null)
+        fonts.import(uriFor(named("Two")), null)
+
+        assertEquals(listOf("One", "Two"), reopened().fonts.value.map { it.displayName })
+    }
+
+    @Test
+    fun `a corrupt index costs a name and never a font`() = test { fonts ->
+        fonts.import(uriFor(SfntFixtures.sfnt(names = emptyList())), "Picked Name.ttf")
+        index.writeText("{ this is not json")
+
+        val recovered = reopened().fonts.value.single()
+        assertTrue(recovered.file.exists())
+        assertTrue(recovered.displayName, recovered.displayName.isNotBlank())
+    }
+
+    @Test
+    fun `a missing index costs a name and never a font`() = test { fonts ->
+        fonts.import(uriFor(named("Named In Its Tables")), null)
+        assertTrue(index.delete())
+
+        // The name is in the font's own tables, so this one loses nothing.
+        assertEquals("Named In Its Tables", reopened().fonts.value.single().displayName)
+    }
+
+    @Test
+    fun `an index naming a font that is gone does not conjure it back`() = test { fonts ->
+        fonts.import(uriFor(named("Deleted Behind Our Back")), null)
+        dir.listFiles()!!.single { it.name.endsWith(".ttf") }.delete()
+
+        assertEquals(emptyList<UserFont>(), reopened().fonts.value)
+    }
+
+    @Test
+    fun `a staged import that died before its rename is swept`() = test { _ ->
+        dir.mkdirs()
+        File(dir, "orphan.tmp").writeBytes(SfntFixtures.sfnt())
+
+        assertEquals(emptyList<UserFont>(), reopened().fonts.value)
+        assertEquals(emptyList<String>(), tempFiles())
+    }
+
+    @Test
+    fun `a file Liseur did not write is ignored`() = test { _ ->
+        dir.mkdirs()
+        // Not a digest.
+        File(dir, "MyFavourite.ttf").writeBytes(SfntFixtures.sfnt())
+        // Not lowercase hex of the right length.
+        File(dir, "${"A".repeat(64)}.ttf").writeBytes(SfntFixtures.sfnt())
+        File(dir, "${"a".repeat(63)}.ttf").writeBytes(SfntFixtures.sfnt())
+        // A name Liseur could have written, over bytes that disagree with it.
+        File(dir, "${"a".repeat(64)}.ttf").writeBytes(SfntFixtures.sfnt(magic = SfntFixtures.OTTO))
+        File(dir, "${"b".repeat(64)}.ttf").writeBytes(ByteArray(64))
+
+        assertEquals(emptyList<UserFont>(), reopened().fonts.value)
+    }
+
+    // -- the list never lies about the directory ----------------------------
+
+    @Test
+    fun `a failed index write still publishes the font that landed`() = test { fonts ->
+        // The file is there. Whatever happened to the index, the list has
+        // to say so, because the alternative is a font the reader can see
+        // in their storage and not in the app.
+        val bytes = named("Landed")
+        blockIndexWrites()
+
+        val result = fonts.import(uriFor(bytes), null)
+
+        assertEquals(ImportResult.Imported("user:${sha256(bytes)}"), result)
+        assertEquals(listOf("Landed"), fonts.fonts.value.map { it.displayName })
+    }
+
+    @Test
+    fun `a failed index write on removal still publishes the font that went`() = test { fonts ->
+        val bytes = named("Going")
+        fonts.import(uriFor(bytes), null)
+        blockIndexWrites()
+
+        assertEquals(RemovalResult.IndexFailed, fonts.remove("user:${sha256(bytes)}"))
+        assertEquals(emptyList<UserFont>(), fonts.fonts.value)
+        assertFalse(File(dir, "${sha256(bytes)}.ttf").exists())
+    }
+
+    @Test
+    fun `a font that has become unreadable costs itself and not the shelf`() = test { fonts ->
+        fonts.import(uriFor(named("Readable")), null)
+        val gone = named("Unreadable")
+        dir.mkdirs()
+        // A directory where a file should be: what a half-restored backup
+        // or a detached volume can leave behind. `init` is where this is
+        // read, so a throw would cost the whole shelf, permanently.
+        File(dir, "${sha256(gone)}.ttf").mkdirs()
+
+        assertEquals(listOf("Readable"), reopened().fonts.value.map { it.displayName })
+    }
+
+    // -- ordering -----------------------------------------------------------
+
+    @Test
+    fun `the opening scan cannot land on top of a later import`() = runTest {
+        // Without the lock covering the scan, a reader quick enough to
+        // import before it finished would watch the font disappear.
+        val bytes = named("Raced")
+        val fonts = UserFontRepository(context, this, loadCheck = { true })
+
+        val result = fonts.import(uriFor(bytes), null)
+        advanceUntilIdle()
+
+        assertEquals(ImportResult.Imported("user:${sha256(bytes)}"), result)
+        assertEquals(listOf("Raced"), fonts.fonts.value.map { it.displayName })
+    }
+
+    @Test
+    fun `awaitReady returns once the shelf is published`() = runTest {
+        dir.mkdirs()
+        val bytes = named("Already There")
+        File(dir, "${sha256(bytes)}.ttf").writeBytes(bytes)
+
+        val fonts = UserFontRepository(context, this, loadCheck = { true })
+        fonts.awaitReady()
+
+        assertEquals(listOf("Already There"), fonts.fonts.value.map { it.displayName })
+    }
+
+    // -- plumbing -----------------------------------------------------------
+
+    private fun test(
+        loadCheck: (File) -> Boolean = { true },
+        body: suspend TestScope.(UserFontRepository) -> Unit,
+    ) = runTest(StandardTestDispatcher()) {
+        val fonts = UserFontRepository(context, this, loadCheck = loadCheck)
+        fonts.awaitReady()
+        body(fonts)
+    }
+
+    /** A second repository over the same directory, standing in for a restart. */
+    private suspend fun TestScope.reopened(): UserFontRepository =
+        UserFontRepository(context, this, loadCheck = { true }).also { it.awaitReady() }
+
+    /**
+     * Makes the next index write fail, without touching the font files.
+     *
+     * `AtomicFile` stages into `<base>.new`; a non-empty directory there
+     * is something it can neither open nor clear, and its own retry
+     * (`parent.mkdirs()`) cannot help because the parent already exists.
+     */
+    private fun blockIndexWrites() {
+        dir.mkdirs()
+        File(dir, "index.json.new").mkdirs()
+        File(dir, "index.json.new/occupied").writeText("x")
+    }
+
+    /** A font whose own `name` table says [family]. */
+    private fun named(family: String) =
+        SfntFixtures.sfnt(names = listOf(SfntFixtures.name(1, family)))
+
+    private fun uriFor(bytes: ByteArray): Uri = supplying { ByteArrayInputStream(bytes) }
+
+    private fun supplying(stream: () -> InputStream): Uri {
+        val uri = Uri.parse("content://test/${next++}")
+        shadowOf(context.contentResolver).registerInputStreamSupplier(uri, stream)
+        return uri
+    }
+
+    private fun tempFiles() =
+        dir.listFiles().orEmpty().map { it.name }.filter { it.endsWith(".tmp") }
+
+    private fun sha256(bytes: ByteArray) =
+        MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/settings/fonts/FontNamesTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/settings/fonts/FontNamesTest.kt
@@ -1,0 +1,79 @@
+package com.chmouel.liseur.data.settings.fonts
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Names arriving from outside the app.
+ *
+ * Both of the names an imported font can be shown under come from
+ * somewhere Liseur does not control — the file's own `name` table, and
+ * whatever a DocumentsProvider decided to call it. The same sanitiser
+ * has to cover both, which is why there is only one.
+ */
+class FontNamesTest {
+
+    @Test
+    fun `an ordinary name is left alone`() {
+        assertEquals("Literata", FontNames.sanitize("Literata"))
+    }
+
+    @Test
+    fun `trims and collapses whitespace`() {
+        assertEquals("Fixture Text", FontNames.sanitize("  Fixture   Text  "))
+    }
+
+    @Test
+    fun `strips a right-to-left override`() {
+        // Left in, this renders the settings row backwards, and keeps
+        // rendering the rows after it backwards too.
+        assertEquals("Literata gnitteS", FontNames.sanitize("Literata \u202Egnitte\u202CS"))
+    }
+
+    @Test
+    fun `strips every bidi control`() {
+        val hostile = "A\u200E\u200F\u202A\u202B\u202C\u202D\u202E\u2066\u2067\u2068\u2069B"
+        assertEquals("AB", FontNames.sanitize(hostile))
+    }
+
+    @Test
+    fun `turns a newline into a space rather than a second row`() {
+        assertEquals("One Two", FontNames.sanitize("One\nTwo"))
+    }
+
+    @Test
+    fun `drops the NUL padding of a fixed-length record`() {
+        assertEquals("Fixture", FontNames.sanitize("Fixture\u0000\u0000\u0000"))
+    }
+
+    @Test
+    fun `caps a very long name`() {
+        val long = "N".repeat(200)
+        assertEquals(64, FontNames.sanitize(long)!!.length)
+    }
+
+    @Test
+    fun `does not leave a trailing space where the cap fell`() {
+        val name = "W".repeat(63) + " tail"
+        assertEquals("W".repeat(63), FontNames.sanitize(name))
+    }
+
+    @Test
+    fun `a name with nothing in it is no name at all`() {
+        assertNull(FontNames.sanitize(""))
+        assertNull(FontNames.sanitize("   "))
+        assertNull(FontNames.sanitize("\u202E\u2069"))
+    }
+
+    @Test
+    fun `keeps non-Latin scripts, which are the point of the feature`() {
+        assertEquals("思源宋體", FontNames.sanitize("思源宋體"))
+        assertEquals("Шрифт", FontNames.sanitize("Шрифт"))
+    }
+
+    @Test
+    fun `a font that names itself nothing falls back to its digest`() {
+        assertEquals("Imported font 1a2b3c4d", FontNames.fallbackName("1a2b3c4d" + "0".repeat(56)))
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/settings/fonts/SfntFixtures.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/settings/fonts/SfntFixtures.kt
@@ -1,0 +1,162 @@
+package com.chmouel.liseur.data.settings.fonts
+
+import java.io.ByteArrayOutputStream
+
+/**
+ * Font files built out of bytes, for the tests that need one.
+ *
+ * Nothing binary is checked in: a reader of these tests can see exactly
+ * which byte makes an assertion true, and a fixture cannot quietly stop
+ * being the thing it claims to be. Shared between the parser's own tests
+ * and the repository's, which needs files a real parse will accept.
+ */
+object SfntFixtures {
+
+    const val TRUE_TYPE = 0x00010000
+    const val OTTO = 0x4F54544F
+    const val TRUE_TAG = 0x74727565
+    const val NAME_FAMILY = 1
+    const val NAME_TYPOGRAPHIC_FAMILY = 16
+    const val OS2_ITALIC = 0x01
+    const val OS2_BOLD = 0x20
+
+    fun sfnt(
+        magic: Int = TRUE_TYPE,
+        names: List<NameRecord> = listOf(name(NAME_FAMILY, "Fixture")),
+        weightClass: Int = 400,
+        fsSelection: Int = 0,
+        macStyle: Int = 0,
+        withOs2: Boolean = true,
+        weightAxis: Pair<Int, Int>? = null,
+        axisTag: String = "wght",
+    ): ByteArray {
+        val tables = LinkedHashMap<String, ByteArray>()
+        tables["head"] = ByteArray(54).also { it.putU16(44, macStyle) }
+        if (withOs2) {
+            tables["OS/2"] = ByteArray(96).also {
+                it.putU16(4, weightClass)
+                it.putU16(62, fsSelection)
+            }
+        }
+        if (names.isNotEmpty()) tables["name"] = nameTable(names)
+        weightAxis?.let { (min, max) -> tables["fvar"] = fvarTable(axisTag, min, max) }
+
+        val directory = 12 + tables.size * 16
+        val body = ByteArrayOutputStream()
+        val offsets = LinkedHashMap<String, Pair<Int, Int>>()
+        for ((tag, bytes) in tables) {
+            offsets[tag] = (directory + body.size()) to bytes.size
+            body.write(bytes)
+            // Tables are four-byte aligned in a real font; pad so the
+            // fixture is one too.
+            while (body.size() % 4 != 0) body.write(0)
+        }
+
+        val out = ByteArray(directory + body.size())
+        out.putU32(0, magic)
+        out.putU16(4, tables.size)
+        tables.keys.forEachIndexed { i, tag ->
+            val record = 12 + i * 16
+            tag.padEnd(4).toByteArray(Charsets.US_ASCII).copyInto(out, record)
+            val (offset, length) = offsets.getValue(tag)
+            out.putU32(record + 8, offset)
+            out.putU32(record + 12, length)
+        }
+        body.toByteArray().copyInto(out, directory)
+        return out
+    }
+
+    class NameRecord(
+        val nameId: Int,
+        val platform: Int,
+        val encoding: Int,
+        val language: Int,
+        val bytes: ByteArray,
+    )
+
+    fun name(
+        nameId: Int,
+        value: String,
+        platform: Int = 3,
+        encoding: Int = 1,
+        language: Int = 0x409,
+        mac: Boolean = false,
+        ucs4: Boolean = false,
+    ) = NameRecord(
+        nameId = nameId,
+        platform = platform,
+        encoding = encoding,
+        language = language,
+        bytes = when {
+            mac -> value.toByteArray(Charsets.ISO_8859_1)
+            ucs4 -> value.toByteArray(Charsets.UTF_32BE)
+            else -> value.toByteArray(Charsets.UTF_16BE)
+        },
+    )
+
+    fun nameTable(records: List<NameRecord>): ByteArray {
+        val storage = 6 + records.size * 12
+        val strings = ByteArrayOutputStream()
+        val out = ByteArray(storage + records.sumOf { it.bytes.size })
+        out.putU16(0, 0)
+        out.putU16(2, records.size)
+        out.putU16(4, storage)
+        records.forEachIndexed { i, record ->
+            val at = 6 + i * 12
+            out.putU16(at, record.platform)
+            out.putU16(at + 2, record.encoding)
+            out.putU16(at + 4, record.language)
+            out.putU16(at + 6, record.nameId)
+            out.putU16(at + 8, record.bytes.size)
+            out.putU16(at + 10, strings.size())
+            strings.write(record.bytes)
+        }
+        strings.toByteArray().copyInto(out, storage)
+        return out
+    }
+
+    fun fvarTable(tag: String, min: Int, max: Int): ByteArray {
+        val axesOffset = 16
+        val out = ByteArray(axesOffset + 20)
+        out.putU32(0, 0x00010000)
+        out.putU16(4, axesOffset)
+        out.putU16(8, 1)
+        out.putU16(10, 20)
+        tag.toByteArray(Charsets.US_ASCII).copyInto(out, axesOffset)
+        out.putFixed(axesOffset + 4, min)
+        out.putFixed(axesOffset + 8, min)
+        out.putFixed(axesOffset + 12, max)
+        return out
+    }
+
+    fun ByteArray.tableOffset(tag: String): Int {
+        val count = ((this[4].toInt() and 0xFF) shl 8) or (this[5].toInt() and 0xFF)
+        for (i in 0 until count) {
+            val record = 12 + i * 16
+            val found = String(copyOfRange(record, record + 4), Charsets.US_ASCII)
+            if (found == tag.padEnd(4)) {
+                return (0..3).fold(0) { acc, b ->
+                    (acc shl 8) or (this[record + 8 + b].toInt() and 0xFF)
+                }
+            }
+        }
+        throw AssertionError("no $tag table in the fixture")
+    }
+
+    fun ByteArray.putU16(at: Int, value: Int) {
+        this[at] = (value ushr 8).toByte()
+        this[at + 1] = value.toByte()
+    }
+
+    fun ByteArray.putU32(at: Int, value: Int) {
+        this[at] = (value ushr 24).toByte()
+        this[at + 1] = (value ushr 16).toByte()
+        this[at + 2] = (value ushr 8).toByte()
+        this[at + 3] = value.toByte()
+    }
+
+    fun ByteArray.putFixed(at: Int, whole: Int) {
+        putU16(at, whole and 0xFFFF)
+        putU16(at + 2, 0)
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/settings/fonts/SfntFontTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/settings/fonts/SfntFontTest.kt
@@ -1,0 +1,209 @@
+package com.chmouel.liseur.data.settings.fonts
+
+import com.chmouel.liseur.data.settings.fonts.SfntFixtures.NAME_FAMILY
+import com.chmouel.liseur.data.settings.fonts.SfntFixtures.NAME_TYPOGRAPHIC_FAMILY
+import com.chmouel.liseur.data.settings.fonts.SfntFixtures.OS2_BOLD
+import com.chmouel.liseur.data.settings.fonts.SfntFixtures.OS2_ITALIC
+import com.chmouel.liseur.data.settings.fonts.SfntFixtures.OTTO
+import com.chmouel.liseur.data.settings.fonts.SfntFixtures.TRUE_TAG
+import com.chmouel.liseur.data.settings.fonts.SfntFixtures.TRUE_TYPE
+import com.chmouel.liseur.data.settings.fonts.SfntFixtures.name
+import com.chmouel.liseur.data.settings.fonts.SfntFixtures.putU16
+import com.chmouel.liseur.data.settings.fonts.SfntFixtures.putU32
+import com.chmouel.liseur.data.settings.fonts.SfntFixtures.sfnt
+import com.chmouel.liseur.data.settings.fonts.SfntFixtures.tableOffset
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The font parser, fed the kind of bytes a file picker can produce.
+ *
+ * Every fixture is built out of bytes by [SfntFixtures] rather than
+ * checked in as a binary, so a reader of these tests can see exactly
+ * which byte makes the assertion true. The hostile cases matter more
+ * than the happy ones: the input is
+ * a file somebody chose out of a file manager, and the caller is a
+ * callback with nowhere to put an exception.
+ */
+class SfntFontTest {
+
+    @Test
+    fun `reads the typographic family name in preference to the compatibility one`() {
+        val font = sfnt(
+            names = listOf(
+                name(NAME_FAMILY, "Fixture Text Bold"),
+                name(NAME_TYPOGRAPHIC_FAMILY, "Fixture Text"),
+            ),
+        )
+        assertEquals("Fixture Text", SfntFont.parse(font)!!.familyName)
+    }
+
+    @Test
+    fun `prefers the English Windows record over a Mac one`() {
+        val font = sfnt(
+            names = listOf(
+                name(NAME_FAMILY, "Wrong", platform = 1, encoding = 0, language = 0, mac = true),
+                name(NAME_FAMILY, "Right"),
+            ),
+        )
+        assertEquals("Right", SfntFont.parse(font)!!.familyName)
+    }
+
+    @Test
+    fun `reads a Mac record when it is all there is`() {
+        val font = sfnt(
+            names = listOf(
+                name(NAME_FAMILY, "Mac Only", platform = 1, encoding = 0, language = 0, mac = true),
+            ),
+        )
+        assertEquals("Mac Only", SfntFont.parse(font)!!.familyName)
+    }
+
+    @Test
+    fun `reads a UCS-4 Windows record`() {
+        val font = sfnt(names = listOf(name(NAME_FAMILY, "Wide", encoding = 10, ucs4 = true)))
+        assertEquals("Wide", SfntFont.parse(font)!!.familyName)
+    }
+
+    @Test
+    fun `a font with no name table is still a font`() {
+        val parsed = SfntFont.parse(sfnt(names = emptyList()))!!
+        assertNull(parsed.familyName)
+        assertEquals(SfntFormat.TRUE_TYPE, parsed.format)
+    }
+
+    @Test
+    fun `the extension comes from the magic and never from a claim`() {
+        assertEquals("otf", SfntFont.parse(sfnt(magic = OTTO))!!.format.extension)
+        assertEquals("ttf", SfntFont.parse(sfnt(magic = TRUE_TYPE))!!.format.extension)
+        assertEquals("ttf", SfntFont.parse(sfnt(magic = TRUE_TAG))!!.format.extension)
+    }
+
+    @Test
+    fun `reads the weight class`() {
+        assertEquals(300, SfntFont.parse(sfnt(weightClass = 300))!!.weight)
+    }
+
+    @Test
+    fun `falls back to bold when only the flag says so`() {
+        val font = sfnt(weightClass = 0, fsSelection = OS2_BOLD)
+        assertEquals(700, SfntFont.parse(font)!!.weight)
+    }
+
+    @Test
+    fun `falls back to regular when nothing says otherwise`() {
+        assertEquals(400, SfntFont.parse(sfnt(weightClass = 0))!!.weight)
+    }
+
+    @Test
+    fun `reads italic from fsSelection`() {
+        assertEquals(true, SfntFont.parse(sfnt(fsSelection = OS2_ITALIC))!!.italic)
+        assertEquals(false, SfntFont.parse(sfnt(fsSelection = 0))!!.italic)
+    }
+
+    @Test
+    fun `reads italic from macStyle when there is no OS2 table`() {
+        val font = sfnt(macStyle = 0b10, withOs2 = false)
+        assertEquals(true, SfntFont.parse(font)!!.italic)
+    }
+
+    @Test
+    fun `reads a variable weight axis`() {
+        assertEquals(200..900, SfntFont.parse(sfnt(weightAxis = 200 to 900))!!.weightRange)
+    }
+
+    @Test
+    fun `clamps a weight axis rather than letting Readium assert on it`() {
+        // setFontWeight(range) requires 1..1000. An unclamped range from a
+        // malformed fvar would throw while the navigator was being built,
+        // which costs the reader the book, not the font.
+        assertEquals(1..1000, SfntFont.parse(sfnt(weightAxis = 0 to 4000))!!.weightRange)
+    }
+
+    @Test
+    fun `an axis entirely above the allowed range collapses to its edge`() {
+        assertEquals(1000..1000, SfntFont.parse(sfnt(weightAxis = 5000 to 6000))!!.weightRange)
+    }
+
+    @Test
+    fun `discards a weight axis whose maximum is below its minimum`() {
+        assertNull(SfntFont.parse(sfnt(weightAxis = 900 to 200))!!.weightRange)
+    }
+
+    @Test
+    fun `ignores a non-weight axis`() {
+        assertNull(SfntFont.parse(sfnt(weightAxis = 200 to 900, axisTag = "wdth"))!!.weightRange)
+    }
+
+    @Test
+    fun `refuses a font collection`() {
+        assertNull(SfntFont.parse(sfnt(magic = 0x74746366)))
+    }
+
+    @Test
+    fun `refuses WOFF and WOFF2`() {
+        assertNull(SfntFont.parse(sfnt(magic = 0x774F4646)))
+        assertNull(SfntFont.parse(sfnt(magic = 0x774F4632)))
+    }
+
+    @Test
+    fun `refuses an empty file`() {
+        assertNull(SfntFont.parse(ByteArray(0)))
+    }
+
+    @Test
+    fun `refuses a truncated header`() {
+        assertNull(SfntFont.parse(sfnt().copyOf(6)))
+    }
+
+    @Test
+    fun `refuses a file that is only a magic number`() {
+        assertNull(SfntFont.parse(byteArrayOf(0, 1, 0, 0)))
+    }
+
+    @Test
+    fun `survives a table count that could not possibly be true`() {
+        val font = sfnt()
+        font.putU16(4, 60000)
+        assertNull(SfntFont.parse(font))
+    }
+
+    @Test
+    fun `survives a table offset past the end of the file`() {
+        val font = sfnt()
+        // The first record's offset, pointed somewhere that is not there.
+        font.putU32(12 + 8, 0x7FFF_FFF0)
+        // Not a crash and not a lie: the tables it can read, it reads.
+        SfntFont.parse(font)
+    }
+
+    @Test
+    fun `survives an offset and length that would overflow if added`() {
+        val font = sfnt()
+        font.putU32(12 + 8, Int.MAX_VALUE - 4)
+        font.putU32(12 + 12, Int.MAX_VALUE - 4)
+        SfntFont.parse(font)
+    }
+
+    @Test
+    fun `survives a name record pointing outside its own table`() {
+        val font = sfnt(names = listOf(name(NAME_FAMILY, "Fixture")))
+        val nameTable = font.tableOffset("name")
+        // The string offset, moved well past the storage area.
+        font.putU16(nameTable + 6 + 10, 60000)
+        assertNull(SfntFont.parse(font)!!.familyName)
+    }
+
+    @Test
+    fun `survives random bytes`() {
+        val noise = ByteArray(4096) { (it * 31 % 251).toByte() }
+        SfntFont.parse(noise)
+    }
+
+    @Test
+    fun `strips a bidi override out of a family name`() {
+        val font = sfnt(names = listOf(name(NAME_FAMILY, "Fix\u202Eture")))
+        assertEquals("Fixture", SfntFont.parse(font)!!.familyName)
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/UserFontResourcesTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/UserFontResourcesTest.kt
@@ -1,0 +1,159 @@
+package com.chmouel.liseur.reader
+
+import com.chmouel.liseur.data.settings.fonts.UserFont
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.readium.r2.shared.util.Url
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+/**
+ * Which requests from the web view are answered with an imported font.
+ *
+ * The navigator asks the publication for a URL, and the publication is
+ * whatever Liseur wrapped it in. This is the whole of the boundary
+ * between "a font the reader imported" and "any other file on the
+ * device", so it is spelled out rather than assumed: an exact match
+ * against an href built from a font already in the registry, and no path
+ * resolution anywhere.
+ *
+ * Readium's `Url` parses through `android.net.Uri`, so this runs under
+ * Robolectric rather than on the bare JVM.
+ */
+@Config(sdk = [35], application = android.app.Application::class)
+@RunWith(RobolectricTestRunner::class)
+class UserFontResourcesTest {
+
+    private val digest = "a".repeat(64)
+    private val other = "b".repeat(64)
+
+    private val font = UserFont(
+        digest = digest,
+        displayName = "Fixture",
+        file = File("/data/user/0/com.chmouel.liseur/files/fonts/$digest.ttf"),
+        extension = "ttf",
+        italic = false,
+        staticWeight = 400,
+        weightRange = null,
+    )
+
+    private val fonts = listOf(font)
+
+    private fun match(href: String) = UserFontResources.match(Url(href)!!, fonts)
+
+    @Test
+    fun `answers the absolute url a declaration is written with`() {
+        assertEquals(font, match("https://readium_package/__liseur_fonts__/$digest.ttf"))
+        assertEquals(font, UserFontResources.match(UserFontResources.url(font), fonts))
+    }
+
+    @Test
+    fun `answers the relative spelling of the same path`() {
+        assertEquals(font, match("__liseur_fonts__/$digest.ttf"))
+    }
+
+    @Test
+    fun `refuses another host`() {
+        assertNull(match("https://readium_assets/__liseur_fonts__/$digest.ttf"))
+        assertNull(match("https://example.com/__liseur_fonts__/$digest.ttf"))
+        assertNull(match("https://readium_package.example.com/__liseur_fonts__/$digest.ttf"))
+    }
+
+    @Test
+    fun `refuses another scheme`() {
+        assertNull(match("http://readium_package/__liseur_fonts__/$digest.ttf"))
+        assertNull(match("file:///__liseur_fonts__/$digest.ttf"))
+    }
+
+    @Test
+    fun `refuses a port or user-info smuggled into the authority`() {
+        // Requiring the origin as a literal prefix settles all four of
+        // scheme, host, port and user-info in one comparison, which is
+        // why there is no separate assertion for each.
+        assertNull(match("https://readium_package:8080/__liseur_fonts__/$digest.ttf"))
+        assertNull(match("https://evil@readium_package/__liseur_fonts__/$digest.ttf"))
+    }
+
+    @Test
+    fun `refuses traversal in every spelling`() {
+        assertNull(match("__liseur_fonts__/../../databases/liseur.db"))
+        assertNull(match("__liseur_fonts__/%2e%2e/%2e%2e/databases/liseur.db"))
+        assertNull(match("__liseur_fonts__/%2E%2E/liseur.db"))
+        assertNull(match("__liseur_fonts__/..%2f$digest.ttf"))
+        assertNull(match("https://readium_package/__liseur_fonts__/../$digest.ttf"))
+    }
+
+    @Test
+    fun `refuses a separator that only looks like part of the name`() {
+        assertNull(match("__liseur_fonts__/sub/$digest.ttf"))
+        assertNull(match("__liseur_fonts__%2f$digest.ttf"))
+        assertNull(match("__liseur_fonts__/dir%5c$digest.ttf"))
+    }
+
+    @Test
+    fun `refuses a doubled slash`() {
+        assertNull(match("https://readium_package//__liseur_fonts__/$digest.ttf"))
+        assertNull(match("__liseur_fonts__//$digest.ttf"))
+    }
+
+    @Test
+    fun `refuses a well-formed name that is not in the registry`() {
+        // The last line, and the one that means traversal has nothing to
+        // aim at: the file comes from the matched UserFont, never from
+        // joining a url onto a directory.
+        assertNull(match("__liseur_fonts__/$other.ttf"))
+        assertNull(match("__liseur_fonts__/$digest.otf"))
+    }
+
+    @Test
+    fun `refuses an ordinary publication resource`() {
+        assertNull(match("OEBPS/chapter1.xhtml"))
+        assertNull(match("__liseur_fonts__"))
+        assertNull(match("fonts/$digest.ttf"))
+    }
+
+    @Test
+    fun `tolerates a fragment and a query rather than refusing them`() {
+        // Publication.get looks up `href` and then retries with the query
+        // removed. A rule that turned one away would break Readium's own
+        // second attempt at a request that was legitimate to start with.
+        assertEquals(font, match("__liseur_fonts__/$digest.ttf#anything"))
+        assertEquals(font, match("__liseur_fonts__/$digest.ttf?v=1"))
+        assertEquals(font, match("https://readium_package/__liseur_fonts__/$digest.ttf?v=1#x"))
+    }
+
+    @Test
+    fun `refuses an href long enough to be an attack rather than a font`() {
+        assertNull(match("__liseur_fonts__/" + "a".repeat(600) + ".ttf"))
+    }
+
+    @Test
+    fun `the container answers only for the fonts it holds`() {
+        val container = UserFontsContainer { fonts }
+        assertNull(container.get(Url("OEBPS/chapter1.xhtml")!!))
+        assertNull(container.get(Url("__liseur_fonts__/$other.ttf")!!))
+    }
+
+    @Test
+    fun `the container is read afresh so an import lands mid-book`() {
+        var current = emptyList<UserFont>()
+        val container = UserFontsContainer { current }
+        assertEquals(emptySet<Url>(), container.entries)
+        current = fonts
+        assertEquals(setOf(Url("__liseur_fonts__/$digest.ttf")!!), container.entries)
+    }
+
+    @Test
+    fun `a book carrying the reserved path cannot shadow a font`() {
+        // The composite puts this container first precisely because it is
+        // registry-strict: it can only ever answer for a digest it holds,
+        // so it shadows nothing, while the book left first would shadow
+        // the reader's font.
+        val container = UserFontsContainer { fonts }
+        assertNull(container.get(Url("__liseur_fonts__/decoy.xhtml")!!))
+        assertNull(container.get(Url("__liseur_fonts__/index.json")!!))
+    }
+}

--- a/docs/adr/0004-user-imported-fonts.md
+++ b/docs/adr/0004-user-imported-fonts.md
@@ -1,6 +1,6 @@
 # 4. User-imported fonts
 
-Status: proposed
+Status: accepted
 GitHub issue: [#6](https://github.com/chmouel/liseur/issues/6)
 
 ## Context
@@ -14,31 +14,138 @@ every family is APK weight everyone carries.
 
 Let the reader import a font file. Picked through the system file
 picker, copied into the app's own storage, offered in the font row like
-the bundled four, applied when the next book opens.
+the bundled four, applied to the open book at once.
 
 Fit with Liseur's simplicity: one "Add a font…" entry at the end of the
-existing font list in the Advanced sheet. Imported fonts appear in the
-same list with a remove affordance; no manager screen.
+existing font list, and imported fonts in that same list, previewed in
+their own face, with a remove affordance behind a confirmation. No
+manager screen, and — this is what keeps ADR 0001 satisfied — **no new
+row**: the font control the typography sheet and Settings → Reading
+appearance already share is the one that grows.
 
 ## Design
 
-Import is `ACTION_OPEN_DOCUMENT` for `font/ttf` and `font/otf`, the
-bytes copied to `filesDir/fonts/` — copied, not referenced, so the
-choice survives the source file moving or the SAF grant lapsing. The
-family name is read from the font's name table; a file that has none
-falls back to its filename.
+### Storage
 
-`ReaderFont` stops being the whole story: the enum keeps the bundled
-families and `PUBLISHER`, and the font preference becomes an id that is
-either one of those or a user font's filename. `ReaderFont.fromId`
-already tolerates unknown ids by falling back to the default, which is
-exactly what happens if the file behind a chosen font is gone.
+Import is `ACTION_OPEN_DOCUMENT`, the bytes copied to `filesDir/fonts/`
+— copied, not referenced, so the choice survives the source file moving
+or the SAF grant lapsing. The MIME filter includes
+`application/octet-stream`, because `MimeTypeMap` has no `ttf` entry and
+most DocumentsProviders report a font that way; a filter without it
+hides the very files being looked for. Nothing is trusted from the
+provider: the format is decided by the sfnt magic, and the extension on
+disk with it.
 
-Declaration goes through the same `addFontFamilyDeclaration` path the
-bundled fonts use in `epubNavigatorConfiguration`, with the served-asset
-scope widened to cover the app's font directory. That configuration is
-read when a book opens, so an import lands on the next book — the same
-behaviour column mode already has, documented in the same place.
+A font is stored as `<sha256>.<ext>` and known by `user:<sha256>`.
+Content-addressing is what lets a font be deleted, and the same file
+imported again months later, and every book that was reading in it pick
+it straight back up — the id was never a handle into a table, it was
+always the bytes. `filesDir/fonts/index.json` caches only the display
+name, the one thing a font with no `name` table cannot tell us twice; a
+lost or corrupt index costs a name and never a font.
+
+The stored preference is the **raw** choice. An `Imported` id whose file
+is absent stays in DataStore and in `book_typography` untouched, and
+only `ReadingFont.effective(registry)` resolves it to the default for
+rendering. Writing the fallback back would lose the choice for good the
+first time a book was set apart while its font was missing.
+
+### Serving — what this ADR originally got wrong
+
+The first draft of this section said declaration goes through
+`addFontFamilyDeclaration` "with the served-asset scope widened to cover
+the app's font directory". **That cannot work.**
+`EpubNavigatorFragment.Configuration.servedAssets` is only a pattern
+allowlist consulted by `WebViewServer.isServedAsset`. When a path
+matches, the request is handed to a `WebViewAssetLoader` whose single
+path handler is `AssetsPathHandler`, which reads the APK's `assets/` and
+nothing else. Widening `servedAssets` widens *what is allowed*, never
+*where it is read from*, so a file in `filesDir/fonts/` returns 404.
+Readium's own guide documents only assets-bundled fonts.
+
+A `data:` URL is refused by `Url()` — `AbsoluteUrl` requires a
+hierarchical URI and a `data:` URI is opaque. A `file://` URL is refused
+by the web view as a subresource of an `https://` page. There is no
+`@font-face` hook in `readiumCssRsProperties`, which is a typed
+`RsProperties`.
+
+What does work: a request whose host is *not* `readium_assets` is
+treated as a publication resource and goes to `publication.get(href)`,
+and Liseur builds the `Publication` itself. So the book's container is
+wrapped —
+
+```kotlin
+container = CompositeContainer(UserFontsContainer(userFonts::value), container)
+```
+
+— and each family is declared with an **absolute** source,
+`https://readium_package/__liseur_fonts__/<digest>.<ext>`.
+`ReadiumCss.normalizeAssetUrl` is `assetsBaseHref.resolve(url)` and
+`Url.resolve` returns an `AbsoluteUrl` unchanged, so the assets host is
+bypassed. The font lands same-origin with the page, so unlike the
+bundled four it needs no CORS header.
+
+The font container goes **first** in the composite. `CompositeContainer`
+answers with the first match, so with the book first an EPUB carrying a
+resource at the reserved path would shadow the reader's font. Ours is
+safe in front because it is registry-strict: it can only ever answer for
+a digest it holds, so it shadows nothing else.
+
+Matching is exact-string, against an href built from a font already in
+the registry, and rejects `%2f`, `%5c`, `%2e`, dot segments, doubled
+slashes and backslashes on the **raw** url before any normalisation —
+normalising first is what turns `x/../y` into something that compares
+equal. A fragment or query is tolerated rather than refused, because
+`Publication.get` looks up `href` and then retries with the query
+removed, and turning one away would break Readium's own second attempt.
+There is no path concatenation anywhere: the file comes from the matched
+font, so traversal has nothing to aim at even in principle.
+
+**Two couplings to record.** `WebViewServer.PACKAGE_HOSTNAME` is
+`internal`, so `readium_package` is spelled out in
+`UserFontResources.PACKAGE_ORIGIN`; a Readium upgrade that changes it
+breaks this quietly, and this paragraph is where to look. And
+`MimeTypeMap` has no `ttf`/`otf` entry, so an imported font is served
+with a **null `Content-Type`** — verified on device to render anyway,
+for both TTF and OTF, because Blink does not content-type-check
+`@font-face`. It is the same reason the bundled four are served as
+`text/plain` today.
+
+### Applying
+
+All imported families are declared up front, not just the selected one,
+so switching between them is instant as it already is for the bundled
+four; the web view only fetches the family the page uses.
+
+An import applies to the open book immediately. `ReaderScreen`'s
+`key(columnMode, scrollMode, fontKey)` is what actually tears the
+fragment down and rebuilds it — rebuilding the factory alone leaves the
+live fragment in place — so a generation key over the imported ids is
+threaded through that, the factory `remember`, and the `restoreTarget`
+snapshot, which is what keeps the reader on the page they were on rather
+than where the book opened. This is the mechanism a column-mode change
+already uses.
+
+Rebuilding makes a family *available*; it does not choose it, and
+somebody who has just picked a font file plainly means to read in it. So
+a successful import is followed by a selection through the existing
+path, which already knows whether this book is set apart. `AlreadyPresent`
+selects too: re-picking a font you have should land on it, not appear to
+do nothing.
+
+`ReaderViewModel.open()` awaits the repository's first scan before
+taking its font snapshot, or a book already set to an imported font
+opens in the default for a beat and then reflows — unasked for, on the
+screen someone was trying to read.
+
+### Backup
+
+Fonts are **excluded from cloud backup** — they are user-supplied
+binaries, up to 32 of them, against a 25 MB quota — and **included in
+device transfer**, which is not quota-limited and is where "everything
+is as it was on my new phone" is the promise. A cloud restore therefore
+lands on the dormant-id path above: books fall back to the default, and
+re-importing the same file brings every choice back.
 
 ## Consequences
 
@@ -49,6 +156,18 @@ every other reader does with a single-face import.
 Licensing stays the reader's own business, as with any file they put on
 their device; nothing is redistributed.
 
+A font file is hostile input: it was chosen out of a file manager, and
+the parser is reached from a callback with nowhere to put an exception.
+`SfntFont` never throws and returns null instead, and it clamps a
+variable `wght` axis to `1..1000` because Readium's `setFontWeight`
+asserts on the range and would take the reader's book down, not just
+their font. `Typeface.Builder` is run at import as well, because
+plausible sfnt tables are not the same thing as a face this device can
+render, and the failure would otherwise surface inside the dropdown's
+Compose preview.
+
 *Where:* `data/settings/ReaderPrefs.kt`,
-`reader/ReaderPreferencesMapper.kt`, `reader/chrome/TypographySheet.kt`,
-new `data/settings/UserFontRepository.kt`.
+`data/settings/UserFontRepository.kt`,
+`data/settings/fonts/{SfntFont,FontNames,UserFont}.kt`,
+`reader/UserFontResources.kt`, `reader/ReaderPreferencesMapper.kt`,
+`reader/ReaderViewModel.kt`, `ui/reading/ReadingAppearanceControls.kt`.


### PR DESCRIPTION
Closes #6.

Liseur ships four families and a publisher option. A reader who owns a font they love, needs OpenDyslexic, or reads a script the bundled four render badly had no way in, and the bundle cannot grow to meet them all: every family is APK weight everyone carries.

**"Add a font…"** now sits at the end of the font dropdown — in the reader's typography sheet and in Settings → Reading appearance alike. Pick a TTF or an OTF and the open book reflows into it at once, without reopening. Each imported font is listed under the bundled four, previewed in its own face, and removable. Extending the dropdown rather than adding a row is what keeps ADR 0001's constraint on the typography sheet intact.

### Storage and the preference

The file is stored content-addressed under `filesDir/fonts` as `<sha256>.<ext>`, with the extension taken from the sfnt magic rather than the picked name, so the same bytes picked twice dedupe to one entry. A small `AtomicFile` index carries only the display name — the one thing a font with no `name` table cannot re-derive; everything else is re-parsed, so a lost index degrades to "the fonts are still there".

The preference holds `user:<sha256>`, and it is kept **raw**. Delete a font, read for a week, import the same file again, and every book that had it gets it back. Only the *effective* font — resolved against what is actually on disk — reaches Readium, so a missing file is a fallback, never a lost setting.

### Why the serving design differs from ADR 0004

ADR 0004 proposed widening `EpubNavigatorFragment.Configuration.servedAssets`. That cannot work: `servedAssets` is only a pattern allowlist in front of a `WebViewAssetLoader.AssetsPathHandler`, which reads the APK's `assets/` and nothing else. Widening it widens *what is allowed*, never *where it is read from*, so a file in `filesDir` 404s. `data:` URLs, `file://` and raw CSS injection were each checked against Readium 3.3.0 and each ruled out.

What works: wrap the book's container in a `CompositeContainer` and declare each family with an absolute `https://readium_package/…` source. `ReadiumCss.normalizeAssetUrl` resolves against the assets base, and `Url.resolve` returns an absolute URL unchanged, so the request lands on the publication branch instead. The font ends up same-origin with the page, so no CORS header is needed.

The ADR is rewritten and moved to accepted, including a short record of what it originally got wrong.

**Known coupling:** `WebViewServer.PACKAGE_HOSTNAME` is `internal`, so `readium_package` is spelled out in `UserFontResources`. It has a named constant, a comment and an ADR note, so a Readium upgrade that changes it has somewhere to be found.

### Safety

- Ids are digests Liseur generates; the container resolves a URL against the in-memory registry rather than joining it onto a directory, so a traversal cannot reach a file even in principle. URLs are rejected **before** normalisation, since normalising first is what turns `x/../y` into something that compares equal.
- Composite order is font-container-first, safe precisely because that container is registry-strict — an EPUB carrying a resource at the reserved path cannot shadow the reader's font, and a path-collision test covers it.
- The sfnt parser never throws on hostile input and clamps a variable font's `wght` range into the `1..1000` Readium's `setFontWeight` requires — an unclamped range would otherwise take the reader down while the navigator is configured.
- Both the parsed family name and the provider's display name go through one sanitiser that strips control characters and bidi overrides.
- Import streams with the 16 MB cap enforced as it goes, and runs a `Typeface.Builder` load check, because plausible sfnt tables are not the same thing as a font the WebView can use.

### Backup

Fonts are excluded from cloud backup — user binaries against a 25 MB quota, up to 32 of them — and included in device transfer, which is not capped. A cloud restore is then exactly the dormant-id path above: books fall back, and re-importing the same file restores every choice.

### Verification

`testDebugUnitTest` (including new suites for the parser, the sanitiser, the URL matcher, the repository and the preference model), `lintDebug` at 0 errors, `assembleDebug`.

On device, on **both API 26 and API 36**: import through the real picker, TTF and OTF both render, select-on-import, live reflow with the reading position held, switching bundled ↔ imported ↔ imported, a deliberately corrupt `.ttf` refused with a message rather than a crash, removal falling back on the page, and the dormant id surviving a delete/re-import round trip.

One note for the record: a font served this way has a **null `Content-Type`**, because `MimeTypeMap` has no `ttf`/`otf` entry on Android and the manifest is fixed when the publication opens. This was settled with a spike before anything else was built — Blink does not content-type-check `@font-face`, and it renders on both API levels.

### Screenshot

The font dropdown in the reader's typography sheet: the bundled four, then two imported fonts each previewed in its own face with a delete affordance, then "Add a font…". The page behind is reading in the selected imported font.

![font-dropdown.png](https://github.com/user-attachments/assets/850cd6a2-9f22-436c-b1a3-46d3ca87c472)
