### PR TITLE
fix: show reading layout controls directly in settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,11 +271,11 @@ emulator.
 - Reader settings map to Readium `EpubPreferences`; reading themes
   (Light/Sepia/Dark/Black) are decoupled from the app's Material theme.
 - A new reading setting goes in the Advanced sheet
-  (`reader/chrome/AdvancedSheet.kt`), and behind the collapsed Advanced
-  section on Settings → Reading appearance. The typography sheet is the
-  short list a reader changes often — theme, size, brightness, font, and
-  how the book is read — and it only grows for a setting that genuinely
-  belongs there. Make that case in the pull request; the default is
-  Advanced. It grew to eleven controls once, one reasonable row at a
-  time. See `docs/adr/0001-advanced-reading-menu.md`.
+  (`reader/chrome/AdvancedSheet.kt`), and directly on Settings → Reading
+  appearance, which has no Advanced section to collapse it behind. The
+  typography sheet is the short list a reader changes often — theme,
+  size, brightness, font, and how the book is read — and it only grows
+  for a setting that genuinely belongs there. Make that case in the pull
+  request; the default is Advanced. It grew to eleven controls once, one
+  reasonable row at a time. See `docs/adr/0001-advanced-reading-menu.md`.
 - Bundled fonts must be under open licenses (OFL): Literata et al.

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
@@ -135,9 +135,10 @@ fun ReadingAppearanceScreen(
                     lineHeight = prefs.lineHeight,
                     pageMargins = prefs.pageMargins,
                     columnMode = prefs.columnMode,
-                    // Unlike the sheet, there is no book here to be
-                    // scrolled, so the count always has something to
-                    // divide and the control is always worth offering.
+                    // The sheet hides this in a scrolled book, where
+                    // columns don't apply. There is no book here to
+                    // check, so the preference is always offered; the
+                    // reader surface decides whether to honor it.
                     showColumns = true,
                     onLineHeightChanged = onLineHeight,
                     onPageMarginsChanged = onPageMargins,

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
@@ -1,12 +1,5 @@
 package com.chmouel.liseur.ui.settings
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -27,19 +20,13 @@ import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -52,7 +39,6 @@ import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.fonts.UserFont
 import com.chmouel.liseur.data.settings.ReaderTheme
 import com.chmouel.liseur.data.settings.ReaderThemeChoice
-import com.chmouel.liseur.ui.LocalEInk
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.reading.ReadingBrightnessSlider
 import com.chmouel.liseur.ui.reading.ReadingFontDropdown
@@ -146,13 +132,25 @@ fun ReadingAppearanceScreen(
                     onImport = fontLibrary.pick,
                     onRemove = fontLibrary.remove,
                 )
-                AdvancedSection(
-                    prefs = prefs,
-                    onLineHeight = onLineHeight,
-                    onPageMargins = onPageMargins,
-                    onColumnMode = onColumnMode,
-                    onFooterMode = onFooterMode,
-                    onPageTurnAnimation = onPageTurnAnimation,
+                ReadingLayoutControls(
+                    lineHeight = prefs.lineHeight,
+                    pageMargins = prefs.pageMargins,
+                    columnMode = prefs.columnMode,
+                    // Unlike the sheet, there is no book here to be
+                    // scrolled, so the count always has something to
+                    // divide and the control is always worth offering.
+                    showColumns = true,
+                    onLineHeightChanged = onLineHeight,
+                    onPageMarginsChanged = onPageMargins,
+                    onColumnModeChanged = onColumnMode,
+                )
+                ReadingFooterModeDropdown(
+                    selected = prefs.footerMode,
+                    onSelected = onFooterMode,
+                )
+                ReadingPageTurnAnimationToggle(
+                    enabled = prefs.pageTurnAnimation,
+                    onChanged = onPageTurnAnimation,
                 )
                 Text(
                     text = stringResource(R.string.settings_reading_appearance_detail),
@@ -160,71 +158,6 @@ fun ReadingAppearanceScreen(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-        }
-    }
-}
-
-/**
- * The same split the reader sees, on the screen that has no book.
- *
- * The shared settings behind the "Aa" sheet's Advanced row are behind
- * this too, in the same order: a reader who learned where the margins
- * live in one place should not have to learn it again in the other.
- *
- * Only the shared ones. The rest of that sheet has no meaning here —
- * auto-scroll needs a page that is running, and setting a book apart
- * needs a book — so this holds the layout controls, the footer mode and
- * the page-turn animation, and nothing else. See
- * `docs/adr/0001-advanced-reading-menu.md`.
- */
-@Composable
-private fun AdvancedSection(
-    prefs: ReaderPrefs,
-    onLineHeight: (Double?) -> Unit,
-    onPageMargins: (Double?) -> Unit,
-    onColumnMode: (ColumnMode) -> Unit,
-    onFooterMode: (FooterMode) -> Unit,
-    onPageTurnAnimation: (Boolean) -> Unit,
-) {
-    var expanded by rememberSaveable { mutableStateOf(false) }
-
-    TextButton(onClick = { expanded = !expanded }) {
-        Text(
-            stringResource(
-                if (expanded) R.string.reader_hide_advanced else R.string.reader_advanced,
-            ),
-        )
-    }
-    // Sliding this open on electronic paper is a full repaint of the
-    // lower half of the screen for every frame; it is the same list
-    // either way, so it simply appears.
-    val eInk = LocalEInk.current
-    AnimatedVisibility(
-        visible = expanded,
-        enter = if (eInk) EnterTransition.None else fadeIn() + expandVertically(),
-        exit = if (eInk) ExitTransition.None else fadeOut() + shrinkVertically(),
-    ) {
-        Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-            ReadingLayoutControls(
-                lineHeight = prefs.lineHeight,
-                pageMargins = prefs.pageMargins,
-                columnMode = prefs.columnMode,
-                // Unlike the sheet, there is no book here to be
-                // scrolled, so the count always has something to
-                // divide and the control is always worth offering.
-                showColumns = true,
-                onLineHeightChanged = onLineHeight,
-                onPageMarginsChanged = onPageMargins,
-                onColumnModeChanged = onColumnMode,
-            )
-            ReadingFooterModeDropdown(
-                selected = prefs.footerMode,
-                onSelected = onFooterMode,
-            )
-            ReadingPageTurnAnimationToggle(
-                enabled = prefs.pageTurnAnimation,
-                onChanged = onPageTurnAnimation,
-            )
         }
     }
 }

