### PR TITLE
fix(reader): let the page tint the text it has selected

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapper.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapper.kt
@@ -115,8 +115,13 @@ private const val TWO_COLUMN_WIDTH_VW = 45.0
  * Carried as a raw override rather than through
  * `RsProperties.selectionBackgroundColor`, whose `Color.Hex` refuses
  * anything but three or six hex digits — an alpha channel among them.
+ * Spelled `rgba()` rather than `#4A90E266` because eight-digit hex only
+ * became valid in Chromium 62 and the WebView that shipped with our
+ * oldest supported Android was 60: there, the hex form parses as a
+ * custom property and then fails as a colour, which would leave exactly
+ * the page this is here to fix.
  */
-private const val SELECTION_BACKGROUND = "#4A90E266"
+private const val SELECTION_BACKGROUND = "rgba(74, 144, 226, 0.4)"
 
 /**
  * The ink of selected text: the page's own, whatever the theme made it.

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapper.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapper.kt
@@ -91,6 +91,71 @@ fun ReaderPrefs.toEpubPreferences(
 private const val TWO_COLUMN_WIDTH_VW = 45.0
 
 /**
+ * What the page paints behind text the reader has marked out.
+ *
+ * Readium CSS ships `#b4d8fe` and its night rule repeats the same value
+ * with the selected text left at `inherit`, so on a dark page the mark is
+ * the theme's pale ink on a pale blue block — barely readable, which is
+ * what issue #117 reported.
+ *
+ * The answer is one translucent colour rather than four opaque ones. The
+ * blend happens in the page, against whichever background the theme has
+ * put there, so white, beige, dark grey and black each get their own
+ * shade for free — and so does any theme added later. It also has to be
+ * this way round: RS properties are injected when a resource loads, from
+ * the configuration the navigator fragment was *built* with, so a value
+ * chosen per theme could only follow a theme changed mid-book by
+ * rebuilding the fragment under the reader — at every tap of the theme
+ * buttons, and again when the app turns itself dark at dusk.
+ *
+ * Over white it lands within a couple of points of the blue that was
+ * there before, so the two themes nobody complained about keep the look
+ * they had.
+ *
+ * Carried as a raw override rather than through
+ * `RsProperties.selectionBackgroundColor`, whose `Color.Hex` refuses
+ * anything but three or six hex digits — an alpha channel among them.
+ */
+private const val SELECTION_BACKGROUND = "#4A90E266"
+
+/**
+ * The ink of selected text: the page's own, whatever the theme made it.
+ *
+ * Night mode pins this to `inherit`, which is the same answer, and day
+ * mode leaves it unset — `color: var(--RS__selectionTextColor)` is then
+ * invalid at computed-value time and `color` is inherited anyway. Saying
+ * it once, for every theme, means the rule reads as what it does.
+ */
+private const val SELECTION_TEXT = "currentColor"
+
+/** The two of them under the names Readium CSS reads them by. */
+private val selectionOverrides = mapOf(
+    "--RS__selectionBackgroundColor" to SELECTION_BACKGROUND,
+    "--RS__selectionTextColor" to SELECTION_TEXT,
+)
+
+/**
+ * The stylesheet's own properties, as the navigator is built with them.
+ *
+ * Split out from [epubNavigatorConfiguration] to be readable on the JVM:
+ * the configuration around it declares font faces by URL, and a URL is
+ * Android's, so building one at all needs a device.
+ */
+@OptIn(ExperimentalReadiumApi::class)
+internal fun readingRsProperties(columnMode: ColumnMode): RsProperties = RsProperties(
+    colCount = when (columnMode) {
+        ColumnMode.AUTO -> null
+        ColumnMode.ONE -> ColCount.ONE
+        ColumnMode.TWO -> ColCount.TWO
+    },
+    colWidth = when (columnMode) {
+        ColumnMode.TWO -> Length.Vw(TWO_COLUMN_WIDTH_VW)
+        else -> null
+    },
+    overrides = selectionOverrides,
+)
+
+/**
  * The column mode a window this wide can actually carry out.
  *
  * Two things happen here, at either end of the range.
@@ -145,7 +210,8 @@ fun ColumnMode.effectiveFor(widthClass: WidthClass): ColumnMode = when {
  * offers actions a book has no use for, and cannot show highlight colours.
  * Taking it over means taking on what it did for free, so the callback
  * reports the selection on every change and its disappearance on the way
- * out — see the callback itself for why both matter.
+ * out — see the callback itself for why both matter. What the selection
+ * is *painted* in is set here too; see [SELECTION_BACKGROUND].
  *
  * [scroll] switches off Readium's page turns, which in a scrolled book
  * are a whole chapter at a time: a sideways swipe would throw the reader
@@ -163,14 +229,7 @@ fun epubNavigatorConfiguration(
     EpubNavigatorFragment.Configuration {
         servedAssets = listOf("fonts/.*")
         disablePageTurnsWhileScrolling = scroll
-        readiumCssRsProperties = when (columnMode) {
-            ColumnMode.AUTO -> RsProperties()
-            ColumnMode.ONE -> RsProperties(colCount = ColCount.ONE)
-            ColumnMode.TWO -> RsProperties(
-                colCount = ColCount.TWO,
-                colWidth = Length.Vw(TWO_COLUMN_WIDTH_VW),
-            )
-        }
+        readiumCssRsProperties = readingRsProperties(columnMode)
         selectionActionModeCallback = object : ActionMode.Callback {
             override fun onCreateActionMode(mode: ActionMode, menu: Menu): Boolean {
                 onTextSelected()

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapperTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapperTest.kt
@@ -7,15 +7,19 @@ import com.chmouel.liseur.data.settings.ReaderThemeChoice
 import com.chmouel.liseur.ui.WidthClass
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
+import org.readium.r2.navigator.epub.css.ColCount
 import org.readium.r2.navigator.preferences.ColumnCount
 import org.readium.r2.navigator.preferences.Theme
+import org.readium.r2.shared.ExperimentalReadiumApi
 
 /**
  * Columns are the one reading preference the window gets a veto on, so
  * the veto is checked here rather than by opening a book on a tablet.
  */
