### PR TITLE
feat(stats): show when a book was begun and lead the dashboard with the week

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/domain/ReadingStats.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/ReadingStats.kt
@@ -20,6 +20,15 @@ data class BookReadingStats(
      */
     val pendingMs: Long = 0,
     val lastReadAt: Long,
+    /**
+     * When the very first sitting began, over everything on record.
+     *
+     * A fact about the book, not the window: like the streak, it is
+     * answered before the range is applied, because "when did I start
+     * this" does not change with the span the reader chose to look at.
+     * Null only for a book this device never recorded a sitting for.
+     */
+    val firstReadAt: Long? = null,
     /** Where the reader is in it, if known. */
     val progression: Double?,
     val finished: Boolean,
@@ -150,6 +159,10 @@ fun readingStats(
     // applied, so that asking about the last week cannot report a
     // months-long run as seven days.
     val streak = streakDays(recorded, zone, today)
+    // First-read dates are likewise answered from everything: when a
+    // book was begun is a fact about the book, not about the window.
+    val firstStarts = recorded.groupBy { it.bookUrl }
+        .mapValues { (_, spans) -> spans.minOf { it.startedAt } }
     val start = range.startDate(today)
     val counted = if (start == null) recorded else recorded.filter { !it.day(zone).isBefore(start) }
     if (counted.isEmpty()) return ReadingStats.Empty.copy(streakDays = streak)
@@ -166,6 +179,7 @@ fun readingStats(
             totalMs = spans.sumOf { it.durationMs },
             pendingMs = spans.filterNot { it.uploaded }.sumOf { it.durationMs },
             lastReadAt = spans.maxOf { it.lastReadAt },
+            firstReadAt = firstStarts[url],
             progression = book?.progression,
             finished = book?.finished == true,
             sessions = spans.size,

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/StatsRange.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/StatsRange.kt
@@ -64,7 +64,7 @@ enum class StatsRange(val id: String) {
     fun suitsDailyBars(today: LocalDate): Boolean = (days(today) ?: Int.MAX_VALUE) <= MAX_BAR_DAYS
 
     companion object {
-        val Default = LAST_30_DAYS
+        val Default = LAST_7_DAYS
 
         /** As many bars as fit across a phone without becoming hatching. */
         const val MAX_BAR_DAYS = 31

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/BookReadingStatsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/BookReadingStatsScreen.kt
@@ -19,8 +19,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.MenuBook
+import androidx.compose.material.icons.outlined.CalendarMonth
 import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.DateRange
+import androidx.compose.material.icons.outlined.Flag
 import androidx.compose.material.icons.outlined.HourglassBottom
 import androidx.compose.material.icons.outlined.Timer
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -55,6 +57,7 @@ import com.chmouel.liseur.ui.windowWidth
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
 
 /**
@@ -207,17 +210,51 @@ fun BookReadingStatsScreen(
                         modifier = Modifier.fillMaxWidth(),
                         verticalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
+                        val zone = ZoneId.systemDefault()
+                        val lastDate = Instant.ofEpochMilli(stats.lastReadAt)
+                            .atZone(zone)
+                            .toLocalDate()
+                        val firstDate = stats.firstReadAt?.let {
+                            Instant.ofEpochMilli(it).atZone(zone).toLocalDate()
+                        }
+                        if (firstDate != null) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            ) {
+                                BookMetricTile(
+                                    icon = Icons.Outlined.Flag,
+                                    value = firstDate.format(lastReadFormat()),
+                                    label = stringResource(R.string.reading_stats_started_label),
+                                    modifier = Modifier.weight(1f),
+                                )
+                                // Both endpoints count: begun and last read
+                                // on the same day is one day with the book,
+                                // not none.
+                                val daysWithBook =
+                                    ChronoUnit.DAYS.between(firstDate, lastDate) + 1
+                                BookMetricTile(
+                                    icon = Icons.Outlined.CalendarMonth,
+                                    value = if (daysWithBook <= 1L) {
+                                        stringResource(R.string.reading_stats_reading_for_one_day)
+                                    } else {
+                                        stringResource(
+                                            R.string.reading_stats_reading_for_days,
+                                            daysWithBook,
+                                        )
+                                    },
+                                    label = stringResource(R.string.reading_stats_reading_for_label),
+                                    modifier = Modifier.weight(1f),
+                                )
+                            }
+                        }
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.spacedBy(12.dp),
                         ) {
-                            val lastDate = Instant.ofEpochMilli(stats.lastReadAt)
-                                .atZone(ZoneId.systemDefault())
-                                .toLocalDate()
-                                .format(lastReadFormat())
                             BookMetricTile(
                                 icon = Icons.Outlined.DateRange,
-                                value = lastDate,
+                                value = lastDate.format(lastReadFormat()),
                                 label = stringResource(R.string.reading_stats_last_read_label),
                                 modifier = Modifier.weight(1f),
                             )

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingDuration.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingDuration.kt
@@ -28,3 +28,23 @@ fun readingDuration(millis: Long): String {
         else -> stringResource(R.string.duration_hours_minutes, hours, minutes)
     }
 }
+
+/**
+ * The same length of time, shortened to fit above a bar.
+ *
+ * "1h20", "45m" — the abbreviations are unit symbols rather than
+ * words, so they survive untranslated the way "km" does. Null rather
+ * than a dash for an empty day: above a bar of nothing, any text at
+ * all is clutter.
+ */
+fun compactDuration(millis: Long): String? {
+    if (millis <= 0) return null
+    val totalMinutes = TimeUnit.MILLISECONDS.toMinutes(millis).coerceAtLeast(1)
+    val hours = totalMinutes / 60
+    val minutes = totalMinutes % 60
+    return when {
+        hours == 0L -> "${minutes}m"
+        minutes == 0L -> "${hours}h"
+        else -> "${hours}h${minutes.toString().padStart(2, '0')}"
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
@@ -51,6 +51,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
@@ -410,18 +412,48 @@ private fun ActivityCard(stats: ReadingStats, range: StatsRange) {
             // month of them has none to spare.
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 16.dp),
         ) {
-            Text(
-                text = stringResource(
-                    if (daily && range == StatsRange.LAST_7_DAYS) {
-                        R.string.reading_stats_recent
-                    } else {
-                        R.string.reading_stats_calendar
-                    },
-                ),
-                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.padding(horizontal = 4.dp),
-            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(
+                        if (daily && range == StatsRange.LAST_7_DAYS) {
+                            R.string.reading_stats_recent
+                        } else {
+                            R.string.reading_stats_calendar
+                        },
+                    ),
+                    style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f),
+                )
+                // The week's own sum, next to its heading, so the chart
+                // can be read without adding seven bars in one's head.
+                if (daily && range == StatsRange.LAST_7_DAYS) {
+                    val weekMs = stats.recent.sumOf { it.totalMs }
+                    if (weekMs > 0) {
+                        Surface(
+                            shape = CircleShape,
+                            color = MaterialTheme.colorScheme.secondaryContainer,
+                        ) {
+                            Text(
+                                text = stringResource(
+                                    R.string.reading_stats_week_total,
+                                    readingDuration(weekMs),
+                                ),
+                                style = MaterialTheme.typography.labelSmall.copy(
+                                    fontWeight = FontWeight.SemiBold,
+                                ),
+                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                            )
+                        }
+                    }
+                }
+            }
             Spacer(Modifier.height(16.dp))
             if (daily) {
                 WeekBars(stats.recent)
@@ -439,9 +471,16 @@ private fun ActivityCard(stats: ReadingStats, range: StatsRange) {
  * anything, and a bar of nothing reads correctly as a day with no
  * reading in it, which a line would smooth over.
  *
- * Every bar that has reading in it is drawn the same. Singling out the
- * longest day would make the chart a scoreboard with a record to beat,
- * and the height already says which day was the longest.
+ * At a week or less, each bar with reading on it carries its own
+ * figure, because "how long on Tuesday" is the question the chart
+ * exists to answer and a height alone answers it only relatively. Past
+ * a week there is no room for figures, and the heights go back to
+ * speaking for themselves.
+ *
+ * Today's bar is drawn in full and the rest a shade quieter — not as a
+ * grade, but as a cursor: the eye needs to know which bar it is living
+ * in before it can count backwards. The longest day is still not
+ * singled out; the height already says which day was the longest.
  *
  * The gap between bars narrows as they multiply, because the bars are
  * weighted and the gaps are not: thirty-one fixed 8dp gaps eat almost
@@ -463,6 +502,8 @@ private fun WeekBars(days: List<ReadingDay>) {
     // of the captioned ones.
     val lastIndex = days.lastIndex
     val everyBar = days.size <= DAYS_IN_WEEK
+    // Gradients dither into stripes on an e-ink panel; flat ink reads.
+    val eInk = LocalEInk.current
     val gap = when {
         days.size <= DAYS_IN_WEEK -> 8.dp
         days.size <= DAYS_IN_WEEK * 2 -> 5.dp
@@ -471,16 +512,20 @@ private fun WeekBars(days: List<ReadingDay>) {
     }
     // A 6dp radius on a bar 6dp wide is a lozenge, not a bar.
     val corner = if (days.size <= DAYS_IN_WEEK) 6.dp else 2.dp
+    // The figures above the bars need headroom of their own, or the
+    // tallest bar pushes its label out of the card.
+    val chartHeight = if (everyBar) 150.dp else 130.dp
 
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(130.dp),
+            .height(chartHeight),
         horizontalArrangement = Arrangement.spacedBy(gap),
         verticalAlignment = Alignment.Bottom,
     ) {
         days.forEachIndexed { index, day ->
             val captioned = everyBar || (lastIndex - index) % DAYS_IN_WEEK == 0
+            val isToday = index == lastIndex
             val amount = readingDuration(day.totalMs)
             val weekday = day.date.dayOfWeek.getDisplayName(TextStyle.SHORT, locale)
             val barHeight = if (day.totalMs > 0) {
@@ -493,6 +538,16 @@ private fun WeekBars(days: List<ReadingDay>) {
             } else {
                 stringResource(R.string.reading_stats_no_reading_day, weekday)
             }
+            val primary = MaterialTheme.colorScheme.primary
+            val barBrush = when {
+                day.totalMs <= 0 -> SolidColor(MaterialTheme.colorScheme.surfaceContainerHighest)
+                eInk || isToday -> SolidColor(primary)
+                // Yesterday and before fade towards their base, so the
+                // week reads as a shape with today at its leading edge.
+                else -> Brush.verticalGradient(
+                    listOf(primary.copy(alpha = 0.8f), primary.copy(alpha = 0.45f)),
+                )
+            }
             Column(
                 modifier = Modifier
                     .weight(1f)
@@ -503,6 +558,23 @@ private fun WeekBars(days: List<ReadingDay>) {
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Bottom,
             ) {
+                if (everyBar) {
+                    Text(
+                        text = compactDuration(day.totalMs).orEmpty(),
+                        style = MaterialTheme.typography.labelSmall.copy(
+                            fontWeight = if (isToday) FontWeight.Bold else FontWeight.Medium,
+                        ),
+                        color = if (isToday) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                        maxLines = 1,
+                        softWrap = false,
+                        overflow = TextOverflow.Visible,
+                    )
+                    Spacer(Modifier.height(4.dp))
+                }
                 Box(
                     Modifier
                         .fillMaxWidth()
@@ -511,19 +583,19 @@ private fun WeekBars(days: List<ReadingDay>) {
                         // every bar fill its column and look identical.
                         .height(barHeight)
                         .clip(RoundedCornerShape(corner))
-                        .background(
-                            if (day.totalMs > 0) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.surfaceContainerHighest
-                            },
-                        ),
+                        .background(barBrush),
                 )
                 Spacer(Modifier.height(8.dp))
                 Text(
                     text = if (captioned) weekday else "",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.labelSmall.copy(
+                        fontWeight = if (isToday && everyBar) FontWeight.Bold else FontWeight.Normal,
+                    ),
+                    color = if (isToday && everyBar) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
                     maxLines = 1,
                     softWrap = false,
                     overflow = TextOverflow.Visible,

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
@@ -246,29 +246,30 @@ class ReadingStatsViewModel(
                 coverUrl = book.coverUrl,
             )
         }
+        val spans = sessions.map {
+            SessionSpan(
+                bookUrl = it.bookUrl,
+                startedAt = it.startedAt,
+                durationMs = it.durationMs,
+                lastReadAt = it.lastCheckpointAt,
+                uploaded = it.uploadedAt != null,
+                startProgression = it.startProgression,
+                endProgression = it.endProgression,
+            )
+        }
         LocalStats(
             stats = readingStats(
-                sessions = sessions.map {
-                    SessionSpan(
-                        bookUrl = it.bookUrl,
-                        startedAt = it.startedAt,
-                        durationMs = it.durationMs,
-                        lastReadAt = it.lastCheckpointAt,
-                        uploaded = it.uploadedAt != null,
-                        startProgression = it.startProgression,
-                        endProgression = it.endProgression,
-                    )
-                },
+                sessions = spans,
                 books = statsBooks,
                 zone = zone(),
                 today = today(),
                 range = range,
             ),
             books = statsBooks,
-            firstReadAtByUrl = sessions
+            firstReadAtByUrl = spans
                 .filter { it.durationMs > 0 }
                 .groupBy { it.bookUrl }
-                .mapValues { (_, spans) -> spans.minOf { it.startedAt } },
+                .mapValues { (_, sittings) -> sittings.minOf { it.startedAt } },
         )
     }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
@@ -422,6 +422,9 @@ class ReadingStatsViewModel(
                         totalMs = maxOf(localMs, serverMs + pendingMs),
                         pendingMs = pendingMs,
                         lastReadAt = lastReadAt,
+                        // The server has no started-at; the earliest local
+                        // start across the work's URLs is the only source.
+                        firstReadAt = rows.mapNotNull { it.firstReadAt }.minOrNull(),
                         progression = metadata.progression,
                         finished = metadata.finished,
                         sessions = maxOf(

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
@@ -217,6 +217,15 @@ class ReadingStatsViewModel(
     private data class LocalStats(
         val stats: ReadingStats,
         val books: Map<String, StatsBook>,
+        /**
+         * When each URL's first sitting began, over everything on record.
+         *
+         * Kept beside the ranged stats because a row only exists for a
+         * URL with reading inside the window: a moved file whose old URL
+         * was last read before the span would otherwise lose the date it
+         * was begun to the range the reader happens to be looking at.
+         */
+        val firstReadAtByUrl: Map<String, Long>,
     )
 
     private val local = combine(
@@ -256,6 +265,10 @@ class ReadingStatsViewModel(
                 range = range,
             ),
             books = statsBooks,
+            firstReadAtByUrl = sessions
+                .filter { it.durationMs > 0 }
+                .groupBy { it.bookUrl }
+                .mapValues { (_, spans) -> spans.minOf { it.startedAt } },
         )
     }
 
@@ -266,7 +279,13 @@ class ReadingStatsViewModel(
         booksAcrossDevices,
         _range,
     ) { local, server, recent, serverBooks, range ->
-        val merged = mergeDashboard(local.stats, local.books, recent, serverBooks)
+        val merged = mergeDashboard(
+            local.stats,
+            local.books,
+            recent,
+            serverBooks,
+            local.firstReadAtByUrl,
+        )
         ReadingStatsUiState.Ready(
             stats = merged,
             headline = mergeHeadline(merged, local.stats, server, range, today()),
@@ -389,6 +408,7 @@ class ReadingStatsViewModel(
             knownBooks: Map<String, StatsBook>,
             serverRecent: List<InsightDay>?,
             serverBooks: Map<String, WorkInsights>?,
+            firstReadAtByUrl: Map<String, Long> = emptyMap(),
         ): ReadingStats {
             val mergedBooks = local.books.associateBy { it.bookUrl }.toMutableMap()
             serverBooks.orEmpty().entries
@@ -424,7 +444,11 @@ class ReadingStatsViewModel(
                         lastReadAt = lastReadAt,
                         // The server has no started-at; the earliest local
                         // start across the work's URLs is the only source.
-                        firstReadAt = rows.mapNotNull { it.firstReadAt }.minOrNull(),
+                        // Read from the all-time map first: a URL whose
+                        // reading all predates the window has no row to
+                        // carry its date.
+                        firstReadAt = urls.mapNotNull { firstReadAtByUrl[it] }.minOrNull()
+                            ?: rows.mapNotNull { it.firstReadAt }.minOrNull(),
                         progression = metadata.progression,
                         finished = metadata.finished,
                         sessions = maxOf(

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
@@ -226,6 +226,16 @@ class ReadingStatsViewModel(
          * was begun to the range the reader happens to be looking at.
          */
         val firstReadAtByUrl: Map<String, Long>,
+        /**
+         * The span [stats] was computed for.
+         *
+         * Carried with the figures rather than read again from `_range`
+         * downstream: `combine` does not synchronise its inputs, so a
+         * freshly selected span could otherwise be paired with sums
+         * still describing the previous one — a caption over numbers
+         * that do not answer it.
+         */
+        val range: StatsRange,
     )
 
     private val local = combine(
@@ -270,6 +280,7 @@ class ReadingStatsViewModel(
                 .filter { it.durationMs > 0 }
                 .groupBy { it.bookUrl }
                 .mapValues { (_, sittings) -> sittings.minOf { it.startedAt } },
+            range = range,
         )
     }
 
@@ -278,8 +289,7 @@ class ReadingStatsViewModel(
         acrossDevices,
         recentAcrossDevices,
         booksAcrossDevices,
-        _range,
-    ) { local, server, recent, serverBooks, range ->
+    ) { local, server, recent, serverBooks ->
         val merged = mergeDashboard(
             local.stats,
             local.books,
@@ -289,8 +299,8 @@ class ReadingStatsViewModel(
         )
         ReadingStatsUiState.Ready(
             stats = merged,
-            headline = mergeHeadline(merged, local.stats, server, range, today()),
-            range = range,
+            headline = mergeHeadline(merged, local.stats, server, local.range, today()),
+            range = local.range,
         )
     }.stateIn(
         viewModelScope,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -616,6 +616,11 @@
     <string name="reading_stats_no_reading_day">Nothing read on %1$s</string>
     <string name="reading_stats_last_read">Last read %1$s</string>
     <string name="reading_stats_last_read_label">Last read</string>
+    <string name="reading_stats_started_label">Started</string>
+    <string name="reading_stats_reading_for_label">Reading for</string>
+    <string name="reading_stats_reading_for_days">%1$d days</string>
+    <string name="reading_stats_reading_for_one_day">1 day</string>
+    <string name="reading_stats_week_total">%1$s this week</string>
     <string name="reading_stats_progress">%1$d%% through</string>
     <string name="reading_stats_day_read">%1$s on %2$s</string>
     <string name="reading_stats_in_last_days">In the last %1$d days, on every device</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncInsightsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncInsightsTest.kt
@@ -158,7 +158,7 @@ class LiseurSyncInsightsTest {
         val lastRead = "2026-08-11T16:30:00Z"
         server.enqueue(
             ok(
-                """{"from":"2026-07-13","to":"2026-08-11","works":[""" +
+                """{"from":"2026-08-05","to":"2026-08-11","works":[""" +
                     """{"work_id":"w-1","sessions":8,""" +
                     """"total_active_minutes":106.25,"eta_seconds":3600,""" +
                     """"last_read_at":"$lastRead"}]}""",
@@ -172,7 +172,7 @@ class LiseurSyncInsightsTest {
         assertEquals("w-1", book.workId)
         assertEquals(Instant.parse(lastRead).toEpochMilli(), book.lastReadAt)
         assertEquals(
-            "/v1/insights/works?from=2026-07-13&to=2026-08-11",
+            "/v1/insights/works?from=2026-08-05&to=2026-08-11",
             server.takeRequest().target,
         )
     }
@@ -282,7 +282,7 @@ class LiseurSyncInsightsTest {
     @Test
     fun `a reading pace is carried through and a missing one is not invented`() = runTest {
         connect()
-        val span = """"from":"2026-07-13","to":"2026-08-11""""
+        val span = """"from":"2026-08-05","to":"2026-08-11""""
         server.enqueue(
             ok("""{$span,"total_active_minutes":90,"sessions":4,"speed_prog_per_hour":0.25}"""),
         )

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/ReadingStatsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/ReadingStatsTest.kt
@@ -463,4 +463,55 @@ class ReadingStatsTest {
         assertEquals(2, stats.books.single { it.bookUrl == "a" }.sessions)
         assertEquals(1, stats.books.single { it.bookUrl == "b" }.sessions)
     }
+
+    // --- When the book was begun ----------------------------------------
+
+    @Test
+    fun `a book remembers when its first sitting began`() {
+        val begun = noonOn(today.minusDays(2))
+        val stats = readingStats(
+            sessions = listOf(
+                SessionSpan("a", begun, 60_000),
+                SessionSpan("a", noonOn(today), 60_000),
+            ),
+            books = mapOf("a" to book("a")),
+            zone = zone,
+            today = today,
+        )
+        assertEquals(begun, stats.books.single().firstReadAt)
+    }
+
+    @Test
+    fun `when a book was begun is not narrowed by the span being looked at`() {
+        // Begun three months ago, still being read this week. The week
+        // view must not claim the book was started on Tuesday.
+        val begun = noonOn(today.minusDays(90))
+        val stats = readingStats(
+            sessions = listOf(
+                SessionSpan("a", begun, 60_000),
+                SessionSpan("a", noonOn(today), 60_000),
+            ),
+            books = mapOf("a" to book("a")),
+            zone = zone,
+            today = today,
+            range = StatsRange.LAST_7_DAYS,
+        )
+        assertEquals(begun, stats.books.single().firstReadAt)
+    }
+
+    @Test
+    fun `a sitting of no length does not date the beginning of a book`() {
+        // Opened and shut a month ago, actually read yesterday. The
+        // glance is not when reading began.
+        val stats = readingStats(
+            sessions = listOf(
+                SessionSpan("a", noonOn(today.minusDays(30)), 0),
+                SessionSpan("a", noonOn(today.minusDays(1)), 60_000),
+            ),
+            books = mapOf("a" to book("a")),
+            zone = zone,
+            today = today,
+        )
+        assertEquals(noonOn(today.minusDays(1)), stats.books.single().firstReadAt)
+    }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ReadingDurationTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ReadingDurationTest.kt
@@ -1,0 +1,42 @@
+package com.chmouel.liseur.ui.stats
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+/** The short form of a duration, as drawn above a chart bar. */
+class ReadingDurationTest {
+
+    @Test
+    fun `an empty day carries no figure at all`() {
+        assertNull(compactDuration(0))
+        assertNull(compactDuration(-5))
+    }
+
+    @Test
+    fun `under a minute rounds up rather than reading as nothing`() {
+        assertEquals("1m", compactDuration(30_000))
+    }
+
+    @Test
+    fun `minutes alone need no hour`() {
+        assertEquals("45m", compactDuration(TimeUnit.MINUTES.toMillis(45)))
+    }
+
+    @Test
+    fun `a round hour needs no minutes`() {
+        assertEquals("2h", compactDuration(TimeUnit.HOURS.toMillis(2)))
+    }
+
+    @Test
+    fun `hours and minutes pack together`() {
+        assertEquals("1h20", compactDuration(TimeUnit.MINUTES.toMillis(80)))
+    }
+
+    @Test
+    fun `single-digit minutes keep their leading nought`() {
+        // "1h5" reads as an hour and a half at a glance; "1h05" does not.
+        assertEquals("1h05", compactDuration(TimeUnit.MINUTES.toMillis(65)))
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModelTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModelTest.kt
@@ -564,14 +564,18 @@ class ReadingStatsViewModelTest {
             knownBooks = known,
             serverRecent = null,
             serverBooks = mapOf("old" to one, "new" to one),
+            // The old URL was begun before the window the rows describe;
+            // only the all-time map remembers it.
+            firstReadAtByUrl = mapOf("old" to 5L, "new" to 300L),
         )
 
         assertEquals(1, merged.books.size)
         assertEquals("old", merged.books.single().bookUrl)
         assertEquals(50 * 60_000L, merged.books.single().totalMs)
         // The book was begun when its earliest URL was first opened —
-        // moving the file does not restart its history.
-        assertEquals(10L, merged.books.single().firstReadAt)
+        // moving the file does not restart its history, and a start
+        // older than the window is not forgotten by looking at a week.
+        assertEquals(5L, merged.books.single().firstReadAt)
         assertEquals(50 * 60_000L, merged.totalMs)
     }
 

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModelTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModelTest.kt
@@ -92,7 +92,7 @@ class ReadingStatsViewModelTest {
                 as ReadingStatsUiState.Ready
 
             assertEquals(60_000L, loaded.headline.totalMs)
-            assertEquals(30, loaded.headline.rangeDays)
+            assertEquals(7, loaded.headline.rangeDays)
             // Sittings and the streak used to vanish without a server.
             // This device can count both perfectly well.
             assertEquals(1, loaded.headline.sessions)
@@ -112,9 +112,9 @@ class ReadingStatsViewModelTest {
             db.readingSessionDao().insert(session(url, today.minusDays(200), 60_000))
             val model = model()
 
-            val thirty = model.state.first { it is ReadingStatsUiState.Ready }
+            val week = model.state.first { it is ReadingStatsUiState.Ready }
                 as ReadingStatsUiState.Ready
-            assertEquals(0L, thirty.headline.totalMs)
+            assertEquals(0L, week.headline.totalMs)
 
             model.selectRange(StatsRange.ALL_TIME)
             val everything = model.state.first {
@@ -536,12 +536,12 @@ class ReadingStatsViewModelTest {
             books = listOf(
                 BookReadingStats(
                     bookUrl = "old", title = "A book", author = null,
-                    totalMs = 40 * 60_000L, lastReadAt = 100,
+                    totalMs = 40 * 60_000L, lastReadAt = 100, firstReadAt = 10,
                     progression = 0.5, finished = false, sessions = 2,
                 ),
                 BookReadingStats(
                     bookUrl = "new", title = "A book", author = null,
-                    totalMs = 10 * 60_000L, lastReadAt = 400,
+                    totalMs = 10 * 60_000L, lastReadAt = 400, firstReadAt = 300,
                     progression = 0.5, finished = false, sessions = 1,
                 ),
             ),
@@ -569,6 +569,9 @@ class ReadingStatsViewModelTest {
         assertEquals(1, merged.books.size)
         assertEquals("old", merged.books.single().bookUrl)
         assertEquals(50 * 60_000L, merged.books.single().totalMs)
+        // The book was begun when its earliest URL was first opened —
+        // moving the file does not restart its history.
+        assertEquals(10L, merged.books.single().firstReadAt)
         assertEquals(50 * 60_000L, merged.totalMs)
     }
 


### PR DESCRIPTION
## Summary

The reading stats screens now answer "when did I start this book?" and lead with the week rather than the month. The per-book screen gains a Started date and a reading-for-N-days tile; the dashboard defaults to the last 7 days for readers who never picked a span, and in that view each bar carries its day's reading time.

## Changes

- `BookReadingStats.firstReadAt`: the all-time first sitting, computed before the range filter (like the streak, it is a fact about the book, not the window). Zero-length glances do not date it, and a moved file's URLs merge to the earliest start.
- Book stats screen: 2x2 metric grid with **Started** and **Reading for** tiles alongside Last read and Sittings; the row degrades to the old pair when no session start is recorded.
- `StatsRange.Default` is now `LAST_7_DAYS`; a span the reader explicitly picked is persisted and unaffected.
- 7-day chart: compact duration above each bar ("1h20", "45m") via a new pure `compactDuration()`, today's bar and caption emphasised, past days fade through a gradient (flat ink on e-ink), and the card header shows the week's total.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

New tests cover firstReadAt (earliest start, range-independent, glances excluded), the merge across a work's URLs, and the compact formatter. Two liseur-sync insight tests were updated for the 7-day default span.

## Screenshots or recordings

| Dashboard, last 7 days | Book stats with Started |
|---|---|
| ![dashboard](https://github.com/user-attachments/assets/d523a006-0a45-43c4-a390-75cc2cd470c3) | ![book stats](https://github.com/user-attachments/assets/309cfab6-14f4-4815-a455-ef746ade64ab) |

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

