### PR TITLE
feat(reader): choose which side of the page turns forward

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -258,6 +258,7 @@ private fun LiseurApp(settings: AppSettings) {
                 onThemeMode = { scope.launch { repository.setThemeMode(it) } },
                 onDynamicColor = { scope.launch { repository.setDynamicColor(it) } },
                 onVolumeKeys = { scope.launch { repository.setVolumeKeysTurnPages(it) } },
+                onTapZones = { scope.launch { repository.setTapZones(it) } },
                 onEInkMode = { scope.launch { repository.setEInkMode(it) } },
                 onColorEInk = { scope.launch { repository.setColorEInk(it) } },
                 onVendorRefresh = { scope.launch { repository.setVendorRefresh(it) } },

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
@@ -78,10 +78,12 @@ enum class EInkMode(val id: String) {
 /**
  * Which side of a paginated page turns forward.
  *
- * [STANDARD] is the layout the app has always had: the left of the page
- * goes back, the rest goes forward. [SWAPPED] puts the forward turn
- * under the other thumb, for a reader holding the phone in the other
- * hand — every page turn otherwise reaches across the screen.
+ * [STANDARD] is the layout the app has always had: the side the book
+ * came from goes back, the rest goes forward — the left of the page on
+ * a left-to-right book, the right of it on a right-to-left one.
+ * [SWAPPED] puts the forward turn under the other thumb, for a reader
+ * holding the phone in the other hand — every page turn otherwise
+ * reaches across the screen.
  *
  * "The other thumb" and not "the left side": a book that reads right to
  * left already turns forward on the left, so [SWAPPED] puts forward back

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
@@ -75,6 +75,49 @@ enum class EInkMode(val id: String) {
     }
 }
 
+/**
+ * Which side of a paginated page turns forward.
+ *
+ * [STANDARD] is the layout the app has always had: the left of the page
+ * goes back, the rest goes forward. [SWAPPED] puts the forward turn
+ * under the other thumb, for a reader holding the phone in the other
+ * hand — every page turn otherwise reaches across the screen.
+ *
+ * "The other thumb" and not "the left side": a book that reads right to
+ * left already turns forward on the left, so [SWAPPED] puts forward back
+ * on the right there. The preset says which hand is holding the phone,
+ * and leaves the book to say where its next page is.
+ *
+ * Only two, and deliberately: a zone editor is a settings hobby, and a
+ * third preset has to earn its place by describing a hand position that
+ * actually occurs. See `docs/adr/0009-tap-zone-customization.md`.
+ *
+ * The centre and the top strip still reveal the chrome under both, the
+ * volume keys still go forward on down, and a book read by scrolling has
+ * no page sides to tap in the first place.
+ */
+enum class TapZones(val id: String) {
+    STANDARD("standard"),
+    SWAPPED("swapped"),
+    ;
+
+    /**
+     * Whether the sides are the other way round.
+     *
+     * Read against reading direction rather than instead of it: an RTL
+     * book already turns forward on the left, and swapping it puts
+     * forward back on the right. The composition is in
+     * [com.chmouel.liseur.reader.chrome.ReaderTapZones.forward].
+     */
+    val swapped: Boolean get() = this == SWAPPED
+
+    companion object {
+        val Default = STANDARD
+
+        fun fromId(id: String?): TapZones = entries.firstOrNull { it.id == id } ?: Default
+    }
+}
+
 /** Where the Define action sends selected text. */
 enum class DefinitionTarget(val id: String) {
     BUILT_IN("built_in"),
@@ -97,6 +140,7 @@ enum class DefinitionTarget(val id: String) {
  *   On by default where the system can do it; the hand-made palette is
  *   what you get back by turning it off, and what older phones always get.
  * @param volumeKeysTurnPages Volume keys page forward and back while reading.
+ * @param tapZones Which side of a paginated page turns forward.
  * @param resumeLastBook Opening the app goes back into the book you were in.
  * @param keepScreenOn The screen stays awake while a book is open. Off
  *   until asked for: it costs battery, and it overrides a device setting
@@ -128,6 +172,7 @@ data class AppSettings(
     val themeMode: ThemeMode = ThemeMode.Default,
     val dynamicColor: Boolean = true,
     val volumeKeysTurnPages: Boolean = true,
+    val tapZones: TapZones = TapZones.Default,
     val resumeLastBook: Boolean = true,
     val keepScreenOn: Boolean = false,
     val scrollMode: Boolean = false,
@@ -176,6 +221,7 @@ class AppSettingsRepository(private val context: Context) {
         val THEME_MODE = stringPreferencesKey("theme_mode")
         val DYNAMIC_COLOR = booleanPreferencesKey("dynamic_color")
         val VOLUME_KEYS = booleanPreferencesKey("volume_keys_turn_pages")
+        val TAP_ZONES = stringPreferencesKey("tap_zones")
         val RESUME_LAST_BOOK = booleanPreferencesKey("resume_last_book")
         val KEEP_SCREEN_ON = booleanPreferencesKey("keep_screen_on")
         val SCROLL_MODE = booleanPreferencesKey("scroll_mode")
@@ -214,6 +260,7 @@ class AppSettingsRepository(private val context: Context) {
             themeMode = ThemeMode.fromId(p[Keys.THEME_MODE]),
             dynamicColor = p[Keys.DYNAMIC_COLOR] ?: true,
             volumeKeysTurnPages = p[Keys.VOLUME_KEYS] ?: true,
+            tapZones = TapZones.fromId(p[Keys.TAP_ZONES]),
             resumeLastBook = p[Keys.RESUME_LAST_BOOK] ?: true,
             keepScreenOn = p[Keys.KEEP_SCREEN_ON] ?: false,
             scrollMode = p[Keys.SCROLL_MODE] ?: false,
@@ -255,6 +302,10 @@ class AppSettingsRepository(private val context: Context) {
 
     suspend fun setVolumeKeysTurnPages(enabled: Boolean) {
         context.appSettingsStore.edit { it[Keys.VOLUME_KEYS] = enabled }
+    }
+
+    suspend fun setTapZones(zones: TapZones) {
+        context.appSettingsStore.edit { it[Keys.TAP_ZONES] = zones.id }
     }
 
     suspend fun setResumeLastBook(enabled: Boolean) {

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
@@ -337,6 +337,7 @@ class ReaderActivity : FragmentActivity() {
                                     onKeepScreenOnChanged = viewModel::setKeepScreenOn,
                                     scrollModeFlow = viewModel.scrollMode,
                                     onScrollModeChanged = viewModel::setScrollMode,
+                                    tapZonesFlow = viewModel.tapZones,
                                     // Dialogs of this activity's own,
                                     // drawn over the reader. The page
                                     // must not carry on scrolling under

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -106,6 +106,7 @@ import com.chmouel.liseur.data.settings.ReadingFont
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.ReaderTheme
 import com.chmouel.liseur.data.settings.ReaderThemeChoice
+import com.chmouel.liseur.data.settings.TapZones
 import com.chmouel.liseur.reader.chrome.CatchUpPill
 import com.chmouel.liseur.reader.chrome.AdvancedSheet
 import com.chmouel.liseur.reader.chrome.AutoScrollSpeed
@@ -302,6 +303,7 @@ fun ReaderScreen(
     onKeepScreenOnChanged: (Boolean) -> Unit,
     scrollModeFlow: StateFlow<Boolean>,
     onScrollModeChanged: (Boolean) -> Unit,
+    tapZonesFlow: StateFlow<TapZones>,
     // The activity draws dialogs of its own over this screen — a link
     // out of the book, a sync, an offer to send the book up — and a tap
     // on a link never reaches the tap zones, so the screen would
@@ -323,6 +325,8 @@ fun ReaderScreen(
     val prefs by prefsFlow.collectAsStateWithLifecycle()
     val keepScreenOn by keepScreenOnFlow.collectAsStateWithLifecycle()
     val scrollMode by scrollModeFlow.collectAsStateWithLifecycle()
+    val tapZones by tapZonesFlow.collectAsStateWithLifecycle()
+    val swappedZonesNow by rememberUpdatedState(tapZones.swapped)
     // Readium reads vertical text off the book rather than off the
     // reader: it cannot paginate lines that run down the page, so such a
     // book is scrolled whatever the setting says. Everything that asks
@@ -1391,6 +1395,7 @@ fun ReaderScreen(
                     navigator = it,
                     isChromeVisible = { chromeVisibleNow },
                     isScrolling = { effectiveScrollingNow },
+                    isSwapped = { swappedZonesNow },
                     onTurnPage = pageTurner::turn,
                     onShowChrome = { chromeVisible = true },
                     onHideChrome = { chromeVisible = false },
@@ -1551,6 +1556,7 @@ fun ReaderScreen(
                 noNextInLibrary = continuation?.noNextInLibrary == true,
                 seriesCompletion = continuation?.seriesCompletion,
                 rtl = endpaperRtl,
+                swapped = tapZones.swapped,
                 onTurnBack = {
                     showingEnd = false
                     onLeftEndpaper()

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -49,6 +49,7 @@ import com.chmouel.liseur.sync.ReadingPositionPublisher
 import com.chmouel.liseur.data.settings.ColumnMode
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.ReaderThemeChoice
+import com.chmouel.liseur.data.settings.TapZones
 import com.chmouel.liseur.domain.EPSILON
 import com.chmouel.liseur.domain.SeriesExtras
 import com.chmouel.liseur.domain.seriesIdForExtras
@@ -641,6 +642,11 @@ class ReaderViewModel(
         .map { it.scrollMode }
         .combine(readingModeDao.observe(bookId)) { global, own -> own.scrollsWith(global) }
         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    /** Which side of the page turns forward, app-wide. */
+    val tapZones: StateFlow<TapZones> = appSettings.settings
+        .map { it.tapZones }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, TapZones.Default)
 
     /** Most recent position, used to persist progress and to survive recreation. */
     var lastLocator: Locator? = null

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
@@ -50,9 +50,9 @@ import com.chmouel.liseur.ui.windowWidth
  * text block, what the footer says, whether pages turn with an
  * animation, whether the page moves on its own, and whether any of it is
  * this book's alone. The rest of what belongs here — finer typography,
- * read-aloud, imported fonts, tap-zone presets — arrives with its own
- * issue, and the shape of the sheet is the point: five rows, or ten, it
- * is the same sheet and the reader learns it once.
+ * read-aloud, imported fonts — arrives with its own issue, and the shape
+ * of the sheet is the point: five rows, or ten, it is the same sheet and
+ * the reader learns it once.
  *
  * [scrolling] is whether the text runs rather than turns, which is not
  * only the reader's own choice: vertical text is laid out that way

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/Endpaper.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/Endpaper.kt
@@ -79,10 +79,11 @@ import kotlinx.coroutines.delay
  * columns Readium would keep turning through.
  *
  * It is a page, so the same tap zones apply — the back side returns to
- * the last page of the book, the forward side stays put. The actions
- * stay at the foot of the page so a short window or a large font cannot
- * push them off the screen; the colophon above them scrolls if it must.
- * The next volume is a small card of its own: cover, name, and one
+ * the last page of the book, the forward side stays put, and [swapped]
+ * moves which side is which exactly as it does while reading. The
+ * actions stay at the foot of the page so a short window or a large font
+ * cannot push them off the screen; the colophon above them scrolls if it
+ * must. The next volume is a small card of its own: cover, name, and one
  * action, in the reading colours rather than a second chrome.
  */
 @Composable
@@ -99,6 +100,7 @@ fun Endpaper(
     noNextInLibrary: Boolean = false,
     seriesCompletion: SeriesCompletion?,
     rtl: Boolean,
+    swapped: Boolean,
     onTurnBack: () -> Unit,
     onLibrary: () -> Unit,
     onOpenNext: () -> Unit,
@@ -139,7 +141,7 @@ fun Endpaper(
             .background(theme.background)
             .semantics { contentDescription = description }
             .onSizeChanged { size = it }
-            .pointerInput(size, rtl, density) {
+            .pointerInput(size, rtl, swapped, density) {
                 if (size.width <= 0 || size.height <= 0) return@pointerInput
                 detectTapGestures { offset ->
                     val zone = ReaderTapZones.zoneAt(
@@ -149,11 +151,8 @@ fun Endpaper(
                         height = size.height.toFloat(),
                         density = density,
                     )
-                    val forward = when (zone) {
-                        ReaderTapZones.Zone.BACK -> rtl
-                        ReaderTapZones.Zone.FORWARD -> !rtl
-                        ReaderTapZones.Zone.CHROME -> return@detectTapGestures
-                    }
+                    val forward = ReaderTapZones.forward(zone, rtl, swapped)
+                        ?: return@detectTapGestures
                     if (!forward) onTurnBack()
                 }
             },

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReaderTapZones.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReaderTapZones.kt
@@ -34,11 +34,11 @@ import kotlin.math.abs
  * Which side is which is the reader's to choose: [isSwapped] is the
  * Settings → Reading preset, and puts the forward turn under the other
  * thumb for a reader holding the phone in the other hand. It composes
- * with reading direction rather than replacing it: on a left-to-right
- * book that moves forward to the left, and on a right-to-left one,
- * which already turns forward there, it moves forward back to the
- * right. The chrome zones do not move — only the two sides trade
- * places.
+ * with reading direction rather than replacing it: swapping a
+ * left-to-right book moves the forward zone from the right of the page
+ * to the left, and swapping a right-to-left one, which by default turns
+ * forward on the left, moves it back to the right. The chrome zones do
+ * not move — only the two sides trade places.
  *
  * A book read by scrolling has no page to turn, so the whole page
  * becomes the chrome zone and the text is moved by dragging it. Side

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReaderTapZones.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReaderTapZones.kt
@@ -27,6 +27,11 @@ import kotlin.math.abs
  * any tap on the page dismisses it. Page turns are delegated to
  * [onTurnPage] so they can run the page-turn effect.
  *
+ * Which side is which is the reader's to choose: [isSwapped] is the
+ * Settings → Reading preset, and turns the left of the page into the
+ * forward one for a reader holding the phone in the other hand. The
+ * chrome zones do not move — only the two sides trade places.
+ *
  * A book read by scrolling has no page to turn, so the whole page
  * becomes the chrome zone and the text is moved by dragging it. Side
  * taps there would scroll by a screenful with no page-turn to make
@@ -45,6 +50,7 @@ class ReaderTapZones(
     private val navigator: OverflowableNavigator,
     private val isChromeVisible: () -> Boolean,
     private val isScrolling: () -> Boolean = { false },
+    private val isSwapped: () -> Boolean = { false },
     private val onTurnPage: (forward: Boolean) -> Unit,
     private val onShowChrome: () -> Unit,
     private val onHideChrome: () -> Unit,
@@ -64,10 +70,10 @@ class ReaderTapZones(
         val dp = view.resources.displayMetrics.density
         val rtl = navigator.overflow.value.readingProgression == ReadingProgression.RTL
 
-        when (zoneAt(event.point.x, event.point.y, width, height, dp, isScrolling())) {
-            Zone.CHROME -> onShowChrome()
-            Zone.BACK -> onTurnPage(rtl)
-            Zone.FORWARD -> onTurnPage(!rtl)
+        val zone = zoneAt(event.point.x, event.point.y, width, height, dp, isScrolling())
+        when (val forward = forward(zone, rtl, isSwapped())) {
+            null -> onShowChrome()
+            else -> onTurnPage(forward)
         }
         return true
     }
@@ -144,6 +150,27 @@ class ReaderTapZones(
                 fx < BACK_ZONE -> Zone.BACK
                 else -> Zone.FORWARD
             }
+        }
+
+        /**
+         * Which way a tapped [zone] turns the page, or null for the chrome.
+         *
+         * [zoneAt] answers in sides of the screen; this is the one place
+         * that turns a side into a direction, so the reading page and the
+         * endpaper cannot come to different answers about the same tap.
+         *
+         * The two things that reorder the sides compose rather than
+         * overrule each other. [rtl] is the book's: a right-to-left book
+         * turns forward on the left, because that is where the next page
+         * is. [swapped] is the reader's, and means "the other thumb"
+         * whatever the book does — so on an RTL book it puts forward back
+         * on the right. Both at once is the standard layout again, which
+         * is why this is an equality and not a pair of branches.
+         */
+        fun forward(zone: Zone, rtl: Boolean, swapped: Boolean): Boolean? = when (zone) {
+            Zone.CHROME -> null
+            Zone.BACK -> rtl != swapped
+            Zone.FORWARD -> rtl == swapped
         }
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReaderTapZones.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReaderTapZones.kt
@@ -21,16 +21,24 @@ import kotlin.math.abs
  * └─────────┴────────┴────────┘
  * ```
  *
+ * drawn for a left-to-right book on the standard preset.
+ *
  * Tapping the top strip or the center of the page gently reveals the
- * chrome (menu), as fullscreen reading apps do; the left side goes
- * back a page and the rest goes forward. When the chrome is showing,
- * any tap on the page dismisses it. Page turns are delegated to
- * [onTurnPage] so they can run the page-turn effect.
+ * chrome (menu), as fullscreen reading apps do; the side the book came
+ * from goes back a page and the rest goes forward, which is the left of
+ * the page on a left-to-right book and the right of it on a
+ * right-to-left one. When the chrome is showing, any tap on the page
+ * dismisses it. Page turns are delegated to [onTurnPage] so they can
+ * run the page-turn effect.
  *
  * Which side is which is the reader's to choose: [isSwapped] is the
- * Settings → Reading preset, and turns the left of the page into the
- * forward one for a reader holding the phone in the other hand. The
- * chrome zones do not move — only the two sides trade places.
+ * Settings → Reading preset, and puts the forward turn under the other
+ * thumb for a reader holding the phone in the other hand. It composes
+ * with reading direction rather than replacing it: on a left-to-right
+ * book that moves forward to the left, and on a right-to-left one,
+ * which already turns forward there, it moves forward back to the
+ * right. The chrome zones do not move — only the two sides trade
+ * places.
  *
  * A book read by scrolling has no page to turn, so the whole page
  * becomes the chrome zone and the text is moved by dragging it. Side

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
@@ -74,6 +74,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.chmouel.liseur.data.settings.DefinitionTarget
 import com.chmouel.liseur.data.settings.EInkMode
 import com.chmouel.liseur.data.settings.ReaderThemeChoice
+import com.chmouel.liseur.data.settings.TapZones
 import com.chmouel.liseur.data.settings.ThemeMode
 import com.chmouel.liseur.domain.DictionaryUrl
 import com.chmouel.liseur.domain.WiktionaryEditions
@@ -95,6 +96,7 @@ fun SettingsScreen(
     onThemeMode: (ThemeMode) -> Unit,
     onDynamicColor: (Boolean) -> Unit,
     onVolumeKeys: (Boolean) -> Unit,
+    onTapZones: (TapZones) -> Unit,
     onEInkMode: (EInkMode) -> Unit,
     onColorEInk: (Boolean) -> Unit,
     onVendorRefresh: (Boolean) -> Unit,
@@ -277,6 +279,15 @@ fun SettingsScreen(
                         onCheckedChange = onVolumeKeys,
                     )
                     RowDivider()
+                    ChipRow(
+                        title = stringResource(R.string.settings_tap_zones),
+                        subtitle = stringResource(R.string.settings_tap_zones_detail),
+                        options = TapZones.entries,
+                        selected = settings.tapZones,
+                        label = { stringResource(it.label) },
+                        onSelected = onTapZones,
+                    )
+                    RowDivider()
                     SwitchRow(
                         title = stringResource(R.string.settings_resume),
                         subtitle = stringResource(R.string.settings_resume_detail),
@@ -379,6 +390,12 @@ private val EInkMode.label: Int
         EInkMode.AUTO -> R.string.eink_auto
         EInkMode.ON -> R.string.eink_on
         EInkMode.OFF -> R.string.eink_off
+    }
+
+private val TapZones.label: Int
+    get() = when (this) {
+        TapZones.STANDARD -> R.string.tap_zones_standard
+        TapZones.SWAPPED -> R.string.tap_zones_swapped
     }
 
 private val DefinitionTarget.label: Int

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -505,6 +505,10 @@
     <string name="settings_reading">Reading</string>
     <string name="settings_volume_keys">Volume keys turn pages</string>
     <string name="settings_volume_keys_detail">Volume down goes forward, volume up goes back.</string>
+    <string name="settings_tap_zones">Page-turn sides</string>
+    <string name="settings_tap_zones_detail">Which side of the page turns forward when you tap it. Swapped puts the forward turn under the other thumb, for holding the phone in the other hand: in most books the left of the page goes on and the right goes back, and in a book that reads right to left it is the other way about. The middle still opens the menu, the volume keys are unchanged, and a book read by scrolling has no sides to tap.</string>
+    <string name="tap_zones_standard">Standard</string>
+    <string name="tap_zones_swapped">Swapped</string>
     <string name="settings_resume">Open on the book you were reading</string>
     <string name="settings_resume_detail">Skip the library when you left off mid-book.</string>
     <string name="settings_keep_screen_on">Keep the screen on</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/settings/TapZonesTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/settings/TapZonesTest.kt
@@ -1,0 +1,35 @@
+package com.chmouel.liseur.data.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The preset is read back out of a file on a device, so the only thing
+ * worth pinning down is that an id that is not one of the two — from a
+ * version that has not been written yet, or from a corrupt store — lands
+ * a reader on the layout the app has always had rather than reversing
+ * their page turns.
+ */
+class TapZonesTest {
+
+    @Test
+    fun `every preset survives a round trip through its id`() {
+        for (zones in TapZones.entries) {
+            assertEquals(zones, TapZones.fromId(zones.id))
+        }
+    }
+
+    @Test
+    fun `an id from nowhere is the standard layout`() {
+        assertEquals(TapZones.STANDARD, TapZones.Default)
+        assertEquals(TapZones.STANDARD, TapZones.fromId(null))
+        assertEquals(TapZones.STANDARD, TapZones.fromId(""))
+        assertEquals(TapZones.STANDARD, TapZones.fromId("both_forward"))
+    }
+
+    @Test
+    fun `only the swapped preset reorders the sides`() {
+        assertEquals(false, TapZones.STANDARD.swapped)
+        assertEquals(true, TapZones.SWAPPED.swapped)
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/ReaderTapZonesTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/ReaderTapZonesTest.kt
@@ -1,8 +1,10 @@
 package com.chmouel.liseur.reader.chrome
 
+import com.chmouel.liseur.reader.chrome.ReaderTapZones.Companion.forward
 import com.chmouel.liseur.reader.chrome.ReaderTapZones.Companion.zoneAt
 import com.chmouel.liseur.reader.chrome.ReaderTapZones.Zone
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 /**
@@ -93,6 +95,46 @@ class ReaderTapZonesTest {
                 for (fy in listOf(0.02f, 0.25f, 0.5f, 0.75f, 0.98f)) {
                     assertEquals(Zone.CHROME, screen.scrolledAt(fx, fy))
                 }
+            }
+        }
+    }
+
+    @Test
+    fun `the standard preset is the layout the app always had`() {
+        assertEquals(false, forward(Zone.BACK, rtl = false, swapped = false))
+        assertEquals(true, forward(Zone.FORWARD, rtl = false, swapped = false))
+    }
+
+    @Test
+    fun `swapping puts forward on the left`() {
+        assertEquals(true, forward(Zone.BACK, rtl = false, swapped = true))
+        assertEquals(false, forward(Zone.FORWARD, rtl = false, swapped = true))
+    }
+
+    @Test
+    fun `a right-to-left book already turns forward on the left`() {
+        assertEquals(true, forward(Zone.BACK, rtl = true, swapped = false))
+        assertEquals(false, forward(Zone.FORWARD, rtl = true, swapped = false))
+    }
+
+    @Test
+    fun `swapping a right-to-left book comes back to the standard sides`() {
+        // The preset means "the other thumb", not "the left side goes
+        // on", so it composes with the book's direction rather than
+        // overruling it: both reorderings at once cancel out.
+        for (zone in listOf(Zone.BACK, Zone.FORWARD)) {
+            assertEquals(
+                forward(zone, rtl = false, swapped = false),
+                forward(zone, rtl = true, swapped = true),
+            )
+        }
+    }
+
+    @Test
+    fun `no preset gives the chrome a direction`() {
+        for (rtl in listOf(false, true)) {
+            for (swapped in listOf(false, true)) {
+                assertNull(forward(Zone.CHROME, rtl, swapped))
             }
         }
     }

--- a/docs/adr/0001-advanced-reading-menu.md
+++ b/docs/adr/0001-advanced-reading-menu.md
@@ -17,9 +17,14 @@ size, a few layout choices, done.
 ## Decision
 
 The typography sheet gains exactly one new row, **Advanced**, at the
-bottom. Everything that genuinely needs a setting lives behind it.
-Nothing else in the app grows a menu, a screen or a piece of chrome for
-these features.
+bottom. Everything that genuinely needs a reading-comfort setting lives
+behind it, and nothing in the reader grows a second menu, screen or
+piece of chrome for these features.
+
+A feature that turns out not to be about reading comfort is not
+smuggled in behind Advanced either: it goes to the settings surface it
+actually belongs to, next to the setting it is a sibling of. That is a
+row on a screen the app already has, never a new one.
 
 Most of the nine do not even get a row there, because they can be a
 gesture or fold into something that already exists:
@@ -33,13 +38,18 @@ gesture or fold into something that already exists:
 - Translation ([ADR 10](0010-translation-on-selection.md)) is one
   action in the selection popup, switched on from the dictionary
   settings that already exist.
+- The tap-zone preset ([ADR 9](0009-tap-zone-customization.md)) is a
+  chip row in Settings → Reading, beside the volume-key switch it is
+  the thumb's version of. Not a reading-comfort setting after all: it
+  is how the device is held, set once when the app is set up, and it
+  belongs with the other page-turning hardware rather than with the
+  page's appearance.
 
 That leaves the Advanced sheet holding what actually needs a home:
 fine typography ([ADR 2](0002-typography-fine-tuning.md)), read-aloud
 ([ADR 3](0003-read-aloud-tts.md)), user fonts
-([ADR 4](0004-user-imported-fonts.md)), auto-scroll
-([ADR 6](0006-auto-scroll.md)) and the tap-zone preset
-([ADR 9](0009-tap-zone-customization.md)).
+([ADR 4](0004-user-imported-fonts.md)) and auto-scroll
+([ADR 6](0006-auto-scroll.md)).
 
 ## Consequences
 
@@ -52,8 +62,8 @@ first, not a navigation destination: dismissing it lands back on the
 typography sheet, and dismissing that lands back on the page.
 
 It exists as of auto-scroll ([ADR 6](0006-auto-scroll.md)), which was
-the first of the five to be built and so brought the sheet with it. The
-other four arrive with their own issues.
+the first of the four to be built and so brought the sheet with it. The
+other three arrive with their own issues.
 
 The typography sheet did grow anyway, one reasonable row at a time,
 until it carried eleven controls and the Advanced row held one. Six of

--- a/docs/adr/0009-tap-zone-customization.md
+++ b/docs/adr/0009-tap-zone-customization.md
@@ -1,42 +1,89 @@
 # 9. Tap-zone presets
 
-Status: proposed
+Status: accepted
 GitHub issue: [#46](https://github.com/chmouel/liseur/issues/46)
 
 ## Context
 
-The tap zones are fixed: left edge back, right edge forward, middle for
-chrome. A left-handed reader holding a phone in one hand has the
-forward turn under the wrong thumb every single page. The fix most
-readers actually want is not a zone editor, it is "both edges turn
-forward" or "swap the edges".
+The tap zones are fixed: the edge the book came from goes back, the
+opposite edge goes forward, middle for chrome — on a book that reads
+left to right, that is back on the left and forward on the right. A
+left-handed reader holding a phone in one hand has the forward turn
+under the wrong thumb every single page. The fix most readers actually
+want is not a zone editor, it is "swap the edges".
 
 ## Decision
 
-One three-way preference: **Standard** (today's layout), **Both edges
-forward** (going back stays on the volume keys and the scrubber), and
-**Swapped** (left forward, right back).
+One two-way preference: **Standard** (today's layout, whichever way the
+book reads) and **Swapped** (the other thumb — the sides the other way
+round from whatever Standard gives that book).
 
-Fit with Liseur's simplicity: one row with three choices in the
-Advanced sheet. No draggable zone editor, no per-zone action picker —
-that is a settings hobby, and the three presets cover the readers who
-exist.
+Two, not the three this ADR first proposed. The dropped one was "both
+edges forward", with going back left to the volume keys and the
+scrubber. It is a real way to read, but it is a different kind of
+answer: the other two say which hand is holding the phone, while that
+one takes an action off the page and asks the reader to find it
+somewhere else.
+
+Fit with Liseur's simplicity: one chip row in **Settings → Reading**,
+directly under "Volume keys turn pages". Not the typography sheet this
+ADR first named, and not Reading appearance: a tap zone is not how the
+page looks, it is how the page is turned, and the switch it belongs
+beside is the one that decides what the volume keys do. It is also set
+once, when the app is set up, which is what the reading sheet is
+explicitly not for ([ADR 1](0001-advanced-reading-menu.md)).
+
+No draggable zone editor, no per-zone action picker — that is a
+settings hobby, and the two presets cover the readers who exist.
 
 ## Design
 
-`ReaderTapZones` already resolves a tap position to an action in one
-place; the preset is an enum on `ReaderPrefs` consulted in that
-resolution. The volume keys are untouched — they already give a
-physical back/forward pair whatever the thumbs do.
+`ReaderTapZones.zoneAt` resolves a tap position to a *side of the
+screen*, and stays that way: the ceilings it applies to the chrome zones
+are geometry, and a preset that reorders the sides has nothing to say
+about them. The mapping from a side to a direction moves into one pure
+function, `ReaderTapZones.forward(zone, rtl, swapped)`, so the reading
+page and the endpaper cannot come to different answers about the same
+tap — the endpaper is a page, and had its own copy of that `when`.
 
-Scroll mode keeps its own scroll-aware tap behaviour; the preset only
-reinterprets the paginated edges.
+The preset composes with reading direction rather than overruling it. An
+RTL book turns forward on the left because that is where the next page
+is; Swapped means "the other thumb" whatever the book does, so on an RTL
+book it puts forward back on the right. Both reorderings at once are the
+standard layout again, which is why the function is an equality and not
+a pair of branches.
+
+It lives in `AppSettings` beside `volumeKeysTurnPages` and `scrollMode`,
+reaches the reader as a `StateFlow` on `ReaderViewModel`, and is read
+through a lambda so that changing it does not tear down and rebuild the
+navigator's input listeners.
+
+The volume keys are untouched — they already give a physical
+back/forward pair whatever the thumbs do. Scroll mode keeps its own
+scroll-aware tap behaviour: the whole page is the chrome zone there, so
+a scrolled book never resolves to a side and the preset has nothing to
+reinterpret.
+
+The endpaper is the exception, and deliberately. It is the app's own
+page rather than the book's, is not scrolled by the navigator, and its
+chrome zone does nothing at all — so its sides stay live whatever the
+reading mode, exactly as they did before this preset existed. Taking
+them away in scroll mode would leave a reader who scrolls no tap at all
+to get back into the book. The preset therefore reaches the endpaper
+unconditionally, and the settings text's "no sides to tap" is about the
+book's pages.
 
 ## Consequences
 
-Three presets instead of a matrix means someone will ask for a fourth.
-The bar for adding one is the same as for these: a hand position that
+Two presets instead of a matrix means someone will ask for a third. The
+bar for adding one is the same as for these: a hand position that
 actually occurs, not a preference for novelty.
 
-*Where:* `data/settings/ReaderPrefs.kt`,
-`reader/chrome/ReaderTapZones.kt`, `reader/chrome/TypographySheet.kt`.
+The setting is only in Settings, so a reader cannot try it from the "Aa"
+sheet with the book in front of them. That is the cost of keeping the
+sheet to what is changed often; a preset is chosen once and then
+forgotten.
+
+*Where:* `data/settings/AppSettings.kt`,
+`reader/chrome/ReaderTapZones.kt`, `reader/chrome/Endpaper.kt`,
+`ui/settings/SettingsScreen.kt`.


### PR DESCRIPTION
## Summary

The tap zones are fixed: the edge the book came from goes back, the opposite edge goes forward. A reader holding the phone in the other hand reaches across the screen for every single page turn. Settings → **Reading** gains a two-chip row — **Standard** or **Swapped** — beside the volume-key switch it is the thumb's version of.

Fixes #46. Implements [ADR 9](https://github.com/chmouel/liseur/blob/tap-zone-presets/docs/adr/0009-tap-zone-customization.md), which is rewritten here to match what was actually built.

Two presets, not the three the ADR first proposed. The dropped one — "both edges forward", with going back left to the volume keys — is a different kind of answer: the other two say which hand is holding the phone, while that one takes an action off the page and asks the reader to find it somewhere else.

## Changes

- **`TapZones` enum** (`STANDARD`/`SWAPPED`) in `AppSettings`, DataStore key `tap_zones`. Anyone upgrading lands on Standard, and an unrecognised id does too rather than reversing their page turns.
- **One mapping, `ReaderTapZones.forward(zone, rtl, swapped)`.** `zoneAt` still answers in *sides of the screen* and stays pure geometry; this is the one place a side becomes a direction. `Endpaper` had its own copy of that `when` and now shares this one, so the reading page and the endpaper cannot disagree about the same tap.
- **The preset composes with reading direction rather than overruling it.** It means "the other thumb", not "the left side goes on" — so a right-to-left book, which already turns forward on the left, puts forward back on the right when swapped. Both reorderings at once are the standard layout again, which is why the mapping is an equality and not a pair of branches.
- **Plumbing**: a `StateFlow` on `ReaderViewModel` read through a lambda, so changing the preset does not tear down and rebuild the navigator's input listeners. `Endpaper`'s `pointerInput` is keyed on it.
- **Docs**: ADR 9 rewritten (two presets, Settings home, direction-relative wording, status `accepted`). ADR 9 lands as an explicit exception to [ADR 1](https://github.com/chmouel/liseur/blob/tap-zone-presets/docs/adr/0001-advanced-reading-menu.md), which promised every one of these features would live behind the Advanced sheet — ADR 1 and the `AdvancedSheet` KDoc are corrected rather than left contradicting the code.

Two deliberate non-changes, both recorded in ADR 9:

- **The volume keys are untouched.** They already give a physical back/forward pair whatever the thumbs do.
- **The endpaper is not made scroll-aware.** It is the app's own page, not the navigator's, and its chrome zone does nothing at all — taking its sides away in scroll mode would leave a reader who scrolls no tap at all to get back into the book. Its sides were already live there before this change.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

New tests: `forward()` is pure and covered exhaustively over zone × rtl × swapped (3 × 2 × 2), including that RTL and Swapped cancel and that no preset gives the chrome a direction. `TapZonesTest` pins the id round-trip and the unknown-id fallback. The scroll dimension lives in `zoneAt`, whose existing tests already cover it.

Verified by hand on an emulator, on *Moby Dick* at p.9 of 692:

| | Standard | Swapped |
| --- | --- | --- |
| Tap left | 10 → 9 (back) | 9 → 10 (forward) |
| Tap right | 9 → 10 (forward) | 10 → 9 (back) |
| Tap middle | chrome | chrome |
| Volume down | forward | forward |
| Volume up | back | back |

The choice survives in DataStore across the change.

## Screenshots or recordings

The new row, in Settings → Reading, directly under the volume-key switch:

![Settings → Reading, showing the new Page-turn sides row with Standard selected](https://github.com/user-attachments/assets/2129a750-bd9d-4dc4-9a8d-f11be5cca14b)
## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