--- a/docs/adr/0001-advanced-reading-menu.md
+++ b/docs/adr/0001-advanced-reading-menu.md
@@ -72,10 +72,13 @@ cannot be empty. The rows that do not apply still hide themselves —
 auto-scroll only in a scrolled book, the page-turn animation only in a
 paginated one, columns only when there is width for two.
 
-Settings → Reading appearance shows the same controls without a book,
-so it carries the same split: the six live behind a collapsed
-**Advanced** section there. A reader who learned where the margins are
-in one place does not have to learn it again in the other.
+Settings → Reading appearance shows the same six controls without a
+book, but not behind a collapsed section: that screen has nothing else
+competing for room, so there is no empty-sheet problem to avoid, and a
+reader who came looking for the margins should not have to open
+anything to find them. The typography sheet still collapses them, being
+the surface that stays Kindle-simple; the settings screen just lists
+them.
 
 New reading settings default to Advanced. `AGENTS.md` carries that as a
 convention, so the next reasonable row has to argue its way onto the

--- a/docs/adr/0001-advanced-reading-menu.md
+++ b/docs/adr/0001-advanced-reading-menu.md
@@ -72,8 +72,9 @@ cannot be empty. The rows that do not apply still hide themselves —
 auto-scroll only in a scrolled book, the page-turn animation only in a
 paginated one, columns only when there is width for two.
 
-Settings → Reading appearance shows the same six controls without a
-book, but not behind a collapsed section: that screen has nothing else
+Settings → Reading appearance shows five of the six without a book —
+the just-this-book toggle needs a book to set apart, and there is none
+here — and not behind a collapsed section: that screen has nothing else
 competing for room, so there is no empty-sheet problem to avoid, and a
 reader who came looking for the margins should not have to open
 anything to find them. The typography sheet still collapses them, being


### PR DESCRIPTION
## Summary
- Settings → Reading appearance no longer hides line height, margins, columns, footer mode and page-turn animation behind a collapsed "Advanced" toggle — that screen has nothing else competing for room, so there's no reason to make a reader open a section to find the margins.
- The typography sheet ("Aa" button while reading) keeps its own Advanced collapse, since it's meant to stay Kindle-simple.
- Updated `docs/adr/0001-advanced-reading-menu.md` and `AGENTS.md` to describe the new split instead of the stale "collapsed Advanced section" wording.

## Test plan
- [x] `./gradlew testDebugUnitTest lintDebug` pass
- [x] Verified on an emulator: Settings → Reading appearance shows Line spacing, Margins, Progress and Page turn animation directly, with no Advanced toggle
- Screenshot was captured and checked visually but could not be attached automatically — GitHub's user-attachments upload endpoint requires browser session auth, not a personal access token, so it isn't reachable via `gh`/`curl` from this environment.