+@OptIn(ExperimentalReadiumApi::class)
 class ReaderPreferencesMapperTest {
 
     /** The palette the reader arrived at; irrelevant to these cases. */
@@ -146,5 +150,49 @@ class ReaderPreferencesMapperTest {
         for (palette in ReaderTheme.entries) {
             assertNull(ReaderPrefs().toEpubPreferences(palette).imageFilter)
         }
+    }
+
+    @Test
+    fun `the selection is painted in a colour the page can blend`() {
+        // Readium CSS would otherwise paint an opaque #b4d8fe under both
+        // dark themes' pale ink. The alpha is the whole fix: it is what
+        // lets one value read on white, beige, dark grey and black, and
+        // it is why the value cannot go through RsProperties' own
+        // selectionBackgroundColor, which takes six hex digits at most.
+        val overrides = readingRsProperties(ColumnMode.AUTO).overrides
+        assertEquals("#4A90E266", overrides["--RS__selectionBackgroundColor"])
+        assertEquals("currentColor", overrides["--RS__selectionTextColor"])
+    }
+
+    @Test
+    fun `the selection is painted the same way whatever the page is`() {
+        // No column mode, and no theme either, has any business changing
+        // it: RS properties are fixed when the navigator is built, so a
+        // value that varied would be the one thing here that goes stale
+        // the moment the reader switches theme mid-book.
+        for (columns in ColumnMode.entries) {
+            assertEquals(
+                readingRsProperties(ColumnMode.AUTO).overrides,
+                readingRsProperties(columns).overrides,
+            )
+        }
+    }
+
+    @Test
+    fun `two columns still ask for a width they can fit in`() {
+        // The column count alone is a ceiling: Readium's default 45em
+        // column width means two of them only appear on a screen wide
+        // enough for ninety.
+        val auto = readingRsProperties(ColumnMode.AUTO)
+        assertNull(auto.colCount)
+        assertNull(auto.colWidth)
+
+        val one = readingRsProperties(ColumnMode.ONE)
+        assertEquals(ColCount.ONE, one.colCount)
+        assertNull(one.colWidth)
+
+        val two = readingRsProperties(ColumnMode.TWO)
+        assertEquals(ColCount.TWO, two.colCount)
+        assertNotNull(two.colWidth)
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapperTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/ReaderPreferencesMapperTest.kt
@@ -159,8 +159,10 @@ class ReaderPreferencesMapperTest {
         // lets one value read on white, beige, dark grey and black, and
         // it is why the value cannot go through RsProperties' own
         // selectionBackgroundColor, which takes six hex digits at most.
+        // Spelled rgba() and not eight-digit hex, which the WebView on
+        // our oldest Android is two versions too old to parse.
         val overrides = readingRsProperties(ColumnMode.AUTO).overrides
-        assertEquals("#4A90E266", overrides["--RS__selectionBackgroundColor"])
+        assertEquals("rgba(74, 144, 226, 0.4)", overrides["--RS__selectionBackgroundColor"])
         assertEquals("currentColor", overrides["--RS__selectionTextColor"])
     }
 


### PR DESCRIPTION
## Summary

Selecting text in the reader was painted in Readium CSS's own `#b4d8fe`, which liseur never overrode. Readium's night rule repeats that same blue and pins the selected text to `inherit`, so on the Dark and Black themes a marked passage is the theme's pale ink on a pale blue block. Measured on an emulator: **1.4:1**. Light and Sepia escaped it only because their ink is dark.

The fix gives the property an alpha channel instead of a colour per theme. The blend then happens in the page, against whatever background the theme put there, so every theme gets its own shade, including any theme added later.

Fixes #117

## Changes

- `--RS__selectionBackgroundColor` set to `rgba(74, 144, 226, 0.4)` and `--RS__selectionTextColor` to `currentColor`, on the RS properties the navigator is built with.
- RS properties split into `readingRsProperties()` so they can be read on the JVM. The configuration around them declares font faces by URL, and a URL is Android's.
- Unit tests for the selection colours and for the column properties that moved with them.

### Why translucent rather than four colours

RS properties are injected when a resource loads, from the configuration the navigator fragment was **built** with, and `EpubNavigatorViewModel` only recomputes the USER properties on a preference change. A colour chosen per theme could therefore only follow a theme changed mid-book by rebuilding the fragment under the reader: at every tap of the theme buttons, and again when the app turns itself dark at dusk. One translucent value needs no rebuild and no JavaScript.

It goes through the `overrides` map because `RsProperties.selectionBackgroundColor` takes a `Color.Hex`, which refuses anything but three or six hex digits.

### Why `rgba()` and not `#4A90E266`

Eight-digit hex became valid in Chromium 62, and the WebView that shipped on Android 8 was 60. On a WebView that old the hex form parses as a custom property and then fails as a colour, which leaves exactly the page this is meant to fix, on the oldest phones the app supports. `rgba()` is the same colour in a syntax every WebView has understood.

### Measured on an emulator (selected text against its own tint)

| Theme | Before | After |
| --- | --- | --- |
| Light | 12:1 | 12:1 (`rgb(183,211,243)`, within a couple of points of the old blue) |
| Sepia | 8:1 | 7.3:1 |
| Dark | 1.5:1 | **5.6:1** |
| Black | **1.4:1** | **5.9:1** |

Re-measured on an API 26 emulator after the `rgba()` change: Black gives `rgb(30,58,90)` under `rgb(184,184,184)`, 5.9:1, the same numbers as API 36.

### Saved highlights

Checked, and deliberately left alone. A yellow highlight on the Black theme renders as `rgb(77,64,24)` under ink at `rgb(205,192,152)`, so 5.7:1. It reads; it only looks muted, because Readium paints the tint at 30% over the text. Raising that alpha to brighten the mark pushes the text the other way, to around 3.1:1 at 50%, so the current setting is the readable end of that trade.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on an API 36 emulator: a selection under all four reading themes, and a theme switched mid-book to confirm the tint follows without reopening the book.
- [x] Manually tested on an API 26 emulator, the oldest Android the app supports, to confirm the colour syntax renders there.

## Screenshots or recordings

Black theme, same page and same word, before then after:

<img width="32%" alt="Black theme before" src="https://github.com/user-attachments/assets/32fa37f8-8fa2-482a-9d3f-4fd62e0ce4fa" /> <img width="32%" alt="Black theme after" src="https://github.com/user-attachments/assets/b4af61d6-3620-4921-b572-6b3e79972079" /> <img width="32%" alt="Dark theme after" src="https://github.com/user-attachments/assets/0427ccff-8e39-4f45-9193-6cc0ac1cac27" />

The third is the Dark theme after the fix, selected without reopening the book. The theme was switched with the book open, which is the case a per-theme colour could not have covered.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
