### PR TITLE
feat(reader): jump straight to a page number

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
@@ -373,6 +373,8 @@ class ReaderActivity : FragmentActivity() {
                                             chapterTitleAtPosition = viewModel::chapterTitleAtPosition,
                                             positionAtProgression = viewModel::positionAtProgression,
                                             locatorAtPosition = viewModel::locatorAtPosition,
+                                            goToPagePrompt = viewModel::goToPagePrompt,
+                                            resolvePage = viewModel::resolvePage,
                                             locatorAtOrBeforeProgression =
                                                 viewModel::locatorAtOrBeforeProgression,
                                             prepareLocator = viewModel::prepareLocator,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -127,7 +127,10 @@ import com.chmouel.liseur.reader.chrome.ReadingScrubber
 import com.chmouel.liseur.reader.chrome.ContentsScreen
 import com.chmouel.liseur.reader.chrome.Endpaper
 import com.chmouel.liseur.reader.chrome.FootnoteCard
+import com.chmouel.liseur.reader.chrome.GoToPageDialog
 import com.chmouel.liseur.reader.chrome.TypographySheet
+import com.chmouel.liseur.reader.progress.GoToPageDestination
+import com.chmouel.liseur.reader.progress.GoToPagePrompt
 import com.chmouel.liseur.reader.progress.ReaderProgress
 import com.chmouel.liseur.reader.progress.ExactLocatorAnchor
 import com.chmouel.liseur.reader.progress.OpeningRestoration
@@ -319,6 +322,7 @@ fun ReaderScreen(
     var chromeVisible by remember { mutableStateOf(false) }
     var showToc by remember { mutableStateOf(false) }
     var searchFor by remember { mutableStateOf<String?>(null) }
+    var goToPage by remember { mutableStateOf(false) }
     var searchHit by remember { mutableStateOf<Locator?>(null) }
     var sheet by remember { mutableStateOf(ReaderSheet.NONE) }
     val chromeVisibleNow by rememberUpdatedState(chromeVisible)
@@ -1078,6 +1082,7 @@ fun ReaderScreen(
         sheet == ReaderSheet.NONE &&
         !showToc &&
         searchFor == null &&
+        !goToPage &&
         footnote == null &&
         selection == null &&
         noteFor == null &&
@@ -1673,6 +1678,9 @@ fun ReaderScreen(
                                 navigateLater(it, NavigatorPositionEvent.LOCAL_JUMP)
                             }
                         },
+                        onGoToPage = {
+                            if (onProgressAction.goToPagePrompt() != null) goToPage = true
+                        },
                     )
                 }
             }
@@ -1998,6 +2006,21 @@ fun ReaderScreen(
         )
     }
 
+    if (goToPage) {
+        onProgressAction.goToPagePrompt()?.let { prompt ->
+            GoToPageDialog(
+                prompt = prompt,
+                resolve = onProgressAction.resolvePage,
+                onConfirm = { destination ->
+                    goToPage = false
+                    onProgressAction.onJump()
+                    navigateLater(destination.locator, NavigatorPositionEvent.LOCAL_JUMP)
+                },
+                onDismiss = { goToPage = false },
+            )
+        }
+    }
+
     // Taking the other device's position moves the reader there, which is
     // a jump like any other: the way back stays one tap away. The way back
     // is recorded before the move, so it is not done again here.
