### PR TITLE
feat: move reading settings to their own screen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,7 +272,10 @@ emulator.
   (Light/Sepia/Dark/Black) are decoupled from the app's Material theme.
 - A new reading setting goes in the Advanced sheet
   (`reader/chrome/AdvancedSheet.kt`), and directly on Settings → Reading
-  appearance, which has no Advanced section to collapse it behind. The
+  appearance if it is about how the page *looks*, or on Settings →
+  Reading & navigation (`ui/settings/ReadingNavigationScreen.kt`) if it
+  is about how the book is turned, held or looked up. Neither settings
+  screen has an Advanced section to collapse a row behind. The
   typography sheet is the short list a reader changes often — theme,
   size, brightness, font, and how the book is read — and it only grows
   for a setting that genuinely belongs there. Make that case in the pull

--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -57,6 +57,7 @@ import com.chmouel.liseur.ui.settings.AboutScreen
 import com.chmouel.liseur.ui.settings.LicencesScreen
 import com.chmouel.liseur.ui.settings.SettingsScreen
 import com.chmouel.liseur.ui.settings.ReadingAppearanceScreen
+import com.chmouel.liseur.ui.settings.ReadingNavigationScreen
 import com.chmouel.liseur.ui.settings.AnnotationBackupUi
 import com.chmouel.liseur.ui.LocalEInk
 import com.chmouel.liseur.ui.ProvideEInk
