### PR TITLE
fix(library): show a cover for a book that never declares one

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/data/library/LocalLibraryRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/library/LocalLibraryRepository.kt
@@ -3,6 +3,7 @@ package com.chmouel.liseur.data.library
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.net.Uri
 import android.util.Log
 import android.provider.DocumentsContract
@@ -488,16 +489,108 @@ class LocalLibraryRepository(
     }
 
     private suspend fun saveCover(publication: Publication, identity: String): String? {
-        val cover = publication.cover() ?: return null
-        val dir = File(context.filesDir, "covers").apply { mkdirs() }
-        val file = File(dir, "${sha1Hex(identity)}.jpg")
+        // The whole thing, not just the write. `publication.cover()`
+        // reads an entry out of the archive and decodes it, and this is
+        // reached from `importBook`, which the library view model
+        // launches in `viewModelScope` — so without this the shelf is
+        // drawn on the thread doing the decoding.
         return withContext(Dispatchers.IO) {
+            val cover = publication.cover()
+                ?: coverNamedCover(publication)
+                ?: return@withContext null
+            val dir = File(context.filesDir, "covers").apply { mkdirs() }
+            val file = File(dir, "${sha1Hex(identity)}.jpg")
             runCatching {
                 file.outputStream().use { cover.compress(Bitmap.CompressFormat.JPEG, 85, it) }
                 file.absolutePath
             }.getOrNull()
         }
     }
+
+    /**
+     * The cover of a book that never says it has one.
+     *
+     * Readium finds a cover by the two routes a publication can declare
+     * it: the EPUB 3 `cover-image` property, and the EPUB 2 `<meta
+     * name="cover">` pointer at a manifest id. A book that uses neither
+     * has no cover as far as the format is concerned, and some do —
+     * their artwork is reachable only because the first page of the
+     * book happens to be an XHTML page that displays it. That is why
+     * such a book looks fine in a reader and turns up blank on a shelf.
+     *
+     * So when nothing usable comes back, fall back to the near-universal
+     * convention and take an image the book called `cover`. "Nothing
+     * usable" is the honest description and it is deliberate: a
+     * declaration that points at an entry which is missing or will not
+     * decode leaves Readium with no cover either, and falling through to
+     * the convention is a better answer than a blank tile. liseur-sync's
+     * candidate list behaves the same way for the same reason.
+     *
+     * It is only ever reached once the declared routes have come back
+     * empty, because a declaration is a statement and a filename is a
+     * guess. Being a guess is also why the match is exact and why the
+     * bytes behind it are treated as hostile: see [isNamedCover] and
+     * [decodeBounded].
+     *
+     * One asymmetry with the server is worth naming: liseur-sync also
+     * matches a manifest *id* of `cover`, so it resolves
+     * `<item id="cover" href="front.jpg"/>` where this does not.
+     * Readium's `Link` does not carry the manifest id, so there is
+     * nothing here to match on. The filename is the common case by a
+     * long way, and disagreeing costs a cover rather than correctness.
+     */
+    private suspend fun coverNamedCover(publication: Publication): Bitmap? {
+        // Both collections, because Readium splits the manifest into the
+        // spine and everything else, and an image is occasionally a
+        // spine item. Resource order and then spine order: neither is
+        // the manifest's own order, but both are fixed, so a book with
+        // two candidates always resolves to the same one.
+        val link = (publication.resources + publication.readingOrder).firstOrNull {
+            it.mediaType?.isBitmap == true && isNamedCover(it.url().filename)
+        } ?: return null
+        // Off the main thread by the time anything is read or decoded —
+        // belt and braces with [saveCover], which already dispatches,
+        // because a suspend function that reads and decodes should not
+        // depend on its caller to be safe.
+        return withContext(Dispatchers.IO) {
+            val resource = publication.get(link) ?: return@withContext null
+            val bytes = try {
+                // Asking the range rather than trusting `length()`, which
+                // Readium documents as a hint that "might not reflect the
+                // actual bytes length". Out-of-range reads are clamped, so
+                // a small entry comes back whole, and one byte past the
+                // limit is enough to tell a file at the limit from one
+                // over it.
+                resource.read(0 until MAX_COVER_BYTES + 1).getOrNull()
+            } finally {
+                resource.close()
+            }
+            if (bytes == null || bytes.size > MAX_COVER_BYTES) null else decodeBounded(bytes)
+        }
+    }
+
+    /**
+     * Turns bytes chosen by their name into a bitmap of a sane size.
+     *
+     * A declared cover was at least pointed at by the book; this one was
+     * picked because of what it is called, out of an archive that may
+     * have arrived from anywhere. An image header can claim any
+     * dimensions it likes, and a few kilobytes of it can ask for
+     * gigabytes of pixels, so the header is read on its own first — with
+     * `inJustDecodeBounds`, which allocates nothing — and the real
+     * decode is subsampled down to something a shelf can use.
+     */
+    private fun decodeBounded(bytes: ByteArray): Bitmap? = runCatching {
+        val header = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeByteArray(bytes, 0, bytes.size, header)
+        val sample = coverSampleSize(header.outWidth, header.outHeight) ?: return@runCatching null
+        BitmapFactory.decodeByteArray(
+            bytes,
+            0,
+            bytes.size,
+            BitmapFactory.Options().apply { inSampleSize = sample },
+        )
+    }.getOrNull()
 
     private companion object {
         const val TAG = "local-library"
@@ -511,7 +604,52 @@ class LocalLibraryRepository(
          * competing with the covers the reader is waiting for.
          */
         const val BACKFILL_PAUSE_MS = 250L
+
+        /**
+         * The most encoded bytes worth reading for a guessed cover.
+         *
+         * Cover artwork runs to a few hundred kilobytes; this is roomy
+         * enough that no real book meets it and small enough that a file
+         * named `cover.jpg` to be read cannot cost much.
+         */
+        const val MAX_COVER_BYTES = 16L * 1024 * 1024
     }
+}
+
+/**
+ * The most pixels a cover is decoded to.
+ *
+ * The bound is on area rather than on either edge, because what is
+ * being guarded is the allocation: at four bytes a pixel this is 16MB,
+ * and an ordinary portrait cover of 1600 by 2400 comes to less, so a
+ * real book is decoded whole and only the absurd is brought down.
+ */
+private const val MAX_COVER_PIXELS = 2048L * 2048
+
+/**
+ * How much to subsample an image of [width] by [height], or null when
+ * the header did not describe an image at all.
+ *
+ * `BitmapFactory` rounds `inSampleSize` down to a power of two, so
+ * powers of two are what this returns — asking for 3 and silently
+ * getting 2 would put the bound somewhere other than where it reads.
+ * A header that could not be parsed leaves the dimensions at -1, which
+ * is the null: there is nothing to decode and no point trying. A
+ * nonsensical bound is the same answer, because there is no sample size
+ * that would satisfy it and looking for one does not end.
+ */
+internal fun coverSampleSize(width: Int, height: Int, max: Long = MAX_COVER_PIXELS): Int? {
+    if (width <= 0 || height <= 0 || max <= 0) return null
+    var sample = 1
+    // Long, and both edges floored at one: a 100000 by 1 image samples
+    // its short edge to zero long before its long edge is small enough,
+    // and a zero would make the product look acceptable.
+    while ((width / sample).coerceAtLeast(1).toLong() *
+        (height / sample).coerceAtLeast(1) > max
+    ) {
+        sample *= 2
+    }
+    return sample
 }
 
 internal fun sha1Hex(value: String): String =
