### PR TITLE
fix(stats): compare a period against the same point in the last one

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/domain/ReadingStats.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/ReadingStats.kt
@@ -3,11 +3,13 @@ package com.chmouel.liseur.domain
 import java.time.DayOfWeek
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import java.time.temporal.WeekFields
 import kotlin.math.abs
 import kotlin.math.roundToInt
+import kotlin.math.roundToLong
 
 /** What one book's reading adds up to. */
 data class BookReadingStats(
@@ -338,23 +340,78 @@ data class SpanTotals(val totalMs: Long, val pendingMs: Long) {
 /**
  * What [sessions] add up to over [span], on both ends inclusive.
  *
- * The bounded sibling of [readingStats], for the baseline a period is
- * compared against. It deliberately shares [day] and the same
+ * The bounded sibling of [readingStats], for the two halves of a
+ * period-over-period comparison. It deliberately shares the same
  * "a sitting of no length is not a sitting" filter: a comparison whose
- * two halves disagreed about which side of midnight an evening fell on
- * would report a difference the reader did not make.
+ * halves disagreed about what counted would report a difference the
+ * reader did not make.
+ *
+ * [through] stops the count part-way through the span's last day, which
+ * is what makes a finished period comparable with one that has only
+ * reached this afternoon. Every earlier day in the span is counted
+ * whole, whatever hour its reading happened at.
+ *
+ * The time of day is resolved to a moment on that last day rather than
+ * compared as a wall clock, so that the two weekends a year the clocks
+ * move are answered rather than ignored. Where the hour is struck twice
+ * it is the first of them; where it does not exist at all it is moved on
+ * by the length of the hour that was skipped. Either way there is exactly
+ * one cutoff, on the day being counted, and reading is measured against
+ * the same instants it was recorded at.
+ *
+ * A sitting still running at that cutoff is counted for the share of its
+ * length that had elapsed. This is the one place a sitting is divided,
+ * and it is divided because the sitting it is being compared with — the
+ * one open on the reader's screen right now — is already only recorded
+ * as far as its last checkpoint. Dropping the older one whole, or
+ * keeping it whole, would compare an afternoon with something else.
+ *
+ * Midnight is not such a cutoff. With no time of day named the span runs
+ * to the end of its last day, and a sitting that ran past that midnight
+ * belongs whole to the day it ended on, exactly as it does in the
+ * headline above and on liseur-sync. Splitting it here would make the
+ * two halves of a comparison disagree with the total over them.
  */
-fun readingTotals(sessions: List<SessionSpan>, zone: ZoneId, span: DateSpan): SpanTotals {
+fun readingTotals(
+    sessions: List<SessionSpan>,
+    zone: ZoneId,
+    span: DateSpan,
+    through: LocalTime = LocalTime.MAX,
+): SpanTotals {
+    val from = span.from.atStartOfDay(zone).toInstant().toEpochMilli()
+    val cutoff = span.to.atTime(through).atZone(zone).toInstant().toEpochMilli()
+    val cutShort = through != LocalTime.MAX
     var total = 0L
     var pending = 0L
     for (session in sessions) {
         if (session.durationMs <= 0) continue
-        val day = session.day(zone)
-        if (day.isBefore(span.from) || day.isAfter(span.to)) continue
-        total += session.durationMs
-        if (!session.uploaded) pending += session.durationMs
+        if (session.lastReadAt < from) continue
+        val counted =
+            if (cutShort) session.countedBy(cutoff)
+            else if (session.lastReadAt <= cutoff) session.durationMs
+            else 0
+        if (counted <= 0) continue
+        total += counted
+        if (!session.uploaded) pending += counted
     }
     return SpanTotals(total, pending)
+}
+
+/**
+ * How much of a sitting had happened by [cutoff].
+ *
+ * Whole when it had already ended, nothing when it had not yet begun,
+ * and otherwise the share of its length that the wall clock says had
+ * gone by. The length is active time from a monotonic clock and the
+ * extent is wall-clock, so the share is an estimate; it is a far closer
+ * one than nought or all of it.
+ */
+private fun SessionSpan.countedBy(cutoff: Long): Long {
+    if (lastReadAt <= cutoff) return durationMs
+    if (startedAt >= cutoff) return 0
+    val extent = lastReadAt - startedAt
+    if (extent <= 0) return 0
+    return (durationMs.toDouble() * (cutoff - startedAt) / extent).roundToLong()
 }
 
 /** Which way a period went against the one before it. */

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/ReadingStats.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/ReadingStats.kt
@@ -371,6 +371,17 @@ data class SpanTotals(val totalMs: Long, val pendingMs: Long) {
  * belongs whole to the day it ended on, exactly as it does in the
  * headline above and on liseur-sync. Splitting it here would make the
  * two halves of a comparison disagree with the total over them.
+ *
+ * When a time of day *is* named, the span is an interval between two
+ * moments rather than a run of whole days, and the day a sitting is
+ * dated to stops deciding the matter. A sitting begun before the cutoff
+ * and still running at it counts for its elapsed part whether it went on
+ * to end that evening or past the following midnight. That is the point
+ * rather than an oversight: the sitting on the other side of the
+ * comparison is the one open on the reader's screen at this moment, and
+ * it will not be dated to any day until they put the book down. Dropping
+ * the older one for having ended on the Wednesday would measure a reader
+ * mid-chapter against nothing at all.
  */
 fun readingTotals(
     sessions: List<SessionSpan>,

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/StatsRange.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/StatsRange.kt
@@ -2,6 +2,7 @@ package com.chmouel.liseur.domain
 
 import java.time.DayOfWeek
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.temporal.ChronoUnit
 import java.time.temporal.TemporalAdjusters
 import java.time.temporal.WeekFields
@@ -93,13 +94,21 @@ enum class StatsRange(val id: String) {
      * Null for a span with no previous period to name, which is only
      * [ALL_TIME] — and would be any rolling window, were one added back.
      *
-     * The baseline is deliberately partial. Comparing the first Wednesday
-     * of a month with the whole of the month before it would report every
-     * reader as falling behind on the second of every month, so the
-     * baseline stops at the same point in its own period that today is at
-     * in this one.
+     * The baseline is deliberately partial, in both directions. Comparing
+     * the first Wednesday of a month with the whole of the month before it
+     * would report every reader as falling behind on the second of every
+     * month, so the baseline stops on the same day of its own period that
+     * today is in this one — and, because today itself has only reached
+     * [through], it stops at that time of day too. Without the second
+     * bound the afternoon is measured against a completed evening, and the
+     * sentence under the headline slides towards "less" through every
+     * day and springs back at midnight.
      */
-    fun comparison(today: LocalDate, weekStart: DayOfWeek): ComparisonSpans? {
+    fun comparison(
+        today: LocalDate,
+        weekStart: DayOfWeek,
+        through: LocalTime = LocalTime.MAX,
+    ): ComparisonSpans? {
         val period = when (this) {
             THIS_WEEK -> ComparisonPeriod.WEEK
             THIS_MONTH -> ComparisonPeriod.MONTH
@@ -128,6 +137,7 @@ enum class StatsRange(val id: String) {
             period = period,
             current = DateSpan(from, today),
             previous = previous,
+            through = through,
         )
     }
 
@@ -179,4 +189,21 @@ data class ComparisonSpans(
     val period: ComparisonPeriod,
     val current: DateSpan,
     val previous: DateSpan,
+    /**
+     * The wall-clock time each span stops at on its last day.
+     *
+     * Wall clock rather than an instant, deliberately. An instant an
+     * exact week ago is an hour adrift of the reader's Tuesday
+     * afternoon on the two weekends a year the clocks move, and would
+     * hand one side of the comparison an hour the other never had. This
+     * is the time of day the reader has reached, and it means the same
+     * thing on both sides whatever the offset was; where a day has no
+     * such time, or two of them, [readingTotals] says which one it took.
+     *
+     * It applies to the last day of each span alike. [previous] ends on
+     * the day matching today a period ago, and stopping only that one
+     * would measure a Tuesday afternoon against a Tuesday that had had
+     * its evening.
+     */
+    val through: LocalTime,
 )

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
@@ -908,6 +908,14 @@ private val StatsRange.caption: Int
  * telling two colours apart — and there are no two colours to tell
  * apart, because a quiet week is not an error state. Both take
  * `onSurfaceVariant`, the same weight as the caption below.
+ *
+ * Every one of those sentences names this device, and it is not
+ * decoration. The figure above is every device's reading and says so in
+ * the caption below; this line is a comparison, and a comparison holds
+ * only between two figures gathered the same way, so both of its halves
+ * are this device's own sittings. Saying "12% less than last week" over
+ * an all-device total would be a claim about a reader's month that the
+ * arithmetic underneath has not made. See ADR 18.
  */
 @Composable
 private fun ComparisonLine(comparison: ReadingComparison) {

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
@@ -21,7 +21,6 @@ import com.chmouel.liseur.domain.ReadingComparison
 import com.chmouel.liseur.domain.ReadingDay
 import com.chmouel.liseur.domain.ReadingStats
 import com.chmouel.liseur.domain.SessionSpan
-import com.chmouel.liseur.domain.SpanTotals
 import com.chmouel.liseur.domain.StatsBook
 import com.chmouel.liseur.domain.StatsRange
 import com.chmouel.liseur.domain.compareReading
@@ -32,7 +31,9 @@ import com.chmouel.liseur.domain.readingStats
 import com.chmouel.liseur.domain.readingTotals
 import java.time.DayOfWeek
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.util.Locale
 import kotlin.math.roundToLong
 import kotlinx.coroutines.Job
@@ -104,21 +105,22 @@ class ReadingStatsViewModel(
     private val settings: AppSettingsRepository? = null,
     initialRange: StatsRange = StatsRange.Default,
     private val zone: () -> ZoneId = ZoneId::systemDefault,
-    private val today: (ZoneId) -> LocalDate = LocalDate::now,
+    private val now: (ZoneId) -> ZonedDateTime = ZonedDateTime::now,
     initialWeekStart: DayOfWeek = localeWeekStart(Locale.getDefault()),
 ) : ViewModel() {
 
     /**
      * Everything that decides which question the screen is asking.
      *
-     * One value rather than four, because all four have to move
-     * together. The span, the day it ends on, the day the reader's week
-     * begins and the zone the sums are done in are a single question,
-     * and the answers to it — this device's and the server's — are only
-     * comparable if they were asked the same one. While the day and the
-     * zone were sampled from the clock wherever they happened to be
-     * needed, "this week" could be resolved twice in one emission and
-     * come out differently either side of midnight.
+     * One value rather than five, because all of them have to move
+     * together. The span, the day it ends on, the time of day it has
+     * reached, the day the reader's week begins and the zone the sums
+     * are done in are a single question, and the answers to it — this
+     * device's and the server's — are only comparable if they were asked
+     * the same one. While the day and the zone were sampled from the
+     * clock wherever they happened to be needed, "this week" could be
+     * resolved twice in one emission and come out differently either
+     * side of midnight.
      *
      * It also makes an answer refusable. A `combine` does not
      * synchronise its inputs, so a server reply can arrive between a
@@ -131,16 +133,41 @@ class ReadingStatsViewModel(
         val weekStart: DayOfWeek,
         val zone: ZoneId,
         val today: LocalDate,
-    )
+        /**
+         * How far into [today] the clock had got when this was sampled.
+         *
+         * Taken from the same reading as [today], never from a second
+         * one: a date read at a minute to midnight and a time read a
+         * moment later would put the cutoff at the top of a day the date
+         * says is already over, and empty the baseline's last day.
+         */
+        val timeOfDay: LocalTime,
+    ) {
+        /**
+         * The part of this that a server answer is an answer to.
+         *
+         * [timeOfDay] is left out on purpose. It decides where *this
+         * device* stops counting the baseline's last day, and the server
+         * is not asked about that day at all — so a reply fetched at
+         * four o'clock is still a reply to the question asked at five.
+         * Were it in, every visit to the screen would sample a new time,
+         * refuse the answers already on hand, and drop the headline back
+         * to local figures until the network answered again.
+         */
+        fun asked(): StatsWindow = copy(timeOfDay = LocalTime.MIDNIGHT)
+    }
 
     /** A server answer, and the question it was the answer to. */
     private data class Answered<T>(val window: StatsWindow, val value: T)
 
     private fun <T> Answered<T>?.forWindow(window: StatsWindow): T? =
-        this?.takeIf { it.window == window }?.value
+        this?.takeIf { it.window.asked() == window.asked() }?.value
 
     private val _window = MutableStateFlow(
-        zone().let { StatsWindow(initialRange, initialWeekStart, it, today(it)) },
+        zone().let { zone ->
+            val at = now(zone)
+            StatsWindow(initialRange, initialWeekStart, zone, at.toLocalDate(), at.toLocalTime())
+        },
     )
 
     val range: StateFlow<StatsRange> =
@@ -158,7 +185,6 @@ class ReadingStatsViewModel(
     private var refresh: Job? = null
 
     private val _acrossDevices = MutableStateFlow<Answered<InsightsSummary?>?>(null)
-    private val _previousAcrossDevices = MutableStateFlow<Answered<InsightsSummary?>?>(null)
     private val _recentAcrossDevices = MutableStateFlow<Answered<List<InsightDay>?>?>(null)
     private val _booksAcrossDevices = MutableStateFlow<Answered<Map<String, WorkInsights>?>?>(null)
 
@@ -170,16 +196,6 @@ class ReadingStatsViewModel(
      * answer the same question differently are a doubt, not a feature.
      */
     private val acrossDevices = _acrossDevices.asStateFlow()
-
-    /**
-     * The same, for the period this one is being measured against.
-     *
-     * Kept apart from [acrossDevices] rather than fetched with it so
-     * that a slow baseline cannot hold up the headline. Either may fail
-     * on its own; a baseline that does falls back to this device's own
-     * history, which is what the whole screen does without a server.
-     */
-    private val previousAcrossDevices = _previousAcrossDevices.asStateFlow()
     private val recentAcrossDevices = _recentAcrossDevices.asStateFlow()
     private val booksAcrossDevices = _booksAcrossDevices.asStateFlow()
 
@@ -238,7 +254,6 @@ class ReadingStatsViewModel(
 
     private fun forgetServerAnswers() {
         _acrossDevices.value = null
-        _previousAcrossDevices.value = null
         _recentAcrossDevices.value = null
         _booksAcrossDevices.value = null
     }
@@ -246,12 +261,13 @@ class ReadingStatsViewModel(
     /**
      * Refreshes the server decoration whenever a statistics screen opens.
      *
-     * The window moves to today first, and before the check for a server.
-     * Nothing here observes the clock, so this visit is the moment the
-     * screen learns what day it is; doing it after the early return would
-     * leave the one reader with no server — for whom the local figures
-     * are the entire screen — looking at yesterday's week for as long as
-     * the app stayed open.
+     * The window moves to the present first, and before the check for a
+     * server. Nothing here observes the clock, so this visit is the
+     * moment the screen learns what day it is and how far into it the
+     * reader has got; doing it after the early return would leave the one
+     * reader with no server — for whom the local figures are the entire
+     * screen — looking at yesterday's week for as long as the app stayed
+     * open.
      *
      * Each refresh then replaces the last outright: the previous one is
      * cancelled and its answers are refused by generation, not by which
@@ -263,29 +279,20 @@ class ReadingStatsViewModel(
      */
     fun refreshServerInsights() {
         val zone = zone()
-        _window.update { it.copy(zone = zone, today = today(zone)) }
+        val at = now(zone)
+        _window.update {
+            it.copy(zone = zone, today = at.toLocalDate(), timeOfDay = at.toLocalTime())
+        }
         val window = _window.value
         val source = insights ?: return
         val token = ++generation
         refresh?.cancel()
-        val spans = window.range.comparison(window.today, window.weekStart)
-        // A span with nothing to compare against must not keep an answer
-        // fetched while it had one.
-        if (spans == null) _previousAcrossDevices.value = null
         refresh = viewModelScope.launch {
             val end = window.today
             val week = window.weekStart
             launch {
                 val summary = source.summary(window.range, end, week)
                 if (token == generation) _acrossDevices.value = Answered(window, summary)
-            }
-            if (spans != null) {
-                launch {
-                    val summary = source.summary(spans.previous.from, spans.previous.to)
-                    if (token == generation) {
-                        _previousAcrossDevices.value = Answered(window, summary)
-                    }
-                }
             }
             launch {
                 val calendar = source.calendar(
@@ -352,14 +359,21 @@ class ReadingStatsViewModel(
         /** The two spans being compared, or null for a span with none. */
         val spans: ComparisonSpans?,
         /**
-         * This device's own reading over [spans]'s baseline period.
+         * This period and the one before it, from this device alone.
          *
-         * Reduced from the same session list, in the same zone, by the
-         * same day rule as [stats]. Anything less and the two halves of
-         * the comparison could disagree about which side of midnight an
-         * evening fell on, and report a difference the reader never made.
+         * Both reduced from the same session list, in the same zone, by
+         * the same day rule as [stats], and both stopped at the same
+         * time of day. Anything less and the two halves could disagree
+         * about which side of midnight an evening fell on, and report a
+         * difference the reader never made.
+         *
+         * Not the headline's figure for this period, which runs to the
+         * end of today across every device: there is no baseline that
+         * can be built that way, and a comparison whose halves counted
+         * different machines is arithmetic pretending to be a habit.
          */
-        val previous: SpanTotals?,
+        val currentMs: Long,
+        val previousMs: Long,
     )
 
     private val local = combine(
@@ -391,7 +405,8 @@ class ReadingStatsViewModel(
                 endProgression = it.endProgression,
             )
         }
-        val comparison = window.range.comparison(window.today, window.weekStart)
+        val comparison = window.range
+            .comparison(window.today, window.weekStart, window.timeOfDay)
         LocalStats(
             stats = readingStats(
                 sessions = spans,
@@ -408,7 +423,12 @@ class ReadingStatsViewModel(
                 .mapValues { (_, sittings) -> sittings.minOf { it.startedAt } },
             window = window,
             spans = comparison,
-            previous = comparison?.let { readingTotals(spans, window.zone, it.previous) },
+            currentMs = comparison
+                ?.let { readingTotals(spans, window.zone, it.current, it.through).totalMs }
+                ?: 0L,
+            previousMs = comparison
+                ?.let { readingTotals(spans, window.zone, it.previous, it.through).totalMs }
+                ?: 0L,
         )
     }
 
@@ -417,8 +437,8 @@ class ReadingStatsViewModel(
         acrossDevices,
         recentAcrossDevices,
         booksAcrossDevices,
-        previousAcrossDevices,
-    ) { local, server, recent, serverBooks, previousServer ->
+    ) { local, server, recent, serverBooks ->
+
         val window = local.window
         val merged = mergeDashboard(
             local.stats,
@@ -434,8 +454,8 @@ class ReadingStatsViewModel(
                 local = local.stats,
                 server = server.forWindow(window),
                 spans = local.spans,
-                previousLocal = local.previous,
-                previousServer = previousServer.forWindow(window),
+                currentMs = local.currentMs,
+                previousMs = local.previousMs,
             ),
             range = window.range,
         )
@@ -510,26 +530,44 @@ class ReadingStatsViewModel(
          * server that reports a streak but no pace should not cost the
          * reader the pace this device works out for itself.
          *
-         * The baseline is merged by the same rule as the total it is
-         * measured against, and that is the point of doing it here
-         * rather than anywhere else: were the current period allowed to
-         * count a second device and the previous one not, an evening on
-         * a laptop would appear in one half of the comparison and vanish
-         * from the other, and the screen would report a change in the
-         * reader's habits that was really a change in its own arithmetic.
+         * The comparison beneath it is the one figure on this screen the
+         * server does not touch, and that is deliberate. What the
+         * sentence claims is a *relationship* between two spans, and a
+         * relationship only holds between two figures gathered the same
+         * way. Both sides are therefore this device's own sittings, over
+         * spans that stop at the same time of day.
          *
-         * A baseline the server could not answer for falls back to this
-         * device's own history rather than hiding the comparison. That
-         * is what the rest of the screen does without a server, and a
-         * statistics screen is not worth an error.
+         * Mixing the two sources within a side cannot be made safe here.
+         * A summary aggregates whole days, so the day that stops where
+         * the clock has got to is one no server can answer for, and the
+         * only way to use a server at all would be to add its whole days
+         * to this device's part-day. That sum is unsound twice over.
+         * Its days are the *server's* calendar days, and this device
+         * splits by its own zone, so an offset between the two leaves
+         * the two spans overlapping — reading counted once by the server
+         * and again in the part-day — or with a gap between them. And
+         * were one of the two requests to fail, one side would count
+         * every device while the other counted one, which is the
+         * evening-on-a-laptop reported as a change in the reader's
+         * habits that the whole comparison exists to avoid.
+         *
+         * The cost is that a reader with a second device is compared
+         * against themselves on this one. It is an undercount of both
+         * sides alike, which is what leaves the percentage between them
+         * standing, and the figure over it still counts everything.
+         *
+         * It is also why the comparison does not simply use [totalMs].
+         * That figure is the most complete one available and belongs
+         * over the screen, but it counts every device right up to this
+         * minute, and there is no baseline that can be built that way.
          */
         internal fun mergeHeadline(
             merged: ReadingStats,
             local: ReadingStats,
             server: InsightsSummary?,
             spans: ComparisonSpans? = null,
-            previousLocal: SpanTotals? = null,
-            previousServer: InsightsSummary? = null,
+            currentMs: Long = 0,
+            previousMs: Long = 0,
         ): StatsHeadline {
             val totalMs = maxOf(
                 merged.totalMs,
@@ -541,16 +579,7 @@ class ReadingStatsViewModel(
                 streakDays = maxOf(local.streakDays, server?.streakDays ?: 0),
                 progressionPerHour = server?.progressionPerHour ?: local.progressionPerHour,
                 comparison = spans?.let {
-                    val baseline = previousLocal ?: SpanTotals.Empty
-                    compareReading(
-                        period = it.period,
-                        currentMs = totalMs,
-                        previousMs = maxOf(
-                            baseline.totalMs,
-                            (previousServer?.activeMinutes?.minutesAsMillis() ?: 0L) +
-                                baseline.pendingMs,
-                        ),
-                    )
+                    compareReading(it.period, currentMs = currentMs, previousMs = previousMs)
                 },
             )
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -679,10 +679,12 @@
     <string name="reading_stats_this_year">This year, on every device</string>
     <string name="reading_stats_this_year_local">This year</string>
     <string name="reading_stats_in_total">In total</string>
-    <string name="reading_stats_compare_more">%1$d%% more than %2$s</string>
-    <string name="reading_stats_compare_less">%1$d%% less than %2$s</string>
-    <string name="reading_stats_compare_more_than">More than %1$s</string>
-    <string name="reading_stats_compare_same">Same as %1$s</string>
+    <!-- The figure above these is every device's; the comparison under it is
+         this one's alone, so each of them says so. See ADR 18. -->
+    <string name="reading_stats_compare_more">%1$d%% more than %2$s, on this device</string>
+    <string name="reading_stats_compare_less">%1$d%% less than %2$s, on this device</string>
+    <string name="reading_stats_compare_more_than">More than %1$s, on this device</string>
+    <string name="reading_stats_compare_same">Same as %1$s, on this device</string>
     <string name="reading_stats_period_week">last week</string>
     <string name="reading_stats_period_month">last month</string>
     <string name="reading_stats_period_year">last year</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/ReadingStatsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/ReadingStatsTest.kt
@@ -750,6 +750,44 @@ class ReadingStatsTest {
     }
 
     /**
+     * A sitting running past the cutoff counts, wherever it ended.
+     *
+     * The reader's own sitting at this moment has not ended anywhere
+     * yet. It will be dated to tonight or to tomorrow depending on when
+     * they put the book down, and the comparison cannot wait to find
+     * out. So the evening a week ago that ran past midnight is counted
+     * for the part of it that had gone by this time, exactly as today's
+     * is — the day it was eventually filed under decides the headline,
+     * not this.
+     */
+    @Test
+    fun `a sitting that outlived the day still counts up to the cutoff`() {
+        val lastDay = today.minusDays(7)
+        val startedAt = at(lastDay, 18, 0)
+        // Six hours on the clock, ending at half past midnight, of which
+        // three were active reading.
+        val session = SessionSpan(
+            "a",
+            startedAt,
+            10_800_000,
+            lastReadAt = startedAt + 21_600_000,
+        )
+        val span = DateSpan(lastDay.minusDays(1), lastDay)
+
+        // Forty minutes in: a ninth of the six hours, so a ninth of the
+        // three that were read.
+        assertEquals(
+            1_200_000L,
+            readingTotals(listOf(session), zone, span, LocalTime.of(18, 40)).totalMs,
+        )
+
+        // The same sitting is not in that span at all once the span runs
+        // to the end of its day: it ended on the next one, and that is
+        // where the headline files it.
+        assertEquals(0L, readingTotals(listOf(session), zone, span, LocalTime.MAX).totalMs)
+    }
+
+    /**
      * The hour struck twice is the first of them.
      *
      * On the morning the clocks go back, 02:30 happens twice in Paris.

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/ReadingStatsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/ReadingStatsTest.kt
@@ -5,7 +5,9 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.ZoneId
+import java.time.ZonedDateTime
 
 /** The arithmetic behind the dashboard. */
 class ReadingStatsTest {
@@ -16,6 +18,10 @@ class ReadingStatsTest {
     /** Midday on a given day, in the zone the sums are done in. */
     private fun noonOn(date: LocalDate): Long =
         date.atTime(12, 0).atZone(zone).toInstant().toEpochMilli()
+
+    /** A given hour on a given day, in that same zone. */
+    private fun at(date: LocalDate, hour: Int, minute: Int): Long =
+        date.atTime(hour, minute).atZone(zone).toInstant().toEpochMilli()
 
     private fun book(url: String, finished: Boolean = false, progression: Double? = null) =
         StatsBook(url, "Title of $url", "An Author", progression, finished)
@@ -601,6 +607,226 @@ class ReadingStatsTest {
             span = DateSpan(today.minusDays(6), today),
         )
         assertEquals(SpanTotals.Empty, totals)
+    }
+
+    /**
+     * The baseline's last day stops where today's clock has got to.
+     *
+     * A period that has only reached four in the afternoon measured
+     * against a completed evening reports the reader as falling behind
+     * every day, and back level at midnight.
+     */
+    @Test
+    fun `a baseline leaves out what came after the hour today has reached`() {
+        val lastDay = today.minusDays(7)
+        val morning = SessionSpan("a", at(lastDay, 10, 0), 60_000)
+        val evening = SessionSpan("a", at(lastDay, 20, 0), 60_000)
+
+        val totals = readingTotals(
+            sessions = listOf(morning, evening),
+            zone = zone,
+            span = DateSpan(lastDay, lastDay),
+            through = LocalTime.of(16, 0),
+        )
+        assertEquals(60_000L, totals.totalMs)
+
+        // Sitting still, the reader crosses the same hour and it counts.
+        assertEquals(
+            120_000L,
+            readingTotals(
+                sessions = listOf(morning, evening),
+                zone = zone,
+                span = DateSpan(lastDay, lastDay),
+                through = LocalTime.of(21, 0),
+            ).totalMs,
+        )
+    }
+
+    /** Only the last day is cut short; every day before it is whole. */
+    @Test
+    fun `an earlier day in the baseline keeps its evening`() {
+        val lastDay = today.minusDays(7)
+        val totals = readingTotals(
+            sessions = listOf(
+                SessionSpan("a", at(lastDay.minusDays(1), 23, 0), 60_000),
+                SessionSpan("a", at(lastDay, 23, 0), 60_000),
+            ),
+            zone = zone,
+            span = DateSpan(lastDay.minusDays(1), lastDay),
+            through = LocalTime.of(9, 0),
+        )
+        assertEquals(60_000L, totals.totalMs)
+    }
+
+    /**
+     * The cutoff dates a sitting by where it ended, as everything does.
+     *
+     * A stretch begun before the hour and still running past it is one
+     * the reader had not finished by this time last week either.
+     */
+    @Test
+    fun `a sitting that ran past the hour is dated by where it ended`() {
+        val lastDay = today.minusDays(7)
+        val startedAt = at(lastDay, 15, 30)
+        val session = SessionSpan(
+            "a",
+            startedAt,
+            3_600_000,
+            lastReadAt = startedAt + 3_600_000,
+        )
+
+        // Half past four is half an hour in.
+        assertEquals(
+            1_800_000L,
+            readingTotals(listOf(session), zone, DateSpan(lastDay, lastDay), LocalTime.of(16, 0))
+                .totalMs,
+        )
+        assertEquals(
+            3_600_000L,
+            readingTotals(listOf(session), zone, DateSpan(lastDay, lastDay), LocalTime.of(17, 0))
+                .totalMs,
+        )
+    }
+
+    /**
+     * Midnight divides nothing, whichever way the sitting crossed it.
+     *
+     * The end of a day is where one belongs, not where one is cut: a
+     * sitting is dated by where it ended, here and in the headline and
+     * on liseur-sync alike. Were the last midnight of a span a cutoff
+     * like any other, the two halves of a comparison would not add up
+     * to the whole the reader is shown above them.
+     */
+    @Test
+    fun `the end of a day divides no sitting`() {
+        val startedAt = at(today.minusDays(8), 23, 30)
+        val session = SessionSpan("a", startedAt, 3_600_000, lastReadAt = startedAt + 3_600_000)
+
+        val before = DateSpan(today.minusDays(9), today.minusDays(8))
+        val after = DateSpan(today.minusDays(7), today.minusDays(7))
+        assertEquals(0L, readingTotals(listOf(session), zone, before, LocalTime.MAX).totalMs)
+        assertEquals(3_600_000L, readingTotals(listOf(session), zone, after, LocalTime.MAX).totalMs)
+    }
+
+    /**
+     * A sitting still running at the cutoff counts for what had elapsed.
+     *
+     * The sitting it is being compared with is the one open on the
+     * reader's screen right now, and that one is only recorded as far as
+     * its last checkpoint. Dropping this one whole would compare an
+     * afternoon with nothing; keeping it whole would compare it with an
+     * evening.
+     */
+    @Test
+    fun `a sitting straddling the cutoff counts for the part that had gone`() {
+        val lastDay = today.minusDays(7)
+        val startedAt = at(lastDay, 15, 0)
+        // An hour on the clock, of which forty minutes was actually read.
+        val session = SessionSpan(
+            "a",
+            startedAt,
+            2_400_000,
+            lastReadAt = startedAt + 3_600_000,
+        )
+
+        // A quarter of the way in: a quarter of the forty minutes.
+        assertEquals(
+            600_000L,
+            readingTotals(listOf(session), zone, DateSpan(lastDay, lastDay), LocalTime.of(15, 15))
+                .totalMs,
+        )
+        // Begun but not yet reached.
+        assertEquals(
+            0L,
+            readingTotals(listOf(session), zone, DateSpan(lastDay, lastDay), LocalTime.of(15, 0))
+                .totalMs,
+        )
+        // Over and done with.
+        assertEquals(
+            2_400_000L,
+            readingTotals(listOf(session), zone, DateSpan(lastDay, lastDay), LocalTime.of(16, 0))
+                .totalMs,
+        )
+    }
+
+    /**
+     * The hour struck twice is the first of them.
+     *
+     * On the morning the clocks go back, 02:30 happens twice in Paris.
+     * A cutoff that named the wall clock and nothing else would count
+     * reading from the second of them against a period that had only
+     * reached the first, which is the extra hour this rule exists to
+     * refuse.
+     */
+    @Test
+    fun `an hour the clocks repeat is counted once, at its first turn`() {
+        // 25 October 2026: 03:00 CEST becomes 02:00 CET in Paris.
+        val fallBack = LocalDate.of(2026, 10, 25)
+        val first = ZonedDateTime.of(fallBack, LocalTime.of(2, 30), zone)
+            .withEarlierOffsetAtOverlap()
+        val second = first.withLaterOffsetAtOverlap()
+        assertTrue(second.toInstant() > first.toInstant())
+
+        val sessions = listOf(
+            SessionSpan("a", first.toInstant().toEpochMilli(), 60_000),
+            SessionSpan("a", second.toInstant().toEpochMilli(), 60_000),
+        )
+
+        assertEquals(
+            60_000L,
+            readingTotals(sessions, zone, DateSpan(fallBack, fallBack), LocalTime.of(2, 30))
+                .totalMs,
+        )
+        // Later in the day both are behind the reader.
+        assertEquals(
+            120_000L,
+            readingTotals(sessions, zone, DateSpan(fallBack, fallBack), LocalTime.of(9, 0))
+                .totalMs,
+        )
+    }
+
+    /**
+     * An hour the clocks skip is moved on by the hour that was skipped.
+     *
+     * 02:30 does not exist in Paris on the morning the clocks go
+     * forward, and a comparison cannot simply refuse to happen on it.
+     * There is one defined answer, it is the one `java.time` gives, and
+     * it stays on the day the reader is looking at.
+     */
+    @Test
+    fun `an hour the clocks skip is moved on by the length of the gap`() {
+        // 29 March 2026: 02:00 CET becomes 03:00 CEST in Paris, so a
+        // cutoff of 02:30 resolves to 03:30.
+        val springForward = LocalDate.of(2026, 3, 29)
+        val resolved = ZonedDateTime.of(springForward, LocalTime.of(3, 30), zone)
+        val justBefore = SessionSpan("a", resolved.toInstant().toEpochMilli() - 60_000, 60_000)
+        val justAfter = SessionSpan("a", resolved.toInstant().toEpochMilli() + 60_000, 60_000)
+
+        val totals = readingTotals(
+            sessions = listOf(justBefore, justAfter),
+            zone = zone,
+            span = DateSpan(springForward, springForward),
+            through = LocalTime.of(2, 30),
+        )
+        assertEquals(60_000L, totals.totalMs)
+    }
+
+    /** A cut-short day keeps unsent time apart just as a whole one does. */
+    @Test
+    fun `a cut short baseline still says what no server has heard`() {
+        val lastDay = today.minusDays(7)
+        val totals = readingTotals(
+            sessions = listOf(
+                SessionSpan("a", at(lastDay, 9, 0), 60_000, uploaded = true),
+                SessionSpan("a", at(lastDay, 10, 0), 30_000, uploaded = false),
+                SessionSpan("a", at(lastDay, 20, 0), 90_000, uploaded = false),
+            ),
+            zone = zone,
+            span = DateSpan(lastDay, lastDay),
+            through = LocalTime.of(12, 0),
+        )
+        assertEquals(90_000L, totals.totalMs)
+        assertEquals(30_000L, totals.pendingMs)
     }
 
     // --- More, less, or the same --------------------------------------

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/StatsRangeTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/StatsRangeTest.kt
@@ -6,6 +6,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.DayOfWeek
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import java.util.Locale
@@ -225,6 +226,60 @@ class StatsRangeTest {
         for (weekStart in DayOfWeek.entries) {
             assertNull(StatsRange.ALL_TIME.comparison(wednesday, weekStart))
         }
+    }
+
+    /**
+     * The baseline stops where the clock has got to, not at midnight.
+     *
+     * Without this a Wednesday afternoon is measured against the whole
+     * of the Wednesday before, evening included, and the sentence under
+     * the headline drifts towards "less" through every day and springs
+     * back at midnight.
+     */
+    @Test
+    fun `the baseline stops at the time of day the reader has reached`() {
+        val spans = StatsRange.THIS_WEEK.comparison(
+            wednesday,
+            DayOfWeek.MONDAY,
+            LocalTime.of(16, 7),
+        )!!
+        assertEquals(LocalTime.of(16, 7), spans.through)
+        // The dates are untouched by it: only the last of them is cut short.
+        assertEquals(
+            DateSpan(wednesday.minusWeeks(1).minusDays(2), wednesday.minusWeeks(1)),
+            spans.previous,
+        )
+    }
+
+    /** Asked for nothing in particular, a baseline is a whole day long. */
+    @Test
+    fun `a baseline with no time of day named runs to the end of its last day`() {
+        assertEquals(
+            LocalTime.MAX,
+            StatsRange.THIS_WEEK.comparison(wednesday, DayOfWeek.MONDAY)!!.through,
+        )
+    }
+
+    /**
+     * The cutoff applies to both sides, or it fixes nothing.
+     *
+     * Stopping only the baseline would leave a Tuesday afternoon
+     * measured against a Tuesday evening still; stopping only this
+     * period would invert the same drift.
+     */
+    @Test
+    fun `the same time of day bounds both sides`() {
+        val spans = StatsRange.THIS_WEEK.comparison(
+            wednesday,
+            DayOfWeek.MONDAY,
+            LocalTime.NOON,
+        )!!
+        // One value, read by whatever counts either side.
+        assertEquals(LocalTime.NOON, spans.through)
+        // And the two spans end on days a week apart, so noon on each is
+        // the same point of the same weekday.
+        assertEquals(spans.current.to.minusWeeks(1), spans.previous.to)
+        assertEquals(spans.current.from.minusWeeks(1), spans.previous.from)
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ComparisonWordingTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ComparisonWordingTest.kt
@@ -1,0 +1,65 @@
+package com.chmouel.liseur.ui.stats
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.chmouel.liseur.R
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The comparison names the device it was counted on.
+ *
+ * The total above it is every device's reading and its caption says so.
+ * The sentence beneath is not: both of its halves are this device's own
+ * sittings, because a comparison only holds between two figures gathered
+ * the same way and a server cannot be asked about a day that stops where
+ * the clock has got to. See ADR 18.
+ *
+ * A reader who does all their reading on one machine loses nothing by
+ * being told so. A reader with two would otherwise read a claim about
+ * their month that the arithmetic never made — and the drift is silent,
+ * which is why this is a test and not a comment.
+ */
+@Config(sdk = [35], application = android.app.Application::class)
+@RunWith(RobolectricTestRunner::class)
+class ComparisonWordingTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `every comparison sentence says which device it counted`() {
+        val sentences = listOf(
+            context.getString(R.string.reading_stats_compare_more, 25, "last week"),
+            context.getString(R.string.reading_stats_compare_less, 25, "last month"),
+            context.getString(R.string.reading_stats_compare_more_than, "last year"),
+            context.getString(R.string.reading_stats_compare_same, "last week"),
+        )
+
+        for (sentence in sentences) {
+            assertTrue(sentence, sentence.contains("this device"))
+        }
+    }
+
+    /**
+     * And the total above it still says it counted all of them.
+     *
+     * The two lines sit in one card, so the contrast between them is the
+     * whole of what tells the reader which figure is which.
+     */
+    @Test
+    fun `the total above it still names every device`() {
+        val captions = listOf(
+            R.string.reading_stats_this_week,
+            R.string.reading_stats_this_month,
+            R.string.reading_stats_this_year,
+        )
+
+        for (caption in captions) {
+            val text = context.getString(caption)
+            assertTrue(text, text.contains("every device"))
+        }
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModelTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModelTest.kt
@@ -19,13 +19,13 @@ import com.chmouel.liseur.domain.ComparisonSpans
 import com.chmouel.liseur.domain.DateSpan
 import com.chmouel.liseur.domain.ReadingDay
 import com.chmouel.liseur.domain.ReadingStats
-import com.chmouel.liseur.domain.SpanTotals
 import com.chmouel.liseur.domain.StatsBook
 import com.chmouel.liseur.domain.StatsRange
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -799,7 +799,7 @@ class ReadingStatsViewModelTest {
             db.readingSessionDao().insert(session(url, today, 60_000))
             db.readingSessionDao().insert(session(url, today.minusDays(6), 60_000))
             var day = today
-            val model = model(today = { day })
+            val model = model(now = { day.atTime(LocalTime.MAX).atZone(it) })
 
             val sunday = model.state.first { it is ReadingStatsUiState.Ready }
                 as ReadingStatsUiState.Ready
@@ -815,6 +815,44 @@ class ReadingStatsViewModelTest {
             // one this reader read on.
             assertEquals(ComparisonDirection.LESS, monday.headline.comparison!!.direction)
             assertEquals(100, monday.headline.comparison!!.percent)
+        } finally {
+            models.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    /**
+     * An afternoon is not measured against a completed evening.
+     *
+     * The baseline's last day stops at the hour today has reached, or
+     * the sentence under the headline drifts towards "less" as every
+     * afternoon wears on and springs back at midnight — a change in the
+     * arithmetic, reported as a change in the reader's habits.
+     */
+    @Test
+    fun `the baseline stops where today's clock has got to`() = runTest {
+        Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        try {
+            val url = "calibre:one"
+            db.bookDao().upsert(book(url))
+            // `today` is a Sunday, the week begins on a Monday, so the
+            // baseline's last day is the Sunday before.
+            val lastSunday = today.minusWeeks(1)
+            db.readingSessionDao().insert(session(url, today, 120_000, LocalTime.of(10, 0)))
+            db.readingSessionDao().insert(session(url, lastSunday, 60_000, LocalTime.of(10, 0)))
+            // Read after the hour today has reached: that evening has
+            // not happened yet as far as this comparison is concerned.
+            db.readingSessionDao().insert(session(url, lastSunday, 60_000, LocalTime.of(20, 0)))
+            val model = model(now = { today.atTime(LocalTime.NOON).atZone(it) })
+
+            val ready = model.state.first { it is ReadingStatsUiState.Ready }
+                as ReadingStatsUiState.Ready
+
+            assertEquals(120_000L, ready.headline.totalMs)
+            // Two minutes against the one the reader had read by noon,
+            // not against the two they finished the evening on.
+            assertEquals(ComparisonDirection.MORE, ready.headline.comparison!!.direction)
+            assertEquals(100, ready.headline.comparison!!.percent)
         } finally {
             models.clear()
             Dispatchers.resetMain()
@@ -868,78 +906,99 @@ class ReadingStatsViewModelTest {
         }
     }
 
-    // ---- The baseline the server answers for ------------------------
+    // ---- The two sides of the comparison ----------------------------
 
     /**
-     * The baseline is merged the same way the headline above it is.
+     * The comparison is this device's own reading, on both sides.
      *
-     * The server counts every device but not the last twenty minutes,
-     * which are still queued to upload. Both periods are offered that
-     * same allowance, or a second device appears in one of them and
-     * vanishes from the other, and the percentage is a comparison of
-     * two different populations.
+     * The headline over it counts every device; the sentence under it
+     * cannot, because a summary aggregates whole days and neither side
+     * ends on one. Adding a server's whole days to this device's part
+     * day would either double-count the overlap between the server's
+     * calendar and this one's, or drop the gap between them, and would
+     * count one population on one side if a single request failed.
      */
     @Test
-    fun `the baseline counts other devices and this one's unsent time alike`() {
+    fun `the comparison ignores the server the headline is merged with`() {
         val local = localStats(totalMs = TimeUnit.MINUTES.toMillis(60))
         val headline = ReadingStatsViewModel.mergeHeadline(
             merged = local,
             local = local,
-            server = InsightsSummary(activeMinutes = 60.0, sessions = 2, streakDays = 1),
+            // A second device read four hours this one never saw.
+            server = InsightsSummary(activeMinutes = 240.0, sessions = 9, streakDays = 4),
             spans = spans,
-            previousLocal = SpanTotals(
-                totalMs = TimeUnit.MINUTES.toMillis(20),
-                pendingMs = TimeUnit.MINUTES.toMillis(20),
-            ),
-            previousServer = InsightsSummary(activeMinutes = 100.0, sessions = 4, streakDays = 2),
+            currentMs = TimeUnit.MINUTES.toMillis(60),
+            previousMs = TimeUnit.MINUTES.toMillis(30),
         )
 
-        // A hundred server minutes plus the twenty this device has not
-        // sent: a hundred and twenty against this period's sixty.
-        assertEquals(ComparisonDirection.LESS, headline.comparison!!.direction)
-        assertEquals(50, headline.comparison!!.percent)
-    }
-
-    /** A baseline the server could not answer falls back to this device. */
-    @Test
-    fun `a baseline the server declined falls back to this device`() {
-        val local = localStats(totalMs = TimeUnit.MINUTES.toMillis(60))
-        val headline = ReadingStatsViewModel.mergeHeadline(
-            merged = local,
-            local = local,
-            server = null,
-            spans = spans,
-            previousLocal = SpanTotals(totalMs = TimeUnit.MINUTES.toMillis(30), pendingMs = 0),
-            previousServer = null,
-        )
-
+        // The figure above counts the other device.
+        assertEquals(TimeUnit.MINUTES.toMillis(240), headline.totalMs)
+        // The sentence below compares like with like: sixty against thirty.
         assertEquals(ComparisonDirection.MORE, headline.comparison!!.direction)
         assertEquals(100, headline.comparison!!.percent)
     }
 
     /**
-     * A server that answers nought is answering, not failing.
+     * A baseline of nothing leaves the direction without a figure.
      *
-     * Both cases arrive as the same value, and they mean the same thing
-     * here: nothing to divide by, so the sentence drops its figure.
+     * There is nothing to divide by, and "infinitely more than last
+     * week" is not a sentence to put under a reading total.
      */
     @Test
-    fun `a server baseline of nothing reads as no baseline at all`() {
+    fun `a baseline of nothing reads as no percentage at all`() {
         val local = localStats(totalMs = TimeUnit.MINUTES.toMillis(60))
         val headline = ReadingStatsViewModel.mergeHeadline(
             merged = local,
             local = local,
             server = null,
             spans = spans,
-            previousLocal = SpanTotals.Empty,
-            previousServer = InsightsSummary(activeMinutes = 0.0, sessions = 0, streakDays = 0),
+            currentMs = TimeUnit.MINUTES.toMillis(60),
+            previousMs = 0,
         )
 
         assertEquals(ComparisonDirection.MORE, headline.comparison!!.direction)
         assertNull(headline.comparison!!.percent)
     }
 
-    /** With no spans there is no comparison, whatever the server said. */
+    /**
+     * The headline's own figure is never one side of the comparison.
+     *
+     * On the first day of a period the two sides are a few hours each,
+     * and the difference between counting one device and counting them
+     * all is the whole sentence. A reader whose laptop did the reading
+     * would be told they had read six times more than a period in which
+     * they had in fact read exactly as much.
+     */
+    @Test
+    fun `the first day of a period compares two halves counted alike`() {
+        val local = localStats(totalMs = TimeUnit.MINUTES.toMillis(10))
+        val firstDay = ComparisonSpans(
+            period = ComparisonPeriod.MONTH,
+            current = DateSpan(LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 1)),
+            previous = DateSpan(LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 1)),
+            through = LocalTime.NOON,
+        )
+
+        val headline = ReadingStatsViewModel.mergeHeadline(
+            merged = local,
+            local = local,
+            // An hour today, fifty minutes of it on a device this one
+            // cannot see; the same hour on the first of last month.
+            server = InsightsSummary(activeMinutes = 60.0, sessions = 3, streakDays = 1),
+            spans = firstDay,
+            currentMs = TimeUnit.MINUTES.toMillis(10),
+            previousMs = TimeUnit.MINUTES.toMillis(10),
+        )
+
+        // The headline still says what every device read.
+        assertEquals(TimeUnit.MINUTES.toMillis(60), headline.totalMs)
+        // The sentence says the reader is level, which they are, and a
+        // level reader is given no figure to read into.
+        assertEquals(ComparisonDirection.SAME, headline.comparison!!.direction)
+        assertNull(headline.comparison!!.percent)
+    }
+
+    /** With no spans there is no comparison, whatever was counted. */
     @Test
     fun `a span with nothing before it keeps no comparison`() {
         val local = localStats(totalMs = TimeUnit.MINUTES.toMillis(60))
@@ -948,8 +1007,8 @@ class ReadingStatsViewModelTest {
             local = local,
             server = null,
             spans = null,
-            previousLocal = SpanTotals(totalMs = TimeUnit.MINUTES.toMillis(30), pendingMs = 0),
-            previousServer = InsightsSummary(activeMinutes = 30.0, sessions = 1, streakDays = 1),
+            currentMs = TimeUnit.MINUTES.toMillis(60),
+            previousMs = TimeUnit.MINUTES.toMillis(30),
         )
 
         assertNull(headline.comparison)
@@ -959,6 +1018,7 @@ class ReadingStatsViewModelTest {
         period = ComparisonPeriod.WEEK,
         current = DateSpan(LocalDate.of(2026, 8, 3), LocalDate.of(2026, 8, 9)),
         previous = DateSpan(LocalDate.of(2026, 7, 27), LocalDate.of(2026, 8, 2)),
+        through = LocalTime.MAX,
     )
 
     private fun localStats(totalMs: Long) = ReadingStats(
@@ -969,8 +1029,13 @@ class ReadingStatsViewModelTest {
         recent = emptyList(),
     )
 
-    private fun session(url: String, day: LocalDate, durationMs: Long): ReadingSession {
-        val at = day.atTime(LocalTime.NOON).atZone(zone).toInstant().toEpochMilli()
+    private fun session(
+        url: String,
+        day: LocalDate,
+        durationMs: Long,
+        time: LocalTime = LocalTime.NOON,
+    ): ReadingSession {
+        val at = day.atTime(time).atZone(zone).toInstant().toEpochMilli()
         return ReadingSession(
             bookUrl = url,
             startedAt = at,
@@ -982,7 +1047,10 @@ class ReadingStatsViewModelTest {
 
     private fun model(
         zone: () -> ZoneId = { this.zone },
-        today: () -> LocalDate = { this.today },
+        // The end of the day unless a test says otherwise: a baseline
+        // stops where the clock has got to, and a test that is not about
+        // that wants its last day counted whole.
+        now: (ZoneId) -> ZonedDateTime = { this.today.atTime(LocalTime.MAX).atZone(it) },
         weekStart: DayOfWeek = DayOfWeek.MONDAY,
     ): ReadingStatsViewModel {
         val factory = viewModelFactory {
@@ -992,7 +1060,7 @@ class ReadingStatsViewModelTest {
                     bookDao = db.bookDao(),
                     progressDao = db.readingProgressDao(),
                     zone = zone,
-                    today = { today() },
+                    now = now,
                     // Pinned rather than read off the JVM's locale: the
                     // week's first day is what decides how far the
                     // default span reaches, and a test that reaches a

--- a/docs/adr/0018-period-over-period-reading-comparison.md
+++ b/docs/adr/0018-period-over-period-reading-comparison.md
@@ -48,6 +48,37 @@ of the immediately preceding calendar period:
   month and day in the previous year. A leap-day comparison ends on 28
   February in a non-leap year.
 
+Each side's last day stops at the time of day the reader has reached, not
+at midnight. Matching the day is not enough on its own: the current
+period's final day is today, counted only as far as *now*, while the
+baseline's is a complete twenty-four hours. Without the second bound a
+Tuesday afternoon is measured against the whole of the Tuesday before,
+evening included, so the sentence slides towards "less than last week" as
+every day wears on and springs back at midnight — a change in the
+arithmetic, reported to the reader as a change in their habits.
+
+The bound is named as a wall-clock time rather than as an instant exactly
+one period ago, because "as far as I have got today" is what the reader
+means and an instant a week ago is an hour adrift of it on the two
+weekends a year the clocks move. Naming it is not the same as comparing
+it: on each side it is resolved against that side's own day to a single
+moment, so the clocks moving cannot hand one side an hour the other never
+had. Where an hour is struck twice the earlier of the two is taken; where
+one is skipped the cutoff moves on by the length of the gap. Neither case
+is likely and both are decided rather than left to whatever a wall-clock
+comparison would happen to do.
+
+A sitting still running at that moment is counted for the share of its
+length that had elapsed. Everywhere else a sitting belongs whole to the
+day it ended on, and midnight still divides nothing: the rule is there so
+that this device, the headline above and liseur-sync all agree which day
+reading happened on. The cutoff answers a different question — how much
+had been read by now — and the sitting on the other side of the
+comparison is the one open on the reader's screen, which is itself only
+recorded as far as its last checkpoint. Counted whole it would be an
+evening measured against an afternoon; dropped whole it would be an
+afternoon measured against nothing.
+
 Only active reading time is compared. Books, sessions, streak, pace, and
 finished counts continue to describe the selected current span and do not
 gain deltas. A single comparison under the large reading-time figure keeps
@@ -93,21 +124,61 @@ current span and its previous-period baseline. It owns the month-end and
 leap-year clamping rules and is tested independently of Compose and Android.
 Ranges that are not calendar-to-date return no comparison span.
 
-Local totals for both spans are reduced from the same session snapshot and
-timezone. The current dashboard continues to use `readingStats()` for its
-books, chart, and headline; the comparison only needs the total duration for
-the baseline. Sessions are assigned to days by the same rule as the existing
+Totals for both spans are reduced from the same session snapshot, in the
+same timezone, by the same `readingTotals()` call with the same cutoff. The
+current dashboard continues to use `readingStats()` for its books, chart,
+and headline. Sessions are assigned to days by the same rule as the existing
 statistics so midnight and timezone behaviour cannot disagree between the
 headline and its comparison.
 
-When liseur-sync is connected, `LiseurSyncInsights` requests summaries by
-explicit `from` and `to` dates for both periods. Each displayed total uses
-the existing merge rule: the larger of the local total and the server total
-plus locally pending time for that exact span. The two server answers are
-accepted independently. If the previous-period answer fails, the app uses
-the local baseline; if local history cannot represent a trustworthy
-cross-device baseline, the comparison is simply local, as the rest of the
-screen already is when server insights are unavailable.
+A sitting still running at the cutoff is counted for the share of its
+length that had elapsed, and that is the one place a sitting is divided.
+Midnight still divides nothing: a sitting belongs whole to the day it ended
+on, here as in the headline and on liseur-sync, so the two halves of a
+comparison still add up to a total over both. The proration exists because
+the sitting on the other side is the one open on the reader's screen, which
+is itself only recorded as far as its last checkpoint — counted whole the
+older one would be an evening against an afternoon, dropped whole it would
+be an afternoon against nothing.
+
+The clock is sampled once, as a single zoned moment, and the day and the
+time of day are both read off it. Two readings could straddle midnight and
+put the cutoff at the top of a day the date says is already over, which
+would empty a span's last day.
+
+When liseur-sync is connected, `LiseurSyncInsights` still supplies the
+headline: the reader does not care which machine did the reading, and the
+merge rule there is the larger of the local total and the server total plus
+this device's locally pending time.
+
+**The comparison beneath it is local on both sides, and does not consult
+the server at all.** What the sentence claims is a *relationship* between
+two spans, and a relationship only holds between two figures gathered the
+same way. Both sides are therefore this device's own sittings, reduced over
+spans that stop at the same time of day.
+
+Mixing the two sources within a side cannot be made safe. A summary
+aggregates whole days, so a day stopping where the clock has got to is one
+no server can answer for; the only way to use a server at all would be to
+add its whole days to this device's part-day, and that sum is unsound twice
+over:
+
+- Its days are the *server's* calendar days — `InsightDay` is documented as
+  such — while this device splits by its own zone. An offset between the
+  two leaves the server's final whole day overlapping the device's partial
+  day, so uploaded reading is counted by the server and again locally; a
+  westward offset leaves a gap instead. The server does not declare its
+  timezone, so the app cannot align the split.
+- The two requests fail independently. One succeeding and the other timing
+  out would leave one side counting every device and the other counting
+  one — an evening on a laptop appearing in one half of the comparison and
+  vanishing from the other, which is exactly the false report of a changed
+  habit this whole decision exists to prevent. `summary()` also folds a
+  genuinely empty period into the same `null` as a failure, so the two
+  cannot be told apart.
+
+Neither is a hypothetical the arithmetic can be hardened against; both
+disappear when a side has one source.
 
 Stale replies are guarded twice. The existing refresh generation refuses
 an answer from a superseded request; that is not sufficient on its own,
@@ -116,7 +187,13 @@ still be paired with a local snapshot taken before the range changed. So
 the span, the week's first day, the timezone and today's date are held as
 one value, and every server answer is tagged with the one it was asked
 about. An answer whose tag no longer matches the local snapshot is
-ignored rather than merged.
+ignored rather than merged. The time of day travels in that same value but
+is deliberately left out of the tag: it bounds the comparison, which is
+local, and the server is never asked about it, so a reply fetched at four
+o'clock is still an answer to the question asked at five. Were it in the
+tag, every visit to the screen would sample a new time, refuse the answers
+already on hand, and drop the headline back to local figures until the
+network answered again.
 
 `StatsHeadline` carries an optional comparison value containing the previous
 total and its period label. `BentoHero` renders it immediately beneath the
@@ -127,8 +204,27 @@ new dependency, setting, or server endpoint is required.
 
 The default weekly view gains context that grows fairly through the week:
 Wednesday is compared with Monday-to-Wednesday, not with all seven days of
-last week. Month and year views follow the same rule, so a partial period is
-never measured against a completed one.
+last week, and Wednesday lunchtime with Monday-to-Wednesday lunchtime rather
+than with a Wednesday that had its evening. Month and year views follow the
+same rule, so a partial period is never measured against a completed one.
+
+A reader with a second device is compared against themselves on this one,
+and **the sentence says so**: every wording of it ends "on this device",
+directly under a total captioned "on every device". The two lines sit in
+one card and the contrast between them is what tells the reader which
+figure is which.
+
+Naming the scope is not politeness, it is the claim being made. Leaving
+both devices out of both halves does not preserve the all-device
+percentage — a laptop that did four hours last week and none this week
+would still show "more than last week" on a phone that read a little more
+than it did before. What the line reports is a trend *on this device*, and
+that is a true and useful thing to report; reporting it as a trend in the
+reader's month would not be. A test asserts the qualifier is present, so it
+cannot drift out of the strings later.
+
+The comparison costs no network request. The baseline summary this ADR
+originally specified is gone.
 
 The range menu loses three entries and gains one, which is the cost of the
 comparison applying everywhere it is offered. A reader who used "Last 90


### PR DESCRIPTION
## Summary

The comparison under the reading total already measured a partial period
against the matching *elapsed portion* of the one before it — Monday to
Tuesday against last Monday to last Tuesday, not against all seven days of
last week. What it did not do was stop the two sides at the same time of day.

Today counted only as far as *now*; the matching day a period ago counted its
whole twenty-four hours. So on Tuesday afternoon you were measured against a
Tuesday that had had its evening, the sentence drifted towards "less than last
week" as every day wore on, and it sprang back at midnight — a change in the
arithmetic, reported as a change in your habits.

## Changes

- **Both sides now stop at the wall-clock time the reader has reached.** It is
  named as a time of day, because "as far as I have got today" is what it
  means, but resolved against each side's own day to an *instant*, so the two
  weekends a year the clocks move cannot hand one side an hour the other never
  had. Where an hour is struck twice the earlier is taken; where one is skipped
  the cutoff moves on by the length of the gap.

- **A sitting still running at that instant counts for the share of its length
  that had elapsed.** It is the one place a sitting is divided, and it is
  divided because the sitting on the other side is the one open on your screen,
  which is itself only recorded as far as its last checkpoint. Midnight still
  divides nothing: a sitting belongs whole to the day it ended on, here as in
  the headline and on liseur-sync, so the halves of a comparison still add up to
  a total over both.

- **The comparison no longer consults the server**, and is this device's own
  sittings on both sides. A summary aggregates whole days, so a day stopping
  where the clock has got to is one no server can answer for, and the only way
  to use one would be to add its whole days to this device's part-day. That sum
  is unsound twice over — those are the *server's* calendar days while the split
  is in the device's zone, so an offset between them counts uploaded reading
  twice or leaves a gap, and no timezone is declared to align it by; and the two
  requests fail independently, so one timing out would count every device on one
  side and one on the other, which is the false report of a changed habit the
  comparison exists to prevent.

- **Every wording of the sentence now says "on this device"**, under a total
  still captioned "on every device". Leaving the other machine out of both
  halves does not preserve the all-device percentage; what the line establishes
  is a trend on this device, and it should say so. `ComparisonWordingTest` keeps
  both halves of that contrast from drifting out of the strings.

- Removes two `summary()` requests per refresh, and ~80 lines net.

ADR 0018 is amended throughout: the clock alignment, the DST policy, the
proration and its midnight exemption, and why the comparison is local.

## Testing

- [x] `./gradlew testDebugUnitTest` — 1936 tests, 0 failures
- [x] `./gradlew lintDebug` — 0 errors
- [x] `./gradlew assembleDebug`
- [x] Manually tested on an emulator (screenshot below)

Mutation-checked: removing the proration branch fails 2 tests, giving the
baseline `LocalTime.MAX` instead of the reached time fails 1, and dropping the
`cutShort` guard failed 1 before that guard's own simplification.

New tests cover the cutoff at a quarter in / at the start / after the end, the
end of a day dividing no sitting, a DST fall-back hour counted once at its first
turn, a spring-forward gap moved on by the gap length, and the first day of a
period comparing two halves counted alike.

## Screenshots or recordings

Tuesday evening, 18:40. The sentence under the total reads "469% more than
last week, **on this device**" directly above the caption "This week, on every
device" — the contrast between the two lines is what says which figure is
which. The bar chart shows the week so far, with Tuesday still part-way
through; it is that partial day the baseline is now stopped to match.

<img src="https://github.com/user-attachments/assets/b965f425-577b-49cc-98b8-06c76289930c" width="380" alt="Reading stats, This week: 10 h 43 min, 469% more than last week, on this device" />

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