@@ -2200,6 +2223,8 @@ class ReaderProgressActions(
     val chapterTitleAtPosition: (Int) -> String?,
     val positionAtProgression: (Float) -> Int,
     val locatorAtPosition: (Int) -> Locator?,
+    val goToPagePrompt: () -> GoToPagePrompt?,
+    val resolvePage: (String) -> GoToPageDestination?,
     val locatorAtOrBeforeProgression: (Double) -> Locator?,
     val prepareLocator: (Locator) -> Locator,
     val onApproximateResume: () -> Unit,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -62,6 +62,9 @@ import com.chmouel.liseur.reader.annotations.markedPassage
 import com.chmouel.liseur.ui.messageRes
 import com.chmouel.liseur.reader.progress.BookPositions
 import com.chmouel.liseur.reader.progress.ExactLocatorAnchor
+import com.chmouel.liseur.reader.progress.GoToPageDestination
+import com.chmouel.liseur.reader.progress.GoToPagePrompt
+import com.chmouel.liseur.reader.progress.GoToPageResolver
 import com.chmouel.liseur.reader.footnotes.FootnoteResolver
 import com.chmouel.liseur.reader.progress.ReaderProgress
 import com.chmouel.liseur.reader.progress.ReadingPace
@@ -94,6 +97,7 @@ import org.readium.r2.navigator.epub.EpubNavigatorFactory
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.publication.epub.pageList
 import org.readium.r2.shared.publication.indexOfFirstWithHref
 import org.readium.r2.shared.publication.services.search.search
 import org.readium.r2.shared.util.AbsoluteUrl
@@ -519,7 +523,7 @@ class ReaderViewModel(
         // On failure the disagreement stays preserved and will be
         // settled on the next open; the book still opens now.
         if (outcome != ResolveOutcome.Done || !takeRemote) return
-        if (bookPositions == null) bookPositions = BookPositions.of(publication)
+        positionsFor(publication)
         offerWayBack(localLocator, here, preview)
     }
 
@@ -561,8 +565,7 @@ class ReaderViewModel(
 
     /** Navigates to the exact adopted locator, or conservatively before its percentage. */
     private suspend fun goToRemotePosition(preview: SyncPreview) {
-        val positions = bookPositions ?: BookPositions.of(publication ?: return)
-            .also { bookPositions = it }
+        val positions = positionsFor(publication ?: return)
         val stored = progressDao.get(bookId) ?: return
         val exact = runCatching { Locator.fromJSON(JSONObject(stored.locatorJson)) }
             .getOrNull()
@@ -590,6 +593,7 @@ class ReaderViewModel(
 
     private var publication: Publication? = null
     private var bookPositions: BookPositions? = null
+    private var goToPageResolver: GoToPageResolver? = null
     private var speed = ReadingSpeedEstimator()
     private var jumpBackTimer: Job? = null
     private var catchUpChecking = false
@@ -783,8 +787,7 @@ class ReaderViewModel(
                 bookPace = stored?.readingPace
                     ?: ReadingPace.Unknown,
             )
-            val positions = BookPositions.of(publication)
-            bookPositions = positions
+            val positions = positionsFor(publication)
             if (pulledAutomatically != null) {
                 val localLocator = beforeSync?.locatorJson
                     ?.let { runCatching { Locator.fromJSON(JSONObject(it)) }.getOrNull() }
@@ -1024,6 +1027,10 @@ class ReaderViewModel(
     /** The locator for a position on the scrubber, numbered from 1. */
     fun locatorAtPosition(position: Int): Locator? = bookPositions?.locatorAt(position)
 
+    fun goToPagePrompt(): GoToPagePrompt? = goToPageResolver?.prompt
+
+    fun resolvePage(answer: String): GoToPageDestination? = goToPageResolver?.resolve(answer)
+
     fun locatorAtOrBeforeProgression(progression: Double): Locator? =
         bookPositions?.locatorAtOrBeforeProgression(progression)
 
@@ -1046,6 +1053,19 @@ class ReaderViewModel(
         return positions.chapters
             .map { (it.firstPosition - 1) / denominator }
             .filter { it > 0f }
+    }
+
+    /** Builds the synthetic and printed-page indexes together, once per book. */
+    private suspend fun positionsFor(publication: Publication): BookPositions {
+        bookPositions?.let { return it }
+        return BookPositions.of(publication).also { positions ->
+            bookPositions = positions
+            goToPageResolver = GoToPageResolver(
+                pageList = publication.pageList,
+                positions = positions,
+                locatorFromLink = publication::locatorFromLink,
+            )
+        }
     }
 
     private fun progressAt(

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/GoToPageDialog.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/GoToPageDialog.kt
@@ -1,0 +1,126 @@
+package com.chmouel.liseur.reader.chrome
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.chmouel.liseur.R
+import com.chmouel.liseur.reader.progress.GoToPageDestination
+import com.chmouel.liseur.reader.progress.GoToPagePrompt
+import com.chmouel.liseur.reader.progress.PageNumbering
+
+/** Asks for an exact printed page or synthetic reader position. */
+@Composable
+fun GoToPageDialog(
+    prompt: GoToPagePrompt,
+    resolve: (String) -> GoToPageDestination?,
+    onConfirm: (GoToPageDestination) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var answer by rememberSaveable(prompt.numbering, prompt.firstLabel, prompt.lastLabel) {
+        mutableStateOf("")
+    }
+    val destination = resolve(answer)
+    val invalid = answer.isNotBlank() && destination == null
+    val printed = prompt.numbering == PageNumbering.PRINTED
+    val submit: () -> Unit = { destination?.let(onConfirm) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                stringResource(
+                    if (printed) R.string.go_to_printed_page_title else R.string.go_to_page_title,
+                ),
+            )
+        },
+        text = {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedTextField(
+                    value = answer,
+                    onValueChange = { answer = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    label = {
+                        Text(
+                            stringResource(
+                                if (printed) {
+                                    R.string.go_to_printed_page_label
+                                } else {
+                                    R.string.go_to_page_position_label
+                                },
+                            ),
+                        )
+                    },
+                    supportingText = if (invalid) {
+                        {
+                            Text(
+                                stringResource(
+                                    if (printed) {
+                                        R.string.go_to_printed_page_invalid
+                                    } else {
+                                        R.string.go_to_page_position_invalid
+                                    },
+                                ),
+                            )
+                        }
+                    } else {
+                        null
+                    },
+                    isError = invalid,
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = if (printed) KeyboardType.Text else KeyboardType.Number,
+                        imeAction = ImeAction.Go,
+                    ),
+                    keyboardActions = KeyboardActions(onGo = { submit() }),
+                )
+                Text(
+                    text = stringResource(
+                        if (printed) {
+                            R.string.go_to_printed_page_range
+                        } else {
+                            R.string.go_to_page_position_range
+                        },
+                        prompt.firstLabel,
+                        prompt.lastLabel,
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                destination?.chapterTitle?.let { chapter ->
+                    Text(
+                        text = stringResource(R.string.go_to_page_chapter, chapter),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = submit, enabled = destination != null) {
+                Text(stringResource(R.string.go_to_page_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
+        },
+    )
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReadingProgressUi.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReadingProgressUi.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.MenuBook
@@ -34,6 +36,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -153,7 +156,7 @@ fun ReadingScrubber(
             .fillMaxWidth()
             .background(theme.background)
             .padding(horizontal = 20.dp)
-            .padding(top = 8.dp, bottom = 12.dp),
+            .padding(top = 8.dp, bottom = 2.dp),
         verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
         Text(
@@ -183,12 +186,26 @@ fun ReadingScrubber(
             ),
             modifier = Modifier.chapterTicks(chapterTicks, accent.copy(alpha = 0.5f)),
         )
-        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+        Row(
+            Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             FooterHint(stringResource(R.string.footer_percent, progress.percent), accent)
             FooterHint(
                 stringResource(R.string.footer_page, previewPosition, progress.totalPositions),
                 accent,
-                Modifier.clickableWithoutRipple(onGoToPage),
+                Modifier
+                    .clickableWithoutRipple(
+                        onClick = onGoToPage,
+                        role = Role.Button,
+                        onClickLabel = stringResource(R.string.go_to_page_title),
+                    )
+                    // The readout is a line of small print, so the tap
+                    // target is grown to a comfortable size around it
+                    // rather than left the height of the text.
+                    .heightIn(min = 48.dp)
+                    .wrapContentHeight(Alignment.CenterVertically),
             )
         }
     }
@@ -210,10 +227,16 @@ private fun FooterHint(text: String, color: Color, modifier: Modifier = Modifier
  * don't turn the page.
  */
 @Composable
-private fun Modifier.clickableWithoutRipple(onClick: () -> Unit): Modifier =
+private fun Modifier.clickableWithoutRipple(
+    onClick: () -> Unit,
+    role: Role? = null,
+    onClickLabel: String? = null,
+): Modifier =
     clickable(
         interactionSource = remember { MutableInteractionSource() },
         indication = null,
+        role = role,
+        onClickLabel = onClickLabel,
         onClick = onClick,
     )
 

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReadingProgressUi.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReadingProgressUi.kt
@@ -138,6 +138,7 @@ fun ReadingScrubber(
     titleAtPosition: (Int) -> String?,
     positionAtProgression: (Float) -> Int,
     onSeek: (Int) -> Unit,
+    onGoToPage: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     if (progress == null) return
@@ -187,17 +188,19 @@ fun ReadingScrubber(
             FooterHint(
                 stringResource(R.string.footer_page, previewPosition, progress.totalPositions),
                 accent,
+                Modifier.clickableWithoutRipple(onGoToPage),
             )
         }
     }
 }
 
 @Composable
-private fun FooterHint(text: String, color: Color) {
+private fun FooterHint(text: String, color: Color, modifier: Modifier = Modifier) {
     Text(
         text = text,
         style = MaterialTheme.typography.labelSmall,
         color = color.copy(alpha = 0.6f),
+        modifier = modifier,
     )
 }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/progress/GoToPage.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/progress/GoToPage.kt
@@ -1,0 +1,76 @@
+package com.chmouel.liseur.reader.progress
+
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Locator
+
+/** Which page number the go-to-page dialog asks the reader for. */
+enum class PageNumbering {
+    PRINTED,
+    POSITION,
+}
+
+/** The wording and accepted endpoints shown by the go-to-page dialog. */
+data class GoToPagePrompt(
+    val numbering: PageNumbering,
+    val firstLabel: String,
+    val lastLabel: String,
+)
+
+/** A valid page together with the chapter the dialog can preview. */
+data class GoToPageDestination(
+    val locator: Locator,
+    val chapterTitle: String?,
+)
+
+/**
+ * Resolves the page labels a reader can type.
+ *
+ * An EPUB page list is deliberately kept as labels: roman numerals,
+ * missing numbers and repeated labels are all valid. When labels repeat,
+ * the first page with that label wins, matching the order of the book.
+ */
+class GoToPageResolver(
+    pageList: List<Link>,
+    private val positions: BookPositions,
+    private val locatorFromLink: (Link) -> Locator?,
+) {
+    private val orderedPrintedPages: List<Pair<String, Link>> = pageList.mapNotNull { link ->
+        link.title?.trim()?.takeIf(String::isNotEmpty)?.let { it to link }
+    }
+    private val printedPages: Map<String, Link> = buildMap {
+        orderedPrintedPages.forEach { (label, link) -> putIfAbsent(label, link) }
+    }
+
+    val prompt: GoToPagePrompt = if (orderedPrintedPages.isNotEmpty()) {
+        GoToPagePrompt(
+            numbering = PageNumbering.PRINTED,
+            firstLabel = orderedPrintedPages.first().first,
+            lastLabel = orderedPrintedPages.last().first,
+        )
+    } else {
+        GoToPagePrompt(
+            numbering = PageNumbering.POSITION,
+            firstLabel = "1",
+            lastLabel = positions.totalPositions.toString(),
+        )
+    }
+
+    /** Returns null when [answer] is not a page this book declares. */
+    fun resolve(answer: String): GoToPageDestination? {
+        val label = answer.trim()
+        val locator = when (prompt.numbering) {
+            PageNumbering.PRINTED -> printedPages[label]?.let(locatorFromLink)
+            PageNumbering.POSITION -> {
+                val position = label.toIntOrNull()
+                    ?.takeIf { it in 1..positions.totalPositions }
+                    ?: return null
+                positions.locatorAt(position)
+            }
+        } ?: return null
+        val chapter = positions.resolve(locator)
+            ?.position
+            ?.let(positions::chapterAt)
+            ?.title
+        return GoToPageDestination(locator, chapter)
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,6 +123,16 @@
     <string name="footer_page">Page %1$d of %2$d</string>
     <string name="footer_page_compact">%1$d of %2$d</string>
     <string name="footer_percent">%d%%</string>
+    <string name="go_to_page_title">Go to page</string>
+    <string name="go_to_printed_page_title">Go to printed page</string>
+    <string name="go_to_page_position_label">Page shown in the footer</string>
+    <string name="go_to_printed_page_label">Printed page</string>
+    <string name="go_to_page_position_range">Enter a page from %1$s to %2$s.</string>
+    <string name="go_to_printed_page_range">This book lists printed pages from %1$s to %2$s.</string>
+    <string name="go_to_page_position_invalid">Enter a page in this range.</string>
+    <string name="go_to_printed_page_invalid">This book does not list that printed page.</string>
+    <string name="go_to_page_chapter">Chapter: %s</string>
+    <string name="go_to_page_confirm">Go</string>
     <string name="duration_under_minute">Less than a minute</string>
     <string name="duration_hours_and_minutes">%1$s %2$s</string>
     <plurals name="duration_minutes">

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/progress/GoToPageResolverTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/progress/GoToPageResolverTest.kt
@@ -1,0 +1,159 @@
+package com.chmouel.liseur.reader.progress
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Locator
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(sdk = [35], application = android.app.Application::class)
+@RunWith(RobolectricTestRunner::class)
+class GoToPageResolverTest {
+
+    @Test
+    fun `synthetic positions accept only the pages the footer shows`() {
+        val spine = spine("first.xhtml" to 2, "second.xhtml" to 2)
+        val resolver = GoToPageResolver(emptyList(), spine.positions()) { null }
+
+        assertEquals(PageNumbering.POSITION, resolver.prompt.numbering)
+        assertEquals("1", resolver.prompt.firstLabel)
+        assertEquals("4", resolver.prompt.lastLabel)
+        assertEquals(3, resolver.resolve(" 3 ")?.locator?.locations?.position)
+        assertNull(resolver.resolve("0"))
+        assertNull(resolver.resolve("5"))
+        assertNull(resolver.resolve("iii"))
+    }
+
+    @Test
+    fun `printed pages keep their labels and reject a missing page`() {
+        val pages = listOf(
+            link("front.xhtml", "iv"),
+            link("chapter.xhtml#page-1", "1"),
+            link("chapter.xhtml#page-3", "3"),
+        )
+        val spine = spine("front.xhtml" to 1, "chapter.xhtml" to 3)
+        val resolver = GoToPageResolver(pages, spine.positions(), spine::locatorFromLink)
+
+        assertEquals(PageNumbering.PRINTED, resolver.prompt.numbering)
+        assertEquals("iv", resolver.prompt.firstLabel)
+        assertEquals("3", resolver.prompt.lastLabel)
+
+        val destination = resolver.resolve("3")
+        // Readium moves the fragment out of the href, which is what lets
+        // BookPositions match the page against a resource of the spine.
+        assertEquals("chapter.xhtml", destination?.locator?.href?.toString())
+        assertEquals(listOf("page-3"), destination?.locator?.locations?.fragments)
+        assertNull(resolver.resolve("2"))
+    }
+
+    @Test
+    fun `a printed page outside the reading order resolves to nothing`() {
+        val spine = spine("first.xhtml" to 2, "second.xhtml" to 2)
+        val pages = listOf(link("missing.xhtml#page-9", "9"))
+        val resolver = GoToPageResolver(pages, spine.positions(), spine::locatorFromLink)
+
+        assertNull(resolver.resolve("9"))
+    }
+
+    @Test
+    fun `printed page previews the chapter at its resolved position`() {
+        val spine = spine("first.xhtml" to 2, "second.xhtml" to 2)
+        val positions = spine.positions(
+            chapters = listOf(
+                BookChapter("First", 1, 2),
+                BookChapter("Second", 3, 4),
+            ),
+        )
+        val page = link("second.xhtml#page-12", "12")
+        val resolver = GoToPageResolver(listOf(page), positions, spine::locatorFromLink)
+
+        assertEquals("Second", resolver.resolve("12")?.chapterTitle)
+    }
+
+    @Test
+    fun `the first repeated printed label wins`() {
+        val spine = spine("volume-1.xhtml" to 1, "volume-2.xhtml" to 1)
+        val first = link("volume-1.xhtml", "1")
+        val second = link("volume-2.xhtml", "1")
+        val resolver = GoToPageResolver(listOf(first, second), spine.positions(), spine::locatorFromLink)
+
+        assertEquals("volume-1.xhtml", resolver.resolve("1")?.locator?.href?.toString())
+    }
+
+    private fun spine(vararg resources: Pair<String, Int>) = Spine(resources.toList())
+
+    /** A reading order of resources, each covering a number of positions. */
+    private class Spine(private val resources: List<Pair<String, Int>>) {
+
+        /** Readium's positions, grouped by resource as the real service groups them. */
+        fun positions(chapters: List<BookChapter> = emptyList()): BookPositions {
+            var position = 0
+            val byResource = resources.map { (href, count) ->
+                (0 until count).map { index ->
+                    position += 1
+                    locator(
+                        href = href,
+                        position = position,
+                        progression = index.toDouble() / count,
+                    )
+                }
+            }
+            return BookPositions(
+                locators = byResource.flatten(),
+                chapters = chapters,
+                chapterIndexByResource = emptyMap(),
+                positionsByResource = byResource,
+            )
+        }
+
+        /**
+         * What Readium's `Publication.locatorFromLink` hands back: the fragment
+         * moves out of the href into the locations, no synthetic position is
+         * attached, and only a fragment-less link gets a progression. A link
+         * pointing outside the reading order gets nothing.
+         */
+        fun locatorFromLink(link: Link): Locator? {
+            val href = link.url().toString()
+            val resource = href.substringBefore('#')
+            if (resources.none { it.first == resource }) return null
+            val fragment = href.substringAfter('#', "").takeIf(String::isNotEmpty)
+            return locator(
+                href = resource,
+                fragment = fragment,
+                progression = 0.0.takeIf { fragment == null },
+            )
+        }
+    }
+
+    private companion object {
+
+        fun link(href: String, title: String): Link = requireNotNull(
+            Link.fromJSON(JSONObject().put("href", href).put("title", title)),
+        )
+
+        fun locator(
+            href: String,
+            position: Int? = null,
+            progression: Double? = null,
+            fragment: String? = null,
+        ): Locator {
+            val locations = JSONObject()
+            position?.let { locations.put("position", it) }
+            progression?.let { locations.put("progression", it) }
+            fragment?.let { locations.put("fragments", JSONArray().put(it)) }
+            return requireNotNull(
+                Locator.fromJSON(
+                    JSONObject()
+                        .put("href", href)
+                        .put("type", "application/xhtml+xml")
+                        .put("locations", locations),
+                ),
+            )
+        }
+    }
+}

--- a/docs/adr/0017-go-to-page.md
+++ b/docs/adr/0017-go-to-page.md
@@ -1,0 +1,150 @@
+# 17. Go to page
+
+Status: accepted
+GitHub issue: [#115](https://github.com/chmouel/liseur/issues/115)
+
+## Context
+
+The scrubber is the only absolute move Liseur has. It is a fine
+instrument for "somewhere in the last third" and a hopeless one for
+"page 212": five hundred pages under a thumb's width means every drag
+is a hunt and every overshoot is another.
+
+The number is often not the reader's to guess. A citation gives one. A
+reading group says where to start. A note on paper from last week says
+87. A paper copy of the same book, open on the table, says where its
+owner stopped. In each of those the reader knows precisely where they
+want to be and has no way to say it.
+
+Everything needed to take them there already exists.
+`BookPositions` numbers positions from 1 and hands out
+`locatorAt(position)`; `ReaderViewModel` already exposes it as
+`locatorAtPosition()` for the scrubber. `chapterAt()` already knows
+which chapter a position falls in. `onJump()` already records the way
+back, and `JumpBackPill` already offers it. What is missing is the
+question.
+
+There is also a second sense of "page" the app currently ignores. An
+EPUB may declare a `page-list`: a nav mapping the printed edition's page
+numbers onto points in the text, which is exactly the number a citation
+quotes and exactly the number written on the paper note. Readium parses
+it, and `Publication.pageList` in `readium-shared` 3.3.0 hands it over
+as links. Liseur reads past it, and the page number in its footer is
+Readium's synthetic position — stable, layout-independent, and unrelated
+to what the paper book called that page.
+
+## Decision
+
+The page readout already printed under the scrubber — "Page 142 of 517"
+— becomes tappable, and opens a small dialog asking for a page. Typing
+one moves the book there.
+
+Where a book declares a `page-list`, the dialog asks for and accepts the
+printed page. Where it does not, it asks for the position the footer is
+already showing. The dialog says which of the two it wants, and names
+the chapter the typed page falls in before the reader commits.
+
+Fit with Liseur's simplicity: no new control and no new setting. The
+readout is already on screen, already carrying the number a reader would
+type, drawn in the shape they would type it, in the one surface that is
+already about moving through the book. The top bar, which already
+carries three icons, gains nothing.
+
+The entry point was the whole question, and three other places were
+considered. A row in the Contents screen is findable but two taps away
+and behind a tab strip, for an answer the scrubber row is already
+displaying. A long-press on the scrubber has no affordance and would go
+undiscovered. The footer's own page number is tempting and wrong: footer
+taps already cycle the middle slot, a quiet gesture worth leaving alone,
+and the footer is the page the reader is trying to read past — putting a
+dialog under it makes the text itself a control.
+
+## Design
+
+`ReadingScrubber` in `reader/chrome/ReadingProgressUi.kt` draws the
+readout as a `FooterHint` in the row beneath the slider. It gains an
+`onGoToPage` callback and `clickableWithoutRipple`, which the file
+already defines for exactly this — chrome that must swallow a tap
+without turning the page and without a ripple.
+
+This composes with [ADR 7](0007-scrubber-page-peek.md), which stops a
+drag from navigating until release. That ADR changes what dragging the
+thumb does; this changes what tapping the readout does. Neither takes
+the other's gesture. The readout 0007 leans on while the thumb is down
+is the same one that opens this dialog when it is not, which is an
+argument for the two shipping in either order.
+
+The dialog itself is a `reader/chrome/GoToPageDialog.kt`, an
+`AlertDialog` in the shape `NoteDialog` already uses, holding a text
+field, the chapter hint, and the range it will accept. `ReaderScreen`
+holds a `goToPage: Boolean` beside `showToc` and `searchFor`, and the
+confirm path is the one every other jump takes:
+
+```kotlin
+onProgressAction.onJump()
+navigateLater(locator, NavigatorPositionEvent.LOCAL_JUMP)
+```
+
+so the "back to page N" pill appears with no new state at all, and the
+speed estimator is already told not to count the jump as reading.
+
+The resolving is pure and lives in `reader/progress/`, beside
+`BookPositions`, so it is testable on the JVM without an emulator. It
+answers two questions — what to ask for, and what a typed answer means —
+from a `page-list` index built once when the publication opens, the same
+moment `BookPositions.of()` is built.
+
+The index is not an integer range, and the design must not pretend
+otherwise. A `page-list` label is a string: roman numerals across front
+matter, then arabic, is the ordinary case, and "iv" through "xxii"
+followed by 1 through 480 is neither sorted nor contiguous as a number.
+Labels can also repeat across volumes and can be absent entirely for
+stretches of a book. So the index is a map from label to `Link`, an
+ordered list of the labels for range hints, and nothing more. A label
+the book does not carry is refused — the field says so, and the dialog
+does not move the book — rather than rounded to the nearest thing, which
+would silently answer a different question from the one asked.
+
+`publication.locatorFromLink(link)` turns the chosen `page-list` link
+into a locator, the same call `ReaderScreen` already makes for a
+Contents entry, so a printed page and a chapter arrive by one path.
+
+The chapter hint resolves a `page-list` link through
+`BookPositions.resolve()` and then names the position with
+`chapterAt()`, the same title the scrubber shows while it is
+dragged. Typing a number is blind in a way
+dragging is not; the hint is to a typed page what the scrubber's
+label is to a drag, and it is what catches a reader who typed 212 into a
+book whose printed pages the file never declared.
+
+## Consequences
+
+The scrubber row stops being the only way to make an absolute move, and
+becomes the way to *find* the other one. A reader following a citation
+into a book that carries its printed pages lands on the page the
+citation meant, which is a thing Liseur could not do at all.
+
+Two senses of "page" now exist in the app, and that is a genuine cost.
+The footer will keep showing the synthetic position while the dialog
+asks for the printed one, on the same book, in the same session. It is
+the lesser of the two costs: the alternative is to keep asking for a
+number nobody outside the app has ever seen. The dialog naming what it
+wants, and the chapter hint confirming where that lands, is what carries
+the difference. Renumbering the footer to the printed page is a much
+larger change — the scrubber, time-left, sync progressions and every
+stored annotation position hang off the synthetic ones — and is
+deliberately not proposed here.
+
+Books with a `page-list` are a minority, and the ones that have it are
+disproportionately the scholarly editions where a citation is most
+likely to send someone. The fallback costs nothing: a book without one
+behaves exactly as the footer already reads.
+
+No new preference, no row in the typography or Advanced sheets, one new
+dialog, one new pure file with its test, and a handful of strings in
+`app/src/main/res/values/strings.xml`.
+
+*Where:* `reader/chrome/ReadingProgressUi.kt`,
+`reader/chrome/GoToPageDialog.kt` (new), `reader/progress/` (new
+resolver beside `BookPositions.kt`), `reader/ReaderViewModel.kt`,
+`reader/ReaderScreen.kt`, `res/values/strings.xml`.


### PR DESCRIPTION
## Summary

The page count under the reader's scrubber is now a button. Tap it, type a page
number, and the book goes there.

When a book carries its printed edition's page numbers, those are the numbers it
asks for, so a page taken from a citation or from a paper copy lands where it
should. Otherwise it asks for the page shown in the footer. A page the book does
not have is refused rather than rounded to the nearest one, and the chapter the
number lands in is named before the jump is confirmed. Getting back is the same
pill an entry from the contents already leaves behind.

## Changes

- Tapping the page count in the scrubber row opens a "Go to page" dialog.
- Books declaring the printed edition's page numbers are asked for those. Other
  books are asked for the page the footer shows.
- A number the book does not have leaves the confirm button disabled instead of
  moving to the nearest page.
- The chapter a valid number lands in is named before the jump is confirmed.
- The readout announces itself as a button and has a comfortable tap area, so a
  slightly high or low tap still opens the dialog.
- Records the reasoning in `docs/adr/0017-go-to-page.md`.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

Checked on an emulator with Moby Dick: typing 300 named chapter LIV, the jump
landed there, and it left a "Back to page 9" pill.

## Screenshots or recordings

![The page count in the scrubber row, and the go to page dialog it opens](https://github.com/user-attachments/assets/f2b95edb-0fd6-4ebd-a12e-6b598e69ec20)

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
