### PR TITLE
feat(eink): a colour palette, honest animations, and scrimless sheets on e-paper

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -92,12 +92,12 @@ class MainActivity : ComponentActivity() {
             ProvideEInk(settings.eInkMode) {
                 LiseurTheme(
                     darkTheme = settings.themeMode.isDark(),
-                    // A palette lifted from a wallpaper is chosen for how
-                    // its colours sit together, which is exactly what a
-                    // greyscale screen throws away — hence the monochrome
-                    // override below, which takes precedence.
+                    // E-paper needs stable colours rather than a palette
+                    // lifted from the wallpaper. The central e-ink policy
+                    // below therefore takes precedence over dynamic colour.
                     dynamicColor = settings.dynamicColor,
-                    monochrome = LocalEInk.current,
+                    eInk = LocalEInk.current,
+                    colorEInk = settings.colorEInk,
                 ) {
                     LiseurApp(settings)
                 }
@@ -259,6 +259,7 @@ private fun LiseurApp(settings: AppSettings) {
                 onDynamicColor = { scope.launch { repository.setDynamicColor(it) } },
                 onVolumeKeys = { scope.launch { repository.setVolumeKeysTurnPages(it) } },
                 onEInkMode = { scope.launch { repository.setEInkMode(it) } },
+                onColorEInk = { scope.launch { repository.setColorEInk(it) } },
                 onVendorRefresh = { scope.launch { repository.setVendorRefresh(it) } },
                 vendorName = context.container.eInkDisplay.vendor,
                 onResumeLastBook = { scope.launch { repository.setResumeLastBook(it) } },

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
@@ -108,6 +108,8 @@ enum class DefinitionTarget(val id: String) {
  * @param librarySortReversed The library order read back to front.
  * @param libraryFilters What the library grid is narrowed to.
  * @param eInkMode Whether to drop animation for an electronic paper screen.
+ * @param colorEInk Keep the small useful colour palette on a colour e-paper
+ *   panel. Ignored while e-ink mode is inactive.
  * @param vendorRefresh Whether to drive the panel through the maker's own
  *   screen controller where the device has one. Off until asked for: it
  *   is reached by reflection into firmware that differs between devices
@@ -133,6 +135,7 @@ data class AppSettings(
     val librarySortReversed: Boolean = false,
     val libraryFilters: LibraryFilters = LibraryFilters.None,
     val eInkMode: EInkMode = EInkMode.Default,
+    val colorEInk: Boolean = false,
     val vendorRefresh: Boolean = false,
     val definitionTarget: DefinitionTarget = DefinitionTarget.Default,
     val dictionaryLookupEnabled: Boolean = false,
@@ -181,6 +184,7 @@ class AppSettingsRepository(private val context: Context) {
         val LIBRARY_FILTERS = stringPreferencesKey("library_filters")
         val LIBRARY_GROUP_BY_SERIES = booleanPreferencesKey("library_group_by_series")
         val EINK_MODE = stringPreferencesKey("eink_mode")
+        val COLOR_EINK = booleanPreferencesKey("color_eink")
         val VENDOR_REFRESH = booleanPreferencesKey("vendor_refresh")
         val DEFINITION_TARGET = stringPreferencesKey("definition_target")
         val DICTIONARY_ENABLED = booleanPreferencesKey("dictionary_lookup_enabled")
@@ -220,6 +224,7 @@ class AppSettingsRepository(private val context: Context) {
                 groupBySeries = p[Keys.LIBRARY_GROUP_BY_SERIES] ?: true,
             ),
             eInkMode = EInkMode.fromId(p[Keys.EINK_MODE]),
+            colorEInk = p[Keys.COLOR_EINK] ?: false,
             vendorRefresh = p[Keys.VENDOR_REFRESH] ?: false,
             definitionTarget = DefinitionTarget.fromId(p[Keys.DEFINITION_TARGET]),
             dictionaryLookupEnabled = p[Keys.DICTIONARY_ENABLED] ?: false,
@@ -301,6 +306,10 @@ class AppSettingsRepository(private val context: Context) {
 
     suspend fun setEInkMode(mode: EInkMode) {
         context.appSettingsStore.edit { it[Keys.EINK_MODE] = mode.id }
+    }
+
+    suspend fun setColorEInk(enabled: Boolean) {
+        context.appSettingsStore.edit { it[Keys.COLOR_EINK] = enabled }
     }
 
     suspend fun setVendorRefresh(enabled: Boolean) {

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
@@ -146,7 +146,8 @@ class ReaderActivity : FragmentActivity() {
                 LiseurTheme(
                     darkTheme = appIsDark,
                     dynamicColor = settings.dynamicColor,
-                    monochrome = LocalEInk.current,
+                    eInk = LocalEInk.current,
+                    colorEInk = settings.colorEInk,
                 ) {
                     // Nothing may touch the view model until the book has a
                     // name, because building it is what fixes that name.

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import android.view.WindowManager
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -39,7 +41,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -1680,11 +1681,22 @@ fun ReaderScreen(
         // leaves the last one behind, so a 300ms slide arrives as a stack
         // of smeared bars. Snapping it into place is the same gesture,
         // drawn once.
-        val chromeAnim = if (LocalEInk.current) 0 else CHROME_ANIM_MS
+        val chromeEnter = if (eInk) {
+            EnterTransition.None
+        } else {
+            slideInVertically(tween(CHROME_ANIM_MS)) { -it } +
+                fadeIn(tween(CHROME_ANIM_MS))
+        }
+        val chromeExit = if (eInk) {
+            ExitTransition.None
+        } else {
+            slideOutVertically(tween(CHROME_ANIM_MS)) { -it } +
+                fadeOut(tween(CHROME_ANIM_MS))
+        }
         AnimatedVisibility(
             visible = chromeVisible && !showingEnd,
-            enter = slideInVertically(tween(chromeAnim)) { -it } + fadeIn(tween(chromeAnim)),
-            exit = slideOutVertically(tween(chromeAnim)) { -it } + fadeOut(tween(chromeAnim)),
+            enter = chromeEnter,
+            exit = chromeExit,
             modifier = Modifier.align(Alignment.TopCenter),
         ) {
             TopAppBar(
@@ -2257,6 +2269,7 @@ fun SendingNote(
     onDone: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val eInk = LocalEInk.current
     LaunchedEffect(title) {
         if (title != null) {
             delay(SENDING_NOTE_MS)
@@ -2265,8 +2278,8 @@ fun SendingNote(
     }
     AnimatedVisibility(
         visible = title != null,
-        enter = fadeIn(),
-        exit = fadeOut(),
+        enter = if (eInk) EnterTransition.None else fadeIn(),
+        exit = if (eInk) ExitTransition.None else fadeOut(),
         modifier = modifier,
     ) {
         Snackbar(

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/BookmarkRibbon.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/BookmarkRibbon.kt
@@ -1,7 +1,6 @@
 package com.chmouel.liseur.reader.annotations
 
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
@@ -10,7 +9,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.chmouel.liseur.ui.LocalEInk
@@ -53,15 +51,16 @@ fun BookmarkRibbon(
     // The spring is a flourish on a screen that can draw it. On
     // electronic paper it is a dozen full refreshes of the corner of the
     // page, so the ribbon simply appears.
-    val extended by animateFloatAsState(
-        targetValue = if (bookmarked) 1f else 0f,
-        animationSpec = if (LocalEInk.current) {
-            snap()
-        } else {
-            spring(dampingRatio = 0.55f, stiffness = 420f)
-        },
-        label = "bookmarkRibbon",
-    )
+    val target = if (bookmarked) 1f else 0f
+    val extended = if (LocalEInk.current) {
+        target
+    } else {
+        animateFloatAsState(
+            targetValue = target,
+            animationSpec = spring(dampingRatio = 0.55f, stiffness = 420f),
+            label = "bookmarkRibbon",
+        ).value
+    }
     val label = stringResource(
         if (bookmarked) R.string.reader_remove_bookmark else R.string.reader_add_bookmark,
     )

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -30,6 +29,7 @@ import com.chmouel.liseur.data.settings.AutoScrollPreference
 import com.chmouel.liseur.data.settings.ColumnMode
 import com.chmouel.liseur.data.settings.FooterMode
 import com.chmouel.liseur.data.settings.ReaderPrefs
+import com.chmouel.liseur.ui.LiseurModalBottomSheet
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.reading.ReadingFooterModeDropdown
 import com.chmouel.liseur.ui.reading.ReadingLayoutControls
@@ -81,7 +81,7 @@ fun AdvancedSheet(
     onTypographyIsOwnChanged: (Boolean) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    ModalBottomSheet(onDismissRequest = onDismiss) {
+    LiseurModalBottomSheet(onDismissRequest = onDismiss) {
         Column(
             Modifier
                 .verticalScroll(rememberScrollState())

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/Endpaper.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/Endpaper.kt
@@ -119,11 +119,16 @@ fun Endpaper(
             revealNext = true
         }
     }
-    val nextReveal by animateFloatAsState(
-        targetValue = if (revealNext) 1f else 0f,
-        animationSpec = tween(if (eInk) 0 else NEXT_REVEAL_ANIM_MS),
-        label = "endpaper next volume",
-    )
+    val revealTarget = if (revealNext) 1f else 0f
+    val nextReveal = if (eInk) {
+        revealTarget
+    } else {
+        animateFloatAsState(
+            targetValue = revealTarget,
+            animationSpec = tween(NEXT_REVEAL_ANIM_MS),
+            label = "endpaper next volume",
+        ).value
+    }
     val missingLabel = seriesIndexLabel(missingIndex)
     val showSeriesWindow = finishedVolume != null &&
         (missingLabel != null || next?.volume != null)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/TypographySheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/TypographySheet.kt
@@ -15,7 +15,6 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,6 +28,7 @@ import com.chmouel.liseur.data.settings.ReaderFont
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.ReaderTheme
 import com.chmouel.liseur.data.settings.ReaderThemeChoice
+import com.chmouel.liseur.ui.LiseurModalBottomSheet
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.reading.ReadingBrightnessSlider
 import com.chmouel.liseur.ui.reading.ReadingFontDropdown
@@ -66,7 +66,7 @@ fun TypographySheet(
     onOpenAdvanced: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    ModalBottomSheet(onDismissRequest = onDismiss) {
+    LiseurModalBottomSheet(onDismissRequest = onDismiss) {
         Column(
             Modifier
                 .verticalScroll(rememberScrollState())

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/dictionary/DefinitionSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/dictionary/DefinitionSheet.kt
@@ -13,7 +13,6 @@ import com.chmouel.liseur.ui.BusyIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -31,6 +30,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.chmouel.liseur.R
 import com.chmouel.liseur.domain.DictionaryUrl
+import com.chmouel.liseur.ui.LiseurModalBottomSheet
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.windowWidth
 
@@ -69,7 +69,7 @@ fun DefinitionSheet(
         state = client.define(term, languages, baseUrl)
     }
 
-    ModalBottomSheet(
+    LiseurModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
     ) {

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/EInk.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/EInk.kt
@@ -108,15 +108,19 @@ fun isEInkDevice(packageManager: PackageManager): Boolean = isEInkDevice(
 fun ProvideEInk(mode: EInkMode, content: @Composable () -> Unit) {
     val context = LocalContext.current
     val detected = remember(context) { isEInkDevice(context.packageManager) }
-    if (!mode.resolve(detected)) {
-        CompositionLocalProvider(LocalEInk provides false, content = content)
-        return
-    }
+    val active = mode.resolve(detected)
+    // Read the ordinary values before providing anything. Keeping one
+    // provider tree for both answers matters: changing Auto/Off to On from
+    // Settings must update how that screen is drawn, not dispose the whole
+    // app below this point and recreate it back at the library.
+    val indication = LocalIndication.current
+    val ripple = LocalRippleConfiguration.current
+    val overscroll = LocalOverscrollFactory.current
     CompositionLocalProvider(
-        LocalEInk provides true,
-        LocalIndication provides EInkPressIndication,
-        LocalRippleConfiguration provides null,
-        LocalOverscrollFactory provides null,
+        LocalEInk provides active,
+        LocalIndication provides if (active) EInkPressIndication else indication,
+        LocalRippleConfiguration provides if (active) null else ripple,
+        LocalOverscrollFactory provides if (active) null else overscroll,
         content = content,
     )
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/LiseurModalBottomSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/LiseurModalBottomSheet.kt
@@ -61,6 +61,11 @@ fun LiseurModalBottomSheet(
     // a sheet that raises the IME already lifts itself with imePadding(), and
     // a resized window would take that space a second time and squeeze the
     // sheet's body away.
+    //
+    // An unclipped window is not laid out around a display cutout either, so
+    // the insets a ModalBottomSheet gets for free are applied here by hand:
+    // the top, or a full-height sheet runs under the status bar, and the
+    // sides, or a landscape cutout sits over the controls.
     Popup(
         alignment = Alignment.BottomCenter,
         onDismissRequest = onDismissRequest,
@@ -74,7 +79,10 @@ fun LiseurModalBottomSheet(
             shadowElevation = 0.dp,
             border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
             modifier = modifier
-                .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Top))
+                .windowInsetsPadding(
+                    WindowInsets.safeDrawing
+                        .only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
+                )
                 .widthIn(max = BottomSheetDefaults.SheetMaxWidth)
                 .fillMaxWidth(),
         ) {

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/LiseurModalBottomSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/LiseurModalBottomSheet.kt
@@ -1,0 +1,87 @@
+package com.chmouel.liseur.ui
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+
+/**
+ * A Material sheet that does not repaint the page behind it on e-paper.
+ *
+ * Material's default scrim dims the whole window. On electronic paper that
+ * turns opening a small control into a full-screen refresh and leaves the
+ * dimmed text behind as ghosting when it closes. The sheet itself is already
+ * opaque; dropping the scrim and its lift leaves only the region containing
+ * the controls to change. The popup appears in its final position immediately.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LiseurModalBottomSheet(
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    sheetState: SheetState = rememberModalBottomSheetState(),
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val eInk = LocalEInk.current
+    if (!eInk) {
+        ModalBottomSheet(
+            onDismissRequest = onDismissRequest,
+            modifier = modifier,
+            sheetState = sheetState,
+            content = content,
+        )
+        return
+    }
+
+    // A popup has no hidden-to-expanded state to animate through and no
+    // window-sized scrim. Focusable keeps taps and Back with the sheet;
+    // clicking outside dismisses it without forwarding that click to the page.
+    // Clipping off keeps the keyboard from resizing the popup's own window:
+    // a sheet that raises the IME already lifts itself with imePadding(), and
+    // a resized window would take that space a second time and squeeze the
+    // sheet's body away.
+    Popup(
+        alignment = Alignment.BottomCenter,
+        onDismissRequest = onDismissRequest,
+        properties = PopupProperties(focusable = true, clippingEnabled = false),
+    ) {
+        Surface(
+            shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+            color = MaterialTheme.colorScheme.surface,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+            tonalElevation = 0.dp,
+            shadowElevation = 0.dp,
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+            modifier = modifier
+                .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Top))
+                .widthIn(max = BottomSheetDefaults.SheetMaxWidth)
+                .fillMaxWidth(),
+        ) {
+            Column(Modifier.navigationBarsPadding()) {
+                BottomSheetDefaults.DragHandle(Modifier.align(Alignment.CenterHorizontally))
+                content()
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
@@ -82,7 +82,6 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material.icons.outlined.BarChart
 import androidx.compose.material.icons.outlined.MoreVert
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
@@ -139,6 +138,7 @@ import com.chmouel.liseur.data.db.Book
 import com.chmouel.liseur.data.calibre.DownloadProgress
 import com.chmouel.liseur.data.db.DownloadState
 import com.chmouel.liseur.ui.LocalEInk
+import com.chmouel.liseur.ui.LiseurModalBottomSheet
 import com.chmouel.liseur.ui.UploadBookOfferDialog
 import com.chmouel.liseur.ui.BRAND_TILE_ASPECT
 import com.chmouel.liseur.ui.BusyIndicator
@@ -989,7 +989,7 @@ internal fun BookActionsSheet(
     onDeleteFromServer: () -> Unit,
     onUploadToServer: () -> Unit,
 ) {
-    ModalBottomSheet(onDismissRequest = onDismiss) {
+    LiseurModalBottomSheet(onDismissRequest = onDismiss) {
         Column(
             Modifier
                 .align(Alignment.CenterHorizontally)

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/SeriesPickerSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/SeriesPickerSheet.kt
@@ -412,7 +412,11 @@ private fun SeriesOptionRow(ranked: RankedSeries, selected: Boolean, onClick: ()
     val option = ranked.option
     val eInk = LocalEInk.current
     val background = if (eInk) {
-        Color.Transparent
+        // The wash is drawn, not animated: the tick alone is a thin mark
+        // to find on a grey panel. surfaceVariant rather than
+        // secondaryContainer because monochrome flattens the latter to
+        // very nearly the surface it sits on.
+        if (selected) MaterialTheme.colorScheme.surfaceVariant else Color.Transparent
     } else {
         animateColorAsState(
             targetValue = if (selected) {

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/SeriesPickerSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/SeriesPickerSheet.kt
@@ -36,7 +36,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -84,6 +83,7 @@ import com.chmouel.liseur.domain.sortKey
 import com.chmouel.liseur.domain.suggestedSeries
 import com.chmouel.liseur.domain.suggestedVolume
 import com.chmouel.liseur.ui.LocalEInk
+import com.chmouel.liseur.ui.LiseurModalBottomSheet
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.windowWidth
 import kotlinx.coroutines.launch
@@ -136,6 +136,7 @@ internal fun SeriesPickerSheet(
     val ranked = remember(typed, options) { rankSeriesOptions(typed, options) }
     val listState = rememberLazyListState()
     val scope = rememberCoroutineScope()
+    val eInk = LocalEInk.current
 
     // A narrowed list read from wherever the reader had scrolled to is a
     // list of results they cannot see. Every keystroke puts the best
@@ -161,7 +162,7 @@ internal fun SeriesPickerSheet(
         }
     }
 
-    ModalBottomSheet(
+    LiseurModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
     ) {
@@ -204,7 +205,12 @@ internal fun SeriesPickerSheet(
                 onRemove = { chosen = null },
                 onReset = onReset,
                 onResetShared = onResetShared,
-                onJump = { index -> scope.launch { listState.animateScrollToItem(index) } },
+                onJump = { index ->
+                    scope.launch {
+                        if (eInk) listState.scrollToItem(index)
+                        else listState.animateScrollToItem(index)
+                    }
+                },
                 modifier = Modifier.weight(1f),
             )
             HorizontalDivider()
@@ -405,14 +411,18 @@ private fun SectionHeader(label: String) {
 private fun SeriesOptionRow(ranked: RankedSeries, selected: Boolean, onClick: () -> Unit) {
     val option = ranked.option
     val eInk = LocalEInk.current
-    val background by animateColorAsState(
-        targetValue = when {
-            !selected -> Color.Transparent
-            eInk -> MaterialTheme.colorScheme.surfaceVariant
-            else -> MaterialTheme.colorScheme.secondaryContainer
-        },
-        label = "seriesRowBackground",
-    )
+    val background = if (eInk) {
+        Color.Transparent
+    } else {
+        animateColorAsState(
+            targetValue = if (selected) {
+                MaterialTheme.colorScheme.secondaryContainer
+            } else {
+                Color.Transparent
+            },
+            label = "seriesRowBackground",
+        ).value
+    }
     val count = pluralStringResource(
         R.plurals.series_book_count,
         option.volumeCount,
@@ -427,7 +437,7 @@ private fun SeriesOptionRow(ranked: RankedSeries, selected: Boolean, onClick: ()
             .fillMaxWidth()
             .padding(horizontal = 12.dp, vertical = 2.dp)
             .clip(RoundedCornerShape(12.dp))
-            .background(if (eInk) Color.Transparent else background)
+            .background(background)
             // Selectable rather than clickable: a screen reader should
             // say this is one of a set and which one is chosen, not that
             // there is a button here called The Expanse.
@@ -511,10 +521,15 @@ private fun ActionRow(
 @Composable
 private fun SelectedTick(selected: Boolean) {
     val eInk = LocalEInk.current
-    val scale by animateFloatAsState(
-        targetValue = if (selected) 1f else 0f,
-        label = "seriesRowTick",
-    )
+    val target = if (selected) 1f else 0f
+    val scale = if (eInk) {
+        target
+    } else {
+        animateFloatAsState(
+            targetValue = target,
+            label = "seriesRowTick",
+        ).value
+    }
     Box(Modifier.size(24.dp), contentAlignment = Alignment.Center) {
         if (selected || (!eInk && scale > 0f)) {
             Icon(

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/AboutScreen.kt
@@ -1,6 +1,7 @@
 package com.chmouel.liseur.ui.settings
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.tween
@@ -139,11 +140,11 @@ fun AboutScreen(
                         .apply { targetState = true },
                     // A fade is a run of whole-screen repaints on electronic
                     // paper, so the quote is simply there when the screen is.
-                    enter = fadeIn(
-                        animationSpec = tween(
-                            durationMillis = if (LocalEInk.current) 0 else 300,
-                        ),
-                    ),
+                    enter = if (LocalEInk.current) {
+                        EnterTransition.None
+                    } else {
+                        fadeIn(animationSpec = tween(durationMillis = 300))
+                    },
                     modifier = Modifier.padding(top = 48.dp),
                 ) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerKindPicker.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerKindPicker.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
@@ -32,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import com.chmouel.liseur.R
 import com.chmouel.liseur.data.remote.ServerKind
 import com.chmouel.liseur.data.remote.SyncAbility
+import com.chmouel.liseur.ui.LiseurModalBottomSheet
 
 /**
  * Choosing which kind of server the library lives on.
@@ -90,7 +90,7 @@ internal fun ServerKindSheet(
     onPick: (ServerKind) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    ModalBottomSheet(onDismissRequest = onDismiss) {
+    LiseurModalBottomSheet(onDismissRequest = onDismiss) {
         Column(
             Modifier
                 .verticalScroll(rememberScrollState())

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
@@ -78,6 +78,7 @@ import com.chmouel.liseur.data.settings.ThemeMode
 import com.chmouel.liseur.domain.DictionaryUrl
 import com.chmouel.liseur.domain.WiktionaryEditions
 import com.chmouel.liseur.reader.dictionary.WiktionaryClient
+import com.chmouel.liseur.ui.LocalEInk
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.reading.label
 import com.chmouel.liseur.ui.windowWidth
@@ -95,6 +96,7 @@ fun SettingsScreen(
     onDynamicColor: (Boolean) -> Unit,
     onVolumeKeys: (Boolean) -> Unit,
     onEInkMode: (EInkMode) -> Unit,
+    onColorEInk: (Boolean) -> Unit,
     onVendorRefresh: (Boolean) -> Unit,
     vendorName: String?,
     onResumeLastBook: (Boolean) -> Unit,
@@ -304,6 +306,15 @@ fun SettingsScreen(
                         label = { stringResource(it.label) },
                         onSelected = onEInkMode,
                     )
+                    if (LocalEInk.current) {
+                        RowDivider()
+                        SwitchRow(
+                            title = stringResource(R.string.settings_color_eink),
+                            subtitle = stringResource(R.string.settings_color_eink_detail),
+                            checked = settings.colorEInk,
+                            onCheckedChange = onColorEInk,
+                        )
+                    }
                     vendorName?.let { vendor ->
                         RowDivider()
                         SwitchRow(

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/theme/Theme.kt
@@ -172,6 +172,20 @@ private val MonoDarkColors = darkColorScheme(
     onErrorContainer = Color.White,
 )
 
+/** Which palette policy the resolved e-ink setting asks the app to use. */
+internal enum class EInkPalette {
+    NONE,
+    MONOCHROME,
+    COLOR,
+}
+
+/** A saved colour preference has no effect while the central mode is off. */
+internal fun eInkPalette(eInk: Boolean, colorEInk: Boolean): EInkPalette = when {
+    !eInk -> EInkPalette.NONE
+    colorEInk -> EInkPalette.COLOR
+    else -> EInkPalette.MONOCHROME
+}
+
 /** Whether this device can take its colours from the wallpaper. */
 val dynamicColorAvailable: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
 
@@ -192,20 +206,25 @@ fun LiseurTheme(
     // Wallpaper colours where the system offers them; the palette above
     // is the fallback, and what you get back by turning this off.
     dynamicColor: Boolean = dynamicColorAvailable,
-    // Greyscale hardware: drop hue entirely and spend the range on
-    // contrast. Wins over dynamicColor, which is meaningless here.
-    monochrome: Boolean = false,
+    // Electronic paper never uses wallpaper-derived colours: its useful
+    // palette must be stable and small. A colour panel keeps Liseur's own
+    // restrained accents; a monochrome one spends the full range on contrast.
+    eInk: Boolean = false,
+    colorEInk: Boolean = false,
     content: @Composable () -> Unit,
 ) {
     val context = LocalContext.current
-    val colorScheme = when {
-        monochrome -> if (darkTheme) MonoDarkColors else MonoLightColors
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+    val colorScheme = when (eInkPalette(eInk, colorEInk)) {
+        EInkPalette.MONOCHROME -> if (darkTheme) MonoDarkColors else MonoLightColors
+        EInkPalette.COLOR -> if (darkTheme) DarkColors else LightColors
+        EInkPalette.NONE -> if (dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             if (darkTheme) dynamicDarkColorScheme(context)
             else dynamicLightColorScheme(context)
+        } else if (darkTheme) {
+            DarkColors
+        } else {
+            LightColors
         }
-        darkTheme -> DarkColors
-        else -> LightColors
     }
 
     val typography = remember { liseurTypography(literataFamily(context.assets)) }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -500,6 +500,8 @@
     <string name="settings_scroll_mode_detail">The chapter runs on as one long page instead of being broken into pages you turn. A single book can be set apart from the reader\'s own switch.</string>
     <string name="settings_eink">E-ink screen</string>
     <string name="settings_eink_detail">Drops animation, which electronic paper smears rather than draws. Detected automatically; set it yourself if the guess is wrong.</string>
+    <string name="settings_color_eink">Color E-ink</string>
+    <string name="settings_color_eink_detail">Keep useful accents and highlight colors with a small, static palette.</string>
     <string name="eink_auto">Auto</string>
     <string name="eink_on">On</string>
     <string name="eink_off">Off</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -500,8 +500,8 @@
     <string name="settings_scroll_mode_detail">The chapter runs on as one long page instead of being broken into pages you turn. A single book can be set apart from the reader\'s own switch.</string>
     <string name="settings_eink">E-ink screen</string>
     <string name="settings_eink_detail">Drops animation, which electronic paper smears rather than draws. Detected automatically; set it yourself if the guess is wrong.</string>
-    <string name="settings_color_eink">Color E-ink</string>
-    <string name="settings_color_eink_detail">Keep useful accents and highlight colors with a small, static palette.</string>
+    <string name="settings_color_eink">Colour E-ink</string>
+    <string name="settings_color_eink_detail">Keep useful accents and highlight colours with a small, static palette.</string>
     <string name="eink_auto">Auto</string>
     <string name="eink_on">On</string>
     <string name="eink_off">Off</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/theme/EInkThemeTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/theme/EInkThemeTest.kt
@@ -1,0 +1,26 @@
+package com.chmouel.liseur.ui.theme
+
+import com.chmouel.liseur.data.settings.AppSettings
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class EInkThemeTest {
+
+    @Test
+    fun `e-ink starts monochrome`() {
+        assertFalse(AppSettings().colorEInk)
+        assertEquals(EInkPalette.MONOCHROME, eInkPalette(eInk = true, colorEInk = false))
+    }
+
+    @Test
+    fun `a color panel keeps the static color palette`() {
+        assertEquals(EInkPalette.COLOR, eInkPalette(eInk = true, colorEInk = true))
+    }
+
+    @Test
+    fun `the color preference is ignored while e-ink is off`() {
+        assertEquals(EInkPalette.NONE, eInkPalette(eInk = false, colorEInk = false))
+        assertEquals(EInkPalette.NONE, eInkPalette(eInk = false, colorEInk = true))
+    }
+}


### PR DESCRIPTION
## Summary

Three things an e-paper reader notices, on a branch that had been carrying them uncommitted.

Colour e-paper exists, and Liseur was painting it grey. E-ink mode turned the whole app
monochrome on the reasoning that a greyscale panel throws hue away, which inverts the moment
the panel can draw a highlight in the colour the reader chose. A **Colour E-ink** switch says
which kind of panel this is; it stays off by default, because the wrong guess is worse in that
direction. Dynamic colour does not come back either way — e-paper wants few colours, always
the same ones.

Every animation guard so far was a zero-length duration or a `snap()`. The animation still
ran; it just finished on the first frame, which is one repaint more than the screen needed and,
on a panel that leaves the previous frame behind, a ghost. They are declined outright now.

And Material's modal sheet dims the whole window to show an opaque sheet. On e-paper that is a
full-screen refresh to open a small control, and the dimmed text is still faintly there after
it closes.

## Changes

- `eInkPalette()` states the three-way palette policy — off, monochrome, or Liseur's own static
  palette — as one pure function that the theme and the tests both read. `LiseurTheme`'s
  `monochrome` parameter becomes `eInk` + `colorEInk`. A saved colour preference is inert while
  e-ink mode is off, so turning e-ink on later cannot surprise the reader with a setting they
  made months ago.
- `EnterTransition.None` / `ExitTransition.None` and plain target reads replace the
  zero-duration specs in the reader chrome, the bookmark ribbon, the endpaper's next-volume
  reveal, the About quote, and the series picker's tick and row wash.
- `ProvideEInk` no longer returns early for the inactive case. Two provider trees meant that
  switching **E-ink screen** from Off to On disposed everything below the provider and rebuilt
  it, putting the reader back at the library instead of redrawing the screen they were on.
- `LiseurModalBottomSheet` keeps `ModalBottomSheet` everywhere else and, on e-paper, draws the
  same surface in a focusable popup with no scrim. All six sheets go through it.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on `emulator-5554` (API 36): both palettes, all six sheets, and the
      series picker with the keyboard raised.

A popup is its own window, which bit twice and is worth flagging for review. Without
`clippingEnabled = false` the keyboard resizes that window, so a sheet that lifts itself with
`imePadding()` — the series picker does, so that typing does not put **Save** out of reach — is
lifted twice and squeezed down to its header; that was reproducible before the fix and the sheet
is unusable in that state. And a popup has none of `BottomSheetDefaults.windowInsets`, so a
full-height sheet needs the top inset applied by hand or it runs under the status bar.

## Screenshots or recordings

E-ink mode on throughout. The book covers are bitmaps and are untouched either way; what
changes is the chrome.

| Colour E-ink off (monochrome) | Colour E-ink on |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/a1cd508c-032e-4b86-8b51-0fb99d99a191" width="330"> | <img src="https://github.com/user-attachments/assets/86a1b45d-6255-4c2a-a037-f88520196279" width="330"> |

The new switch, under the existing **E-ink screen** setting:

<img src="https://github.com/user-attachments/assets/76c20a4f-30f0-4136-8907-49d66f79f634" width="330">

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

