### PR TITLE
feat(stats): start the week where the reader's locale starts it

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLocale
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -37,6 +38,7 @@ import com.chmouel.liseur.reader.ReaderActivity
 import kotlinx.coroutines.launch
 import androidx.compose.runtime.saveable.listSaver
 import com.chmouel.liseur.domain.displayTitle
+import com.chmouel.liseur.domain.localeWeekStart
 import com.chmouel.liseur.ui.stats.BookReadingStatsScreen
 import com.chmouel.liseur.ui.stats.ReadingStatsScreen
 import com.chmouel.liseur.ui.stats.ReadingStatsViewModel
@@ -205,6 +207,11 @@ private fun LiseurApp(settings: AppSettings) {
             val model: ReadingStatsViewModel = viewModel(
                 factory = ReadingStatsViewModel.factory(),
             )
+            // The view model outlives the configuration change that a
+            // language switch is, so the week's first day is pushed in
+            // from here, where the locale is observable state.
+            val weekStart = localeWeekStart(LocalLocale.current.platformLocale)
+            LaunchedEffect(model, weekStart) { model.setWeekStart(weekStart) }
             LaunchedEffect(model) { model.refreshServerInsights() }
             val statsState by model.state.collectAsStateWithLifecycle()
             ReadingStatsScreen(
@@ -232,6 +239,8 @@ private fun LiseurApp(settings: AppSettings) {
                 val model: ReadingStatsViewModel = viewModel(
                     factory = ReadingStatsViewModel.factory(),
                 )
+                val weekStart = localeWeekStart(LocalLocale.current.platformLocale)
+                LaunchedEffect(model, weekStart) { model.setWeekStart(weekStart) }
                 LaunchedEffect(model, target.bookUrl) { model.refreshServerInsights() }
                 val bookStatsState by remember(model, target.bookUrl) { model.forBook(target.bookUrl) }
                     .collectAsStateWithLifecycle()

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncInsights.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncInsights.kt
@@ -6,8 +6,10 @@ import com.chmouel.liseur.data.remote.ServerKind
 import com.chmouel.liseur.data.db.WorkIdentityDao
 import com.chmouel.liseur.domain.StatsRange
 import java.io.IOException
+import java.time.DayOfWeek
 import java.time.Instant
 import java.time.LocalDate
+import java.time.temporal.WeekFields
 import org.json.JSONObject
 
 /**
@@ -69,10 +71,14 @@ class LiseurSyncInsights(
     private val http: LiseurSyncHttp = LiseurSyncHttp(),
 ) {
 
-    suspend fun summary(range: StatsRange = StatsRange.Default, today: LocalDate): InsightsSummary? {
+    suspend fun summary(
+        range: StatsRange = StatsRange.Default,
+        today: LocalDate,
+        weekStart: DayOfWeek = WeekFields.ISO.firstDayOfWeek,
+    ): InsightsSummary? {
         val account = account() ?: return null
         val credentials = account.credentials ?: return null
-        val from = range.startDate(today)
+        val from = range.startDate(today, weekStart)
         val answer = try {
             http.get(
                 LiseurSyncApi.insightsSummary(account.baseUrl, from, today),
@@ -181,12 +187,13 @@ class LiseurSyncInsights(
     suspend fun allBooks(
         range: StatsRange = StatsRange.Default,
         today: LocalDate,
+        weekStart: DayOfWeek = WeekFields.ISO.firstDayOfWeek,
     ): Map<String, WorkInsights>? {
         val account = account() ?: return null
         val credentials = account.credentials ?: return null
         val aliases = identityDao.aliasesFor(account.accountKey).filter { it.usable }
         if (aliases.isEmpty()) return emptyMap()
-        val from = range.startDate(today)
+        val from = range.startDate(today, weekStart)
         val answer = try {
             http.get(
                 LiseurSyncApi.allWorkInsights(account.baseUrl, from, today),

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/ReadingStats.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/ReadingStats.kt
@@ -1,9 +1,11 @@
 package com.chmouel.liseur.domain
 
+import java.time.DayOfWeek
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
+import java.time.temporal.WeekFields
 
 /** What one book's reading adds up to. */
 data class BookReadingStats(
@@ -146,6 +148,11 @@ const val RECENT_DAYS = 7
  *
  * [range] narrows every figure here except the streak, which is counted
  * over the whole of [sessions] on purpose — see [ReadingStats.streakDays].
+ *
+ * [weekStart] is which day the reader's calendar begins on, and only
+ * [StatsRange.THIS_WEEK] consults it. It defaults to the ISO Monday so
+ * that a caller with no locale to hand still gets a defined week rather
+ * than whichever one the JVM was started in.
  */
 fun readingStats(
     sessions: List<SessionSpan>,
@@ -153,6 +160,7 @@ fun readingStats(
     zone: ZoneId,
     today: LocalDate,
     range: StatsRange = StatsRange.Default,
+    weekStart: DayOfWeek = WeekFields.ISO.firstDayOfWeek,
 ): ReadingStats {
     val recorded = sessions.filter { it.durationMs > 0 }
     // The streak is answered from everything, before the window is
@@ -163,7 +171,7 @@ fun readingStats(
     // book was begun is a fact about the book, not about the window.
     val firstStarts = recorded.groupBy { it.bookUrl }
         .mapValues { (_, spans) -> spans.minOf { it.startedAt } }
-    val start = range.startDate(today)
+    val start = range.startDate(today, weekStart)
     val counted = if (start == null) recorded else recorded.filter { !it.day(zone).isBefore(start) }
     if (counted.isEmpty()) return ReadingStats.Empty.copy(streakDays = streak)
 
@@ -195,7 +203,7 @@ fun readingStats(
         booksRead = stats.size,
         booksFinished = stats.count { it.finished },
         books = stats,
-        recent = dailySeries(counted, zone, today, range),
+        recent = dailySeries(counted, zone, today, range, weekStart),
         sessions = counted.size,
         pendingSessions = counted.count { !it.uploaded },
         streakDays = streak,
@@ -227,9 +235,10 @@ private fun dailySeries(
     zone: ZoneId,
     today: LocalDate,
     range: StatsRange,
+    weekStart: DayOfWeek,
 ): List<ReadingDay> {
     val byDay = sessions.groupBy { it.day(zone) }
-    val start = range.startDate(today)
+    val start = range.startDate(today, weekStart)
         ?: byDay.keys.minOrNull()
         ?: today.minusDays((RECENT_DAYS - 1).toLong())
     val span = ChronoUnit.DAYS.between(start, today)

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/StatsRange.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/StatsRange.kt
@@ -1,6 +1,19 @@
 package com.chmouel.liseur.domain
 
+import java.time.DayOfWeek
 import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
+import java.time.temporal.WeekFields
+import java.util.Locale
+
+/**
+ * Which day [locale] considers a week to begin on.
+ *
+ * Spelled once, because a screen that starts its week on Monday beside
+ * a chart that starts it on Sunday is not a formatting difference, it
+ * is two different weeks.
+ */
+fun localeWeekStart(locale: Locale): DayOfWeek = WeekFields.of(locale).firstDayOfWeek
 
 /**
  * How far back the reading dashboard is looking.
@@ -20,7 +33,7 @@ import java.time.LocalDate
  * than the list beneath it could not be explained to anybody.
  */
 enum class StatsRange(val id: String) {
-    LAST_7_DAYS("7d"),
+    THIS_WEEK("7d"),
     LAST_30_DAYS("30d"),
     LAST_90_DAYS("90d"),
     LAST_YEAR("365d"),
@@ -31,13 +44,20 @@ enum class StatsRange(val id: String) {
     /**
      * The first day counted, or null for a span with no beginning.
      *
+     * "This week" runs from the most recent [weekStart] to today, so it
+     * holds one to seven days and grows through the week. A rolling
+     * seven days would be a longer span more of the time, but it begins
+     * on a different weekday every morning, which makes the chart
+     * impossible to compare with the one the reader saw yesterday and
+     * puts the same weekday at both ends of it.
+     *
      * "This year" is resolved against [today] rather than a day count,
      * because the first of January is a different distance away every
      * time it is asked, and a fixed 365 would call last December part of
      * this year for most of the spring.
      */
-    fun startDate(today: LocalDate): LocalDate? = when (this) {
-        LAST_7_DAYS -> today.minusDays(6)
+    fun startDate(today: LocalDate, weekStart: DayOfWeek): LocalDate? = when (this) {
+        THIS_WEEK -> today.with(TemporalAdjusters.previousOrSame(weekStart))
         LAST_30_DAYS -> today.minusDays(29)
         LAST_90_DAYS -> today.minusDays(89)
         LAST_YEAR -> today.minusDays(364)
@@ -52,8 +72,10 @@ enum class StatsRange(val id: String) {
      * day-by-day chart is drawn, so it counts both endpoints: a seven
      * day range is seven bars, not six.
      */
-    fun days(today: LocalDate): Int? =
-        startDate(today)?.let { java.time.temporal.ChronoUnit.DAYS.between(it, today).toInt() + 1 }
+    fun days(today: LocalDate, weekStart: DayOfWeek): Int? =
+        startDate(today, weekStart)?.let {
+            java.time.temporal.ChronoUnit.DAYS.between(it, today).toInt() + 1
+        }
 
     /**
      * Whether the span is short enough to read as a row of daily bars.
@@ -61,10 +83,11 @@ enum class StatsRange(val id: String) {
      * Past this a bar per day is a picket fence nobody can read a
      * weekday off, and the heatmap takes over.
      */
-    fun suitsDailyBars(today: LocalDate): Boolean = (days(today) ?: Int.MAX_VALUE) <= MAX_BAR_DAYS
+    fun suitsDailyBars(today: LocalDate, weekStart: DayOfWeek): Boolean =
+        (days(today, weekStart) ?: Int.MAX_VALUE) <= MAX_BAR_DAYS
 
     companion object {
-        val Default = LAST_7_DAYS
+        val Default = THIS_WEEK
 
         /** As many bars as fit across a phone without becoming hatching. */
         const val MAX_BAR_DAYS = 31

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/BookReadingStatsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/BookReadingStatsScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalLocale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -51,6 +52,7 @@ import com.chmouel.liseur.R
 import com.chmouel.liseur.data.liseursync.WorkInsights
 import com.chmouel.liseur.domain.BookReadingStats
 import com.chmouel.liseur.domain.StatsRange
+import com.chmouel.liseur.domain.localeWeekStart
 import com.chmouel.liseur.ui.BusyIndicator
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.windowWidth
@@ -192,9 +194,20 @@ fun BookReadingStatsScreen(
                                 color = MaterialTheme.colorScheme.surfaceContainerHigh,
                             ) {
                                 Text(
-                                    text = range.days(LocalDate.now())?.let {
-                                        stringResource(R.string.reading_stats_in_last_days_local, it)
-                                    } ?: stringResource(R.string.reading_stats_in_total),
+                                    text = when {
+                                        range == StatsRange.THIS_WEEK ->
+                                            stringResource(R.string.reading_stats_this_week_local)
+
+                                        else -> range.days(
+                                            LocalDate.now(),
+                                            localeWeekStart(LocalLocale.current.platformLocale),
+                                        )?.let {
+                                            stringResource(
+                                                R.string.reading_stats_in_last_days_local,
+                                                it,
+                                            )
+                                        } ?: stringResource(R.string.reading_stats_in_total)
+                                    },
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingDuration.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingDuration.kt
@@ -27,7 +27,7 @@ sealed interface DurationParts {
 /**
  * Splits [millis] into the largest units that still say something.
  *
- * Rounded to the minute and no finer. Seconds are noise here — nobody
+ * Resolved to the minute and no finer. Seconds are noise here — nobody
  * reads for four minutes and eleven seconds, they read for a few
  * minutes — and showing them would invite the reader to watch a number
  * that is only ever an estimate tick upwards.

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingDuration.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingDuration.kt
@@ -6,45 +6,109 @@ import com.chmouel.liseur.R
 import java.util.concurrent.TimeUnit
 
 /**
- * A length of time, said the way a person would say it.
+ * A length of time, broken into the units a person would say it in.
+ *
+ * Pure, and separate from the composable that words it, so the rules
+ * below can be written down as tests rather than reasoned about.
+ */
+sealed interface DurationParts {
+    /** Nothing recorded at all. */
+    data object None : DurationParts
+
+    /** Something, but less than the smallest unit worth naming. */
+    data object UnderMinute : DurationParts
+    data class Minutes(val minutes: Int) : DurationParts
+    data class Hours(val hours: Int, val minutes: Int) : DurationParts
+
+    /** A day or more. [hours] is 0 for a whole number of days. */
+    data class Days(val days: Int, val hours: Int) : DurationParts
+}
+
+/**
+ * Splits [millis] into the largest units that still say something.
  *
  * Rounded to the minute and no finer. Seconds are noise here — nobody
  * reads for four minutes and eleven seconds, they read for a few
  * minutes — and showing them would invite the reader to watch a number
  * that is only ever an estimate tick upwards.
+ *
+ * Past a day the minutes go too. "17 d 4 h 23 min" is a figure nobody
+ * reads to the end of, and the last term is a rounding error beside the
+ * first.
+ *
+ * Every unit truncates, never rounds up. The dashboard keeps its
+ * headline at or above the sum of the rows beneath it on purpose, and a
+ * total that rounded up while its parts rounded down would break that
+ * in the one direction that reads as a bug.
+ *
+ * Nothing above days. An all-time total of "312 d 4 h" is a large
+ * number honestly stated; the same in weeks is arithmetic homework.
  */
-@Composable
-fun readingDuration(millis: Long): String {
-    if (millis <= 0) return stringResource(R.string.duration_none)
-    if (millis < TimeUnit.MINUTES.toMillis(1)) {
-        return stringResource(R.string.duration_under_minute)
-    }
+fun durationParts(millis: Long): DurationParts {
+    if (millis <= 0) return DurationParts.None
+    if (millis < TimeUnit.MINUTES.toMillis(1)) return DurationParts.UnderMinute
     val totalMinutes = TimeUnit.MILLISECONDS.toMinutes(millis)
-    val hours = totalMinutes / 60
-    val minutes = totalMinutes % 60
-    return when {
-        hours == 0L -> stringResource(R.string.duration_minutes, minutes)
-        minutes == 0L -> stringResource(R.string.duration_hours, hours)
-        else -> stringResource(R.string.duration_hours_minutes, hours, minutes)
+    val totalHours = totalMinutes / MINUTES_PER_HOUR
+    if (totalHours >= HOURS_PER_DAY) {
+        return DurationParts.Days(
+            days = (totalHours / HOURS_PER_DAY).toInt(),
+            hours = (totalHours % HOURS_PER_DAY).toInt(),
+        )
+    }
+    val minutes = (totalMinutes % MINUTES_PER_HOUR).toInt()
+    if (totalHours == 0L) return DurationParts.Minutes(minutes)
+    return DurationParts.Hours(hours = totalHours.toInt(), minutes = minutes)
+}
+
+/** A length of time, said the way a person would say it. */
+@Composable
+fun readingDuration(millis: Long): String = when (val parts = durationParts(millis)) {
+    DurationParts.None -> stringResource(R.string.duration_none)
+    DurationParts.UnderMinute -> stringResource(R.string.duration_under_minute)
+    is DurationParts.Minutes -> stringResource(R.string.duration_minutes, parts.minutes)
+    is DurationParts.Hours -> if (parts.minutes == 0) {
+        stringResource(R.string.duration_hours, parts.hours)
+    } else {
+        stringResource(R.string.duration_hours_minutes, parts.hours, parts.minutes)
+    }
+
+    is DurationParts.Days -> if (parts.hours == 0) {
+        stringResource(R.string.duration_days, parts.days)
+    } else {
+        stringResource(R.string.duration_days_hours, parts.days, parts.hours)
     }
 }
 
 /**
  * The same length of time, shortened to fit above a bar.
  *
- * "1h20", "45m" — the abbreviations are unit symbols rather than
- * words, so they survive untranslated the way "km" does. Null rather
- * than a dash for an empty day: above a bar of nothing, any text at
- * all is clutter.
+ * "1h20", "45m", "2d3h" — the abbreviations are unit symbols rather
+ * than words, so they survive untranslated the way "km" does. Null
+ * rather than a dash for an empty day: above a bar of nothing, any text
+ * at all is clutter.
+ *
+ * A single day's bar rarely passes twenty-four hours, but it can: a
+ * sitting that runs past midnight is counted whole on the day it ended.
+ * "41h" above a bar is a figure the reader has to convert themselves.
  */
-fun compactDuration(millis: Long): String? {
-    if (millis <= 0) return null
-    val totalMinutes = TimeUnit.MILLISECONDS.toMinutes(millis).coerceAtLeast(1)
-    val hours = totalMinutes / 60
-    val minutes = totalMinutes % 60
-    return when {
-        hours == 0L -> "${minutes}m"
-        minutes == 0L -> "${hours}h"
-        else -> "${hours}h${minutes.toString().padStart(2, '0')}"
+fun compactDuration(millis: Long): String? = when (val parts = durationParts(millis)) {
+    DurationParts.None -> null
+    // A sitting too short to name is still a bar the eye can see.
+    // Captioning it "0m" would read as a fault rather than a moment.
+    DurationParts.UnderMinute -> "1m"
+    is DurationParts.Minutes -> "${parts.minutes}m"
+    is DurationParts.Hours -> if (parts.minutes == 0) {
+        "${parts.hours}h"
+    } else {
+        "${parts.hours}h${parts.minutes.toString().padStart(2, '0')}"
+    }
+
+    is DurationParts.Days -> if (parts.hours == 0) {
+        "${parts.days}d"
+    } else {
+        "${parts.days}d${parts.hours}h"
     }
 }
+
+private const val MINUTES_PER_HOUR = 60L
+private const val HOURS_PER_DAY = 24L

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingHeatmap.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingHeatmap.kt
@@ -27,9 +27,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.chmouel.liseur.R
 import com.chmouel.liseur.domain.ReadingDay
+import com.chmouel.liseur.domain.localeWeekStart
 import java.time.DayOfWeek
 import java.time.format.TextStyle
-import java.time.temporal.WeekFields
 
 /**
  * A long span of reading, one square a day.
@@ -49,7 +49,7 @@ import java.time.temporal.WeekFields
 internal fun ReadingHeatmap(days: List<ReadingDay>, modifier: Modifier = Modifier) {
     if (days.isEmpty()) return
     val locale = LocalLocale.current.platformLocale
-    val firstDayOfWeek = WeekFields.of(locale).firstDayOfWeek
+    val firstDayOfWeek = localeWeekStart(locale)
     // Pad the first column so every row is one weekday, the way a wall
     // calendar reads. Without this the grid is a spiral and the weekday
     // labels down the side are a lie.

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
@@ -75,6 +75,7 @@ import com.chmouel.liseur.domain.BookReadingStats
 import com.chmouel.liseur.domain.ReadingDay
 import com.chmouel.liseur.domain.ReadingStats
 import com.chmouel.liseur.domain.StatsRange
+import com.chmouel.liseur.domain.localeWeekStart
 import com.chmouel.liseur.ui.BusyIndicator
 import com.chmouel.liseur.ui.LocalEInk
 import com.chmouel.liseur.ui.contentWidthCap
@@ -171,7 +172,7 @@ fun ReadingStatsScreen(
                 verticalArrangement = Arrangement.spacedBy(20.dp),
             ) {
                 item {
-                    BentoHero(stats, ready.headline)
+                    BentoHero(stats, ready.headline, ready.range)
                 }
                 item {
                     ActivityCard(stats = stats, range = ready.range)
@@ -211,7 +212,7 @@ fun ReadingStatsScreen(
  * the grid instead of leaving a hole in it.
  */
 @Composable
-private fun BentoHero(stats: ReadingStats, headline: StatsHeadline) {
+private fun BentoHero(stats: ReadingStats, headline: StatsHeadline, range: StatsRange) {
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -258,9 +259,18 @@ private fun BentoHero(stats: ReadingStats, headline: StatsHeadline) {
                     color = MaterialTheme.colorScheme.surfaceContainerHigh,
                 ) {
                     Text(
-                        text = headline.rangeDays?.let {
-                            stringResource(R.string.reading_stats_in_last_days, it)
-                        } ?: stringResource(R.string.reading_stats_in_total),
+                        text = when {
+                            range == StatsRange.THIS_WEEK ->
+                                stringResource(R.string.reading_stats_this_week)
+
+                            headline.rangeDays != null ->
+                                stringResource(
+                                    R.string.reading_stats_in_last_days,
+                                    headline.rangeDays,
+                                )
+
+                            else -> stringResource(R.string.reading_stats_in_total)
+                        },
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
@@ -394,13 +404,14 @@ private fun BentoTile(
  *
  * Bars while a day is still a readable unit, a grid once it is not.
  * Both draw the same days; only the span the reader asked for decides
- * which can be read. "This past week" is only true when it is one —
- * thirty bars under that heading is the screen telling the reader
- * something it can see is false.
+ * which can be read. "This week" is only true when it is one — thirty
+ * bars under that heading is the screen telling the reader something it
+ * can see is false.
  */
 @Composable
 private fun ActivityCard(stats: ReadingStats, range: StatsRange) {
-    val daily = range.suitsDailyBars(LocalDate.now())
+    val weekStart = localeWeekStart(LocalLocale.current.platformLocale)
+    val daily = range.suitsDailyBars(LocalDate.now(), weekStart)
     Surface(
         shape = RoundedCornerShape(18.dp),
         color = MaterialTheme.colorScheme.surfaceContainerLow,
@@ -420,7 +431,7 @@ private fun ActivityCard(stats: ReadingStats, range: StatsRange) {
             ) {
                 Text(
                     text = stringResource(
-                        if (daily && range == StatsRange.LAST_7_DAYS) {
+                        if (daily && range == StatsRange.THIS_WEEK) {
                             R.string.reading_stats_recent
                         } else {
                             R.string.reading_stats_calendar
@@ -432,7 +443,7 @@ private fun ActivityCard(stats: ReadingStats, range: StatsRange) {
                 )
                 // The week's own sum, next to its heading, so the chart
                 // can be read without adding seven bars in one's head.
-                if (daily && range == StatsRange.LAST_7_DAYS) {
+                if (daily && range == StatsRange.THIS_WEEK) {
                     val weekMs = stats.recent.sumOf { it.totalMs }
                     if (weekMs > 0) {
                         Surface(
@@ -862,7 +873,7 @@ private fun RangeMenu(selected: StatsRange, onSelect: (StatsRange) -> Unit) {
 
 private val StatsRange.label: Int
     get() = when (this) {
-        StatsRange.LAST_7_DAYS -> R.string.reading_stats_range_7d
+        StatsRange.THIS_WEEK -> R.string.reading_stats_range_7d
         StatsRange.LAST_30_DAYS -> R.string.reading_stats_range_30d
         StatsRange.LAST_90_DAYS -> R.string.reading_stats_range_90d
         StatsRange.LAST_YEAR -> R.string.reading_stats_range_365d

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
@@ -23,9 +23,13 @@ import com.chmouel.liseur.domain.StatsBook
 import com.chmouel.liseur.domain.StatsRange
 import com.chmouel.liseur.domain.displayAuthor
 import com.chmouel.liseur.domain.displayTitle
+import com.chmouel.liseur.domain.localeWeekStart
 import com.chmouel.liseur.domain.readingStats
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.ZoneId
+import java.time.temporal.WeekFields
+import java.util.Locale
 import kotlin.math.roundToLong
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -97,10 +101,23 @@ class ReadingStatsViewModel(
     initialRange: StatsRange = StatsRange.Default,
     private val zone: () -> ZoneId = ZoneId::systemDefault,
     private val today: () -> LocalDate = { LocalDate.now(ZoneId.systemDefault()) },
+    initialWeekStart: DayOfWeek = localeWeekStart(Locale.getDefault()),
 ) : ViewModel() {
 
     private val _range = MutableStateFlow(initialRange)
     val range: StateFlow<StatsRange> = _range.asStateFlow()
+
+    /**
+     * Which day the reader's week begins on.
+     *
+     * A flow rather than a value read where it is needed, for the same
+     * reason [_range] is one: the sums, the server request and the
+     * caption over them all have to describe one week. Sampling it
+     * inside the aggregation would leave a retained view model holding
+     * last locale's totals under this locale's heading, because a
+     * language change emits nothing the aggregation is listening to.
+     */
+    private val _weekStart = MutableStateFlow(initialWeekStart)
 
     /** Set once the reader has picked a span for themselves. */
     private var rangeChosen = false
@@ -162,6 +179,26 @@ class ReadingStatsViewModel(
     }
 
     /**
+     * Follows the reader's language to a different first day of week.
+     *
+     * Called from the screen, which reads the locale as Compose state,
+     * because a view model outlives the configuration change that moved
+     * it: `Locale.getDefault()` is right when this is constructed and
+     * stale from then on.
+     */
+    fun setWeekStart(day: DayOfWeek) {
+        if (_weekStart.value == day) return
+        _weekStart.value = day
+        // The server was asked for a span that began on the old week's
+        // first day. Its answer is about days this screen no longer
+        // claims to be showing.
+        _acrossDevices.value = null
+        _recentAcrossDevices.value = null
+        _booksAcrossDevices.value = null
+        refreshServerInsights()
+    }
+
+    /**
      * Refreshes the server decoration whenever a statistics screen opens.
      *
      * Each refresh replaces the last outright: the previous one is
@@ -179,13 +216,14 @@ class ReadingStatsViewModel(
         refresh?.cancel()
         refresh = viewModelScope.launch {
             val end = today()
+            val week = _weekStart.value
             launch {
-                val summary = source.summary(range, end)
+                val summary = source.summary(range, end, week)
                 if (token == generation) _acrossDevices.value = summary
             }
             launch {
                 val calendar = source.calendar(
-                    from = range.startDate(end) ?: maxOf(
+                    from = range.startDate(end, week) ?: maxOf(
                         EARLIEST_PLAUSIBLE_DAY,
                         end.minusDays(CALENDAR_HORIZON_DAYS),
                     ),
@@ -194,7 +232,7 @@ class ReadingStatsViewModel(
                 if (token == generation) _recentAcrossDevices.value = calendar
             }
             launch {
-                val books = source.allBooks(range, end)
+                val books = source.allBooks(range, end, week)
                 if (token == generation) _booksAcrossDevices.value = books
             }
         }
@@ -236,6 +274,8 @@ class ReadingStatsViewModel(
          * that do not answer it.
          */
         val range: StatsRange,
+        /** The week's first day [stats] was computed against, likewise. */
+        val weekStart: DayOfWeek,
     )
 
     private val local = combine(
@@ -243,7 +283,8 @@ class ReadingStatsViewModel(
         bookDao.observeAll(),
         progressDao.observeProgressions(),
         _range,
-    ) { sessions, books, progressions, range ->
+        _weekStart,
+    ) { sessions, books, progressions, range, weekStart ->
         val progressionByUrl = progressions.associateBy({ it.bookUrl }, { it.totalProgression })
         val statsBooks = books.associate { book ->
             book.url to StatsBook(
@@ -274,6 +315,7 @@ class ReadingStatsViewModel(
                 zone = zone(),
                 today = today(),
                 range = range,
+                weekStart = weekStart,
             ),
             books = statsBooks,
             firstReadAtByUrl = spans
@@ -281,6 +323,7 @@ class ReadingStatsViewModel(
                 .groupBy { it.bookUrl }
                 .mapValues { (_, sittings) -> sittings.minOf { it.startedAt } },
             range = range,
+            weekStart = weekStart,
         )
     }
 
@@ -299,7 +342,14 @@ class ReadingStatsViewModel(
         )
         ReadingStatsUiState.Ready(
             stats = merged,
-            headline = mergeHeadline(merged, local.stats, server, local.range, today()),
+            headline = mergeHeadline(
+                merged,
+                local.stats,
+                server,
+                local.range,
+                today(),
+                local.weekStart,
+            ),
             range = local.range,
         )
     }.stateIn(
@@ -379,12 +429,13 @@ class ReadingStatsViewModel(
             server: InsightsSummary?,
             range: StatsRange,
             today: LocalDate,
+            weekStart: DayOfWeek = WeekFields.ISO.firstDayOfWeek,
         ): StatsHeadline = StatsHeadline(
             totalMs = maxOf(
                 merged.totalMs,
                 (server?.activeMinutes?.minutesAsMillis() ?: 0L) + local.pendingMs,
             ),
-            rangeDays = range.days(today),
+            rangeDays = range.days(today, weekStart),
             sessions = maxOf(local.sessions, (server?.sessions ?: 0) + local.pendingSessions),
             streakDays = maxOf(local.streakDays, server?.streakDays ?: 0),
             progressionPerHour = server?.progressionPerHour ?: local.progressionPerHour,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -612,7 +612,7 @@
     <string name="reading_stats_total">Time spent reading</string>
     <string name="reading_stats_books_read">Books read from</string>
     <string name="reading_stats_books_finished">Books finished</string>
-    <string name="reading_stats_recent">This past week</string>
+    <string name="reading_stats_recent">This week</string>
     <string name="reading_stats_by_book">By book</string>
     <string name="reading_stats_empty_title">Nothing recorded yet.</string>
     <string name="reading_stats_empty_detail">Liseur starts counting from the moment you open a book. Reading you did before this arrived is not here, because there is no honest way to work out how long it took.</string>
@@ -629,12 +629,14 @@
     <string name="reading_stats_day_read">%1$s on %2$s</string>
     <string name="reading_stats_in_last_days">In the last %1$d days, on every device</string>
     <string name="reading_stats_in_last_days_local">In the last %1$d days</string>
+    <string name="reading_stats_this_week">This week, on every device</string>
+    <string name="reading_stats_this_week_local">This week</string>
     <string name="reading_stats_in_total">In total</string>
     <string name="reading_stats_sessions">Sittings</string>
     <string name="reading_stats_streak">Day streak</string>
     <string name="reading_stats_time_left">About %1$s left, at the pace you have been reading</string>
     <string name="reading_stats_range">Change the span</string>
-    <string name="reading_stats_range_7d">Last 7 days</string>
+    <string name="reading_stats_range_7d">This week</string>
     <string name="reading_stats_range_30d">Last 30 days</string>
     <string name="reading_stats_range_90d">Last 90 days</string>
     <string name="reading_stats_range_365d">Last 365 days</string>
@@ -652,6 +654,8 @@
     <string name="duration_minutes">%1$d min</string>
     <string name="duration_hours">%1$d h</string>
     <string name="duration_hours_minutes">%1$d h %2$d min</string>
+    <string name="duration_days">%1$d d</string>
+    <string name="duration_days_hours">%1$d d %2$d h</string>
     <string name="duration_none">None</string>
     <string name="more_options">More</string>
     <string name="reader_footnote">Note</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncInsightsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncInsightsTest.kt
@@ -158,7 +158,7 @@ class LiseurSyncInsightsTest {
         val lastRead = "2026-08-11T16:30:00Z"
         server.enqueue(
             ok(
-                """{"from":"2026-08-05","to":"2026-08-11","works":[""" +
+                """{"from":"2026-08-10","to":"2026-08-11","works":[""" +
                     """{"work_id":"w-1","sessions":8,""" +
                     """"total_active_minutes":106.25,"eta_seconds":3600,""" +
                     """"last_read_at":"$lastRead"}]}""",
@@ -172,7 +172,7 @@ class LiseurSyncInsightsTest {
         assertEquals("w-1", book.workId)
         assertEquals(Instant.parse(lastRead).toEpochMilli(), book.lastReadAt)
         assertEquals(
-            "/v1/insights/works?from=2026-08-05&to=2026-08-11",
+            "/v1/insights/works?from=2026-08-10&to=2026-08-11",
             server.takeRequest().target,
         )
     }
@@ -237,7 +237,7 @@ class LiseurSyncInsightsTest {
         connect()
         server.enqueue(
             ok(
-                """{"from":"2026-08-05","to":"2026-08-11",""" +
+                """{"from":"2026-08-10","to":"2026-08-11",""" +
                     """"total_active_minutes":90,"sessions":4}""",
             ),
         )
@@ -282,7 +282,7 @@ class LiseurSyncInsightsTest {
     @Test
     fun `a reading pace is carried through and a missing one is not invented`() = runTest {
         connect()
-        val span = """"from":"2026-08-05","to":"2026-08-11""""
+        val span = """"from":"2026-08-10","to":"2026-08-11""""
         server.enqueue(
             ok("""{$span,"total_active_minutes":90,"sessions":4,"speed_prog_per_hour":0.25}"""),
         )
@@ -298,12 +298,12 @@ class LiseurSyncInsightsTest {
         connect()
         server.enqueue(
             ok(
-                """{"from":"2026-08-05","to":"2026-08-11",""" +
+                """{"from":"2026-08-10","to":"2026-08-11",""" +
                     """"total_active_minutes":0,"sessions":0}""",
             ),
         )
 
-        assertNull(insights().summary(StatsRange.LAST_7_DAYS, TODAY))
+        assertNull(insights().summary(StatsRange.THIS_WEEK, TODAY))
     }
 
     private fun insights() = LiseurSyncInsights(

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/ReadingStatsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/ReadingStatsTest.kt
@@ -129,7 +129,7 @@ class ReadingStatsTest {
             books = mapOf("a" to book("a")),
             zone = zone,
             today = today,
-            range = StatsRange.LAST_7_DAYS,
+            range = StatsRange.THIS_WEEK,
         )
         assertEquals(RECENT_DAYS, stats.recent.size)
         assertEquals(today, stats.recent.last().date)
@@ -217,7 +217,7 @@ class ReadingStatsTest {
             books = mapOf("a" to book("a")),
             zone = zone,
             today = today,
-            range = StatsRange.LAST_7_DAYS,
+            range = StatsRange.THIS_WEEK,
         )
         assertEquals(60_000L, stats.totalMs)
         assertEquals(1, stats.sessions)
@@ -239,7 +239,7 @@ class ReadingStatsTest {
         fun countedIn(range: StatsRange) =
             readingStats(sessions, books, zone, today, range).sessions
 
-        assertEquals(2, countedIn(StatsRange.LAST_7_DAYS))
+        assertEquals(2, countedIn(StatsRange.THIS_WEEK))
         assertEquals(3, countedIn(StatsRange.LAST_30_DAYS))
         assertEquals(4, countedIn(StatsRange.LAST_90_DAYS))
         assertEquals(5, countedIn(StatsRange.LAST_YEAR))
@@ -255,7 +255,7 @@ class ReadingStatsTest {
             books = mapOf("a" to book("a")),
             zone = zone,
             today = today,
-            range = StatsRange.LAST_7_DAYS,
+            range = StatsRange.THIS_WEEK,
         )
         assertEquals(60_000, stats.totalMs)
     }
@@ -299,7 +299,7 @@ class ReadingStatsTest {
             books = mapOf("a" to book("a")),
             zone = zone,
             today = today,
-            range = StatsRange.LAST_7_DAYS,
+            range = StatsRange.THIS_WEEK,
         )
         assertTrue(stats.isEmpty)
         assertEquals(0, stats.sessions)
@@ -340,7 +340,7 @@ class ReadingStatsTest {
             mapOf("a" to book("a")),
             zone,
             today,
-            StatsRange.LAST_7_DAYS,
+            StatsRange.THIS_WEEK,
         )
         assertEquals(7, stats.sessions)
         assertEquals(20, stats.streakDays)
@@ -362,7 +362,7 @@ class ReadingStatsTest {
             books = mapOf("a" to book("a"), "b" to book("b")),
             zone = zone,
             today = today,
-            range = StatsRange.LAST_7_DAYS,
+            range = StatsRange.THIS_WEEK,
         )
         assertEquals(5_400_000, stats.totalMs)
         assertEquals(1_800_000, stats.pendingMs)
@@ -494,7 +494,7 @@ class ReadingStatsTest {
             books = mapOf("a" to book("a")),
             zone = zone,
             today = today,
-            range = StatsRange.LAST_7_DAYS,
+            range = StatsRange.THIS_WEEK,
         )
         assertEquals(begun, stats.books.single().firstReadAt)
     }

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/StatsRangeTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/StatsRangeTest.kt
@@ -1,0 +1,154 @@
+package com.chmouel.liseur.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Locale
+
+/** Where each span begins, and which day of the week it begins on. */
+class StatsRangeTest {
+
+    private val zone: ZoneId = ZoneId.of("Europe/Paris")
+
+    // A Wednesday, so a week-aligned span is neither empty nor whole.
+    private val wednesday: LocalDate = LocalDate.of(2026, 8, 5)
+
+    @Test
+    fun `the week begins where the reader's calendar begins`() {
+        assertEquals(DayOfWeek.WEDNESDAY, wednesday.dayOfWeek)
+        assertEquals(
+            LocalDate.of(2026, 8, 3),
+            StatsRange.THIS_WEEK.startDate(wednesday, DayOfWeek.MONDAY),
+        )
+        assertEquals(
+            LocalDate.of(2026, 8, 2),
+            StatsRange.THIS_WEEK.startDate(wednesday, DayOfWeek.SUNDAY),
+        )
+        // Some locales, Maldivian among them, start on a Friday.
+        assertEquals(
+            LocalDate.of(2026, 7, 31),
+            StatsRange.THIS_WEEK.startDate(wednesday, DayOfWeek.FRIDAY),
+        )
+    }
+
+    @Test
+    fun `the first day of the week is a week of one day, not of none`() {
+        val monday = LocalDate.of(2026, 8, 3)
+        assertEquals(monday, StatsRange.THIS_WEEK.startDate(monday, DayOfWeek.MONDAY))
+        assertEquals(1, StatsRange.THIS_WEEK.days(monday, DayOfWeek.MONDAY))
+    }
+
+    @Test
+    fun `the last day of the week is a week of seven`() {
+        val sunday = LocalDate.of(2026, 8, 9)
+        assertEquals(
+            LocalDate.of(2026, 8, 3),
+            StatsRange.THIS_WEEK.startDate(sunday, DayOfWeek.MONDAY),
+        )
+        assertEquals(7, StatsRange.THIS_WEEK.days(sunday, DayOfWeek.MONDAY))
+    }
+
+    @Test
+    fun `the week grows a day at a time and never past seven`() {
+        val monday = LocalDate.of(2026, 8, 3)
+        val counted = (0L..6L).map {
+            StatsRange.THIS_WEEK.days(monday.plusDays(it), DayOfWeek.MONDAY)
+        }
+        assertEquals(listOf(1, 2, 3, 4, 5, 6, 7), counted)
+    }
+
+    @Test
+    fun `a partial week is always short enough to draw as bars`() {
+        for (offset in 0L..6L) {
+            assertTrue(
+                StatsRange.THIS_WEEK.suitsDailyBars(
+                    LocalDate.of(2026, 8, 3).plusDays(offset),
+                    DayOfWeek.MONDAY,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `the longer spans stay rolling day counts, whatever the locale`() {
+        for (weekStart in DayOfWeek.entries) {
+            assertEquals(
+                wednesday.minusDays(29),
+                StatsRange.LAST_30_DAYS.startDate(wednesday, weekStart),
+            )
+            assertEquals(
+                wednesday.withDayOfYear(1),
+                StatsRange.THIS_YEAR.startDate(wednesday, weekStart),
+            )
+            assertNull(StatsRange.ALL_TIME.startDate(wednesday, weekStart))
+        }
+    }
+
+    @Test
+    fun `the stored id survives the range being renamed`() {
+        // DataStore holds "7d" from before this was a calendar week. A
+        // reader upgrading must not be silently moved to another span.
+        assertEquals(StatsRange.THIS_WEEK, StatsRange.fromId("7d"))
+        assertEquals("7d", StatsRange.THIS_WEEK.id)
+    }
+
+    @Test
+    fun `English and French disagree about Sunday, and both are obeyed`() {
+        assertEquals(DayOfWeek.SUNDAY, localeWeekStart(Locale.US))
+        assertEquals(DayOfWeek.MONDAY, localeWeekStart(Locale.FRANCE))
+    }
+
+    @Test
+    fun `the chart spans the week so far, empty days included`() {
+        // Read on the Monday and again on the Wednesday, nothing between.
+        val sessions = listOf(
+            SessionSpan("a", noon(LocalDate.of(2026, 8, 3)), 60_000),
+            SessionSpan("a", noon(wednesday), 60_000),
+        )
+        val stats = readingStats(
+            sessions = sessions,
+            books = mapOf("a" to StatsBook("a", "A", null, null, false)),
+            zone = zone,
+            today = wednesday,
+            range = StatsRange.THIS_WEEK,
+            weekStart = DayOfWeek.MONDAY,
+        )
+        assertEquals(
+            listOf(
+                LocalDate.of(2026, 8, 3),
+                LocalDate.of(2026, 8, 4),
+                wednesday,
+            ),
+            stats.recent.map { it.date },
+        )
+        // The gap is the information. Dropping it would read as an
+        // unbroken run of two days.
+        assertEquals(0L, stats.recent[1].totalMs)
+    }
+
+    @Test
+    fun `a Sunday-first week reaches back a day further than a Monday-first one`() {
+        // The Sunday before the Wednesday. An American reader counts it
+        // as this week; a French one counts it as last.
+        val sessions = listOf(SessionSpan("a", noon(LocalDate.of(2026, 8, 2)), 60_000))
+        val books = mapOf("a" to StatsBook("a", "A", null, null, false))
+        fun countedFrom(weekStart: DayOfWeek) = readingStats(
+            sessions = sessions,
+            books = books,
+            zone = zone,
+            today = wednesday,
+            range = StatsRange.THIS_WEEK,
+            weekStart = weekStart,
+        ).totalMs
+
+        assertEquals(60_000L, countedFrom(DayOfWeek.SUNDAY))
+        assertEquals(0L, countedFrom(DayOfWeek.MONDAY))
+    }
+
+    private fun noon(date: LocalDate): Long =
+        date.atTime(12, 0).atZone(zone).toInstant().toEpochMilli()
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ReadingDurationTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ReadingDurationTest.kt
@@ -39,4 +39,68 @@ class ReadingDurationTest {
         // "1h5" reads as an hour and a half at a glance; "1h05" does not.
         assertEquals("1h05", compactDuration(TimeUnit.MINUTES.toMillis(65)))
     }
+
+    @Test
+    fun `a day past midnight is said in days, not in forty-one hours`() {
+        assertEquals("1d17h", compactDuration(TimeUnit.MINUTES.toMillis(41 * 60 + 30)))
+        assertEquals("2d", compactDuration(TimeUnit.HOURS.toMillis(48)))
+    }
 }
+
+/** How a length of time is broken up before it is worded. */
+class DurationPartsTest {
+
+    @Test
+    fun `nothing and less than nothing are both nothing`() {
+        assertEquals(DurationParts.None, durationParts(0))
+        assertEquals(DurationParts.None, durationParts(-1))
+    }
+
+    @Test
+    fun `seconds are not a unit anybody reads in`() {
+        assertEquals(DurationParts.UnderMinute, durationParts(59_000))
+        assertEquals(DurationParts.Minutes(1), durationParts(TimeUnit.MINUTES.toMillis(1)))
+    }
+
+    @Test
+    fun `an hour short of a day is still said in hours`() {
+        assertEquals(
+            DurationParts.Hours(23, 59),
+            durationParts(TimeUnit.MINUTES.toMillis(23 * 60 + 59)),
+        )
+    }
+
+    @Test
+    fun `a full day turns over into days`() {
+        assertEquals(DurationParts.Days(1, 0), durationParts(TimeUnit.HOURS.toMillis(24)))
+    }
+
+    @Test
+    fun `days keep their hours but drop their minutes`() {
+        // 51 h 40 min. The forty minutes are a rounding error beside two
+        // days, and naming them makes the figure unreadable.
+        assertEquals(
+            DurationParts.Days(2, 3),
+            durationParts(TimeUnit.MINUTES.toMillis(51 * 60 + 40)),
+        )
+    }
+
+    @Test
+    fun `every unit truncates so a total never outgrows its parts`() {
+        // Not "2 d": rounding up here would let the headline claim more
+        // than the rows it is a sum of.
+        assertEquals(
+            DurationParts.Days(1, 23),
+            durationParts(TimeUnit.MINUTES.toMillis(47 * 60 + 59)),
+        )
+    }
+
+    @Test
+    fun `nothing above days, however long the reader has owned the app`() {
+        assertEquals(
+            DurationParts.Days(312, 4),
+            durationParts(TimeUnit.HOURS.toMillis(312 * 24 + 4)),
+        )
+    }
+}
+

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModelTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModelTest.kt
@@ -17,6 +17,7 @@ import com.chmouel.liseur.domain.ReadingDay
 import com.chmouel.liseur.domain.ReadingStats
 import com.chmouel.liseur.domain.StatsBook
 import com.chmouel.liseur.domain.StatsRange
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneId
@@ -46,7 +47,7 @@ class ReadingStatsViewModelTest {
     private lateinit var models: ViewModelStore
 
     private val zone = ZoneId.of("Europe/Paris")
-    private val today = LocalDate.of(2026, 8, 10)
+    private val today = LocalDate.of(2026, 8, 9)
 
     @Before
     fun open() {
@@ -140,16 +141,53 @@ class ReadingStatsViewModelTest {
                 db.readingSessionDao().insert(session(url, today.minusDays(back.toLong()), 60_000))
             }
             val model = model()
-            model.selectRange(StatsRange.LAST_7_DAYS)
+            model.selectRange(StatsRange.THIS_WEEK)
 
             val week = model.state.first {
-                it is ReadingStatsUiState.Ready && it.range == StatsRange.LAST_7_DAYS
+                it is ReadingStatsUiState.Ready && it.range == StatsRange.THIS_WEEK
             } as ReadingStatsUiState.Ready
 
             // Seven days of reading counted, but twenty days of streak:
             // a streak is a fact about the reader, not about the window.
             assertEquals(7, week.headline.sessions)
             assertEquals(20, week.headline.streakDays)
+        } finally {
+            models.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test
+    fun `changing language moves the week without changing the reading`() = runTest {
+        Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        try {
+            // today is a Sunday. A Monday-first reader counts it as the
+            // last day of this week; a Sunday-first reader as the first,
+            // so the Saturday before belongs to one week and not the
+            // other.
+            val url = "calibre:one"
+            db.bookDao().upsert(book(url))
+            db.readingSessionDao().insert(session(url, today, 60_000))
+            db.readingSessionDao().insert(session(url, today.minusDays(1), 60_000))
+            val model = model()
+            model.selectRange(StatsRange.THIS_WEEK)
+
+            val mondayFirst = model.state.first {
+                it is ReadingStatsUiState.Ready && it.range == StatsRange.THIS_WEEK
+            } as ReadingStatsUiState.Ready
+            assertEquals(120_000L, mondayFirst.headline.totalMs)
+            assertEquals(7, mondayFirst.headline.rangeDays)
+
+            model.setWeekStart(DayOfWeek.SUNDAY)
+
+            // Nothing about the sessions changed, only where the week
+            // begins. The sums, the caption and the chart must all move
+            // together, or the screen describes two different weeks.
+            val sundayFirst = model.state.first {
+                it is ReadingStatsUiState.Ready && it.headline.rangeDays == 1
+            } as ReadingStatsUiState.Ready
+            assertEquals(60_000L, sundayFirst.headline.totalMs)
+            assertEquals(listOf(today), sundayFirst.stats.recent.map { it.date })
         } finally {
             models.clear()
             Dispatchers.resetMain()
@@ -633,6 +671,12 @@ class ReadingStatsViewModelTest {
                     progressDao = db.readingProgressDao(),
                     zone = { zone },
                     today = { today },
+                    // Pinned rather than read off the JVM's locale: the
+                    // week's first day is what decides how far the
+                    // default span reaches, and a test that reaches a
+                    // different distance on a different machine is not
+                    // testing anything.
+                    initialWeekStart = DayOfWeek.MONDAY,
                 )
             }
         }


### PR DESCRIPTION
## Summary

Two changes to how the reading dashboard states time.

**The seven-day range becomes the calendar week.** "Last 7 days" was a rolling
`today.minusDays(6)` window, so on a Wednesday the chart began on a Thursday and
the first bar was a different weekday every morning. It now begins on the
locale's first day of the week — Monday in France, Sunday in the US, Friday
where that is the week's start — which is the same `WeekFields.of(locale).firstDayOfWeek`
boundary the heatmap already padded its grid from. The chart holds one to seven
bars and grows through the week.

The range's stored id stays `"7d"`, so a reader who had it selected still has it
selected. Only the enum constant and the label change.

**Durations grow a day unit.** `readingDuration` topped out at hours, so an
all-time total read `56 h 14 min`. Past 24 hours it now reads `2 d 8 h`. Parts
truncate rather than round — `47 h 59 min` is `1 d 23 h`, not `2 d` — because the
headline is a `maxOf` over the rows beneath it and rounding one side up while the
other rounds down would put it above their sum, which reads as a bug.

30/90/365 days are left as rolling day counts.

## Changes

- `domain/StatsRange.kt`: `LAST_7_DAYS` → `THIS_WEEK` (id `"7d"` unchanged);
  `startDate` / `days` / `suitsDailyBars` take a required `weekStart`; new
  top-level `localeWeekStart(locale)` helper, which `ReadingHeatmap` now uses too.
- `domain/ReadingStats.kt`, `data/liseursync/LiseurSyncInsights.kt`: `weekStart`
  threaded through, so the local sums and the server query ask for the same first
  and last day. The two halves of the screen disagreeing about where the week
  began is exactly what `StatsRange`'s doc comment warns about.
- `ui/stats/ReadingStatsViewModel.kt`: `weekStart` is a `MutableStateFlow` input
  to the aggregation combine and is carried in `LocalStats`, following the file's
  existing pattern for `range`. `setWeekStart()` re-requests the server answers.
  `MainActivity` pushes `localeWeekStart(LocalLocale.current.platformLocale)`,
  so a locale configuration change on a retained ViewModel recomputes both halves
  rather than merging a new-locale server answer into old-locale local totals.
- `ui/stats/ReadingDuration.kt`: pure `durationParts()` behind a `DurationParts`
  sealed interface, so the arithmetic is unit-testable without Robolectric;
  `readingDuration` is a thin `stringResource` lookup over it. `compactDuration`
  gains `2d` / `2d3h`.
- Strings: `duration_days`, `duration_days_hours`, `reading_stats_this_week{,_local}`
  added; `reading_stats_range_7d` and `reading_stats_recent` both now read
  "This week", since the menu entry and the heading naming the same span
  differently is what makes a partial week look wrong.

No translated resource directories exist, so there are no parallel string files
to update.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

New tests: `domain/StatsRangeTest.kt` (Monday-, Sunday- and Friday-first weeks,
`days()` returning 1 through 7, the `"7d"` id contract, `localeWeekStart` for
`Locale.US` vs `Locale.FRANCE`), `DurationPartsTest`, and a ViewModel test that
changes the week's first day and asserts the totals, the caption and the bar
series all move together.

Verified on `emulator-5554` with 71 seeded sittings and the clock pinned to a
Wednesday.

## Screenshots or recordings

**This week, en-US** — bars captioned Sun · Mon · Tue · Wed:

![stats_us.png](https://github.com/user-attachments/assets/fc74d679-7662-40bf-931d-1a50fc21df20)

**This week, fr-FR** — the same reading, bars captioned lun. · mar. · mer.:

![stats_fr.png](https://github.com/user-attachments/assets/263996dc-37cd-481a-90b2-6307338950d6)

**All time** — 56.2 hours reads `2 d 8 h`:

![stats_all.png](https://github.com/user-attachments/assets/f2871a1a-3c97-47c9-b518-b619a908dfad)

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

---

**Open question:** the day strings use symbol style `2 d 8 h`, to match the
neighbouring `%1$d h %2$d min`. If the headline should read `2 days 8 hrs` in
words instead, that is a two-string change plus plurals, and worth deciding
before translations exist.