@@ -151,6 +152,7 @@ private enum class Screen {
     LIBRARY,
     SETTINGS,
     READING_APPEARANCE,
+    READING_NAVIGATION,
     SERVER_ACCOUNT,
     LICENCES,
     ABOUT,
@@ -267,20 +269,38 @@ private fun LiseurApp(settings: AppSettings) {
                 dynamicColorAvailable = dynamicColorAvailable,
                 onThemeMode = { scope.launch { repository.setThemeMode(it) } },
                 onDynamicColor = { scope.launch { repository.setDynamicColor(it) } },
-                onVolumeKeys = { scope.launch { repository.setVolumeKeysTurnPages(it) } },
-                onTapZones = { scope.launch { repository.setTapZones(it) } },
-                onEInkMode = { scope.launch { repository.setEInkMode(it) } },
-                onColorEInk = { scope.launch { repository.setColorEInk(it) } },
-                onVendorRefresh = { scope.launch { repository.setVendorRefresh(it) } },
-                vendorName = context.container.eInkDisplay.vendor,
-                onResumeLastBook = { scope.launch { repository.setResumeLastBook(it) } },
-                onKeepScreenOn = { scope.launch { repository.setKeepScreenOn(it) } },
                 onGroupSeries = { grouped ->
                     scope.launch {
                         repository.editLibraryFilters { it.copy(groupBySeries = grouped) }
                     }
                 },
+                onOpenAccount = {
+                    accountReturnsTo = Screen.SETTINGS
+                    screen = Screen.SERVER_ACCOUNT
+                },
+                onOpenReadingAppearance = { screen = Screen.READING_APPEARANCE },
+                onOpenReadingNavigation = { screen = Screen.READING_NAVIGATION },
+                backup = annotationBackup,
+                connections = context.container.connections,
+                onOpenAbout = { screen = Screen.ABOUT },
+                onBack = { screen = Screen.LIBRARY },
+            )
+        }
+
+        Screen.READING_NAVIGATION -> {
+            val back = { screen = Screen.SETTINGS }
+            BackHandler { back() }
+            ReadingNavigationScreen(
+                settings = settings,
+                vendorName = context.container.eInkDisplay.vendor,
+                onVolumeKeys = { scope.launch { repository.setVolumeKeysTurnPages(it) } },
+                onTapZones = { scope.launch { repository.setTapZones(it) } },
+                onResumeLastBook = { scope.launch { repository.setResumeLastBook(it) } },
                 onScrollMode = { scope.launch { repository.setScrollMode(it) } },
+                onKeepScreenOn = { scope.launch { repository.setKeepScreenOn(it) } },
+                onEInkMode = { scope.launch { repository.setEInkMode(it) } },
+                onColorEInk = { scope.launch { repository.setColorEInk(it) } },
+                onVendorRefresh = { scope.launch { repository.setVendorRefresh(it) } },
                 onDefinitionTarget = {
                     scope.launch { repository.setDefinitionTarget(it) }
                 },
@@ -290,15 +310,7 @@ private fun LiseurApp(settings: AppSettings) {
                 onDictionaryBaseUrl = {
                     scope.launch { repository.setDictionaryBaseUrl(it) }
                 },
-                onOpenAccount = {
-                    accountReturnsTo = Screen.SETTINGS
-                    screen = Screen.SERVER_ACCOUNT
-                },
-                onOpenReadingAppearance = { screen = Screen.READING_APPEARANCE },
-                backup = annotationBackup,
-                connections = context.container.connections,
-                onOpenAbout = { screen = Screen.ABOUT },
-                onBack = { screen = Screen.LIBRARY },
+                onBack = back,
             )
         }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingNavigationScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingNavigationScreen.kt
@@ -1,0 +1,409 @@
+package com.chmouel.liseur.ui.settings
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.chmouel.liseur.R
+import com.chmouel.liseur.data.settings.AppSettings
+import com.chmouel.liseur.data.settings.DefinitionTarget
+import com.chmouel.liseur.data.settings.EInkMode
+import com.chmouel.liseur.data.settings.TapZones
+import com.chmouel.liseur.domain.DictionaryUrl
+import com.chmouel.liseur.domain.WiktionaryEditions
+import com.chmouel.liseur.reader.dictionary.WiktionaryClient
+import com.chmouel.liseur.ui.LocalEInk
+import com.chmouel.liseur.ui.contentWidthCap
+import com.chmouel.liseur.ui.windowWidth
+
+/**
+ * How a book is turned, held and looked up — everything about reading
+ * that is not how the page looks.
+ *
+ * Its own screen for the same reason the Advanced sheet is its own
+ * sheet (`docs/adr/0001-advanced-reading-menu.md`): the settings list
+ * grew one reasonable row at a time until the section a reader was
+ * looking for was somewhere in the middle of eight switches. The
+ * dictionary comes along because looking a word up is something you do
+ * with a book open, not a thing the app does on its own.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReadingNavigationScreen(
+    settings: AppSettings,
+    vendorName: String?,
+    onVolumeKeys: (Boolean) -> Unit,
+    onTapZones: (TapZones) -> Unit,
+    onResumeLastBook: (Boolean) -> Unit,
+    onScrollMode: (Boolean) -> Unit,
+    onKeepScreenOn: (Boolean) -> Unit,
+    onEInkMode: (EInkMode) -> Unit,
+    onColorEInk: (Boolean) -> Unit,
+    onVendorRefresh: (Boolean) -> Unit,
+    onDefinitionTarget: (DefinitionTarget) -> Unit,
+    onDictionaryLookup: (Boolean) -> Unit,
+    onDictionaryBaseUrl: (String) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+
+    Scaffold(
+        modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        topBar = {
+            LargeTopAppBar(
+                title = { Text(stringResource(R.string.settings_reading_navigation)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.Outlined.ArrowBack,
+                            contentDescription = stringResource(R.string.back),
+                        )
+                    }
+                },
+                scrollBehavior = scrollBehavior,
+            )
+        },
+    ) { padding ->
+        Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.TopCenter) {
+            Column(
+                Modifier
+                    // widthIn must come before fillMaxWidth: fillMaxSize would
+                    // pin the width to the window first, leaving the cap with a
+                    // fixed constraint it cannot narrow.
+                    .widthIn(max = contentWidthCap(windowWidth()))
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 20.dp)
+                    .padding(bottom = 32.dp),
+            ) {
+                SettingsGroup(stringResource(R.string.settings_reading)) {
+                    SwitchRow(
+                        title = stringResource(R.string.settings_volume_keys),
+                        subtitle = stringResource(R.string.settings_volume_keys_detail),
+                        checked = settings.volumeKeysTurnPages,
+                        onCheckedChange = onVolumeKeys,
+                    )
+                    RowDivider()
+                    ChipRow(
+                        title = stringResource(R.string.settings_tap_zones),
+                        subtitle = stringResource(R.string.settings_tap_zones_detail),
+                        options = TapZones.entries,
+                        selected = settings.tapZones,
+                        label = { stringResource(it.label) },
+                        onSelected = onTapZones,
+                    )
+                    RowDivider()
+                    SwitchRow(
+                        title = stringResource(R.string.settings_resume),
+                        subtitle = stringResource(R.string.settings_resume_detail),
+                        checked = settings.resumeLastBook,
+                        onCheckedChange = onResumeLastBook,
+                    )
+                    RowDivider()
+                    SwitchRow(
+                        title = stringResource(R.string.settings_scroll_mode),
+                        subtitle = stringResource(R.string.settings_scroll_mode_detail),
+                        checked = settings.scrollMode,
+                        onCheckedChange = onScrollMode,
+                    )
+                }
+
+                // The e-ink rows are about the panel the book is drawn
+                // on, not about reading, and under the reading header
+                // they read as one more preference rather than as what
+                // they are: a description of the hardware.
+                SettingsGroup(stringResource(R.string.settings_screen)) {
+                    SwitchRow(
+                        title = stringResource(R.string.settings_keep_screen_on),
+                        subtitle = stringResource(R.string.settings_keep_screen_on_detail),
+                        checked = settings.keepScreenOn,
+                        onCheckedChange = onKeepScreenOn,
+                    )
+                    RowDivider()
+                    ChipRow(
+                        title = stringResource(R.string.settings_eink),
+                        subtitle = stringResource(R.string.settings_eink_detail),
+                        options = EInkMode.entries,
+                        selected = settings.eInkMode,
+                        label = { stringResource(it.label) },
+                        onSelected = onEInkMode,
+                    )
+                    if (LocalEInk.current) {
+                        RowDivider()
+                        SwitchRow(
+                            title = stringResource(R.string.settings_color_eink),
+                            subtitle = stringResource(R.string.settings_color_eink_detail),
+                            checked = settings.colorEInk,
+                            onCheckedChange = onColorEInk,
+                        )
+                    }
+                    vendorName?.let { vendor ->
+                        RowDivider()
+                        SwitchRow(
+                            title = stringResource(R.string.settings_vendor_refresh),
+                            subtitle = stringResource(
+                                R.string.settings_vendor_refresh_found,
+                                vendor,
+                            ),
+                            checked = settings.vendorRefresh,
+                            onCheckedChange = onVendorRefresh,
+                        )
+                    }
+                }
+
+                SettingsGroup(stringResource(R.string.settings_dictionary)) {
+                    ChipRow(
+                        title = stringResource(R.string.settings_define_with),
+                        options = DefinitionTarget.entries,
+                        selected = settings.definitionTarget,
+                        label = { stringResource(it.label) },
+                        onSelected = onDefinitionTarget,
+                    )
+                    if (settings.definitionTarget == DefinitionTarget.BUILT_IN) {
+                        RowDivider()
+                        SwitchRow(
+                            title = stringResource(R.string.settings_dictionary_lookup),
+                            subtitle = stringResource(R.string.settings_dictionary_lookup_detail),
+                            checked = settings.dictionaryLookupEnabled,
+                            onCheckedChange = onDictionaryLookup,
+                        )
+                        if (settings.dictionaryLookupEnabled) {
+                            RowDivider()
+                            DictionarySiteRow(
+                                baseUrl = settings.dictionaryBaseUrl,
+                                onBaseUrl = onDictionaryBaseUrl,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Where definitions come from.
+ *
+ * Shown only once online lookups are on, because until then there is no
+ * site to pick. A dropdown of editions by name replaced the bare URL
+ * field after a reader misspelled fr.wiktionary.org and got nothing but
+ * an HTTP 501 out of it — a name cannot be typo'd. Mirrors still fit
+ * through the custom entry, which keeps what is typed and only commits
+ * it on Done, once it parses — so a half-typed address never becomes
+ * the stored one. Every committed choice is then tried against the site
+ * once, right here, so a dead address fails under the field and not
+ * later in the reader.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DictionarySiteRow(baseUrl: String, onBaseUrl: (String) -> Unit) {
+    val storedEdition = remember(baseUrl) { WiktionaryEditions.editionOf(baseUrl) }
+    var customChosen by remember(baseUrl) { mutableStateOf(storedEdition == null) }
+    var expanded by remember { mutableStateOf(false) }
+    var typed by remember(baseUrl) { mutableStateOf(if (storedEdition == null) baseUrl else "") }
+    val normalised = remember(typed) { DictionaryUrl.normalise(typed) }
+    val invalid = typed.isNotBlank() && normalised == null
+
+    // Probed only when the reader commits a choice here — never on
+    // merely opening the screen, because a request nobody asked for
+    // has no place in this app.
+    var probeTarget by remember { mutableStateOf<String?>(null) }
+    var probeResult by remember { mutableStateOf<ProbeUi>(ProbeUi.Idle) }
+    val client = remember { WiktionaryClient() }
+    LaunchedEffect(baseUrl) {
+        // The stored site moved under us (a restore, another writer):
+        // whatever the probe said, it said it about somewhere else.
+        if (probeTarget != null && probeTarget != baseUrl) {
+            probeTarget = null
+            probeResult = ProbeUi.Idle
+        }
+    }
+    LaunchedEffect(probeTarget) {
+        val target = probeTarget ?: return@LaunchedEffect
+        probeResult = ProbeUi.Checking
+        val error = client.probe(target)
+        probeResult = if (error == null) {
+            ProbeUi.Ok(DictionaryUrl.hostOf(target))
+        } else {
+            ProbeUi.Unreachable(DictionaryUrl.hostOf(target), error)
+        }
+    }
+    val commit = { url: String ->
+        onBaseUrl(url)
+        probeTarget = url
+    }
+
+    Column(Modifier.padding(horizontal = 16.dp, vertical = 10.dp)) {
+        Text(
+            text = stringResource(R.string.settings_dictionary_site),
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Text(
+            text = stringResource(R.string.settings_dictionary_site_detail),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = it },
+            modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
+        ) {
+            OutlinedTextField(
+                value = if (customChosen) {
+                    stringResource(R.string.settings_dictionary_site_custom)
+                } else {
+                    storedEdition?.nativeName.orEmpty()
+                },
+                onValueChange = {},
+                readOnly = true,
+                singleLine = true,
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+            )
+            ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                WiktionaryEditions.all.forEach { edition ->
+                    DropdownMenuItem(
+                        text = { Text(edition.nativeName) },
+                        onClick = {
+                            expanded = false
+                            customChosen = false
+                            commit(edition.baseUrl)
+                        },
+                    )
+                }
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.settings_dictionary_site_custom)) },
+                    onClick = {
+                        expanded = false
+                        customChosen = true
+                    },
+                )
+            }
+        }
+        if (customChosen) {
+            OutlinedTextField(
+                value = typed,
+                onValueChange = { typed = it },
+                modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
+                singleLine = true,
+                isError = invalid,
+                placeholder = { Text(stringResource(R.string.settings_dictionary_site_hint)) },
+                supportingText = if (invalid) {
+                    { Text(stringResource(R.string.settings_dictionary_site_invalid)) }
+                } else {
+                    null
+                },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Uri,
+                    imeAction = ImeAction.Done,
+                ),
+                // Committed on Done, not per keystroke: a commit stores
+                // the setting and probes the site, and a half-typed host
+                // deserves neither.
+                keyboardActions = KeyboardActions(onDone = { normalised?.let(commit) }),
+            )
+        }
+        when (val probe = probeResult) {
+            ProbeUi.Idle -> Unit
+            ProbeUi.Checking -> Text(
+                text = stringResource(R.string.settings_dictionary_site_checking),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+            is ProbeUi.Ok -> Text(
+                text = stringResource(R.string.settings_dictionary_site_ok, probe.host),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+            is ProbeUi.Unreachable -> Text(
+                text = stringResource(
+                    R.string.settings_dictionary_site_unreachable,
+                    probe.host,
+                    probe.error,
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+        }
+        if (baseUrl != DictionaryUrl.DEFAULT_BASE_URL) {
+            TextButton(
+                onClick = {
+                    typed = ""
+                    customChosen = false
+                    commit(DictionaryUrl.DEFAULT_BASE_URL)
+                },
+            ) {
+                Text(stringResource(R.string.settings_dictionary_site_reset))
+            }
+        }
+    }
+}
+
+/** The one-shot check of a committed dictionary site, as the row shows it. */
+private sealed interface ProbeUi {
+    data object Idle : ProbeUi
+    data object Checking : ProbeUi
+    data class Ok(val host: String) : ProbeUi
+    data class Unreachable(val host: String, val error: String) : ProbeUi
+}
+
+private val EInkMode.label: Int
+    get() = when (this) {
+        EInkMode.AUTO -> R.string.eink_auto
+        EInkMode.ON -> R.string.eink_on
+        EInkMode.OFF -> R.string.eink_off
+    }
+
+/** Internal: the Settings row summarises the current side in its subtitle. */
+internal val TapZones.label: Int
+    get() = when (this) {
+        TapZones.STANDARD -> R.string.tap_zones_standard
+        TapZones.SWAPPED -> R.string.tap_zones_swapped
+    }
+
+private val DefinitionTarget.label: Int
+    get() = when (this) {
+        DefinitionTarget.BUILT_IN -> R.string.definition_target_builtin
+        DefinitionTarget.EXTERNAL_APP -> R.string.definition_target_external
+    }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsRows.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsRows.kt
@@ -1,0 +1,160 @@
+package com.chmouel.liseur.ui.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.HelpOutline
+import androidx.compose.material3.Card
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+
+/**
+ * The rows the settings screens are built out of.
+ *
+ * Shared rather than private to one screen since Settings grew a second
+ * page of its own: a switch that looks and behaves differently
+ * depending on which page it landed on would be the first thing a
+ * reader noticed about the split.
+ */
+
+/**
+ * A section of the settings: a title over one rounded card, with the
+ * rows inside it divided by hairlines.
+ *
+ * The screen used to put every switch in a card of its own, which read
+ * as a stack of boxed islands whose padding changed from section to
+ * section. One card per section puts the rows on a single axis and
+ * makes the sections themselves the unit of the screen.
+ */
+@Composable
+internal fun SettingsGroup(
+    title: String,
+    onHelp: (() -> Unit)? = null,
+    // Named by whoever offers the help, since only they know what it is
+    // about. Optional because most sections have none to offer.
+    helpDescription: String? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(top = 24.dp, bottom = 8.dp),
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        onHelp?.let {
+            Icon(
+                Icons.Outlined.HelpOutline,
+                contentDescription = helpDescription,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .padding(start = 4.dp)
+                    .size(32.dp)
+                    .clickable(onClick = it)
+                    .padding(6.dp),
+            )
+        }
+    }
+    Card(Modifier.fillMaxWidth()) {
+        Column(content = content)
+    }
+}
+
+@Composable
+internal fun RowDivider() {
+    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+}
+
+@Composable
+internal fun SwitchRow(
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    enabled: Boolean = true,
+) {
+    ListItem(
+        headlineContent = { Text(title) },
+        supportingContent = { Text(subtitle) },
+        trailingContent = {
+            Switch(checked = checked, onCheckedChange = null, enabled = enabled)
+        },
+        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+        modifier = Modifier
+            // One tap target for the whole row, so the switch is not the
+            // only thing you are allowed to hit. Toggleable rather than
+            // merely clickable, so the row carries its own on-or-off state
+            // and a screen reader can say which it is.
+            .toggleable(
+                value = checked,
+                enabled = enabled,
+                role = Role.Switch,
+                onValueChange = onCheckedChange,
+            ),
+    )
+}
+
+/**
+ * A row whose answer is one of a few chips — the theme, the e-ink
+ * behaviour. Shaped like the other rows so it sits on the same axis:
+ * the label where a headline would be, the chips where supporting
+ * text would go.
+ */
+@Composable
+internal fun <T> ChipRow(
+    title: String,
+    subtitle: String? = null,
+    options: List<T>,
+    selected: T,
+    label: @Composable (T) -> String,
+    onSelected: (T) -> Unit,
+) {
+    Column(
+        Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
+    ) {
+        Text(title, style = MaterialTheme.typography.bodyLarge)
+        subtitle?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Row(
+            modifier = Modifier
+                .padding(top = 8.dp)
+                .selectableGroup(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            options.forEach { option ->
+                FilterChip(
+                    selected = selected == option,
+                    onClick = { onSelected(option) },
+                    label = { Text(label(option)) },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
@@ -1,7 +1,6 @@
 package com.chmouel.liseur.ui.settings
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -12,42 +11,29 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.selection.selectableGroup
-import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.outlined.MenuBook
 import androidx.compose.material.icons.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.FileOpen
 import androidx.compose.material.icons.outlined.FileUpload
 import androidx.compose.material.icons.outlined.CloudDownload
-import androidx.compose.material.icons.outlined.HelpOutline
 import androidx.compose.material.icons.outlined.TextFormat
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -58,28 +44,18 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.Role
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.chmouel.liseur.R
 import com.chmouel.liseur.data.settings.AppSettings
 import com.chmouel.liseur.data.ConnectionsState
 import com.chmouel.liseur.data.library.Inspection
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.chmouel.liseur.data.settings.DefinitionTarget
-import com.chmouel.liseur.data.settings.EInkMode
 import com.chmouel.liseur.data.settings.ReaderThemeChoice
-import com.chmouel.liseur.data.settings.TapZones
 import com.chmouel.liseur.data.settings.ThemeMode
-import com.chmouel.liseur.domain.DictionaryUrl
-import com.chmouel.liseur.domain.WiktionaryEditions
-import com.chmouel.liseur.reader.dictionary.WiktionaryClient
-import com.chmouel.liseur.ui.LocalEInk
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.reading.label
 import com.chmouel.liseur.ui.windowWidth
@@ -95,21 +71,10 @@ fun SettingsScreen(
     dynamicColorAvailable: Boolean,
     onThemeMode: (ThemeMode) -> Unit,
     onDynamicColor: (Boolean) -> Unit,
-    onVolumeKeys: (Boolean) -> Unit,
-    onTapZones: (TapZones) -> Unit,
-    onEInkMode: (EInkMode) -> Unit,
-    onColorEInk: (Boolean) -> Unit,
-    onVendorRefresh: (Boolean) -> Unit,
-    vendorName: String?,
-    onResumeLastBook: (Boolean) -> Unit,
-    onKeepScreenOn: (Boolean) -> Unit,
     onGroupSeries: (Boolean) -> Unit,
-    onScrollMode: (Boolean) -> Unit,
-    onDefinitionTarget: (DefinitionTarget) -> Unit,
-    onDictionaryLookup: (Boolean) -> Unit,
-    onDictionaryBaseUrl: (String) -> Unit,
     onOpenAccount: () -> Unit,
     onOpenReadingAppearance: () -> Unit,
+    onOpenReadingNavigation: () -> Unit,
     backup: AnnotationBackupUi,
     connections: ConnectionsState,
     onOpenAbout: () -> Unit,
@@ -239,6 +204,7 @@ fun SettingsScreen(
                 SettingsGroup(
                     title = stringResource(R.string.settings_remote_library),
                     onHelp = { showLibraryHelp.value = true },
+                    helpDescription = stringResource(R.string.settings_library_help_title),
                 ) {
                     val catalog by connections.catalog.collectAsStateWithLifecycle(null)
                     ConnectionRow(
@@ -272,98 +238,33 @@ fun SettingsScreen(
                 }
 
                 SettingsGroup(stringResource(R.string.settings_reading)) {
-                    SwitchRow(
-                        title = stringResource(R.string.settings_volume_keys),
-                        subtitle = stringResource(R.string.settings_volume_keys_detail),
-                        checked = settings.volumeKeysTurnPages,
-                        onCheckedChange = onVolumeKeys,
-                    )
-                    RowDivider()
-                    ChipRow(
-                        title = stringResource(R.string.settings_tap_zones),
-                        subtitle = stringResource(R.string.settings_tap_zones_detail),
-                        options = TapZones.entries,
-                        selected = settings.tapZones,
-                        label = { stringResource(it.label) },
-                        onSelected = onTapZones,
-                    )
-                    RowDivider()
-                    SwitchRow(
-                        title = stringResource(R.string.settings_resume),
-                        subtitle = stringResource(R.string.settings_resume_detail),
-                        checked = settings.resumeLastBook,
-                        onCheckedChange = onResumeLastBook,
-                    )
-                    RowDivider()
-                    SwitchRow(
-                        title = stringResource(R.string.settings_scroll_mode),
-                        subtitle = stringResource(R.string.settings_scroll_mode_detail),
-                        checked = settings.scrollMode,
-                        onCheckedChange = onScrollMode,
-                    )
-                    RowDivider()
-                    SwitchRow(
-                        title = stringResource(R.string.settings_keep_screen_on),
-                        subtitle = stringResource(R.string.settings_keep_screen_on_detail),
-                        checked = settings.keepScreenOn,
-                        onCheckedChange = onKeepScreenOn,
-                    )
-                    RowDivider()
-                    ChipRow(
-                        title = stringResource(R.string.settings_eink),
-                        subtitle = stringResource(R.string.settings_eink_detail),
-                        options = EInkMode.entries,
-                        selected = settings.eInkMode,
-                        label = { stringResource(it.label) },
-                        onSelected = onEInkMode,
-                    )
-                    if (LocalEInk.current) {
-                        RowDivider()
-                        SwitchRow(
-                            title = stringResource(R.string.settings_color_eink),
-                            subtitle = stringResource(R.string.settings_color_eink_detail),
-                            checked = settings.colorEInk,
-                            onCheckedChange = onColorEInk,
-                        )
-                    }
-                    vendorName?.let { vendor ->
-                        RowDivider()
-                        SwitchRow(
-                            title = stringResource(R.string.settings_vendor_refresh),
-                            subtitle = stringResource(
-                                R.string.settings_vendor_refresh_found,
-                                vendor,
-                            ),
-                            checked = settings.vendorRefresh,
-                            onCheckedChange = onVendorRefresh,
-                        )
-                    }
-                }
-
-                SettingsGroup(stringResource(R.string.settings_dictionary)) {
-                    ChipRow(
-                        title = stringResource(R.string.settings_define_with),
-                        options = DefinitionTarget.entries,
-                        selected = settings.definitionTarget,
-                        label = { stringResource(it.label) },
-                        onSelected = onDefinitionTarget,
-                    )
-                    if (settings.definitionTarget == DefinitionTarget.BUILT_IN) {
-                        RowDivider()
-                        SwitchRow(
-                            title = stringResource(R.string.settings_dictionary_lookup),
-                            subtitle = stringResource(R.string.settings_dictionary_lookup_detail),
-                            checked = settings.dictionaryLookupEnabled,
-                            onCheckedChange = onDictionaryLookup,
-                        )
-                        if (settings.dictionaryLookupEnabled) {
-                            RowDivider()
-                            DictionarySiteRow(
-                                baseUrl = settings.dictionaryBaseUrl,
-                                onBaseUrl = onDictionaryBaseUrl,
+                    // The section behind this row had grown to eight
+                    // switches, a chip row and two rows that only some
+                    // screens ever show, which is a list to be read
+                    // through rather than a place to go. The dictionary
+                    // went with it: looking a word up is something you
+                    // do with a book open.
+                    ConnectionRow(
+                        icon = {
+                            Icon(
+                                Icons.AutoMirrored.Outlined.MenuBook,
+                                contentDescription = null,
                             )
-                        }
-                    }
+                        },
+                        title = stringResource(R.string.settings_reading_navigation),
+                        // Which side turns the page is nothing to a
+                        // scrolled book, so a scrolling reader is told
+                        // that instead of a side that does not apply.
+                        subtitle = if (settings.scrollMode) {
+                            stringResource(R.string.settings_reading_navigation_scrolling)
+                        } else {
+                            stringResource(
+                                R.string.settings_reading_navigation_paged,
+                                stringResource(settings.tapZones.label),
+                            )
+                        },
+                        onClick = onOpenReadingNavigation,
+                    )
                 }
 
                 SettingsGroup(stringResource(R.string.settings_export_import)) {
@@ -385,272 +286,6 @@ private val ThemeMode.label: Int
         ThemeMode.DARK -> R.string.theme_dark
     }
 
-private val EInkMode.label: Int
-    get() = when (this) {
-        EInkMode.AUTO -> R.string.eink_auto
-        EInkMode.ON -> R.string.eink_on
-        EInkMode.OFF -> R.string.eink_off
-    }
-
-private val TapZones.label: Int
-    get() = when (this) {
-        TapZones.STANDARD -> R.string.tap_zones_standard
-        TapZones.SWAPPED -> R.string.tap_zones_swapped
-    }
-
-private val DefinitionTarget.label: Int
-    get() = when (this) {
-        DefinitionTarget.BUILT_IN -> R.string.definition_target_builtin
-        DefinitionTarget.EXTERNAL_APP -> R.string.definition_target_external
-    }
-
-/**
- * Where definitions come from.
- *
- * Shown only once online lookups are on, because until then there is no
- * site to pick. A dropdown of editions by name replaced the bare URL
- * field after a reader misspelled fr.wiktionary.org and got nothing but
- * an HTTP 501 out of it — a name cannot be typo'd. Mirrors still fit
- * through the custom entry, which keeps what is typed and only commits
- * it on Done, once it parses — so a half-typed address never becomes
- * the stored one. Every committed choice is then tried against the site
- * once, right here, so a dead address fails under the field and not
- * later in the reader.
- */
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun DictionarySiteRow(baseUrl: String, onBaseUrl: (String) -> Unit) {
-    val storedEdition = remember(baseUrl) { WiktionaryEditions.editionOf(baseUrl) }
-    var customChosen by remember(baseUrl) { mutableStateOf(storedEdition == null) }
-    var expanded by remember { mutableStateOf(false) }
-    var typed by remember(baseUrl) { mutableStateOf(if (storedEdition == null) baseUrl else "") }
-    val normalised = remember(typed) { DictionaryUrl.normalise(typed) }
-    val invalid = typed.isNotBlank() && normalised == null
-
-    // Probed only when the reader commits a choice here — never on
-    // merely opening the screen, because a request nobody asked for
-    // has no place in this app.
-    var probeTarget by remember { mutableStateOf<String?>(null) }
-    var probeResult by remember { mutableStateOf<ProbeUi>(ProbeUi.Idle) }
-    val client = remember { WiktionaryClient() }
-    LaunchedEffect(baseUrl) {
-        // The stored site moved under us (a restore, another writer):
-        // whatever the probe said, it said it about somewhere else.
-        if (probeTarget != null && probeTarget != baseUrl) {
-            probeTarget = null
-            probeResult = ProbeUi.Idle
-        }
-    }
-    LaunchedEffect(probeTarget) {
-        val target = probeTarget ?: return@LaunchedEffect
-        probeResult = ProbeUi.Checking
-        val error = client.probe(target)
-        probeResult = if (error == null) {
-            ProbeUi.Ok(DictionaryUrl.hostOf(target))
-        } else {
-            ProbeUi.Unreachable(DictionaryUrl.hostOf(target), error)
-        }
-    }
-    val commit = { url: String ->
-        onBaseUrl(url)
-        probeTarget = url
-    }
-
-    Column(Modifier.padding(horizontal = 16.dp, vertical = 10.dp)) {
-        Text(
-            text = stringResource(R.string.settings_dictionary_site),
-            style = MaterialTheme.typography.bodyLarge,
-        )
-        Text(
-            text = stringResource(R.string.settings_dictionary_site_detail),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        ExposedDropdownMenuBox(
-            expanded = expanded,
-            onExpandedChange = { expanded = it },
-            modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
-        ) {
-            OutlinedTextField(
-                value = if (customChosen) {
-                    stringResource(R.string.settings_dictionary_site_custom)
-                } else {
-                    storedEdition?.nativeName.orEmpty()
-                },
-                onValueChange = {},
-                readOnly = true,
-                singleLine = true,
-                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .menuAnchor(MenuAnchorType.PrimaryNotEditable),
-            )
-            ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-                WiktionaryEditions.all.forEach { edition ->
-                    DropdownMenuItem(
-                        text = { Text(edition.nativeName) },
-                        onClick = {
-                            expanded = false
-                            customChosen = false
-                            commit(edition.baseUrl)
-                        },
-                    )
-                }
-                DropdownMenuItem(
-                    text = { Text(stringResource(R.string.settings_dictionary_site_custom)) },
-                    onClick = {
-                        expanded = false
-                        customChosen = true
-                    },
-                )
-            }
-        }
-        if (customChosen) {
-            OutlinedTextField(
-                value = typed,
-                onValueChange = { typed = it },
-                modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
-                singleLine = true,
-                isError = invalid,
-                placeholder = { Text(stringResource(R.string.settings_dictionary_site_hint)) },
-                supportingText = if (invalid) {
-                    { Text(stringResource(R.string.settings_dictionary_site_invalid)) }
-                } else {
-                    null
-                },
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Uri,
-                    imeAction = ImeAction.Done,
-                ),
-                // Committed on Done, not per keystroke: a commit stores
-                // the setting and probes the site, and a half-typed host
-                // deserves neither.
-                keyboardActions = KeyboardActions(onDone = { normalised?.let(commit) }),
-            )
-        }
-        when (val probe = probeResult) {
-            ProbeUi.Idle -> Unit
-            ProbeUi.Checking -> Text(
-                text = stringResource(R.string.settings_dictionary_site_checking),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(top = 8.dp),
-            )
-            is ProbeUi.Ok -> Text(
-                text = stringResource(R.string.settings_dictionary_site_ok, probe.host),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(top = 8.dp),
-            )
-            is ProbeUi.Unreachable -> Text(
-                text = stringResource(
-                    R.string.settings_dictionary_site_unreachable,
-                    probe.host,
-                    probe.error,
-                ),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.error,
-                modifier = Modifier.padding(top = 8.dp),
-            )
-        }
-        if (baseUrl != DictionaryUrl.DEFAULT_BASE_URL) {
-            TextButton(
-                onClick = {
-                    typed = ""
-                    customChosen = false
-                    commit(DictionaryUrl.DEFAULT_BASE_URL)
-                },
-            ) {
-                Text(stringResource(R.string.settings_dictionary_site_reset))
-            }
-        }
-    }
-}
-
-/** The one-shot check of a committed dictionary site, as the row shows it. */
-private sealed interface ProbeUi {
-    data object Idle : ProbeUi
-    data object Checking : ProbeUi
-    data class Ok(val host: String) : ProbeUi
-    data class Unreachable(val host: String, val error: String) : ProbeUi
-}
-
-/**
- * A section of the settings: a title over one rounded card, with the
- * rows inside it divided by hairlines.
- *
- * The screen used to put every switch in a card of its own, which read
- * as a stack of boxed islands whose padding changed from section to
- * section. One card per section puts the rows on a single axis and
- * makes the sections themselves the unit of the screen.
- */
-@Composable
-private fun SettingsGroup(
-    title: String,
-    onHelp: (() -> Unit)? = null,
-    content: @Composable ColumnScope.() -> Unit,
-) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.padding(top = 24.dp, bottom = 8.dp),
-    ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.primary,
-        )
-        onHelp?.let {
-            Icon(
-                Icons.Outlined.HelpOutline,
-                contentDescription = stringResource(R.string.settings_library_help_title),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier
-                    .padding(start = 4.dp)
-                    .size(32.dp)
-                    .clickable(onClick = it)
-                    .padding(6.dp),
-            )
-        }
-    }
-    Card(Modifier.fillMaxWidth()) {
-        Column(content = content)
-    }
-}
-
-@Composable
-private fun RowDivider() {
-    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-}
-
-@Composable
-private fun SwitchRow(
-    title: String,
-    subtitle: String,
-    checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
-    enabled: Boolean = true,
-) {
-    ListItem(
-        headlineContent = { Text(title) },
-        supportingContent = { Text(subtitle) },
-        trailingContent = {
-            Switch(checked = checked, onCheckedChange = null, enabled = enabled)
-        },
-        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-        modifier = Modifier
-            // One tap target for the whole row, so the switch is not the
-            // only thing you are allowed to hit. Toggleable rather than
-            // merely clickable, so the row carries its own on-or-off state
-            // and a screen reader can say which it is.
-            .toggleable(
-                value = checked,
-                enabled = enabled,
-                role = Role.Switch,
-                onValueChange = onCheckedChange,
-            ),
-    )
-}
-
 @Composable
 private fun PlainRow(title: String, onClick: () -> Unit) {
     ListItem(
@@ -658,49 +293,6 @@ private fun PlainRow(title: String, onClick: () -> Unit) {
         colors = ListItemDefaults.colors(containerColor = Color.Transparent),
         modifier = Modifier.clickable(onClick = onClick),
     )
-}
-
-/**
- * A row whose answer is one of a few chips — the theme, the e-ink
- * behaviour. Shaped like the other rows so it sits on the same axis:
- * the label where a headline would be, the chips where supporting
- * text would go.
- */
-@Composable
-private fun <T> ChipRow(
-    title: String,
-    subtitle: String? = null,
-    options: List<T>,
-    selected: T,
-    label: @Composable (T) -> String,
-    onSelected: (T) -> Unit,
-) {
-    Column(
-        Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
-    ) {
-        Text(title, style = MaterialTheme.typography.bodyLarge)
-        subtitle?.let {
-            Text(
-                text = it,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-        Row(
-            modifier = Modifier
-                .padding(top = 8.dp)
-                .selectableGroup(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            options.forEach { option ->
-                FilterChip(
-                    selected = selected == option,
-                    onClick = { onSelected(option) },
-                    label = { Text(label(option)) },
-                )
-            }
-        }
-    }
 }
 
 /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -560,6 +560,10 @@
     <string name="footer_mode_none">Hide the footer</string>
 
     <string name="settings_reading">Reading</string>
+    <string name="settings_reading_navigation">Reading &amp; navigation</string>
+    <string name="settings_reading_navigation_paged">Paged. Page-turn sides: %1$s</string>
+    <string name="settings_reading_navigation_scrolling">Read by scrolling.</string>
+    <string name="settings_screen">Screen</string>
     <string name="settings_volume_keys">Volume keys turn pages</string>
     <string name="settings_volume_keys_detail">Volume down goes forward, volume up goes back.</string>
     <string name="settings_tap_zones">Page-turn sides</string>

--- a/docs/adr/0001-advanced-reading-menu.md
+++ b/docs/adr/0001-advanced-reading-menu.md
@@ -98,3 +98,14 @@ first sheet rather than simply land there.
 *Where:* `reader/chrome/TypographySheet.kt`,
 `reader/chrome/AdvancedSheet.kt`,
 `ui/settings/ReadingAppearanceScreen.kt`.
+
+## Update
+
+The Settings screen went the way this ADR describes the sheet going.
+Its Reading section had grown to eight switches, a chip row and two
+rows that only some devices show, so it moved behind a single row into
+**Settings → Reading & navigation**
+(`ui/settings/ReadingNavigationScreen.kt`), taking the dictionary
+section with it. Reading appearance is unchanged and still holds how
+the page looks; the tap-zone chip row named above is now on the new
+screen. `AGENTS.md` names both destinations.

--- a/docs/adr/0009-tap-zone-customization.md
+++ b/docs/adr/0009-tap-zone-customization.md
@@ -87,3 +87,11 @@ forgotten.
 *Where:* `data/settings/AppSettings.kt`,
 `reader/chrome/ReaderTapZones.kt`, `reader/chrome/Endpaper.kt`,
 `ui/settings/SettingsScreen.kt`.
+
+## Update
+
+The Reading section it landed in later moved behind a row of its own,
+so the chip row is now in **Settings → Reading & navigation**
+(`ui/settings/ReadingNavigationScreen.kt`), still directly under
+"Volume keys turn pages" and still not in Reading appearance. See
+`docs/adr/0001-advanced-reading-menu.md`.


### PR DESCRIPTION
## Summary

Reading and navigation controls used to be mixed into the main Settings screen. They now live on their own "Reading & navigation" screen, linked from a single row on Settings. The main screen is shorter, and page-turning, volume keys, and screen behavior sit together in one place.

## Changes

- Added a "Reading & navigation" settings screen holding the controls that used to live directly on Settings.
- Settings now shows one row linking to that screen instead of listing every reading control inline.
- Moved the shared row-building code both screens use into one place, so the two stay visually consistent.
- Updated two architecture decision docs to point at the new screen.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on an emulator: opened Settings, followed the new "Reading & navigation" row, and confirmed the moved controls (volume keys, page-turn sides, open on last book, read by scrolling, keep screen on, etc.) work.

## Screenshots or recordings

![Reading & navigation screen](https://github.com/user-attachments/assets/62a8e4d9-0a30-45af-9779-7b00864d7b54)

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.