@@ -529,3 +667,24 @@ internal fun sha1Hex(value: String): String =
  */
 internal fun importedFileName(digest: ByteArray): String =
     digest.joinToString("", postfix = ".epub") { "%02x".format(it) }
+
+/**
+ * Whether a file inside a book is named as its cover.
+ *
+ * The extension is dropped before comparing, so `cover.jpg`, `cover.png`
+ * and a bare `cover` all answer the same, and the comparison ignores
+ * case because the convention is written every way round. The match is
+ * deliberately exact after that: `cover-page`, `covers` and
+ * `frontcover` are not covers, and a book with several images would
+ * otherwise be a lottery.
+ *
+ * Kept out of the repository, and out of Android, so the rule that
+ * decides what a reader sees on the shelf can be tested without a
+ * device. It mirrors `coverStem` in liseur-sync.
+ */
+internal fun isNamedCover(filename: String?): Boolean {
+    val name = filename ?: return false
+    val dot = name.lastIndexOf('.')
+    val stem = if (dot > 0) name.substring(0, dot) else name
+    return stem.equals("cover", ignoreCase = true)
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/library/CoverSampleSizeTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/library/CoverSampleSizeTest.kt
@@ -1,0 +1,90 @@
+package com.chmouel.liseur.data.library
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The bound on decoding an image chosen by its filename.
+ *
+ * A declared cover was at least pointed at by the book. This one was
+ * picked out of an untrusted archive because of what it is called, and
+ * an image header can ask for any amount of memory it likes, so the
+ * bound is the thing that makes guessing safe.
+ */
+class CoverSampleSizeTest {
+    private val max = 2048L * 2048
+
+    /**
+     * The bound exists to refuse the absurd, not to choose a display
+     * size, so an ordinary cover has to come through untouched.
+     */
+    @Test
+    fun `a cover of ordinary size is decoded whole`() {
+        assertEquals(1, coverSampleSize(1600, 2400, max))
+        assertEquals(1, coverSampleSize(2048, 2048, max))
+    }
+
+    @Test
+    fun `an image just over the bound is halved`() {
+        assertEquals(2, coverSampleSize(2048, 2049, max))
+    }
+
+    /**
+     * `BitmapFactory` rounds `inSampleSize` down to a power of two, so
+     * returning anything else would put the real bound somewhere other
+     * than where the code says it is.
+     */
+    @Test
+    fun `the answer is always a power of two`() {
+        for (edge in listOf(2049, 3000, 5000, 9000, 20_000, 100_000)) {
+            val sample = coverSampleSize(edge, edge, max)!!
+            assertTrue(sample > 0 && sample and (sample - 1) == 0)
+        }
+    }
+
+    /** However big the claim, the result is within the bound. */
+    @Test
+    fun `a decompression bomb is brought under the bound`() {
+        for (edge in listOf(10_000, 65_535, Int.MAX_VALUE)) {
+            val sample = coverSampleSize(edge, edge, max)!!
+            assertTrue((edge / sample).toLong() * (edge / sample) <= max)
+        }
+    }
+
+    /**
+     * A long thin image samples its short edge to nothing long before
+     * its long edge is small enough. Flooring each edge at one is what
+     * stops the product reading as zero and the loop stopping early on
+     * an image that is still enormous.
+     */
+    @Test
+    fun `a long thin image is still bounded`() {
+        val sample = coverSampleSize(Int.MAX_VALUE, 1, max)!!
+        assertTrue(Int.MAX_VALUE / sample <= max)
+    }
+
+    /**
+     * A header that could not be parsed leaves the dimensions at -1.
+     * There is nothing to decode, and saying so is cheaper than letting
+     * the decoder discover it.
+     */
+    @Test
+    fun `an unreadable header is not an image`() {
+        assertNull(coverSampleSize(-1, -1, max))
+        assertNull(coverSampleSize(0, 0, max))
+        assertNull(coverSampleSize(100, 0, max))
+        assertNull(coverSampleSize(0, 100, max))
+    }
+
+    /**
+     * No sample size satisfies a bound of nothing, so looking for one
+     * would not end. Refusing is the only answer that terminates.
+     */
+    @Test
+    fun `a bound of nothing is refused rather than searched for`() {
+        assertNull(coverSampleSize(100, 100, 0))
+        assertNull(coverSampleSize(100, 100, -1))
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/library/IsNamedCoverTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/library/IsNamedCoverTest.kt
@@ -1,0 +1,81 @@
+package com.chmouel.liseur.data.library
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The last-resort rule for a book that declares no cover at all.
+ *
+ * It only decides between images that are already in the publication,
+ * and only once both declared routes have come back empty, so the cost
+ * of being wrong is a wrong picture rather than a missing book. It is
+ * still worth pinning: this is what a reader sees on the shelf.
+ */
+class IsNamedCoverTest {
+    @Test
+    fun `the conventional names count`() {
+        assertTrue(isNamedCover("cover.jpg"))
+        assertTrue(isNamedCover("cover.jpeg"))
+        assertTrue(isNamedCover("cover.png"))
+    }
+
+    /**
+     * The name rule knows nothing about formats, and does not need to:
+     * a candidate is only considered when Readium already called it a
+     * bitmap, and `MediaType.isBitmap` is BMP, GIF, JPEG, PNG, TIFF and
+     * WEBP. So `cover.svg` passing here does not mean an SVG cover
+     * works — the media type is what turns it away, one step earlier.
+     */
+    @Test
+    fun `the rule is about the name, not the format`() {
+        assertTrue(isNamedCover("cover.svg"))
+        assertTrue(isNamedCover("cover.txt"))
+    }
+
+    @Test
+    fun `an extension is not required`() {
+        assertTrue(isNamedCover("cover"))
+    }
+
+    @Test
+    fun `the convention is written every way round`() {
+        assertTrue(isNamedCover("Cover.jpg"))
+        assertTrue(isNamedCover("COVER.JPG"))
+    }
+
+    /**
+     * Only the last dot is an extension. A book that spells its cover
+     * `cover.small.jpg` is naming a variant, not the cover.
+     */
+    @Test
+    fun `only the final extension is dropped`() {
+        assertFalse(isNamedCover("cover.small.jpg"))
+    }
+
+    /**
+     * The whole point of matching exactly: a book has one cover, and
+     * several images whose names merely contain the word would make the
+     * choice arbitrary.
+     */
+    @Test
+    fun `a name that merely contains cover is not one`() {
+        assertFalse(isNamedCover("cover-page.jpg"))
+        assertFalse(isNamedCover("covers.jpg"))
+        assertFalse(isNamedCover("frontcover.jpg"))
+        assertFalse(isNamedCover("cover_1.jpg"))
+        assertFalse(isNamedCover("9781958803684_cover.jpg"))
+    }
+
+    /** A dotfile has no stem to drop, so it is compared whole. */
+    @Test
+    fun `a leading dot is not an extension`() {
+        assertFalse(isNamedCover(".cover"))
+    }
+
+    @Test
+    fun `nothing at all is not a cover`() {
+        assertFalse(isNamedCover(null))
+        assertFalse(isNamedCover(""))
+    }
+}


### PR DESCRIPTION
Follow-on from #134 and from the matching liseur-sync change (`42cd9a3`).

## What was wrong

After uploading *Né pour courir* (McDougall), the server renders a cover for it and the phone still shows a placeholder.

That is not a stale cover or a cache: liseur never extracted one, and `books.cover_path` was always null. `saveCover()` asks `publication.cover()`, which resolves `linkWithRel("cover")` — populated from exactly two declarations:

- EPUB 3: a manifest item with `properties="cover-image"`
- EPUB 2: `<meta name="cover" content="<manifest-id>"/>`

That book has neither, and an empty `<guide/>`. Its artwork sits at `OEBPS/Images/cover.jpg` and is reachable only because the first spine item is a `cover.xhtml` page that displays it — which is why it looks normal while being read and blank on a shelf.

The device cannot borrow the server’s answer: `LibraryScreen` renders `book.coverPath ?: book.coverUrl`, and adoption after an upload deliberately writes `coverUrl = null`. Nor should it — a book that was never uploaded has the same problem.

## What this does

Falls back to the near-universal convention: a bitmap the book called `cover`. Same rule liseur-sync just gained, so a book looks the same in both places.

Reached whenever Readium produced *no* cover, which is broader than "nothing was declared" — a declaration pointing at a missing or undecodable entry also leaves `cover()` null, and falling through is the better answer. The server’s candidate list does the same.

It stays a guess, and is treated as one:

- **Exact match** once the extension is dropped. `covers.jpg`, `frontcover.jpg`, `cover-page.jpg` and `9781958803684_cover.jpg` are not covers; a book with several images cannot become a lottery.
- **Bounded read.** `resource.read(0 until MAX_COVER_BYTES + 1)` rather than a `length()` check — Readium documents `length()` as a hint that "might not reflect the actual bytes length", and out-of-range reads as clamped.
- **Bounded decode.** An `inJustDecodeBounds` header pass allocates nothing, then `inSampleSize`. The bound is on **area**, not either edge, because what is guarded is the allocation: 2048² is 16MB at four bytes a pixel, and an ordinary 1600×2400 cover fits under it untouched.
- **Both collections**, resource order then spine order, since an image is occasionally a spine item.

## Also here

`saveCover()` moves entirely to `Dispatchers.IO`. It is reached from `importBook`, which `LibraryViewModel` launches in `viewModelScope`, so the shelf was being drawn on the thread decoding the cover. Already true of the declared path; this adds a second decode behind the same call.

## Documented, not closed

liseur-sync also matches a manifest **id** of `cover`, resolving `<item id="cover" href="front.jpg"/>`. Readium’s `Link` does not carry the manifest id, so there is nothing to match on at this layer. Disagreeing costs a cover, not correctness.

## Scope

Covers are extracted at index time only. **A book already on the shelf without a cover keeps its placeholder until it is removed and re-added** — including the one that prompted this. A `cover_checked` column plus a batch pass (mirroring the `series_checked` column and `backfillSeries()` that already exist for this exact shape of problem) was offered and declined, so this is a conscious trade.

Not attempted: the `<guide><reference type="cover">` route (usually names XHTML, and guide hrefs routinely carry fragments), and using the server’s rendered cover as a fallback (helps only uploaded books, and makes the shelf depend on a network call).

## Tests

15 pure JVM cases, no Robolectric:

- `IsNamedCoverTest` (8) — extensions, case, only the final extension dropped, near-misses, leading dot, null/empty, and one stating the rule is about the name not the format (`cover.svg` matches here and is turned away a step earlier by `isBitmap`).
- `CoverSampleSizeTest` (7) — ordinary cover decoded whole, just over the bound, always a power of two, a bomb up to `Int.MAX_VALUE`, a long thin image, an unreadable header, a bound of nothing.

`make check` passes.

No screenshot: the only reproducing book is on a physical phone holding real reading positions, and the fallback is not retroactive, so it would show the placeholder either way. The equivalent Go rule was verified against the same EPUB and resolved `OEBPS/Images/cover.jpg`.