### PR TITLE
docs: clean up Markdown prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,15 @@
-# Liseur — Copilot instructions
+# Liseur: Copilot instructions
 
 Open-source Android ebook reader: local EPUB library + calibre-web,
 Komga and liseur-sync clients (browse/download and position sync against
 any of them), with a Kindle-inspired reading experience. Kotlin + Jetpack Compose + Readium Kotlin Toolkit.
-FOSS-only dependencies — the app targets F-Droid inclusion. See `README.md`
+FOSS-only dependencies. The app targets F-Droid inclusion. See `README.md`
 for user-facing goals.
 
 ## Build, test, lint
 
-Always use the wrapper (`./gradlew`), never a system-wide `gradle` —
-the project is pinned to Gradle 9.6.1 via `gradle/wrapper/`.
+Always use the wrapper (`./gradlew`), never a system-wide `gradle`.
+The project is pinned to Gradle 9.6.1 via `gradle/wrapper/`.
 
 ```bash
 ./gradlew assembleDebug              # unsigned debug APK -> app/build/outputs/apk/debug/
@@ -51,8 +51,8 @@ CI (`.github/workflows/build.yml`) runs `testDebugUnitTest`, `lintDebug`, and
 An emulator is scratch space. Boot one, install over whatever is on it,
 wipe its storage, reseed the demo shelf, write straight into the app's
 database with `adb shell run-as`, rotate it, drive it with
-`adb shell input` — no permission needed for any of it, and no need to
-ask before starting. Everything on an emulator can be rebuilt in a
+`adb shell input`. These operations need no permission or approval.
+Everything on an emulator can be rebuilt in a
 minute by `make reset`, so there is nothing there worth protecting.
 `make shutdown` when you are done, or say you left it running.
 
@@ -95,9 +95,9 @@ credential is absent, so Play is never what makes a release fail, and
 `hack/release --no-play` asks for that skip. Promoting a build out of
 internal testing is a manual action in the console.
 
-Toolchain: JDK 17, AGP 9.x (built-in Kotlin support — **do not** add the
-`org.jetbrains.kotlin.android` plugin, only `org.jetbrains.kotlin.plugin.compose`
-is applied), compileSdk/targetSdk 37, minSdk 26. Dependencies are managed in
+Toolchain: JDK 17, AGP 9.x. AGP has built-in Kotlin support, so **do not** add the
+`org.jetbrains.kotlin.android` plugin; only `org.jetbrains.kotlin.plugin.compose`
+is applied. compileSdk/targetSdk 37, minSdk 26. Dependencies are managed in
 `gradle/libs.versions.toml` (version catalog).
 
 ## Git hooks
@@ -111,14 +111,14 @@ push. Skip with `git push --no-verify`.
 
 ## Hard constraints
 
-- **F-Droid compatibility**: every dependency must be FOSS and come from
-  Maven Central or Google's Maven repo. No proprietary blobs, trackers,
+- Every dependency must be FOSS and come from Maven Central or Google's
+  Maven repo, for F-Droid compatibility. No proprietary blobs, trackers,
   analytics, or Google Play services. In particular, never add
-  `readium-lcp` (depends on the proprietary liblcp).
-- **The release build must stay reproducible** (`hack/verify-reproducible`
-  must pass): F-Droid rebuilds every tag from source. Do not remove the
-  `dependenciesInfo` or `packaging.jniLibs.keepDebugSymbols` settings in
-  `app/build.gradle.kts` — both exist only for this. `DEVELOPER.md`
+  `readium-lcp`, since it depends on the proprietary liblcp.
+- The release build must stay reproducible: `hack/verify-reproducible`
+  must pass, because F-Droid rebuilds every tag from source. Do not remove
+  the `dependenciesInfo` or `packaging.jniLibs.keepDebugSymbols` settings in
+  `app/build.gradle.kts`; both exist only for this. `DEVELOPER.md`
   explains why.
 - Network access is limited to the user-configured book server
   (calibre-web, Komga or liseur-sync) and opt-in dictionary lookups.
@@ -127,22 +127,22 @@ push. Skip with `git push --no-verify`.
 
 Single `:app` module, layered packages under `com.chmouel.liseur`:
 
-- `data/` — Room database, DataStore settings, local library repository
+- `data/`: Room database, DataStore settings, local library repository
   (SAF folder scanning + Readium streamer metadata extraction), and the
   remote-server layer: `data/remote/` holds provider-neutral contracts;
   `data/calibre/` (OPDS + Kobo sync), `data/komga/` (REST) and
   `data/liseursync/` (native REST + append-only op log) implement them,
   and `RemoteRouter` dispatches on the connected server's kind.
-  liseur-sync is a full `ServerKind` like the other two — it catalogs,
-  serves files, and syncs — and its position sync also covers books
+  liseur-sync is a full `ServerKind` like the other two: it catalogs,
+  serves files, and syncs, and its position sync also covers books
   that never came from a server, resolving them by their hashes.
-- `domain/` — small use-case layer, only where logic is non-trivial
+- `domain/`: small use-case layer, only where logic is non-trivial
   (sync merge, time-left estimator). Keep pure and JVM-testable.
-- `reader/` — Readium `EpubNavigatorFragment` hosted in Compose, plus the
+- `reader/`: Readium `EpubNavigatorFragment` hosted in Compose, plus the
   custom reading chrome (tap zones, typography sheet, progress, annotations,
   search).
-- `ui/` — Compose screens: theme (`ui/theme`), library, settings.
-- `sync/` — WorkManager workers for downloads, uploads and position sync.
+- `ui/`: Compose screens: theme (`ui/theme`), library, settings.
+- `sync/`: WorkManager workers for downloads, uploads and position sync.
 
 State management: plain `ViewModel` + `StateFlow`, unidirectional data flow.
 DI is a manual composition root (no Hilt/Koin). Extract non-trivial logic
@@ -158,7 +158,7 @@ emulator.
   exchanges percentage progression (`locations.totalProgression`); Komga
   and liseur-sync exchange a full locator, so they also restore the
   exact spot. All three go
-  through `domain/ReadingStateMerge.kt` — write conflict rules there, once,
+  through `domain/ReadingStateMerge.kt`; write conflict rules there, once,
   not per provider.
 - One server is connected at a time. Anything provider-shaped belongs
   behind a `data/remote/` contract, not in a `when (kind)` at the call
@@ -173,7 +173,7 @@ emulator.
   server answers `duplicate`. Do not introduce a random id or a
   `pending_ops` table.
 - A book's name on liseur-sync is a `work_alias`. A book from its
-  own catalog resolves through `POST /v1/books/{id}/resolve` — the
+  own catalog resolves through `POST /v1/books/{id}/resolve`. The
   server reads the identifiers off its record, so no download is needed
   and two devices name it identically. Any other book resolves from
   SHA-256 + KOReader partial-MD5 + a normalised `ta:` title/author. A
@@ -183,7 +183,7 @@ emulator.
 - Statistics from a server are decoration. Every failure there is
   null and silent; the stats screen is built from local sessions and
   must stand on its own. The two sources are merged by maximum and never
-  by sum — the server's count already contains this device's uploads —
+  by sum (the server's count already contains this device's uploads),
   and an answer to a window other than the one on screen is refused. See
   `docs/adr/0021-cross-device-reading-statistics.md`.
 - Annotations are the exception to that rule, because they are mutable
@@ -191,7 +191,7 @@ emulator.
   reproducible the moment the reader edits the row. `annotation_sync`
   holds what the server confirmed *and* the exact bytes of any request
   in flight, written before the call and replayed verbatim through
-  `postRaw` — first send and retry alike. Do not rebuild an item from
+  `postRaw`, for both the first send and any retry. Do not rebuild an item from
   `JSONObject` on the way out; `org.json` has no key ordering and the
   server compares raw bytes. Two fingerprints: the acknowledged one is
   content only (never `base_rev`, never `edition_sha`), the pending one
@@ -218,7 +218,7 @@ emulator.
   against. A note landing the first time gets a copy picked the same way
   every run; one already filed here goes back where it already lives.
   Pass the known `bookId` rather than sending `edition_sha` on a note.
-- The annotation pass runs settle → pull → reconcile → push → deletes,
+- The annotation pass runs settle -> pull -> reconcile -> push -> deletes,
   and that order is not negotiable. Reconciling a work's live set before
   pushing is what stops an offline edit to a swept tombstone being sent
   as a create, which resurrects a highlight the reader deleted
@@ -238,8 +238,8 @@ emulator.
   newer one the reader wrote after the request left. Compare the local
   content, not the sync row: editing a highlight does not touch it.
 - Every annotation network call checks the account is still the
-  connected one first, not just before storing the answer — the request
-  is the side effect. A record's home alias is likewise re-read inside
+  connected one first, not just before storing the answer, because the
+  request is the side effect. A record's home alias is likewise re-read inside
   the transaction that commits it, so a file that took over the path
   mid-pass cannot have another book's highlight anchored into it.
 - An annotation id is opaque, so `.` and `..` are ids to carry and push
@@ -252,7 +252,7 @@ emulator.
   dropping only the agreements would push every mark again as new when
   the book came back. `BookRemoval.contentReplaced()` is the one path
   that clears both, in one transaction, because a different file took
-  over the path — a sync row with no annotation behind it reads as a
+  over the path: a sync row with no annotation behind it reads as a
   deletion the reader made.
 - Per-account annotation state is cleared inside
   `RemoteAccountRepository.forgetSyncPeer()`, never at a call site.
@@ -266,7 +266,7 @@ emulator.
   local row keeps its own `url`, because that is the key every reading
   position, annotation and session hangs off, and only `remote_uuid` and
   `download_href` are written (`BookDao.linkToRemote`). Never rewrite
-  `books.url` to the server's spelling — the reader's place goes with it.
+  `books.url` to the server's spelling: the reader's place goes with it.
 - Blocking network calls move to `Dispatchers.IO` inside the client that
   blocks, not in the caller. A `suspend` signature reads as a promise
   that the thread is safe, and a repository reached from a
@@ -274,13 +274,13 @@ emulator.
 - Reader settings map to Readium `EpubPreferences`; reading themes
   (Light/Sepia/Dark/Black) are decoupled from the app's Material theme.
 - A new reading setting goes in the Advanced sheet
-  (`reader/chrome/AdvancedSheet.kt`), and directly on Settings → Reading
-  appearance if it is about how the page *looks*, or on Settings →
+  (`reader/chrome/AdvancedSheet.kt`), and directly on Settings -> Reading
+  appearance if it is about how the page *looks*, or on Settings ->
   Reading & navigation (`ui/settings/ReadingNavigationScreen.kt`) if it
   is about how the book is turned, held or looked up. Neither settings
   screen has an Advanced section to collapse a row behind. The
-  typography sheet is the short list a reader changes often — theme,
-  size, brightness, font, and how the book is read — and it only grows
+  typography sheet is the short list a reader changes often (theme,
+  size, brightness, font, and how the book is read), and it only grows
   for a setting that genuinely belongs there. Make that case in the pull
   request; the default is Advanced. It grew to eleven controls once, one
   reasonable row at a time. See `docs/adr/0001-advanced-reading-menu.md`.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -8,7 +8,7 @@ why the remaining gaps are or are not fixable is in
 [`docs/SERVER_CAPABILITIES.md`](docs/SERVER_CAPABILITIES.md).
 
 This project uses the Gradle wrapper, so you don't need Gradle installed
-separately — just a JDK 17+ and the Android SDK (command-line tools are
+separately: just a JDK 17+ and the Android SDK (command-line tools are
 enough; `compileSdk`/`targetSdk` 37 requires a reasonably recent SDK
 Manager package list).
 
@@ -50,8 +50,8 @@ pass show android/liseur.keystore.p12 | base64 -d > /tmp/liseur.p12
 } > keystore.properties
 ```
 
-Contributors without access to that key can generate their own instead —
-any key produces an installable APK, it simply won't update over one
+Contributors without access to that key can generate their own instead.
+Any key produces an installable APK; it simply won't update over one
 signed with the release key:
 
 ```bash
@@ -111,15 +111,15 @@ hack/e2e-upload -r -u http://10.0.2.2:8686 -t <token> -d /srv/books
 A server says no in two places. A token without the scope is refused on
 sight, and the action is never offered. A token that holds the scope but
 finds every folder closed can only be refused by trying, and the app has
-to remember the answer — otherwise it offers, once per book, an action
+to remember the answer; otherwise it offers, once per book, an action
 that silently fails every time. Either way `-r` asserts the app ends up
 not offering, no book was linked, none left the shelf and nothing was
 written into the folder. Run it with the folder still closed, then
 `folder-uploads <folder-id> on` and run the check above, and you have
 covered both answers with one server.
 
-Nothing about it is mocked. Start with a clean shelf — `hack/reset-books`
-then `adb shell pm clear com.chmouel.liseur` — or the counts it compares
+Nothing about it is mocked. Start with a clean shelf (`hack/reset-books`
+then `adb shell pm clear com.chmouel.liseur`), or the counts it compares
 are counting an earlier run.
 
 ### Checking a folder's storage permission
@@ -203,7 +203,7 @@ hack/release --no-play 0.9.0 "..."
 ```
 
 That is the only way to keep Play out of a release once the credential
-has been uploaded once. Deleting the secret by hand does not do it —
+has been uploaded once. Deleting the secret by hand does not do it:
 `hack/release` reads one missing secret as a stale environment and
 uploads them all again from `pass`, Play credential included.
 
@@ -238,16 +238,16 @@ test release is to be quick. Pass `--no-play` to leave Google Play out.
 
 The signature is what makes it worth doing. It is the one F-Droid
 publishes under, through the dual-signing flow, so the APK installs
-straight over a copy that came from F-Droid — no uninstall, no lost
-library — and F-Droid offers the next real release over it afterwards,
+straight over a copy that came from F-Droid, with no uninstall and no
+lost library, and F-Droid offers the next real release over it afterwards,
 as an ordinary update.
 
 That last part is only true because the test build takes a
 `versionCode` and the next real release lands above it. `hack/release`
 counts the next code from the highest one across `main` **and every
 tag**, so a test release at 18 pushes the following real release to 19,
-and F-Droid sees an upgrade. Nobody who installed a test build is stuck
-— but they are on it until the next release goes out, since F-Droid
+and F-Droid sees an upgrade. Nobody who installed a test build is stuck,
+but they are on it until the next release goes out, since F-Droid
 will not offer a lower `versionCode`.
 
 Nothing lands on `main`. The commit that bumps the version is reachable
@@ -259,7 +259,7 @@ F-Droid is told nothing about a test release, but it reads the public tags:
 `v0.9.4-test.1` was once picked up by their `checkupdates` bot, which
 opened a merge request proposing it as the current version. The
 fdroiddata metadata therefore filters what the bot looks at, with
-`UpdateCheckMode: Tags ^v[0-9.]+$` — a test tag no longer matches. Before
+`UpdateCheckMode: Tags ^v[0-9.]+$`; a test tag no longer matches. Before
 any release tag is pushed or submitted, `hack/release` runs
 `hack/verify-fdroid-tags` against that live metadata. It fails closed if a
 final tag would be missed or a test tag would be discovered, so a future
@@ -293,14 +293,14 @@ the only one whose opted-in testers count towards the twelve Play wants
 for fourteen days before a personal developer account may publish.
 Uploading to internal alone, which is what happened up to 0.10.0, leaves
 everyone who followed the instructions on whichever build the closed
-track was last given by hand — 0.9.3, as it turned out, four releases
-back. `hack/store-status` now says so in a line when the closed track
+track was last given by hand (0.9.3, as it turned out, four releases
+back). `hack/store-status` now says so in a line when the closed track
 falls behind internal, because nothing else did.
 
 Nothing about the APK path changes. F-Droid's recipe builds
 `assembleRelease` and never sees `fastlane/Fastfile`, no Gradle
 publishing plugin is applied, and the bundle is an extra output rather
-than a replacement — which is also why the Play step in
+than a replacement, which is also why the Play step in
 `.github/workflows/release.yml` is `continue-on-error` and skips itself
 entirely when the service account secret is absent. A fork, or a rejected
 upload, must not be what makes a release fail. `hack/release --no-play`
@@ -314,8 +314,8 @@ The upload runs `fastlane android internal` with
 other apps on the account; it needs *Release to testing tracks* on Liseur
 under Users and permissions.
 
-A build that is already on internal — a release whose Play step was
-skipped, or one that predates the promotion — can be pushed across
+A build that is already on internal, a release whose Play step was
+skipped, or one that predates the promotion, can be pushed across
 without rebuilding:
 
 ```bash
@@ -337,7 +337,7 @@ app isn't available":
   its own reference says email lists are not supported by the resource.
   That address goes on by hand in the console, and nothing here can do it
   for you.
-- **A Google Group is not an addition to that list, it is a replacement.**
+- The console accepts either an email list or a Google Group, not both.
   The console offers Email and Google Groups as one choice, not two, and
   the API has only a `googleGroups[]` field. Attaching a group cuts off
   every tester already on the email list until each of them joins it,
@@ -345,7 +345,7 @@ app isn't available":
   down. Two things are worth knowing before reaching for one anyway: the
   trap that made the group fail before is avoidable, because a consumer
   group's owner can *directly* add members rather than wait on join
-  requests, but a group still buys no automation — consumer
+  requests, but a group still buys no automation. Consumer
   `@googlegroups.com` membership has no API of any kind, Admin SDK and
   Cloud Identity both being Workspace-only, so it moves the clicking from
   one web UI to another.
@@ -375,14 +375,14 @@ The service account holds *Release to testing tracks*, which covers
 everything in this repository: uploads, promotions, and every read
 `hack/store-status` makes. It deliberately does not hold *Manage testing
 tracks and edit tester lists* (`CAN_MANAGE_TRACK_USERS_GLOBAL`), the
-permission `edits.testers.update` would need — nothing automated has any
+permission `edits.testers.update` would need. Nothing automated has any
 business rewriting who may install the app, and while the track runs off
 an email list that call could not help anyway.
 
 Only the changelog is pushed from the repository. The store listing is
 edited in the console, because Play holds declarations that no file here
-describes — data safety, content rating, target audience, app access, ads
-— and those have to be revisited whenever the app gains a permission,
+describes (data safety, content rating, target audience, app access, ads),
+and those have to be revisited whenever the app gains a permission,
 talks to something new, or changes what it stores. The privacy policy
 Play links to is `docs/PRIVACY.md`, served by GitHub Pages from `main`
 `/docs`; it is a published legal document, so change it in a commit and
@@ -421,11 +421,12 @@ console, and the temporary directory goes away afterwards.
 Two things are written for every release, and they are not the same
 thing:
 
-- The **F-Droid changelog**, `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`.
+- The F-Droid changelog is
+  `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`.
   Written by hand, capped at 500 characters, and passed to
   `hack/release` as the release notes argument. This is what F-Droid
   shows.
-- The **GitHub release notes**, generated during the release by
+- The GitHub release notes are generated during the release by
   `hack/generate-release-notes`. It asks Gemini to turn the commits
   since the previous tag into something a reader would want to read,
   using the hand-written changelog as the summary to lead with. It also
@@ -440,7 +441,7 @@ fall back to the hand-written changelog, so a release is never held up
 by this. The key comes from `pass` under `google/gemini-api` and is
 uploaded to the release environment by `hack/release --sync-secrets`.
 
-The notes can be rewritten after the fact — the body of a release stays
+The notes can be rewritten after the fact: the body of a release stays
 editable even though its tag and assets do not:
 
 ```bash
@@ -515,15 +516,15 @@ space.
 There are two sets, because fastlane and F-Droid publish
 `phoneScreenshots` and `tenInchScreenshots` separately and the README
 embeds the phone set by name. Which one a run writes is decided by how
-wide the device is — under 600dp phone, above it tablet — so a capture
+wide the device is (under 600dp phone, above it tablet), so a capture
 against a tablet cannot quietly overwrite the phone images. Pass
 `--class` for a device whose shape does not match how its pictures
 should be filed.
 
 The phone set is the full tour, seventeen screens, gathered on
 `docs/SCREENSHOTS.md`; the README shows three of them. The tablet set is
-three pictures of what a phone cannot show — two columns, the control
-that chooses them, and a shelf with room on it — and lands in
+three pictures of what a phone cannot show (two columns, the control
+that chooses them, and a shelf with room on it) and lands in
 `docs/screenshots/tablet`. There is no point photographing the settings
 screen twice, and the search and dictionary steps that make the phone
 run slow are skipped, so a tablet run takes a few minutes.
@@ -547,7 +548,7 @@ The definition card is the one capture that needs the device to reach
 something: the run turns the lookup on in Settings, presses words until
 one comes back with senses on it, and puts the switch back where it found
 it. It used to keep the previous image and carry on when nothing came
-back, which is how a stale picture survived several releases — it now
+back, which is how a stale picture survived several releases. It now
 fails. `--no-dictionary` is how to say an offline run was expected.
 
 `--empty` is its own mode, and short: the empty library is the one screen
@@ -560,8 +561,8 @@ Everything that gets published is in the light theme. A dark screenshot
 in a store listing reads as the app looking like that, rather than as the
 app being able to; the dark theme earns more as a line in the description
 than as one picture in six that matches none of the others. The script
-still captures `11-reading-dark` and `17-empty-library-dark` — they are
-useful to look at — it just does not file them with fastlane or the
+still captures `11-reading-dark` and `17-empty-library-dark`, which are
+useful to look at, but it just does not file them with fastlane or the
 README.
 
 Sign out of calibre-web first unless your server holds only books you
@@ -579,25 +580,25 @@ montage docs/screenshots/*.png -tile 6x2 -geometry 320x+6+6 /tmp/sheet.png
 See `AGENTS.md` for the layered package layout and project conventions.
 Key decisions:
 
-- **Readium Kotlin Toolkit** (`readium-shared`, `readium-streamer`,
+- Readium Kotlin Toolkit (`readium-shared`, `readium-streamer`,
   `readium-navigator`, `readium-opds`) does EPUB parsing, rendering, and
-  OPDS feed parsing. `readium-lcp` is deliberately excluded (proprietary
-  liblcp — incompatible with F-Droid).
-- **calibre-web** integration is two protocols: OPDS for browse/search/
+  OPDS feed parsing. `readium-lcp` is deliberately excluded, since it
+  depends on the proprietary liblcp, incompatible with F-Droid.
+- calibre-web integration is two protocols: OPDS for browse/search/
   download, and the Kobo sync protocol (`/kobo/<token>/v1/...`) for
   reading-position sync, exchanging percentage progression like KOReader
   does.
-- **Komga** integration is Komga's own REST API: `POST
+- Komga integration is Komga's own REST API: `POST
   /api/v1/books/list` to browse, `GET /api/v1/books/{id}/file` to
   download, and `GET`/`PUT /api/v1/books/{id}/progression` to sync a
   full Readium locator rather than a percentage.
-- **One server at a time.** `data/remote/` holds provider-neutral
+- One server is connected at a time. `data/remote/` holds provider-neutral
   contracts (`CatalogSource`, `FileSource`, `ServerSetup`,
   `PositionSync`); `data/calibre/` and `data/komga/` implement them, and
   `RemoteRouter` picks the implementation from the connected server's
   `ServerKind`. `domain/ReadingStateMerge.kt` is shared by both, so the
   conflict rules are written once.
-- **Single `:app` module**, manual DI composition root, `ViewModel` +
+- Single `:app` module, manual DI composition root, `ViewModel` +
   `StateFlow`, Room + DataStore for persistence.
 
 ## calibre-web protocols
@@ -635,9 +636,9 @@ against the calibre-web source (`cps/opds.py`, `cps/kobo.py`,
 
 - Downloads honour `Range` (206) and send `ETag`, `Last-Modified` and a
   UTF-8 `Content-Disposition` filename, so resumable downloads work.
-- **A user without the "Allow Downloads" permission gets 401 on
+- A user without the "Allow Downloads" permission gets 401 on
   `/opds/download/...` (403 on the web UI route) while browsing keeps
-  working.** The app must recognise that case and tell the user to enable
+  working. The app must recognise that case and tell the user to enable
   that permission for their account in calibre-web, rather than showing a
   generic failure.
 
@@ -646,7 +647,7 @@ against the calibre-web source (`cps/opds.py`, `cps/kobo.py`,
 Off by default; the admin enables it in Feature Configuration, then each
 user creates a token from their profile page ("Kobo Sync Token"), which
 yields a base URL of the shape `https://host/kobo/<32 hex chars>`. The
-token is the only credential — it never expires and there is no user
+token is the only credential; it never expires and there is no user
 agent or device check.
 
 - `GET /v1/library/sync` returns a JSON array of entities:
@@ -658,8 +659,8 @@ agent or device check.
   when more pages remain. Sending the previous token returns only what
   changed since.
 - `GET|PUT /v1/library/<uuid>/state` reads and writes the reading
-  position. **The PUT handler indexes its keys directly, so
-  `CurrentBookmark`, `Statistics` and `StatusInfo` must all be present**
+  position. The PUT handler indexes its keys directly, so
+  `CurrentBookmark`, `Statistics` and `StatusInfo` must all be present
   (any of them may be `null`); omitting one returns 400:
 
   ```json
@@ -696,14 +697,14 @@ against `BookLifecycle.kt` on master. Every rejection below was provoked
 deliberately rather than read off the schema.
 
 - Auth is `X-API-Key: <key>`, created in Komga's web UI. Identity is
-  `GET /api/v2/users/me` → `{id, email, roles[]}`; there is no
+  `GET /api/v2/users/me` -> `{id, email, roles[]}`; there is no
   `/api/v1/users/me`. `FILE_DOWNLOAD` in `roles` means the account may
   download. Users paste the API-key *page* address, so setup reduces a
   pasted URL to its origin.
 - Browse is `POST /api/v1/books/list?page=&size=&sort=` with an EPUB +
   READY condition; `GET /api/v1/books` is deprecated since 1.19.0. Each
   entry carries `readProgress {page, completed, readDate}` inline, which
-  is the change detector — a routine sync costs one request.
+  is the change detector: a routine sync costs one request.
 - Search is the same endpoint with `fullTextSearch` set, a sibling of
   `condition`.
 - `PUT /progression` validates, in order: `modified` strictly after the
@@ -711,14 +712,14 @@ deliberately rather than read off the schema.
   URL-decoded, exactly matching an internal EPUB file name, with **no**
   leading slash (else `400`); and `locations.progression`, which is
   required. Our `totalProgression` is ignored and recomputed.
-- **There is no page-based fallback.** `PATCH read-progress {"page": N}`
+- There is no page-based fallback. `PATCH read-progress {"page": N}`
   is rejected for reflowable EPUB ("not Divina compatible"); only
   `{"completed": true}` works. On a `400` the client instead fetches
   `GET /api/v1/books/{id}/positions` and snaps to the nearest position
   Komga already knows, keeping the position rather than coarsening it.
   That index is ~330 KB for an ordinary book, so it is only ever fetched
   after a rejection.
-- **`409` is not a failure.** The server holds something at least as
+- `409` is not a failure. The server holds something at least as
   new; the row stays dirty and the next run pulls and reconciles.
 - `GET /progression` answers `204` with an empty body when there is no
   progress. A `404` means the book is unknown, and *is* a failure.
@@ -738,32 +739,32 @@ what lets it sync a book that came off an SD card.
 
 - Auth is `Authorization: Bearer <token>`. `POST /v1/login` with a
   username and password mints device tokens through `POST /v1/tokens`;
-  one scope per token, so signing in asks for two — `sync` and
-  `read-insights` — and a reader who pastes a token made elsewhere
+  one scope per token, so signing in asks for two, `sync` and
+  `read-insights`, and a reader who pastes a token made elsewhere
   usually has only the first. Statistics are simply absent then.
-- **The cursor is the only irreplaceable state.** Everything else can
+- The cursor is the only irreplaceable state. Everything else can
   be asked for again, but ops behind `sync_account.cursor_seq` cannot.
   So a page from `GET /v1/changes?since=` is written and the cursor
   advanced in one transaction, never the other way round. A cursor that
   has fallen below the server's compaction horizon gets `410
   resync_required`; the answer is `GET /v1/heads` and its
   `snapshot_seq`.
-- **Ids are derived, not drawn.** The server treats `op_id` and
+- Ids are derived, not drawn. The server treats `op_id` and
   `session_id` as idempotency keys and compares the whole payload
   behind each: same id and same payload is `duplicate`, same id and a
   different payload is a conflict. So the id is
   `UUIDv3(deviceKey|workId|revision)` and every payload field comes
-  from stored state — `client_ts` is `reading_progress.updated_at`,
+  from stored state: `client_ts` is `reading_progress.updated_at`,
   never the clock. A push interrupted by a dead network is simply
   repeated. The server does not check that the id is a UUIDv7; it is
   opaque, up to 64 characters.
-- `POST /v1/works/resolve` takes every identifier at once — `sha256:`,
-  `pmd5:` (KOReader's partial MD5), `dc:` and `ta:` — and registers all
+- `POST /v1/works/resolve` takes every identifier at once (`sha256:`,
+  `pmd5:` (KOReader's partial MD5), `dc:` and `ta:`) and registers all
   of them against whichever matched, which is how a re-encoded copy and
   the original converge. `409` means they named two different works;
   the server changes nothing and merging is left to the reader.
-- **`ta:` normalisation is an interoperability contract and is not in
-  the schema.** The server matches `ta` aliases by exact string and
+- `ta:` normalisation is an interoperability contract and is not in
+  the schema. The server matches `ta` aliases by exact string and
   computes nothing itself. `WorkIdentifiers.titleAuthor` defines it as
   `fold(title)|fold(author)`, where folding is NFKD, strip `\p{Mn}`,
   lowercase, non-alphanumerics collapsed to single spaces, trimmed. Any
@@ -779,13 +780,13 @@ what lets it sync a book that came off an SD card.
   fractions. **Never send page numbers**: a page is a property of one
   rendering of one edition at one type size, and the server derives
   pages itself when it knows the edition. `idle_ms` is always zero here
-  and honestly so — time is counted only while the reader is in the
+  and honestly so: time is counted only while the reader is in the
   foreground, so time spent elsewhere is already absent rather than
   included and subtracted.
 - Statistics (`/v1/insights/*`) are decoration. Every failure is null
   and silent, and a null `eta_seconds` is carried through untouched: no
   estimate beats an invented one.
-- **Uploading is opt-in twice over.** The server advertises the
+- Uploading is opt-in twice over. The server advertises the
   `library-upload` scope on `GET /v1/token` and marks the folders that
   take uploads in `GET /v1/folders`; without both, the action is not
   offered at all, which is how an older server needs no version check.
@@ -794,7 +795,7 @@ what lets it sync a book that came off an SD card.
   stores nothing twice. `202` means the bytes are safe but the server
   had not catalogued them yet; the worker simply asks again, and the
   digest makes the second ask free.
-- **What follows an upload is adoption, not replacement.** The local row
+- What follows an upload is adoption, not replacement. The local row
   keeps its own `url` and gains `remote_uuid` and `download_href`
   (`BookDao.linkToRemote`). Rewriting the URL to the server's spelling
   would take every reading position, annotation and session with it.
@@ -805,10 +806,10 @@ what lets it sync a book that came off an SD card.
 
 ## F-Droid readiness
 
-- **Dependencies are all FOSS**, from Maven Central or Google's Maven.
+- Dependencies are all FOSS, from Maven Central or Google's Maven.
   In particular `readium-lcp` is deliberately absent: it pulls in the
   proprietary liblcp. The list users see is in `LicencesScreen.kt`.
-- **No trackers or analytics**, and no Google Play services. The only
+- No trackers or analytics, and no Google Play services. The only
   outbound traffic is to the calibre-web or Komga server the user
   configured, and to a dictionary site when a definition is asked for.
   That second one is off until switched on in Settings and the site is
@@ -817,30 +818,30 @@ what lets it sync a book that came off an SD card.
   TetheredNet anti-feature. Together those justify `INTERNET`;
   `ACCESS_NETWORK_STATE` is there for the `NetworkType.CONNECTED`
   constraint on the sync workers.
-- **No non-free assets.** The bundled fonts (Literata, Vollkorn, Atkinson
+- No non-free assets. The bundled fonts (Literata, Vollkorn, Atkinson
   Hyperlegible, Inter) are all OFL; the icon is drawn in-repo as vector
   drawables.
-- **`fonts.googleapis.com` appears in the release dex and is unreachable.**
+- `fonts.googleapis.com` appears in the release dex and is unreachable.
   It is a string inside Readium's `ReadiumCss`, emitted only for families
   registered through `EpubNavigatorFactory`'s separate `googleFonts` list.
   Liseur never sets that list: every `addFontFamilyDeclaration` in
   `ReaderPreferencesMapper.kt` sources its faces from bundled asset paths.
   Worth knowing, because a reviewer grepping the dex for hosts will find
   it and ask.
-- **Reproducible versioning**: `versionCode` and `versionName` only ever
+- Reproducible versioning: `versionCode` and `versionName` only ever
   change in a `chore: release vX.Y.Z` commit made by `hack/release`, and
   every release is tagged. F-Droid's `UpdateCheckMode: Tags` still
   notices a new tag, but `AutoUpdateMode` is `None`: under dual signing
   (below) every release needs its extracted signature delivered by hand,
   which their bot cannot do yet, so `hack/release` opens that merge
   request itself.
-- **Metadata lives in the repo** under
+- Metadata lives in the repo under
   `fastlane/metadata/android/en-US/`: title, descriptions, per-versionCode
   changelogs, icon and screenshots.
-- **The build needs no network beyond Gradle dependencies** and no
+- The build needs no network beyond Gradle dependencies and no
   signing config: `assembleRelease` on a clean checkout produces an
   unsigned APK, which is what F-Droid builds and signs itself.
-- **The build is reproducible.** F-Droid rebuilds from source and will
+- The build is reproducible. F-Droid rebuilds from source and will
   not publish a build it cannot reproduce, so `hack/verify-reproducible`
   builds the release APK twice from two clean checkouts at deliberately
   different paths and compares the two byte for byte:
@@ -862,13 +863,13 @@ what lets it sync a book that came off an SD card.
   embed a dependency manifest encrypted for Google Play, which nobody
   else can reproduce), and `packaging.jniLibs.keepDebugSymbols` covers
   every `.so` (the only native code arrives prebuilt in AndroidX AARs;
-  re-stripping it ties the bytes to the build machine's NDK — this was
+  re-stripping it ties the bytes to the build machine's NDK: this was
   the one thing that made the CI APK differ from a local rebuild).
-- **Publishing our own signature: dual signing (merged 2026-08-21).**
+- Publishing our own signature: dual signing (merged 2026-08-21).
   Because the build is reproducible, F-Droid can publish the
   developer signature. Replacing their signature outright was declined
-  in review — existing F-Droid installs carry F-Droid's key and Android
-  would refuse them every further update — so the app uses F-Droid's
+  in review, since existing F-Droid installs carry F-Droid's key and Android
+  would refuse them every further update, so the app uses F-Droid's
   dual-signing flow instead: for each version F-Droid publishes **two
   APKs**, one signed with its own key (existing users keep updating,
   nothing breaks) and one carrying our signature, grafted onto F-Droid's
@@ -876,7 +877,7 @@ what lets it sync a book that came off an SD card.
   New installs from F-Droid get the developer-signed copy, which is
   interchangeable with the GitHub release. Concretely, the metadata has:
 
-  - `AllowedAPKSigningKeys:` with **two** SHA-256 digests — our
+  - `AllowedAPKSigningKeys:` with **two** SHA-256 digests: our
     certificate and the key F-Droid signs this app with (their reviewer
     added the second; both APKs must pass the check).
   - `AutoUpdateMode: None`: their bot cannot drive this flow, so every
@@ -900,12 +901,12 @@ what lets it sync a book that came off an SD card.
   the developer-signed twin. NewPipe
   ([fdroiddata!46133](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/46133))
   is the worked example this follows.
-- **Checking where things stand.** `hack/store-status` prints the
+- Checking where things stand. `hack/store-status` prints the
   published versions, the index age, what the last build run did with
   the app, the upstream metadata, and any open merge request with its
-  pipeline state — alongside the GitHub releases and the Play tracks,
+  pipeline state, alongside the GitHub releases and the Play tracks,
   so one command answers what each of the three channels is showing.
-- **Submitted.** The inclusion merge request was
+- Submitted. The inclusion merge request was
   [fdroiddata!44292](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/44292)
   (merged), and `hack/release` opens the per-release signature merge
   request described above. See *What F-Droid checks* above for what its

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -42,27 +42,27 @@ not copy your books anywhere.
 
 ## Network access
 
-Liseur talks to exactly two kinds of address, both of which are yours to
-choose:
+Liseur talks to exactly two kinds of address, both chosen by you.
 
-**Your book server.** If, and only if, you connect one, Liseur talks to
-the calibre-web, Komga or liseur-sync server whose address you typed in.
-It sends the credentials that server asked for, downloads the books and
-covers you request, and exchanges your reading position so the same book
-resumes in the right place on another device. That server is operated by
-you or by whoever you chose to trust; this policy does not cover what it
-does with the data it receives.
+### Your book server
 
-**A dictionary site, if you enable it.** Looking a word up online is off
-by default. When you switch it on, Liseur sends the single selected word
-to the dictionary site configured in Settings — by default the public
-Wiktionary API — over HTTPS. No identifier, no book title and no account
-accompanies it. You may point this at any Wiktionary edition or mirror,
-or leave the feature off and hand words to an offline dictionary app
-installed on your device instead. When you pick or type a dictionary
-site in Settings, Liseur checks it once with a fixed word ("book") so a
-dead address fails there and then; no request is made just for opening
-the screen.
+If you connect a book server, Liseur talks to the calibre-web, Komga or
+liseur-sync server whose address you entered. It sends the credentials that
+server asked for, downloads the books and covers you request, and exchanges
+your reading position so the same book resumes in the right place on another
+device. You operate that server, or someone you trust does. This policy does not
+cover what the server does with the data it receives.
+
+### A dictionary site, if you enable it
+
+Looking a word up online is off by default. When you switch it on, Liseur
+sends the single selected word to the dictionary site configured in Settings,
+by default the public Wiktionary API, over HTTPS. No identifier, book title
+or account accompanies it. You may point this at any Wiktionary edition or
+mirror, or leave the feature off and hand words to an offline dictionary app
+installed on your device instead. When you pick or type a dictionary site in
+Settings, Liseur checks it once with a fixed word ("book"). A dead address
+fails then, and opening the screen makes no request.
 
 Liseur never contacts any other host. It requests the `INTERNET` and
 `ACCESS_NETWORK_STATE` permissions for the two purposes above and for
@@ -73,11 +73,11 @@ nothing else.
 Liseur takes part in Android's standard backup, so your library, reading
 positions, highlights, notes and settings can follow you to a new device.
 That backup is handled by Android and stored in your own Google account,
-under Google's terms, not the developer's — Liseur has no access to it.
+under Google's terms, not the developer's. Liseur has no access to it.
 Downloaded book files and generated covers are deliberately excluded.
 Server credentials are included but arrive unreadable on a new device,
-because the key that encrypts them never leaves the old one; Liseur
-notices this and asks you to sign in again.
+because the key that encrypts them never leaves the old one. Liseur notices
+this and asks you to sign in again.
 
 You can turn this off in your device's backup settings.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,7 +18,7 @@ those decisions live in [`adr/`](adr/), starting from
 A restored backup carries the database and the settings across, but not
 the credentials: they are sealed with a key that never leaves the
 original device's keystore. `forgetUnreadableAccount()` notices this on
-launch and drops the account row, which is correct but silent — the user
+launch and drops the account row, which is correct but silent. The user
 just finds themselves signed out with no explanation.
 
 Tell them once, on the calibre-web screen, that credentials cannot travel
@@ -127,17 +127,17 @@ an emulator in CI, which is why it has not happened yet.
 
 Recorded so they do not get raised again without new evidence.
 
-- **Splitting up `ReaderViewModel`.** It is around 500 lines and every
+- Splitting up `ReaderViewModel`. It is around 500 lines and every
   part of it belongs to the same reading session. Splitting it now would
   be refactoring for its own sake. Revisit if a second reader surface or
   a second format arrives.
-- **Interfaces in front of the repositories, or several Gradle modules.**
+- Interfaces in front of the repositories, or several Gradle modules.
   The manual composition root in `AppContainer.kt` is a deliberate
   choice: no Hilt, no Koin, no indirection that only exists for tests.
   The pure logic that needs testing already lives in `domain/`.
-- **Bundling an offline dictionary.** Several megabytes of APK and a
+- Bundling an offline dictionary. Several megabytes of APK and a
   licensing problem for F-Droid, to replace a handoff that already works
   with whichever dictionary the user has installed.
-- **Counting local books in the storage figure.** The settings screen
+- Counting local books in the storage figure. The settings screen
   reports what Liseur has downloaded and therefore what it can free.
   Books in the user's own folder are not Liseur's to count or to reclaim.

--- a/docs/SERVER_CAPABILITIES.md
+++ b/docs/SERVER_CAPABILITIES.md
@@ -27,8 +27,8 @@ side.
 | File download | `GET /api/v1/books/{id}/file` | `KomgaFileSource` | Requires `FILE_DOWNLOAD` role, checked at setup |
 | Position sync | `GET/PUT /api/v1/books/{id}/progression` (R2Progression), `PATCH/DELETE .../read-progress`, `GET .../positions` | `KomgaSyncRepository` via `KomgaProgressionClient` | Full Readium locators with position snapping. Bidirectional, uses shared `reconcileReadingState` |
 | Series metadata | `GET /api/v1/series/{id}` | `KomgaSeriesClient` | On-demand |
-| Book upload | No remote upload API. `POST /api/v1/books/import` accepts JSON with server-side filesystem paths (transient books scanned from a local folder). The only multipart endpoints are for poster/thumbnail images | Not implemented | Not possible from a remote client — Komga's design is filesystem-first, books are placed in library folders and scanned |
-| Book delete | No client-facing delete API | Not implemented | Intentionally hidden — deleting a file is an administrator's job |
+| Book upload | No remote upload API. `POST /api/v1/books/import` accepts JSON with server-side filesystem paths (transient books scanned from a local folder). The only multipart endpoints are for poster/thumbnail images | Not implemented | Not possible from a remote client. Komga's design is filesystem-first: books are placed in library folders and scanned |
+| Book delete | No client-facing delete API | Not implemented | Intentionally hidden. Deleting a file is an administrator's job |
 
 **Capability detection:** `KomgaSetupClient` probes `GET /api/v2/users/me`
 and reads roles. Only `FILE_DOWNLOAD` is currently checked; `canUpload`
@@ -45,7 +45,7 @@ provisioned during setup.
 | Search | `/opds/search?query=` | `CalibreCatalogClient.search()` | |
 | File download | OPDS acquisition links, fallback `/opds/download/{id}/epub/` | `CalibreFileSource` | Uses stored `downloadHref` from the OPDS feed, with a derived fallback |
 | Position sync | Kobo protocol: `/v1/library/sync`, `/v1/library/{uuid}/state` | `KoboSyncRepository` via `KoboClient` | Percentages only, no full locators. Bidirectional, shares `reconcileReadingState`. Kobo token provisioned at setup via a web session |
-| Book upload | Web UI form at `/upload` — multipart POST behind a session cookie and CSRF token, admin permission required | Not implemented | Not a real API: uploading would mean logging in like a browser (`CalibreWebSession`), fetching a CSRF token, and posting to a web UI route. The pattern exists for delete, but it is fragile and considered out of scope for upload |
+| Book upload | Web UI form at `/upload`; multipart POST behind a session cookie and CSRF token, admin permission required | Not implemented | Not a real API: uploading would mean logging in like a browser (`CalibreWebSession`), fetching a CSRF token, and posting to a web UI route. The pattern exists for delete, but it is fragile and considered out of scope for upload |
 | Book delete | Web UI form: `POST /delete/{bookId}` with session cookie and CSRF | `CalibreDeleteClient` via `CalibreBookDeleter` | Works through `CalibreWebSession.logIn()`; checks for the login-page-as-200 pattern that a refused session returns |
 
 **Capability detection:** `CalibreSetupClient` probes `/opds` for the
@@ -87,12 +87,12 @@ into Grimmory with.
 
 Two things have to be set up in Grimmory first, both as an administrator:
 
-1. **Settings → OPDS**: create an OPDS user and share the libraries you want
+1. **Settings -> OPDS**: create an OPDS user and share the libraries you want
    on your phone with it. This is the login Liseur uses; an ordinary
    Grimmory account will not work.
 2. **Settings**: switch the Komga API on. It is off by default.
 
-Then in Liseur, **Settings → Book server → Grimmory**: the address of your
+Then in Liseur, **Settings -> Book server -> Grimmory**: the address of your
 Grimmory server (the same one you open in a browser, with the `/komga` path
 added for you) and the OPDS user's name and password.
 
@@ -118,18 +118,17 @@ the Komga client does would refuse every download.
 **A walk that is not understood does not prune.** `dropVanished()` deletes
 every catalogued book a completed walk did not see, taking its reading
 progress with it. So `GrimmoryCatalogClient` reports `complete = false` for
-anything it cannot account for — a page that does not describe itself, one
+anything it cannot account for: a page that does not describe itself, one
 shorter than the count it declared, a catalog whose size changed between
 pages, the same book counted twice, a `content` field that is not an array,
 an unparseable id, a media type this build has never heard of, or a whole
-catalog that filtered down to nothing — rather than letting a changed
-response read as an emptied library.
+catalog that filtered down to nothing. This prevents a changed response
+from being read as an emptied library.
 
 ## Custom (OPDS, KOReader sync, or one of the two)
 
-Not a product but a standard, and a way in for the servers nobody has
-written a client for: Calibre's own content server, COPS, Kavita, a
-static feed on a NAS. See
+Custom is a standard-based connection for servers with no dedicated client:
+Calibre's own content server, COPS, Kavita, or a static feed on a NAS. See
 [`adr/0015-custom-server.md`](adr/0015-custom-server.md).
 
 A Custom connection holds two addresses and either may be left blank:
@@ -137,16 +136,16 @@ an OPDS catalog root, and a KOReader sync (kosync) server. Filling in
 both is the ordinary case; a catalog with no sync and a sync server with
 no catalog are both real.
 
-**Auth:** Basic, or none at all — plain OPDS is often open, and a blank
+**Auth:** Basic or none at all. Plain OPDS is often open, and a blank
 username and password are stored as an anonymous credential rather than
 as a missing one. The kosync half keeps its own login and stores a
 derived key, never a password.
 
 ### Connecting to one
 
-In Liseur, **Settings → Book server → Custom**:
+In Liseur, **Settings -> Book server -> Custom**:
 
-1. **OPDS catalog address** — the server *root*, not a books path.
+1. **OPDS catalog address:** the server *root*, not a books path.
    Liseur walks the navigation feeds from there to find the shelves.
 2. **Username and password**, if the catalog asks for them. Both blank
    means an open catalog.
@@ -163,23 +162,23 @@ a previous server.
 | Catalog browse | Any Atom/OPDS 1.x feed | `OpdsCatalogClient` | Starts at the root and walks navigation entries breadth-first, following each `next` chain. Bounded by a visited set, a depth limit of 4 and a budget of 400 requests; a walk stopped by a bound reports `complete = false` and prunes nothing |
 | Search | OpenSearch description document, advertised per server | Returns nothing | The description is not at a path that can be guessed and every server fills it in differently. Liseur's library search is local and covers the whole catalog, which is walked into the database anyway |
 | File download | The entry's acquisition link | `OpdsFileSource` | Only DRM-free EPUB (`application/epub+zip`, `application/x-kobo-epub+zip`, or a link that states no type). `buy`, `borrow`, `sample` and `subscribe` are not downloads. An entry with no usable format is listed without a download rather than dropped |
-| Position sync | None — OPDS carries no reading state | `KosyncPositionSync`, paired on the same screen | Percentages only, matched by file hash. With no OPDS address, the pairing covers the books already on the device instead of a catalog's |
+| Position sync | None. OPDS carries no reading state | `KosyncPositionSync`, paired on the same screen | Percentages only, matched by file hash. With no OPDS address, the pairing covers the books already on the device instead of a catalog's |
 | Series metadata | calibre-style `SERIES: Name [n]` in the entry's content block, where a server writes it | Parsed opportunistically | No standard field exists |
 | Book upload / delete | Not part of OPDS 1.x | Not implemented | |
 
 **Capability detection:** `OpdsSetupClient` fetches the root and requires
-it to parse as an Atom `<feed>` — a sign-in page answering 200 with HTML
-is well-formed XML and would otherwise be accepted as a catalog. What is
-stored is the URL that *answered*, so a root that redirects is not
-redirected again on every refresh. `canDownload` is true even for a root
-that lists only shelves: the books are a walk away.
+it to parse as an Atom `<feed>`. A sign-in page answering 200 with HTML is
+well-formed XML and would otherwise be accepted as a catalog. What is stored
+is the URL that *answered*, so a root that redirects is not redirected again
+on every refresh. `canDownload` is true even for a root that lists only
+shelves: the books are a walk away.
 
 **The catalog's password goes to the catalog's origin and nowhere else.**
-A feed is written by someone else and may point anywhere — OPDS is
-federated, so pointing at another host is a feature. Links outside the
-configured origin are still followed, unsigned. Redirects are walked by
-hand so the decision is made before each hop rather than after, and an
-https catalog is never followed down to http.
+A feed is written by someone else and may point anywhere. OPDS is federated,
+so pointing at another host is a feature. Links outside the configured
+origin are still followed, unsigned. Redirects are walked by hand so the
+decision is made before each hop rather than after, and an https catalog is
+never followed down to http.
 
 **A book carries the catalog that issued it.** Entry ids are opaque and
 unique only within their own feed, so `books.url` is
@@ -201,7 +200,7 @@ Already in place, independent of any one server:
 - `BookUploader` interface (`RemoteSources.kt`).
 - `BookUploadWorker`, a WorkManager `CoroutineWorker` that resolves the
   local file, picks a folder, calls the uploader, and adopts the result.
-- `BookUploadRepository` — enqueue/cancel/inFlight via WorkManager.
+- `BookUploadRepository`: enqueue/cancel/inFlight via WorkManager.
 - `ServerCapabilities.canUpload`, detected at setup and stored on
   `RemoteServer.can_upload`.
 - `UploadPolicy` (ASK / ALWAYS / NEVER).
@@ -214,9 +213,9 @@ Already in place, independent of any one server:
 **Known issue:** `BookUploadWorker.adopt()` hardcodes
 `downloadHref = "/v1/books/$remoteBookId/download"`, which is
 liseur-sync's path shape. If a second server ever gets upload support,
-this needs to be parameterised — e.g. `ServerUploadResult.Uploaded`
-carrying its own `downloadHref`, since Komga and calibre-web each use a
-different path.
+this needs to be parameterised, for example with
+`ServerUploadResult.Uploaded` carrying its own `downloadHref`, since Komga
+and calibre-web each use a different path.
 
 ## Delete infrastructure
 

--- a/docs/adr/0001-advanced-reading-menu.md
+++ b/docs/adr/0001-advanced-reading-menu.md
@@ -39,7 +39,7 @@ gesture or fold into something that already exists:
   action in the selection popup, switched on from the dictionary
   settings that already exist.
 - The tap-zone preset ([ADR 9](0009-tap-zone-customization.md)) is a
-  chip row in Settings → Reading, beside the volume-key switch it is
+  chip row in Settings -> Reading, beside the volume-key switch it is
   the thumb's version of. Not a reading-comfort setting after all: it
   is how the device is held, set once when the app is set up, and it
   belongs with the other page-turning hardware rather than with the
@@ -67,9 +67,9 @@ other three arrive with their own issues.
 
 The typography sheet did grow anyway, one reasonable row at a time,
 until it carried eleven controls and the Advanced row held one. Six of
-them have since moved behind Advanced — line height, page margins,
+them have since moved behind Advanced: line height, page margins,
 columns, the footer mode, the page-turn animation and the
-just-this-book toggle — leaving the first sheet the five answers a
+just-this-book toggle, leaving the first sheet the five answers a
 reader changes often: the theme, the size, the light, the face, and
 whether the book is read by scrolling or by turning pages. Keeping the
 screen awake stays there too, being a thing a reader reaches for
@@ -78,13 +78,13 @@ mid-chapter.
 The Advanced row is no longer conditional. It was hidden in a paginated
 book while auto-scroll was all that lived behind it, because the way in
 to an empty sheet is worse than no way in; with six more rows there, it
-cannot be empty. The rows that do not apply still hide themselves —
+cannot be empty. The rows that do not apply still hide themselves:
 auto-scroll only in a scrolled book, the page-turn animation only in a
 paginated one, columns only when there is width for two.
 
-Settings → Reading appearance shows five of the six without a book —
-the just-this-book toggle needs a book to set apart, and there is none
-here — and not behind a collapsed section: that screen has nothing else
+Settings -> Reading appearance shows five of the six without a book (the
+just-this-book toggle needs a book to set apart, and there is none
+here) and not behind a collapsed section: that screen has nothing else
 competing for room, so there is no empty-sheet problem to avoid, and a
 reader who came looking for the margins should not have to open
 anything to find them. The typography sheet still collapses them, being
@@ -104,7 +104,7 @@ first sheet rather than simply land there.
 The Settings screen went the way this ADR describes the sheet going.
 Its Reading section had grown to eight switches, a chip row and two
 rows that only some devices show, so it moved behind a single row into
-**Settings → Reading & navigation**
+**Settings -> Reading & navigation**
 (`ui/settings/ReadingNavigationScreen.kt`), taking the dictionary
 section with it. Reading appearance is unchanged and still holds how
 the page looks; the tap-zone chip row named above is now on the new

--- a/docs/adr/0002-typography-fine-tuning.md
+++ b/docs/adr/0002-typography-fine-tuning.md
@@ -15,7 +15,7 @@ the difference between using the app and not.
 ## Decision
 
 Expose alignment, hyphenation, letter spacing, word spacing, paragraph
-spacing and font weight as rows in the Advanced sheet, and on Settings →
+spacing and font weight as rows in the Advanced sheet, and on Settings ->
 Reading appearance, which has no Advanced section to collapse them
 behind.
 
@@ -43,7 +43,7 @@ because those are what render our pages. Re-check on upgrade.
 `publisherStyles = false` becomes `--USER__advancedSettings:
 readium-advanced-on`, and turning it on **unconditionally restyles
 `:root`, `h1`–`h6`, `p`, `li`, `dd`, `div`, `pre`, `small`, `sub` and
-`sup`** — it normalizes the whole type scale and overrides the sizes the
+`sup`**; it normalizes the whole type scale and overrides the sizes the
 book's designer chose, whatever else is set. It is a large price, and it
 is worth paying only for a setting the reader asked for *and* the book
 can honour.
@@ -53,13 +53,13 @@ Audited property by property in the bundled default stylesheet:
 | Property | Gated on `readium-advanced-on` |
 | --- | --- |
 | `lineHeight`, `textAlign`, `bodyHyphens`, `letterSpacing`, `wordSpacing`, `paraSpacing` | **yes** |
-| `pageMargins`, `fontSize` | no — they work without it |
+| `pageMargins`, `fontSize` | no; they work without it |
 | `fontWeight` | no rule at all; it rides the user-properties `overrides` map |
 
 **This is a behaviour change: page margins used to turn advanced styles
 off and no longer does.** A reader who had only widened their margins
 was losing their book's heading sizes for nothing. Readium's own
-`EpubPreferencesEditor` corroborates it — it gates `pageMargins`' and
+`EpubPreferencesEditor` corroborates it; it gates `pageMargins`' and
 `fontSize`'s effectiveness on nothing but a reflowable publication,
 while gating every one of the six on `!publisherStyles`.
 
@@ -92,7 +92,7 @@ do not agree:
 So **alignment survives into an RTL book and dies in a CJK one**. A
 single "not the default stylesheet" state would tell an Arabic reader
 their alignment control is dead when it works, and a Japanese reader
-that it works when it does not — hence three live states, not two.
+that it works when it does not. Hence three live states, not two.
 Readium's `isTextAlignEffective` says the same thing
 (`stylesheets in [Default, Rtl]`, against `== Default` for the other
 three), but it is `internal`.
@@ -105,14 +105,14 @@ stylesheet has a rule for it. Without the scope, an app-wide letter
 spacing would switch advanced styles on for an Arabic book whose
 stylesheet has no letter-spacing rule: Readium would normalize that
 book's entire type scale and apply none of the spacing that asked for
-it. Pure loss — and it would contradict the row telling the reader the
+it. It would be pure loss, and it would contradict the row telling the reader the
 setting does not apply here.
 
 The values themselves are still *sent*. A setting a book cannot use is
 not erased, it merely stops counting, so it is there for the next book
 that can honour it.
 
-Both narrowings — by property, and by stylesheet — mean strictly *less*
+Both narrowings (by property and by stylesheet) mean strictly *less*
 interference than before.
 
 ### `readingCssFor` mirrors three pieces of `internal` Readium
@@ -121,7 +121,7 @@ interference than before.
 extensions are all `internal`, so the classification is a copy rather
 than a call. It is derived from `publication.metadata` alone, and is
 exact **only because Liseur sets no `language`, `readingProgression` or
-`verticalText` preference and no `EpubDefaults`** — every branch of the
+`verticalText` preference and no `EpubDefaults`**; every branch of the
 resolver that could diverge from metadata is unreachable.
 `ReaderPreferencesMapperTest` pins that invariant, so the day someone
 adds a reading-direction preference the build fails and points here.
@@ -130,8 +130,8 @@ Deriving it from the publication rather than from the navigator's
 resolved settings is what lets the answer exist *before* the navigator
 does. The mapper needs it to build the initial preferences; classifying
 late would mean opening the book one way and correcting it a moment
-later — a reflow, and a reading position that moves while the reader
-watches.
+later, causing a reflow and moving the reading position while the
+reader watches.
 
 The mirror includes Readium's bugs, deliberately, because the sheet has
 to describe the page Readium will actually produce:
@@ -139,9 +139,9 @@ to describe the page Readium will actually produce:
 | Tag | Readium's answer |
 | --- | --- |
 | `ja`, `ko`, `zh`, `zh-Hant`, `zh-TW` | CJK |
-| **`ja-JP`, `ko-KR`** | **not CJK** — `ja`/`ko` are compared against the whole code, and only `zh` is region-stripped |
+| **`ja-JP`, `ko-KR`** | **not CJK**; `ja`/`ko` are compared against the whole code, and only `zh` is region-stripped |
 | `ar`, `fa`, `he` | RTL |
-| **`ar-EG`** | **not RTL** — `isRtl` compares the whole code to a fixed list |
+| **`ar-EG`** | **not RTL**; `isRtl` compares the whole code to a fixed list |
 
 Fix those upstream, not here. Re-check the mirror on every Readium
 upgrade; `ReadingCssTest` is what will notice.
@@ -162,7 +162,7 @@ styling, restored". The rows say **Default**, matching
 
 ### Default versus zero, and the two-way toggle
 
-`0.0` is a value — "no extra spacing" — and it counts as an override.
+`0.0` is a value ("no extra spacing"), and it counts as an override.
 But a null and an explicit `0.0` both rest the thumb at the range start,
 so no drag reaches one from the other and a zero-distance press is not
 guaranteed to report itself. The trailing button is therefore a two-way
@@ -173,28 +173,29 @@ and from an explicit value it returns to Default.
 
 `EpubPreferences` throws from its constructor on a negative `fontSize`,
 `letterSpacing`, `wordSpacing`, `paragraphSpacing`, `pageMargins` or
-`typeScale`, and on a `fontWeight` outside `0.0..2.5` — and the moment
+`typeScale`, and on a `fontWeight` outside `0.0..2.5`; the moment
 that would happen is the moment the reader is changing their settings.
 `NaN >= 0` is `false` and `NaN.coerceIn(a, b)` is still `NaN`, so
 anything not finite has to be refused rather than clamped.
 
 Three categories, because "clamp" and "discard" are different answers:
 
-- **Sliders** (letter, word, paragraph spacing). Not finite or negative
-  → discarded; `0.0` kept; above the maximum clamped, because Liseur's
+- Sliders (letter, word, paragraph spacing). Not finite or negative
+  -> discarded; `0.0` kept; above the maximum clamped, because Liseur's
   ranges are deliberately narrower than Readium's and a larger value is
   a real preference from a wider one.
-- **Segmented doubles** (`lineHeight`, `pageMargins`). The reader can
+- Segmented doubles (`lineHeight`, `pageMargins`). The reader can
   only ever write one of three offered values or nothing, so anything
   else is corruption or another build: out of range is **discarded, never
   clamped**. `lineHeight = 0.0` is below Readium's minimum of `1.0` and
   goes; `pageMargins = 0.0` is inside its range and stays.
-- **`fontSize`**, which has no null to fall back to, falls back to `1.0`
+- `fontSize`, which has no null to fall back to, falls back to `1.0`
   and clamps a finite out-of-range value.
 
 Clamping a negative into range would turn a corrupt byte into an
 explicit override, which would then switch advanced styles on and
-renormalize the book — a page rewritten because a file was damaged.
+renormalize the book. The page would be rewritten because a file was
+damaged.
 `requiresAdvancedStyles` is computed from sanitized values so that
 cannot happen.
 
@@ -204,12 +205,12 @@ and a broken label.
 
 Every door a number comes through calls `sanitized()`: the preference
 store on read and write, a book's own typography row (after the merge,
-not before — the row is the newer and less trustworthy source), and the
+not before; the row is the newer and less trustworthy source), and the
 mapper itself, which is reached by paths that built a `ReaderPrefs`
 directly.
 
 A stored `lineHeight` or `pageMargins` that is valid but none of the
-three offered values — from an older build, or a hand-edited row —
+three offered values (from an older build, or a hand-edited row)
 leaves its segmented row with nothing selected, and is left intact.
 Snapping it to the nearest option would change the page to a setting the
 reader never chose, silently, just because they opened the sheet.
@@ -252,7 +253,7 @@ word spacing needs more words than two paragraphs hold.
 A row whose rule is not in the book's stylesheet is disabled, showing
 its stored value, under a line saying why. Annotating it instead would
 let a reader set letter spacing inside an Arabic book, see nothing
-change, and — before the scoped predicate — have silently normalized
+change and, before the scoped predicate, have silently normalized
 that book's type scale. Now neither half can happen.
 
 The settings screen passes `ReadingCss.Unknown`, where nothing is
@@ -272,22 +273,22 @@ just above.
 
 ## Consequences
 
-- **Two narrowings of existing behaviour**, both meaning less
+- Two narrowings of existing behaviour, both meaning less
   interference: page margins alone no longer normalizes a book's type
   scale, and an RTL or CJK book is no longer normalized for settings its
   stylesheet cannot apply.
-- **Turning advanced styles on reflows the page** and can move the
+- Turning advanced styles on reflows the page and can move the
   reading position. Unchanged in kind, but now it happens in fewer
   cases.
-- **A font weight override reaches everything that inherits it**,
+- A font weight override reaches everything that inherits it,
   headings included, so a book's own emphasis flattens towards the
   chosen weight. That is the setting working as asked, and why the
   default sends nothing.
-- **Three mirrors of `internal` Readium code**, quirks and all, standing
+- Three mirrors of `internal` Readium code, quirks and all, standing
   on an invariant a test pins. A copy drifts; re-check on upgrade.
 - Fixed-layout books honour none of the six, and the rows say so. Font
   size, margins and columns are equally inert there and are *not*
-  disabled — a pre-existing inconsistency this change deliberately did
+  disabled. A pre-existing inconsistency this change deliberately did
   not widen its scope to fix.
 
   > Amended by [ADR-0020](0020-fixed-layout-reading-settings.md),

--- a/docs/adr/0004-user-imported-fonts.md
+++ b/docs/adr/0004-user-imported-fonts.md
@@ -7,7 +7,7 @@ GitHub issue: [#6](https://github.com/chmouel/liseur/issues/6)
 
 Four bundled families cover most tastes, but not the reader who has
 paid for a font they love, needs OpenDyslexic, or reads a script the
-bundled four render badly. The bundle cannot grow to meet them all —
+bundled four render badly. The bundle cannot grow to meet them all;
 every family is APK weight everyone carries.
 
 ## Decision
@@ -19,17 +19,17 @@ the bundled four, applied to the open book at once.
 Fit with Liseur's simplicity: one "Add a font…" entry at the end of the
 existing font list, and imported fonts in that same list, previewed in
 their own face, with a remove affordance behind a confirmation. No
-manager screen, and — this is what keeps ADR 0001 satisfied — **no new
-row**: the font control the typography sheet and Settings → Reading
+manager screen, and **no new row**: this is what keeps ADR 0001
+satisfied. The font control the typography sheet and Settings -> Reading
 appearance already share is the one that grows.
 
 ## Design
 
 ### Storage
 
-Import is `ACTION_OPEN_DOCUMENT`, the bytes copied to `filesDir/fonts/`
-— copied, not referenced, so the choice survives the source file moving
-or the SAF grant lapsing. The MIME filter includes
+Import is `ACTION_OPEN_DOCUMENT`, the bytes copied to `filesDir/fonts/`.
+They are copied, not referenced, so the choice survives the source file
+moving or the SAF grant lapsing. The MIME filter includes
 `application/octet-stream`, because `MimeTypeMap` has no `ttf` entry and
 most DocumentsProviders report a font that way; a filter without it
 hides the very files being looked for. Nothing is trusted from the
@@ -39,7 +39,7 @@ disk with it.
 A font is stored as `<sha256>.<ext>` and known by `user:<sha256>`.
 Content-addressing is what lets a font be deleted, and the same file
 imported again months later, and every book that was reading in it pick
-it straight back up — the id was never a handle into a table, it was
+it straight back up; the id was never a handle into a table, it was
 always the bytes. `filesDir/fonts/index.json` caches only the display
 name, the one thing a font with no `name` table cannot tell us twice; a
 lost or corrupt index costs a name and never a font.
@@ -63,7 +63,7 @@ nothing else. Widening `servedAssets` widens *what is allowed*, never
 *where it is read from*, so a file in `filesDir/fonts/` returns 404.
 Readium's own guide documents only assets-bundled fonts.
 
-A `data:` URL is refused by `Url()` — `AbsoluteUrl` requires a
+A `data:` URL is refused by `Url()`, because `AbsoluteUrl` requires a
 hierarchical URI and a `data:` URI is opaque. A `file://` URL is refused
 by the web view as a subresource of an `https://` page. There is no
 `@font-face` hook in `readiumCssRsProperties`, which is a typed
@@ -72,13 +72,13 @@ by the web view as a subresource of an `https://` page. There is no
 What does work: a request whose host is *not* `readium_assets` is
 treated as a publication resource and goes to `publication.get(href)`,
 and Liseur builds the `Publication` itself. So the book's container is
-wrapped —
+wrapped:
 
 ```kotlin
 container = CompositeContainer(UserFontsContainer(userFonts::value), container)
 ```
 
-— and each family is declared with an **absolute** source,
+Each family is declared with an **absolute** source,
 `https://readium_package/__liseur_fonts__/<digest>.<ext>`.
 `ReadiumCss.normalizeAssetUrl` is `assetsBaseHref.resolve(url)` and
 `Url.resolve` returns an `AbsoluteUrl` unchanged, so the assets host is
@@ -93,7 +93,7 @@ a digest it holds, so it shadows nothing else.
 
 Matching is exact-string, against an href built from a font already in
 the registry, and rejects `%2f`, `%5c`, `%2e`, dot segments, doubled
-slashes and backslashes on the **raw** url before any normalisation —
+slashes and backslashes on the **raw** url before any normalisation;
 normalising first is what turns `x/../y` into something that compares
 equal. A fragment or query is tolerated rather than refused, because
 `Publication.get` looks up `href` and then retries with the query
@@ -106,9 +106,9 @@ font, so traversal has nothing to aim at even in principle.
 `UserFontResources.PACKAGE_ORIGIN`; a Readium upgrade that changes it
 breaks this quietly, and this paragraph is where to look. And
 `MimeTypeMap` has no `ttf`/`otf` entry, so an imported font is served
-with a **null `Content-Type`** — verified on device to render anyway,
+with a **null `Content-Type`** (verified on device to render anyway,
 for both TTF and OTF, because Blink does not content-type-check
-`@font-face`. It is the same reason the bundled four are served as
+`@font-face`). It is the same reason the bundled four are served as
 `text/plain` today.
 
 ### Applying
@@ -119,8 +119,8 @@ four; the web view only fetches the family the page uses.
 
 An import applies to the open book immediately. `ReaderScreen`'s
 `key(columnMode, scrollMode, fontKey)` is what actually tears the
-fragment down and rebuilds it — rebuilding the factory alone leaves the
-live fragment in place — so a generation key over the imported ids is
+fragment down and rebuilds it. Rebuilding the factory alone leaves the
+live fragment in place, so a generation key over the imported ids is
 threaded through that, the factory `remember`, and the `restoreTarget`
 snapshot, which is what keeps the reader on the page they were on rather
 than where the book opened. This is the mechanism a column-mode change
@@ -135,13 +135,13 @@ do nothing.
 
 `ReaderViewModel.open()` awaits the repository's first scan before
 taking its font snapshot, or a book already set to an imported font
-opens in the default for a beat and then reflows — unasked for, on the
+opens in the default for a beat and then reflows, unasked for, on the
 screen someone was trying to read.
 
 ### Backup
 
-Fonts are **excluded from cloud backup** — they are user-supplied
-binaries, up to 32 of them, against a 25 MB quota — and **included in
+Fonts are **excluded from cloud backup**; they are user-supplied
+binaries, up to 32 of them, against a 25 MB quota, and **included in
 device transfer**, which is not quota-limited and is where "everything
 is as it was on my new phone" is the promise. A cloud restore therefore
 lands on the dormant-id path above: books fall back to the default, and

--- a/docs/adr/0005-warm-light.md
+++ b/docs/adr/0005-warm-light.md
@@ -17,8 +17,8 @@ One warmth slider that draws an amber tint over the page, from nothing
 to distinctly candle-lit, remembered like brightness.
 
 Fit with Liseur's simplicity: the slider sits directly under the
-brightness slider in the typography sheet — the two answer the same
-question, "how does the light feel" — and there is no schedule, no
+brightness slider in the typography sheet, because the two answer the
+same question, "how does the light feel", and there is no schedule, no
 automation, no per-theme value.
 
 ## Design

--- a/docs/adr/0006-auto-scroll.md
+++ b/docs/adr/0006-auto-scroll.md
@@ -8,7 +8,7 @@ GitHub issue: [#45](https://github.com/chmouel/liseur/issues/45)
 Scroll mode exists, but the thumb still has to move the page. Reading
 over lunch, on a treadmill, or with one hand in a strap on the train,
 a page that carries itself at reading pace is the difference between
-reading and not. Paginated mode has no equivalent need — the tap zones
+reading and not. Paginated mode has no equivalent need: the tap zones
 and volume keys already turn pages without reaching.
 
 ## Decision
@@ -19,7 +19,7 @@ possible because the row only appears when the book is scrolled.
 
 Fit with Liseur's simplicity: one row in the Advanced sheet, visible
 only in scroll mode. While scrolling, the reader chrome is the pause
-control it already is — a tap shows the chrome and stops the movement.
+control it already is: a tap shows the chrome and stops the movement.
 
 ## Design
 
@@ -28,12 +28,12 @@ model has no navigator. `ReaderScreen` owns the navigator and the
 `PageTurner` that knows how to cross a chapter, so the loop lives there,
 driving a pure `reader/chrome/AutoScroll.kt` that knows nothing of web
 views, densities or frames. A `withFrameNanos` loop turns elapsed time
-into whole pixels — carrying the remainder, so a slow pace still moves —
+into whole pixels, carrying the remainder so a slow pace still moves,
 and calls `scrollBy` on the visible web view.
 
 The notch and the pace are split, and the seam is the direction the
-dependency has to run. `AutoScrollPreference` — the range, the default,
-`snap` and `sanitize` — is in `data/settings/ReaderPrefs.kt` beside
+dependency has to run. `AutoScrollPreference` (the range, the default,
+`snap` and `sanitize`) is in `data/settings/ReaderPrefs.kt` beside
 `ReaderFont`, `FooterMode` and `ColumnMode`, because those bounds
 describe the stored setting: what the slider may show and what the
 preference store may hold. `AutoScrollSpeed` and `AutoScrollTicker` stay
@@ -56,7 +56,7 @@ non-finite pace too, so that invariant does not rest on one caller.
 which is why `ScrollEdgeTurner` reads `canScrollVertically` off it and
 why `R2BasicWebView` hangs its progression notification on
 `onScrollChanged`. A book set in vertical lines is scrolled sideways and
-runs right to left, so it is scrolled by a *negative* horizontal step —
+runs right to left, so it is scrolled by a *negative* horizontal step;
 the same convention `scrollScreenfulScript` and `ScrollEdgeTurner`
 already read.
 
@@ -70,7 +70,7 @@ That is the pause, rather than a separate mechanism for it. In a
 scrolled book every tap is a chrome tap, so a tap raises the chrome and
 the page stops; the next tap hides it and the page carries on. A drag is
 a finger down, so the text goes where the reader puts it and picks up
-from there. "Overlay" is every one of them — both sheets, contents,
+from there. "Overlay" is every one of them: both sheets, contents,
 search, the footnote card, the selection popup, the note dialog, the
 definition sheet, the jump-back and catch-up pills, and the activity's
 own dialogs: an offer nobody has answered is about the page as it was.
@@ -79,7 +79,7 @@ own dialogs: an offer nobody has answered is about the page as it was.
 `scrollMode`: Readium cannot paginate lines that run down the page, so
 it scrolls such a book whatever the preference says. The same derivation
 feeds `ReaderTapZones`, `ScrollEdgeTurner` and `PageTurner`, which read
-the preference alone before — without that, a tap on a vertical book
+the preference alone before; without that, a tap on a vertical book
 turns a page instead of pausing, and this pause does not work at all.
 
 > Amended by [ADR-0020](0020-fixed-layout-reading-settings.md),
@@ -95,17 +95,17 @@ screen's worth of reading time at the reader's pace, then asks
 `PageTurner.stepChapter`, which is what a hand drag past the edge asks
 too. It *reads the answer*: false means there was nowhere to go, and the
 loop disarms rather than sitting against the edge. On true it waits for
-the resource to actually change — not a fixed delay, which would step a
-slow chapter twice and skip one shorter than a screen — and that wait,
-like every other, is bounded and cancellable.
+the resource to actually change, not for a fixed delay, which would step
+a slow chapter twice and skip one shorter than a screen. That wait, like
+every other, is bounded and cancellable.
 
 **Position saving does need something new**, contrary to the first
-draft. Readium answers a scroll with a *debounced* location notification
-— a hundred milliseconds of stillness. A finger drag always ends, so
+draft. Readium answers a scroll with a *debounced* location notification:
+a hundred milliseconds of stillness. A finger drag always ends, so
 that debounce always lands. A page that never stops never lands it, and
 the reader's place would stay where they last lifted a finger. So the
 loop asks the navigator itself, every couple of seconds, through
-`firstVisibleElementLocator` — the same question the debounce would have
+`firstVisibleElementLocator`, the same question the debounce would have
 asked, asked on time, and asked off the frame loop so the page does not
 hitch. Those go in as `READER_MOVEMENT`: auto-scroll is reading, so it
 should teach the pace estimator and count as time spent.
@@ -115,7 +115,7 @@ existed. `firstVisibleElementLocator` answers with a selector and the
 words at the top of the screen and nothing else: no progression, no
 position. `BookPositions.resolve` reads a locator with neither as the
 start of its resource, so every save auto-scroll made filed the reader
-at the top of the chapter they were half way down — and that number is
+at the top of the chapter they were half way down; that number is
 the one the footer shows, the one the pace estimator learns from, and
 the one calibre-web syncs outright and Komga and liseur-sync compare
 when they disagree. Only local resume escaped it, because the anchor
@@ -123,7 +123,7 @@ saved beside the number was still exact.
 
 So the distance is measured too, by `ScrollProgression`: the document's
 own scroll offset over its own length. That is not an approximation of
-Readium's convention but the inverse of it — `readium.scrollToPosition`
+Readium's convention but the inverse of it: `readium.scrollToPosition`
 restores a fraction by multiplying it back out against the same span. A
 page that cannot give one saves nothing that tick, because a place a
 line behind is worth having and a place a chapter behind is not.
@@ -140,7 +140,7 @@ nothing, so it is a synchronous call that has returned before `onStop`
 can begin to close the position queue.
 
 **A book scrolled by hand keeps a place the same way.** Its debounce
-does land — a finger drag ends — but it lands after the reader was
+does land, because a finger drag ends, but it lands after the reader was
 marked inactive if they leave the moment they stop scrolling, and it is
 then dropped as movement nobody made. So the same round trip runs for a
 manually scrolled book, driven not by a frame loop but by the web view's
@@ -153,7 +153,7 @@ exactly the window they scroll in.
 
 That watcher runs for as long as the book is scrolled, armed or not,
 because arming is not running: a finger on the page, the chrome up, a
-dialog open — every one of those stops the carrying loop while leaving
+dialog open; every one of those stops the carrying loop while leaving
 the reader free to scroll by hand, and a gap between the two would be a
 pause with nothing held. It only skips the round trip while the loop is
 actually carrying the page, which is measuring the same thing anyway; it
@@ -184,8 +184,8 @@ from retiring, and why that bookkeeping lives in the collector that
 publishes rather than in a second one watching the same flow. A locator
 Readium announces is captured before it is saved, and a capture
 suspends: clear the held place when the announcement arrives and a
-reader who leaves mid-capture has neither the new place — dropped as
-movement by an inactive reader — nor the old one. So the announcement
+reader who leaves mid-capture has neither the new place (dropped as
+movement by an inactive reader) nor the old one. So the announcement
 only invalidates: measurements in flight are refused, the place already
 held stands, and it is replaced once the new capture has actually been
 taken. A reflow locator is the exception that retires outright, being
@@ -198,8 +198,8 @@ stopped being scrolled. The holder is remembered across all three, so
 each is told explicitly.
 
 Two things are never asked at all. A fixed-layout book has no scroll
-fraction that means anything — nothing reflows, and the document does
-not move under the viewport — and a page being rebuilt by a preference
+fraction that means anything: nothing reflows, and the document does
+not move under the viewport. A page being rebuilt by a preference
 change is not a page the reader moved through, so an open reflow skips
 the tick the way `ReflowScope` gates everything else.
 
@@ -207,7 +207,7 @@ the tick the way `ReflowScope` gates everything else.
 to 10 mapped to dp per second and multiplied by the font size, so
 *lines* per minute stay roughly constant across text sizes. It lives in
 `ReaderPrefs` alongside the typography, which means the flow that maps
-those to `EpubPreferences` gains a `distinctUntilChanged()` — without
+those to `EpubPreferences` gains a `distinctUntilChanged()`; without
 it, dragging the slider would reflow the whole book once per notch for a
 setting the book cannot see.
 
@@ -223,12 +223,12 @@ by a `CachedLookup`.
 
 Holding it is only safe if "current" keeps the meaning `visibleWebView`
 gives it: the view covering the middle of the reader. Attachment will
-not do — Readium keeps the neighbouring chapters attached to its pager,
+not do: Readium keeps the neighbouring chapters attached to its pager,
 so a chapter the reader has left stays attached and, to `isShown`,
 shown. The check is therefore the cheap half of the same question, one
 rect against one point. Mid-transition, when nothing covers the centre,
 the search falls back to the largest visible view, which fails that
-check, so the cache spends those frames looking again — the cost paid on
+check, so the cache spends those frames looking again; the cost paid on
 every frame before, now paid only while a chapter is arriving.
 
 The held view is also dropped on a new position or a layout pass, the
@@ -236,7 +236,7 @@ pair this screen already watches for exactly this reason: Readium
 reports arriving at a resource before laying it out, and a view that
 does not exist yet cannot be found. Invalidating is free and idempotent,
 so it can be said too often. A chapter *changing* is different news and
-rides its own event — positions arrive as the reader moves within a
+rides its own event; positions arrive as the reader moves within a
 chapter, and the ticker's carried fraction and the place kept for the
 pause may only be thrown away when the page they belong to has actually
 gone.
@@ -244,7 +244,7 @@ gone.
 **Someone else turning the page first.** The dwell at a chapter's end is
 the one window where the loop is alive and waiting rather than moving,
 and `ReaderActivity` sends volume and page keys straight to the turner
-without raising the chrome — so auto-scroll stays armed and the dwell
+without raising the chrome, so auto-scroll stays armed and the dwell
 stays alive. The dwell therefore notes which chapter it is waiting in
 and does not step if it is somewhere else when the wait ends: the page
 moved, which is what the wait was there to allow.
@@ -252,7 +252,7 @@ moved, which is what the wait was there to allow.
 Two round trips into the document have the same shape of problem. The
 position the loop saves is fetched and captured while the reader may be
 leaving, so it is discarded unless the chapter it was asked of is still
-open — a save dropped costs one tick, a save kept would file the old
+open: a save dropped costs one tick, a save kept would file the old
 chapter's place as the reader's place in the new one. The place kept for
 the pause outlives the loop, so it is dropped on the way back in unless
 it still points into the open chapter: a book moved elsewhere while the

--- a/docs/adr/0007-scrubber-page-peek.md
+++ b/docs/adr/0007-scrubber-page-peek.md
@@ -13,8 +13,8 @@ reading position.
 
 ## Decision
 
-While the thumb is down, the scrubber only shows — a small label above
-it with the chapter title and page — and the book does not move until
+While the thumb is down, the scrubber only shows a small label above
+it with the chapter title and page, and the book does not move until
 release. After a release that moved the book, a single "Back to page N"
 chip offers the way home, and turning a page dismisses it.
 

--- a/docs/adr/0008-highlight-styles.md
+++ b/docs/adr/0008-highlight-styles.md
@@ -44,7 +44,7 @@ visual register on the page, not a category worth exporting.
 
 The popup gets slightly busier, which is the entire UI cost. The Room
 schema version bumps, joining the migrations that `docs/ROADMAP.md`
-already wants tested. Two styles is deliberate — squiggles and boxes
+already wants tested. Two styles is deliberate: squiggles and boxes
 invite a formatting hobby that has nothing to do with reading.
 
 *Where:* `data/db/BookAnnotation.kt`, `data/db/LiseurDatabase.kt`,

--- a/docs/adr/0009-tap-zone-customization.md
+++ b/docs/adr/0009-tap-zone-customization.md
@@ -6,7 +6,7 @@ GitHub issue: [#46](https://github.com/chmouel/liseur/issues/46)
 ## Context
 
 The tap zones are fixed: the edge the book came from goes back, the
-opposite edge goes forward, middle for chrome — on a book that reads
+opposite edge goes forward, middle for chrome. On a book that reads
 left to right, that is back on the left and forward on the right. A
 left-handed reader holding a phone in one hand has the forward turn
 under the wrong thumb every single page. The fix most readers actually
@@ -15,7 +15,7 @@ want is not a zone editor, it is "swap the edges".
 ## Decision
 
 One two-way preference: **Standard** (today's layout, whichever way the
-book reads) and **Swapped** (the other thumb — the sides the other way
+book reads) and **Swapped** (the other thumb: the sides the other way
 round from whatever Standard gives that book).
 
 Two, not the three this ADR first proposed. The dropped one was "both
@@ -25,7 +25,7 @@ answer: the other two say which hand is holding the phone, while that
 one takes an action off the page and asks the reader to find it
 somewhere else.
 
-Fit with Liseur's simplicity: one chip row in **Settings → Reading**,
+Fit with Liseur's simplicity: one chip row in **Settings -> Reading**,
 directly under "Volume keys turn pages". Not the typography sheet this
 ADR first named, and not Reading appearance: a tap zone is not how the
 page looks, it is how the page is turned, and the switch it belongs
@@ -33,7 +33,7 @@ beside is the one that decides what the volume keys do. It is also set
 once, when the app is set up, which is what the reading sheet is
 explicitly not for ([ADR 1](0001-advanced-reading-menu.md)).
 
-No draggable zone editor, no per-zone action picker — that is a
+No draggable zone editor, no per-zone action picker. That is a
 settings hobby, and the two presets cover the readers who exist.
 
 ## Design
@@ -44,7 +44,7 @@ are geometry, and a preset that reorders the sides has nothing to say
 about them. The mapping from a side to a direction moves into one pure
 function, `ReaderTapZones.forward(zone, rtl, swapped)`, so the reading
 page and the endpaper cannot come to different answers about the same
-tap — the endpaper is a page, and had its own copy of that `when`.
+tap; the endpaper is a page, and had its own copy of that `when`.
 
 The preset composes with reading direction rather than overruling it. An
 RTL book turns forward on the left because that is where the next page
@@ -58,7 +58,7 @@ reaches the reader as a `StateFlow` on `ReaderViewModel`, and is read
 through a lambda so that changing it does not tear down and rebuild the
 navigator's input listeners.
 
-The volume keys are untouched — they already give a physical
+The volume keys are untouched: they already give a physical
 back/forward pair whatever the thumbs do. Scroll mode keeps its own
 scroll-aware tap behaviour: the whole page is the chrome zone there, so
 a scrolled book never resolves to a side and the preset has nothing to
@@ -66,7 +66,7 @@ reinterpret.
 
 The endpaper is the exception, and deliberately. It is the app's own
 page rather than the book's, is not scrolled by the navigator, and its
-chrome zone does nothing at all — so its sides stay live whatever the
+chrome zone does nothing at all, so its sides stay live whatever the
 reading mode, exactly as they did before this preset existed. Taking
 them away in scroll mode would leave a reader who scrolls no tap at all
 to get back into the book. The preset therefore reaches the endpaper
@@ -91,7 +91,7 @@ forgotten.
 ## Update
 
 The Reading section it landed in later moved behind a row of its own,
-so the chip row is now in **Settings → Reading & navigation**
+so the chip row is now in **Settings -> Reading & navigation**
 (`ui/settings/ReadingNavigationScreen.kt`), still directly under
 "Volume keys turn pages" and still not in Reading appearance. See
 `docs/adr/0001-advanced-reading-menu.md`.

--- a/docs/adr/0010-translation-on-selection.md
+++ b/docs/adr/0010-translation-on-selection.md
@@ -15,7 +15,7 @@ translation feature must not quietly widen it.
 ## Decision
 
 A **Translate** action in the selection popup, sending the selection to
-a translation endpoint the user configures themselves — a LibreTranslate
+a translation endpoint the user configures themselves: a LibreTranslate
 instance or anything speaking its API. Off until an endpoint is entered;
 no default server, not even a FOSS one, because a default turns opt-in
 into opt-out.
@@ -44,7 +44,7 @@ configured, and nowhere otherwise.
 
 ## Consequences
 
-Selected passages leave the device — to a server the reader chose,
+Selected passages leave the device for a server the reader chose,
 named in settings, and only when they press Translate. A reader who
 self-hosts LibreTranslate gets translation with no third party at all.
 There is no offline mode; bundling a translation model is the offline

--- a/docs/adr/0011-annotation-sync.md
+++ b/docs/adr/0011-annotation-sync.md
@@ -11,7 +11,7 @@ keeps tombstones for 180 days, and its web reader draws what it holds.
 
 This app is the only thing that actually makes annotations, and it did
 not speak that API. A highlight lived in one phone's Room database and
-died with it — no second device, no web reader, no recovery from a lost
+died with it: no second device, no web reader, no recovery from a lost
 phone beyond the manual backup file.
 
 Positions and sessions were straightforward to sync because they are
@@ -22,8 +22,8 @@ random id or a `pending_ops` table."
 
 Annotations are neither append-only nor single-valued. A highlight is
 edited and deleted, so a payload derived purely from the current row
-cannot be rebuilt once the reader changes that row. An ambiguous push —
-request sent, answer lost — then becomes unreplayable: the retry carries
+cannot be rebuilt once the reader changes that row. An ambiguous push
+(request sent, answer lost) then becomes unreplayable: the retry carries
 different bytes, misses `duplicate`, and resolves as a conflict that
 throws the reader's edit away without saying so.
 
@@ -34,8 +34,8 @@ folded into the existing position-sync pass. Keep the derived-payload
 discipline, and add the one thing mutability requires: a record of the
 request currently in flight.
 
-`annotation_sync(id, peer_id)` holds what the server confirmed —
-`rev`, `seq`, and a content fingerprint — alongside the exact bytes of
+`annotation_sync(id, peer_id)` holds what the server confirmed:
+`rev`, `seq`, and a content fingerprint, alongside the exact bytes of
 any request in the air. Outbound work is the diff between the live
 `annotations` table and that fingerprint, so no DAO method and no call
 site had to learn about sync: a mark becomes syncable by being in the
@@ -46,12 +46,12 @@ one mark and restarts at 1 when the server recreates an id whose
 tombstone has been swept; a device holding the old, higher number would
 read the new record as ancient and refuse it for ever. Seq is the
 account's own clock and only goes up. For the same reason the feed
-cursor moves by the *raw* page — a page whose records this device cannot
+cursor moves by the *raw* page: a page whose records this device cannot
 represent still happened, and taking the account's high-water mark for
 it would step over everything after it.
 
 Two fingerprints, because they answer different questions. The
-acknowledged one covers content only — never `base_rev`, which changes
+acknowledged one covers content only: never `base_rev`, which changes
 on every accepted write and would make a just-confirmed row look dirty
 for ever, and never `edition_sha`, or two devices holding different
 files of one book would push at each other endlessly. The pending one
@@ -63,7 +63,7 @@ The pass has five phases in a fixed order: settle what is in flight,
 pull the delta feed, reconcile a work's live set, push new writes, send
 deletes. Reconcile before push is the load-bearing one. An edit made
 offline, to a record another device deleted long enough ago that its
-tombstone was swept, is an id the server no longer knows — pushed first
+tombstone was swept, is an id the server no longer knows. Pushed first,
 it is not a conflict but a *create*, and the deleted highlight comes
 back. Asking first turns the same situation into a local delete.
 
@@ -78,7 +78,7 @@ reader would notice and could not undo.
 
 ## Design
 
-Room 39 → 40: the `annotation_sync` table, `annotations.updated_at`
+Room 39 -> 40: the `annotation_sync` table, `annotations.updated_at`
 (epoch **microseconds**, backfilled from `created_at`),
 `remote_server.annotation_cursor_seq`, and
 `work_alias.annotations_reconciled_at`.
@@ -91,7 +91,7 @@ way before it is stored, or a record would look dirty the instant it
 landed and be pushed straight back.
 
 Every push goes through `postRaw` with bytes assembled by string
-concatenation — the first send as much as a replay. `org.json.JSONObject`
+concatenation. That is true for the first send as much as for a replay. `org.json.JSONObject`
 is backed by a hash map with no key ordering, so reserialising a
 persisted item would change the bytes the server is comparing and lose
 the duplicate answer the whole design rests on. Locators are
@@ -111,7 +111,7 @@ moving the cursor, would strand every other book for ever. Phases 0 and
 `invalid` is classified rather than blanket-acknowledged, because the
 three classes need opposite treatment. A work the server does not know
 is repaired by re-resolving the alias and retried. The per-work cap of
-2000, or a clock the server reads as more than a day fast, is deferred —
+2000, or a clock the server reads as more than a day fast, is deferred;
 re-resolution repairs neither and retrying loops for ever. A shape the
 server will never take is recorded against its fingerprint and dropped
 until the reader edits the record, which changes the fingerprint and
@@ -119,13 +119,13 @@ tries again. An unrecognised reason is treated as permanent: a stalled
 record is recoverable and shows up in a log; an unbounded retry loop
 against a server that will never say yes is neither.
 
-Every arriving record is validated as though it were hostile — kind in
-the enum, colour on the palette, progression in range, locator parsing —
-because a client that writes whatever arrives into its own database is
-one buggy peer away from trouble and checking costs nothing.
+Every arriving record is validated as though it were hostile: kind in
+the enum, colour on the palette, progression in range, locator parsing.
+A client that writes whatever arrives into its own database is one buggy
+peer away from trouble, and checking costs nothing.
 
-The batch size is the server's to choose — a hundred is only the
-default and `annotation_max_batch` may be lower — so a request refused
+The batch size is the server's to choose. A hundred is only the
+default and `annotation_max_batch` may be lower, so a request refused
 whole is halved and tried again rather than replayed unchanged until the
 account is disconnected. Down to a single item, which is as far as
 splitting goes: one item refused at any size is a bad item, and is
@@ -133,7 +133,7 @@ recorded as such.
 
 An annotation id is opaque to the server, so `.` and `..` are ids
 another client may legitimately hand out, and this device carries and
-pushes them like any other — the id travels in the body there. What no
+pushes them like any other. The id travels in the body there. What no
 client can do is *address* one: a URL parser decodes `%2E%2E` before it
 resolves dot segments, so every escape collapses back to navigation and
 a delete would land on the collection. Refusing such a record on the way
@@ -148,16 +148,17 @@ away. The alias is stale, not the book, so it is dropped and handed back
 to the position sync to be renamed; asking again every run would stall
 that book's marks for good. The stale work id travels back with the
 name, and the position sync deletes against *that* id rather than
-against whatever it reads afterwards — the pass may already have
-repaired the name, and deleting the good one would undo the repair. The same reasoning applies to a file that
+against whatever it reads afterwards, because the pass may already have
+repaired the name, and deleting the good one would undo the repair. The
+same reasoning applies to a file that
 took over a path: `BookRemoval.contentReplaced()` clears the
 fingerprints and the alias along with the marks, or the next pass would
 take the new book for the old one.
 
 A mark the server once knew is offered only if this pass saw the server
 holding it. Agreeing a *work* is not enough: the push rescans a mutable
-table, so a mark edited after the live set was read — or during it, and
-therefore deliberately not judged by it — has not been asked about, and
+table, so a mark edited after the live set was read, or during it and
+therefore deliberately not judged by it, has not been asked about, and
 offering it is a guess about a tombstone that may have been swept. A
 mark never acknowledged cannot resurrect anything and goes either way.
 
@@ -173,7 +174,7 @@ that one, and not over a copy the reader wrote after the request left:
 the server has never been shown it and has therefore ordered nothing
 against it. Such a mark keeps its words, takes the rev the refusal
 taught, and reads dirty, so it goes next pass. The sync row cannot see
-this on its own — editing a highlight writes to `annotations` — so the
+this on its own, because editing a highlight writes to `annotations`; the
 content is compared directly.
 
 A book with a mark to offer is reconciled every pass, however recently
@@ -185,7 +186,7 @@ is never acted on is never wrong. Guessing wrong about a book holding an
 unsettled mark is exactly the resurrection this phase exists to prevent.
 
 Every network call is preceded by a check that the account the pass
-began for is still the connected one — not only every write. A pass runs
+began for is still the connected one, not just every write. A pass runs
 for as long as the network takes, and a disconnect landing in the middle
 of one used to be caught on the way back, by which time this device had
 already told a server it no longer belongs to about a mark. Refusing to
@@ -229,7 +230,7 @@ the reader would watch it move between two copies of one book. Sending
 Highlights survive a lost phone and appear on every paired device and in
 the web reader. The Room schema version bumps again, and the app gains a
 mutable synced entity, which is a genuinely harder thing to hold
-correct than a position — most of the new tests exist to pin the
+correct than a position; most of the new tests exist to pin the
 failure modes rather than the happy path.
 
 Pairing a second account uploads the marks already on this device,
@@ -239,7 +240,7 @@ the same way, `forgetSyncPeer()` keeps the reading and lets the next
 account be told about it, and the reader is the same person either way.
 Recording where each mark came from so it could be withheld would put
 provenance in one synced entity and not the others, which is a bigger
-decision than this ADR — and a wrong one to make silently, since a
+decision than this ADR, and a wrong one to make silently, since a
 reader who moves servers expects to take their reading with them.
 
 Removing a book from this device deliberately leaves both its marks and

--- a/docs/adr/0012-grimmory-komga-shim.md
+++ b/docs/adr/0012-grimmory-komga-shim.md
@@ -5,24 +5,24 @@ Status: accepted
 ## Context
 
 [Issue #89](https://github.com/chmouel/liseur/issues/89): a reader runs
-[Grimmory](https://github.com/grimmory-tools/grimmory) — a self-hosted
+[Grimmory](https://github.com/grimmory-tools/grimmory) (a self-hosted
 library manager, formerly BookLore, hence the `org.booklore` package
-names — which advertises a Komga-compatible API. Pointing Liseur's Komga
+names), which advertises a Komga-compatible API. Pointing Liseur's Komga
 client at it got nowhere.
 
 It is a compatibility *shim*, not Komga. Read against v3.3.3, five things
 stop the Komga client dead:
 
-- **Auth is Basic, with a dedicated OPDS user.** There is no API key
+- Auth is Basic, with a dedicated OPDS user. There is no API key
   anywhere in Grimmory, and `KomgaSetupClient` rejects anything that is
   not one.
-- **It is mounted at `/komga/api`, not `/api`.** Liseur's candidate walk
+- It is mounted at `/komga/api`, not `/api`. Liseur's candidate walk
   only ever strips path segments, so a bare host never reaches it.
-- **`POST /v1/books/list` answers 501.** That is the only route the Komga
+- `POST /v1/books/list` answers 501. That is the only route the Komga
   catalog client walks with, so the library would arrive empty.
-- **Downloads would be refused.** Grimmory hardcodes `roles: ["USER"]`;
+- Downloads would be refused. Grimmory hardcodes `roles: ["USER"]`;
   Liseur gates `canDownload` on `FILE_DOWNLOAD`.
-- **A Basic password would not have been persisted.** `storeLocked()`
+- A Basic password would not have been persisted. `storeLocked()`
   sealed one only for calibre-web, so the account would connect and be
   unusable on the next refresh.
 
@@ -31,16 +31,16 @@ Reading position is absent, not merely different: `/progression`,
 `readProgress` is never populated on a book, so even the catalog walk
 that doubles as Komga's change detector carries nothing.
 
-The scope agreed for this work was the shim: connect, browse, download.
-Not Grimmory support in general.
+The scope agreed for this work was the shim: connect, browse, download,
+not Grimmory support in general.
 
 ## Decision
 
 A new `ServerKind.GRIMMORY`, with its own implementations of the existing
 `data/remote/` contracts under `data/grimmory/`. Grimmory's DTO shapes are
 Komga's, so `KomgaHttp` is reused as-is and `KomgaBooks` after a small
-widening; what genuinely differs — auth, path prefix, listing route,
-format filter, href shape, role gate — is written plainly in the Grimmory
+widening; what genuinely differs (auth, path prefix, listing route,
+format filter, href shape, role gate) is written plainly in the Grimmory
 classes.
 
 No position sync: no entry in `AppContainer.positions`, so
@@ -50,7 +50,7 @@ No position sync: no entry in `AppContainer.positions`, so
 
 **A separate kind, not a Komga variant.** The alternative was a flag on
 the Komga classes. Six behaviours differ, and every one of them would have
-become a branch inside code that real Komga also runs — so a change made
+become a branch inside code that real Komga also runs, so a change made
 for Grimmory could break a server the app already supports. The house rule
 is that anything provider-shaped lives behind a `data/remote/` contract
 rather than a `when (kind)` at the call site; a second kind is what that
@@ -66,8 +66,8 @@ Grimmory's main security chain and 401s, so probing the other way round
 would blame the password for what is really an address.
 
 The candidate walk does *not* strip a trailing `komga` from what was
-typed. It looks like it should — an address pasted at the shim would
-otherwise double the prefix — but only the server can say whether that
+typed. It looks like it should: an address pasted at the shim would
+otherwise double the prefix. But only the server can say whether that
 segment is the shim's or the reverse proxy's, and a Grimmory genuinely
 served under `/komga` would become unreachable. So both spellings are
 tried in order: the doubled one 404s, its parent connects, and the row
@@ -92,7 +92,7 @@ since then nothing answered either way.
 
 **A refresh may not downgrade the scheme.** Every setup client falls back
 to plain HTTP when it is told it may, and `refreshCapabilities()` used to
-tell all of them so unconditionally — which meant an https account that
+tell all of them so unconditionally, which meant an https account that
 was merely down for the afternoon got its stored secret retried in the
 clear, with nobody deciding to. It now passes `allowHttp` only for an
 account already stored as `http://`, so the scheme a reader agreed to at
@@ -106,7 +106,7 @@ they arrive as untrusted JSON, get embedded in URL paths, and are
 persisted as `remoteUuid`. One `parse()` accepts `^[1-9][0-9]*$` and then
 round-trips it through `Long`, so an id Grimmory could not address is
 refused rather than carried as a plausible string. Both the catalog and
-the file source use it — a row that somehow stored a bad id still cannot
+the file source use it; a row that somehow stored a bad id still cannot
 aim a request anywhere unintended. This is the rule already written down
 for annotation ids: an id is opaque to carry, but must be checked before
 it is *addressed*.
@@ -119,57 +119,57 @@ bytes a download returns.
 
 **A response this client cannot account for fails the walk.** A walk
 reporting `complete = true` runs `dropVanished()`, which deletes every
-catalogued book it did not see — and the reading progress, sessions and
+catalogued book it did not see, and the reading progress, sessions and
 history hanging off it. `KomgaBooks.parsePage()` defaults a *missing*
 `last` to `true`, so on the paged route one shape mismatch on page 0 reads
 as "the catalog is one page long" and wipes the rest. So the Grimmory
 walk earns the right to prune, page by page, and gives it up on anything
 it cannot account for:
 
-- **The envelope has to describe itself.** `last`, `number`,
+- The envelope has to describe itself. `last`, `number`,
   `totalPages`, `numberOfElements`, `size` and `totalElements` must all
   be present, be of the type they claim, and agree with each other and
   with the page that was asked for. They are read by type rather than by
   presence: a field that is there and null passes `has()` while `optInt`
   answers 0 and `optBoolean` answers its default, which together spell
-  "page 0 of 0, and the last one" — a body that said nothing, believed
+  "page 0 of 0, and the last one": a body that said nothing, believed
   as one saying the catalog ends here.
-- **The counts have to add up.** `numberOfElements` catches a page short
+- The counts have to add up. `numberOfElements` catches a page short
   of what the server said it sent, which 199 rows where it said 200
   otherwise is not: internally plausible, and a book that would be
   pruned as vanished. A page before the last must be full measured
   against the server's *own* declared `size`, not the 200 that was
   requested, so a server entitled to clamp its page size is not locked
   out of pruning forever. `totalPages` must be the number of pages
-  `totalElements` at that size actually needs — which is how the server
-  works it out too — and on the last page the running count of entries
+  `totalElements` at that size actually needs, which is how the server
+  works it out too, and on the last page the running count of entries
   must equal `totalElements` exactly.
-- **The catalog is pinned to its first answer.** `totalElements`,
+- The catalog is pinned to its first answer. `totalElements`,
   `totalPages` and `size` are held constant for the whole walk. Checking
-  each page only against itself lets a catalog shrink underneath it —
+  each page only against itself lets a catalog shrink underneath it:
   page 0 saying three books over three pages, page 1 saying two and that
-  it is the last — with every count self-consistent and the third book,
+  it is the last, with every count self-consistent and the third book,
   never sent, pruned as one that went away. A catalog being written to
   while it is read is not one to prune against.
-- **No book may be counted twice.** Ids are tracked across the walk,
+- No book may be counted twice. Ids are tracked across the walk,
   because counts alone cannot tell a page of two books from a page
   holding one book twice, and the second shape leaves a book the server
   counted unsent and therefore prunable.
-- **`content` has to be an array.** Absent, JSON null and some other
+- `content` has to be an array. Absent, JSON null and some other
   type all parse to no books, which is exactly what a library someone
   emptied looks like. This is the one shape that ends the walk rather
   than merely forfeiting completion: there is nothing to stream, and no
   reason to trust the paging fields wrapped around it either.
-- **Every entry has to be readable.** An entry that is not an object or
+- Every entry has to be readable. An entry that is not an object or
   carrying an unparseable id forfeits completion while its well-formed
-  neighbours still stream through — on that page and on every page
+  neighbours still stream through, on that page and on every page
   after it. Entries that never became books are counted back into the
   duplicate check, or one malformed row would read as the same book
   twice and stop the walk by the back door.
-- **A media type has to be one of two known lists.** EPUB is readable;
+- A media type has to be one of two known lists. EPUB is readable;
   the six other formats `KomgaMapper.getMediaType()` can return are
-  known and skipped; anything else is unknown. The tempting rule — "not
-  an EPUB means not readable" — cannot tell a comic from an EPUB whose
+  known and skipped; anything else is unknown. The tempting rule, "not
+  an EPUB means not readable," cannot tell a comic from an EPUB whose
   type was spelled differently, and gets the second one wrong by
   deleting it. One ordinary EPUB alongside a hundred respelled ones
   would otherwise keep the walk complete and prune the hundred. Meeting
@@ -181,12 +181,12 @@ it cannot account for:
   is Grimmory saying it does not know either. An EPUB is a zip, so
   filing it under "not a book" would prune one that is merely
   mislabelled.
-- **An unknown type costs the pruning, not the browsing.** It forfeits
+- An unknown type costs the pruning, not the browsing. It forfeits
   completion, but the walk carries on to the end. Stopping there would
   hide every book on the pages behind it: one audiobook early in a large
   library would empty most of the shelf, and the reader would go looking
   for a server fault rather than a format this build has not met.
-- **A catalog of nothing readable is not an emptied one.** A walk that
+- A catalog of nothing readable is not an emptied one. A walk that
   reaches the last page having seen entries but shelved none of them
   refuses to prune, as the backstop for the case where the types are all
   known and all wrong. A server that genuinely holds no EPUBs loses
@@ -196,7 +196,7 @@ it cannot account for:
 implying otherwise: a catalog edited *while* the walk is reading it, in a
 way that keeps its size. Delete one book and add another between two
 requests and the pages shift under the offset, so a book that is still
-there is never sent — and every count, the page arithmetic and the
+there is never sent, and every count, the page arithmetic and the
 uniqueness check all still agree. It would be pruned, taking its reading
 position with it.
 
@@ -227,7 +227,7 @@ and says why. If remote search is ever wired to the UI, Grimmory's OPDS
 `catalog?q=` is the way in.
 
 **`canDownload` is unconditionally true.** There is no `FILE_DOWNLOAD`
-role to report — the shim hardcodes `["USER"]` — and `/file` is open to
+role to report, the shim hardcodes `["USER"]`, and `/file` is open to
 any authenticated OPDS user the library is shared with. Gating on the role
 as the Komga client does would refuse every download.
 
@@ -241,7 +241,7 @@ running server, and they are genuinely indistinguishable from the client.
 
 **Verified against a real server, not a reading of its source.**
 `hack/grimmory-dev` brings up a pinned `ghcr.io/grimmory-tools/grimmory`
-image — **v3.3.3**, never `latest`, so a red test stays attributable —
+image (**v3.3.3**, never `latest`, so a red test stays attributable),
 seeds it over REST with 210 generated EPUBs and one CBZ, and
 `tests/grimmory-connect` drives the app's own screens against it: sign in,
 a shelf that spans more than one real HTTP page, the comic absent, a
@@ -260,12 +260,13 @@ credential set and matched by file hash. That is the way in if position
 sync is ever wanted here; it is a different protocol and a different
 credential, not an extension of this.
 
-Series ids are synthetic — `{libraryId}-{slugified-name}` — so renaming a
+Series ids are synthetic (`{libraryId}-{slugified-name}`), so renaming a
 series in Grimmory changes its id. `SeriesExtrasRepository` is gated on
 Komga and never fires here, which is the right outcome: the id still
 arrives on the book and groups the shelf, and a rename regroups rather
 than corrupts.
 
-`sizeBytes` is `fileSizeKb * 1024`, rounded to the kilobyte. Cosmetic.
+`sizeBytes` is `fileSizeKb * 1024`, rounded to the kilobyte. That is
+cosmetic.
 
 No new dependency, and with OPDS dropped, no XML parsing added at all.

--- a/docs/adr/0013-server-kind-picker.md
+++ b/docs/adr/0013-server-kind-picker.md
@@ -7,8 +7,8 @@ Status: accepted
 [Issue #96](https://github.com/chmouel/liseur/issues/96). The kind picker
 on the book-server screen has been rebuilt once per kind added. It was a
 `SingleChoiceSegmentedButtonRow` while there were two, and adding
-Grimmory (#94) took four labels — "calibre-web", "Komga", "Grimmory",
-"liseur-sync" — past what a phone's width holds. A segmented control does
+Grimmory (#94) took four labels, "calibre-web", "Komga", "Grimmory",
+"liseur-sync", past what a phone's width holds. A segmented control does
 not wrap, so it became a `FlowRow` of `FilterChip`s.
 
 That works, and on a phone it is two rows of chips above a
@@ -16,22 +16,22 @@ That works, and on a phone it is two rows of chips above a
 button. The whole first screenful is spent on a choice most readers make
 once, and three things are wrong with it:
 
-- **The chips carry no information.** A reader who does not already know
+- The chips carry no information. A reader who does not already know
   which of these they run learns nothing from four product names, and
   the card underneath explains only the kind already selected. There is
   no state of this screen in which the four can be compared.
-- **It gets worse as it grows.** Every kind added makes every chip
+- It gets worse as it grows. Every kind added makes every chip
   narrower. A fifth wraps to a third row or starts truncating.
-- **The card is tall and mostly says what the fields say.** Two of the
+- The card is tall and mostly says what the fields say. Two of the
   four `server_intro_*` strings are "give the address of your server and
   the login you use for it", which is the `Server address` and `Password`
   labels restated at four times the height.
 
 ## Decision
 
-One `OutlinedCard` holding a `ListItem` — overline "Which kind of
+One `OutlinedCard` holding a `ListItem`: overline "Which kind of
 server?", headline the selected kind, supporting its tagline and one
-line on whether it keeps your place, trailing a chevron — which opens a
+line on whether it keeps your place, trailing a chevron, which opens a
 `ModalBottomSheet` listing every kind in the same shape with a radio
 button. `ServerKindRow` and `ServerKindSheet`, in their own file.
 
@@ -52,7 +52,7 @@ also makes the first thing a reader sees a wall of prose, when most of
 them know which server they run and want the address box.
 
 **An `ExposedDropdownMenuBox`.** The smallest footprint, and it fixes
-height and scaling — but a menu item is one line, so the taglines have
+height and scaling, but a menu item is one line, so the taglines have
 nowhere to go and we are back to four bare names. It also reads as a
 form field among form fields, when it is the switch deciding which form
 fields exist.
@@ -85,7 +85,7 @@ than dropped:
 `ServerKind.syncAbility` (`EXACT` / `PROGRESSION` / `NONE`) is new, and
 deliberately not `RemoteServer.canSync`. They answer different
 questions: the picker asks what a kind *can ever* do, with no account in
-existence yet, while `canSync` asks whether this account is ready now —
+existence yet, while `canSync` asks whether this account is ready now,
 and for calibre-web that waits on a Kobo token, which is an account's
 problem and not a reason to warn a reader off the kind. Folding them
 together would mean a picker inventing an account to interrogate, or a
@@ -110,7 +110,7 @@ persisted state: sheet visibility is a local `rememberSaveable`, so
 rotation is free and `onKindChange` keeps its signature.
 
 Switching kinds costs one more tap than a chip did. That is the trade,
-and it is a small one — switching is something a reader does while
+and it is a small one: switching is something a reader does while
 working out which server they have, and the sheet is better at that than
 four names ever were.
 
@@ -130,7 +130,7 @@ Licences screen.
 
 Komga's is not. Its repository is MIT, but the icon is, by Komga's own
 README, "based on an icon made by Freepik from flaticon.com", and
-Flaticon's licence is neither transferable nor sublicensable — so
+Flaticon's licence is neither transferable nor sublicensable, so
 Komga's MIT cannot reach it, and F-Droid's inclusion policy requires
 every bundled asset to be redistributable. Komga therefore gets a
 neutral book-server glyph, tinted with the theme rather than left in

--- a/docs/adr/0014-kosync.md
+++ b/docs/adr/0014-kosync.md
@@ -7,7 +7,7 @@ Status: accepted
 [Issue #95](https://github.com/chmouel/liseur/issues/95). Grimmory is
 browsed through its Komga shim (ADR-0012), and the shim carries no
 reading position: `canSync` is false, and the settings screen says
-positions stay on this device. But Grimmory does hold positions — behind
+positions stay on this device. But Grimmory does hold positions, behind
 KOReader's kosync protocol at `{base}/api/koreader`, under a third
 credential set created in its device settings.
 
@@ -20,7 +20,7 @@ of it while pretending otherwise.
 The protocol is small: `GET /users/auth` proves a credential,
 `GET /syncs/progress/{document}` asks where a book stands,
 `PUT /syncs/progress` says where it stands here. A book is named by
-KOReader's partial MD5 of its file bytes — which
+KOReader's partial MD5 of its file bytes, which
 `BookFingerprint.partialMd5` already reproduces, because liseur-sync
 resolution needed it first. Auth is two headers: `x-auth-user` and
 `x-auth-key`, the hex MD5 of the password.
@@ -38,10 +38,10 @@ they can neither see nor resolve, so it is not offered.
 asked in three: the settings section, so it is not shown; the sync
 itself, so it stays quiet; and the foreground policy, so nothing wakes
 it. The last two are what make the rule true rather than merely
-presented. A saved pairing is not permission to sync — an account switch
+presented. A saved pairing is not permission to sync. An account switch
 interrupted halfway, a crash, or a database restored onto a phone that
 never made the pairing all leave a `kosync_peer` row behind a server
-that knows nothing about it — so the peer asks what is connected on
+that knows nothing about it, so the peer asks what is connected on
 every run instead of trusting the row's existence.
 
 A pairing the newly connected server cannot host is dropped, in the
@@ -57,7 +57,7 @@ server.** It is paired *alongside* whatever catalog server is connected,
 from a section on the same settings screen, and lives in its own
 single-row table (`kosync_peer`) with its own lifecycle: disconnecting
 the catalog server leaves it standing, and vice versa. The architecture
-was already shaped for this — `CompositePositionSync` runs a list of
+was already shaped for this: `CompositePositionSync` runs a list of
 `PeerPositionSync`s in turn, and `sync_peer_state` keys agreements by
 `(book_url, peer_id)`, so the kosync partner's baselines and the catalog
 server's cannot overwrite each other. Merging goes through
@@ -68,19 +68,19 @@ fourth set of rules.
 (`remote_uuid` set, a remote-scheme `books.url`, bytes on device).
 kosync needs the file's hash, so only a downloaded book can be spoken
 about at all; restricting to server books keeps the run bounded and
-matches the reason the partner exists — Grimmory's own books, positions
+matches the reason the partner exists: Grimmory's own books, positions
 held next door. The URL check matters: a locally added book *adopted*
 after an upload to liseur-sync also carries a `remote_uuid` but keeps
-its local `url` by design, and its positions already travel natively —
+its local `url` by design, and its positions already travel natively, so
 kosync leaves it alone. kosync has no list endpoint, so a run is one GET
-per candidate — every candidate, deliberately, because a position that
-exists only on the server can be found no other way — stopped early
-when the server stops answering.
+per candidate. It checks every candidate, deliberately, because a
+position that exists only on the server can be found no other way, and
+stops early when the server stops answering.
 
 **Percentage-only fidelity.** The protocol's `progress` field is an
 engine-specific position (a CRe xpointer, a page number) that means
 nothing to Readium. On the way out it carries the percentage as a bare
-string — the shape KOReader itself accepts for engines without an
+string, the shape KOReader itself accepts for engines without an
 xpointer, and the one liseur-sync answers with (verified against its
 kosync adapter and tests). A pull therefore lands at roughly the right
 page, exactly as calibre-web's Kobo sync does, and
@@ -94,11 +94,11 @@ leak exposes is a credential for this one protocol, not a password the
 reader may have reused. The key is still a replayable credential, and a
 cleartext connection exposes it to the network path: the scheme
 defaults to https, and an unreachable https root is never retried over
-http — the downgrade the catalog kinds offer behind a confirmation is
+http; the downgrade the catalog kinds offer behind a confirmation is
 not offered here at all.
 
 **Redirects are not followed.** OkHttp strips `Authorization` when a
-redirect changes host, which protects the catalog kinds — but kosync
+redirect changes host, which protects the catalog kinds, but kosync
 signs with custom `x-auth-*` headers that would be forwarded wholesale,
 and a register body even carries the raw password. No kosync endpoint
 legitimately redirects (the mount root is typed by the reader), so a
@@ -115,12 +115,12 @@ root.
 
 **The account key is `kosync|{url}|{username}`.** Signing in as a
 different kosync user strands the old agreements rather than adopting
-them — the rule every other kind follows — and all per-account state is
+them. That is the rule every other kind follows, and all per-account state is
 cleared through one repository door, the `forgetSyncPeer()` precedent.
 
 **A document name is validated before it is addressed.**
-`^[0-9a-f]{32}$` — exactly KOReader's partial-MD5 shape, the only
-document this client ever computes — or the request is refused as
+`^[0-9a-f]{32}$`, exactly KOReader's partial-MD5 shape, the only
+document this client ever computes, or the request is refused as
 malformed. The `GrimmoryId` rule: opaque to carry, checked before put
 in a URL path.
 
@@ -136,7 +136,7 @@ flows through this same partner, so the rules exist once.
 - Any stock kosync server works the same way, which is tested end to end
   against liseur-sync's `/adapter/kosync`.
 - A book downloaded from elsewhere has different bytes, a different
-  hash, and therefore a different kosync document — two copies of one
+  hash, and therefore a different kosync document, so two copies of one
   work do not exchange positions. That is the protocol's nature, not a
   bug to fix here.
 - `shouldSyncOnForeground` now asks about the kosync partner on its own

--- a/docs/adr/0015-custom-server.md
+++ b/docs/adr/0015-custom-server.md
@@ -8,8 +8,8 @@ Status: accepted
 speaks to four servers, and each one is a client written against a
 particular product: calibre-web's OPDS routes and Kobo endpoints, Komga's
 REST API, liseur-sync's op log, Grimmory through the Komga shim
-(ADR-0012). A reader whose books live on anything else — Calibre's own
-content server, COPS, Kavita, a static feed on a NAS — has no way in.
+(ADR-0012). A reader whose books live on anything else, Calibre's own
+content server, COPS, Kavita, or a static feed on a NAS, has no way in.
 
 OPDS is the standard those servers all speak, and Liseur has parsed it
 since the beginning: `data/calibre/OpdsParser.kt`. But it was never a
@@ -24,17 +24,17 @@ is no obvious server to pair with.
 
 ## Decision
 
-**One kind, two addresses, either of which may be blank.** A Custom
+One kind, two addresses, either of which may be blank. A Custom
 connection holds an OPDS catalog address and a KOReader sync address.
 Filling in both is the ordinary case; a catalog with no sync and a sync
 server with no catalog are both real, and both are things a reader has.
 
-Two kinds — "OPDS" and "kosync" — was the alternative. It was rejected
+Two kinds, "OPDS" and "kosync", was the alternative. It was rejected
 because one server is connected at a time: a reader with a catalog and a
 sync server would have had to choose, and the two halves are not
 alternatives to each other.
 
-**Catalog absence is a column, not an inference.** `remote_server` gains
+Catalog absence is a column, not an inference. `remote_server` gains
 a nullable `catalog_url`. It is the only address any catalog path reads.
 Null means this connection catalogs nothing, and every catalog path
 answers "nothing to do" rather than reporting a failure.
@@ -42,7 +42,7 @@ answers "nothing to do" rather than reporting a failure.
 Modelling it as `baseUrl` plus `canDownload = false` was tried on paper
 and does not work: `RemoteCatalogRepository.refresh()` reads
 `server.credentials` and treats null as a lost account, then asks the
-router for a client and hands it `baseUrl` — so a sync-only connection
+router for a client and hands it `baseUrl`. So a sync-only connection
 would either report a broken account or try to parse a kosync endpoint
 as an Atom feed.
 
@@ -52,11 +52,11 @@ column would tell every existing calibre-web, Komga, Grimmory and
 liseur-sync account that it has no catalog, and those libraries would
 stop refreshing the moment the reader updated.
 
-**A book's identity carries the catalog that issued it.** OPDS entry ids
+A book's identity carries the catalog that issued it. OPDS entry ids
 are opaque and unique only within their own feed: `1` is legal, and two
 unrelated servers can both use it. A downloaded book keeps its URL
 across an account switch, so `custom:{entry-id}` would let a second
-Custom server adopt the first one's rows — the wrong file, the wrong
+Custom server adopt the first one's rows: the wrong file, the wrong
 metadata, somebody else's reading history behind it.
 
 So the URL is `custom:{fingerprint}:{hashed-entry-id}`, the fingerprint
@@ -72,15 +72,15 @@ server picks: one containing `/` is a download that fails, and
 sixteen-byte digest is fixed-length, safe as a filename, and the same
 one on every refresh, which is the whole of what the identity has to do.
 
-**The catalog's password goes to the catalog's origin and nowhere
-else.** A feed is a document written by someone else, and every link in
-it — the next page, a shelf, a cover, the book itself — is an address
+The catalog's password goes to the catalog's origin and nowhere
+else. A feed is a document written by someone else, and every link in
+it, the next page, a shelf, a cover, or the book itself, is an address
 the server chose. OPDS is federated: pointing at another host is a
 feature. `RemoteHttp` signs whatever URL it is handed, so following
 those links as written would post the reader's password wherever the
 feed said.
 
-The rule is by origin — scheme, host and port — and not by origin plus
+The rule is by origin (scheme, host and port), and not by origin plus
 path prefix, which is what the plan for this work proposed. Catalogs
 routinely serve their files from a path beside the feed rather than
 beneath it (`/opds` and `/get`), so a prefix rule breaks the ordinary
@@ -94,18 +94,18 @@ unsigned. `RemoteOrigin.ofOrigin()` drops the path for the kinds whose
 links are absolute, so the rule the catalog is fetched under is the rule
 its covers are fetched under.
 
-**The fingerprint includes the query.** `?shelf=…` and `?library=…` are
+The fingerprint includes the query. `?shelf=…` and `?library=…` are
 how catalogs commonly pick which books to show, so two shelves of one
 server are two catalogs. Trimmed off, they would share one namespace and
 each could adopt the other's books. `RemoteUrl.normaliseBase` drops a
 query for every other kind, where it is noise; OPDS setup opts in.
 
-**Redirects are walked by hand.** Checking where a redirect landed is
+Redirects are walked by hand. Checking where a redirect landed is
 too late: OkHttp re-sends the `Authorization` header on a same-host hop
 and has already delivered the password by the time anything can object.
 `OpdsHttp` disables automatic redirects and decides per hop, before each
 one is sent. An https catalog is never followed down to http, whatever
-the server says — a redirect is not the reader agreeing to send their
+the server says; a redirect is not the reader agreeing to send their
 password in the clear.
 
 The downgrade rule is asked of the *scope*, not of the current call. An
@@ -124,10 +124,10 @@ setup redirect that leaves the origin is refused, and the reader is one
 retyped address away from the same connection. An anonymous one is
 followed, because nothing is being handed out.
 
-**A catalog on the internet does not reach into the house.** A feed can
+A catalog on the internet does not reach into the house. A feed can
 name `192.168.1.1`, `169.254.169.254` or `printer.local` and have the
 phone go and fetch it, which is a reachability probe from outside that
-the reader never asked for and cannot see. Refused — but only from a
+the reader never asked for and cannot see. It is refused, but only from a
 public catalog. Self-hosting is the ordinary case here and lives at
 `192.168.…`, and a catalog already inside the house gains nothing by
 naming its neighbour, so a private root may fetch privately. Judged from
@@ -160,7 +160,7 @@ goes out on every call. Plain HTTP to a public sync server is refused;
 plain HTTP across a network the reader controls is their call to make,
 and refusing it would break most of the sync servers actually in use.
 
-**Links are resolved against the document they were written in.**
+Links are resolved against the document they were written in.
 `RemoteUrl.resolve()` throws an absolute href's host away and rewrites
 it onto the configured base. That is right for a reverse-proxied
 calibre-web and catastrophic for an arbitrary catalog: it would silently
@@ -168,9 +168,9 @@ retarget a CDN acquisition link at the OPDS host. The walker resolves
 against the URL that answered, honouring `xml:base`, and stores absolute
 URLs. `ServerKind.linksAreAbsolute` is where that difference lives.
 
-**The walk is bounded, and says when a bound stopped it.** A catalog
+The walk is bounded, and says when a bound stopped it. A catalog
 root may hold books, or shelves, or shelves of shelves, so the walk has
-to find the books — and stop. Three bounds: a visited set, a depth limit
+to find the books and stop. Three bounds: a visited set, a depth limit
 of four, and a total request budget of four hundred. Depth alone does
 not bound breadth; an author index is one level deep and ten thousand
 feeds across.
@@ -179,7 +179,7 @@ When a bound stops the walk it reports `CatalogWalk(complete = false)`,
 which is what stops the library treating a walk cut short as proof that
 everything it did not reach has been deleted.
 
-**Only formats Readium can open are offered.** An entry commonly
+Only formats Readium can open are offered. An entry commonly
 advertises EPUB, PDF, CBZ, an audiobook and a DRM-protected variant side
 by side. The client picks a DRM-free EPUB; an entry with none is listed
 without a download rather than dropped, because dropping it leaves the
@@ -187,19 +187,19 @@ reader hunting for a book the server does show. `buy`, `borrow`,
 `sample` and `subscribe` are acquisitions in the specification's sense
 and files the reader does not have, so they are not downloads.
 
-**A blank credential is `Anonymous`, not absent.** Plain OPDS is often
+A blank credential is `Anonymous`, not absent. Plain OPDS is often
 unauthenticated. A null `credentials` already means "the stored secret
 cannot be decrypted, this account is lost", so an open catalog spelled
 that way would be reported as broken for ever.
 
-**Both halves are proved before either is written.** Two addresses mean
+Both halves are proved before either is written. Two addresses mean
 two servers that can refuse independently. Both are probed first, and
-publication — retiring the old account, storing the server, adopting or
-dropping the pairing — happens in one transaction. Half a connection is
+publication happens in one transaction: retiring the old account,
+storing the server, adopting or dropping the pairing. Half a connection is
 not what the reader filled in, and a process death between the two
 writes would leave a catalog with last week's pairing attached.
 
-**A connection with no catalog is still signed in as somebody.** Its
+A connection with no catalog is still signed in as somebody. Its
 catalog credential is `Anonymous`, because there is no catalog, but the
 reader typed a name into the sync fields and that name is the account.
 Left out of `remote_server.username`, two kosync users on one sync
@@ -207,13 +207,13 @@ server would share an `accountKey`, a switch between them would read as
 the same account coming back and keep the other person's sync state, and
 Settings could not say who is connected.
 
-**The form is authoritative on every successful Custom connection.** A
+The form is authoritative on every successful Custom connection. A
 filled sync address replaces any existing pairing; an empty one removes
 it. Without that, choosing a catalog-only Custom after Grimmory would
 leave Grimmory's pairing running against a field the reader
 deliberately left blank.
 
-**A sync-only connection speaks about the books on the device.** The
+A sync-only connection speaks about the books on the device. The
 kosync run starts from `bookDao.allRemote()`, whose query is
 `WHERE remote_uuid IS NOT NULL`, so changing a predicate could not have
 done this: a sideloaded book is gone before any predicate sees it. A

--- a/docs/adr/0016-book-details.md
+++ b/docs/adr/0016-book-details.md
@@ -9,16 +9,16 @@ remembers about a book fits on a spine: a title, an author, a cover, a
 series and a place in it, a page count and a size the server claimed.
 Most of what the book says about itself is read past.
 
-`LocalLibraryRepository` opens every EPUB through Readium's streamer —
+`LocalLibraryRepository` opens every EPUB through Readium's streamer,
 in `indexBook()`, in `reindexBook()` when the file's modification time
-moves, and in `indexDownloadedFile()` when a download lands — and takes
+moves, and in `indexDownloadedFile()` when a download lands, and takes
 five things: the title, the author, the cover, the identifier (folded
 into `work_id` by `workIdOf()`), and the series. Behind those,
 `Publication.metadata` was also holding a subtitle, a description, a
 publisher and imprint list, a language list, a publication date, a
 subject list, a page count, an `Accessibility` record, and a full
 contributor list with roles
-— translators, narrators, illustrators, editors. The publication closes
+: translators, narrators, illustrators, editors. The publication closes
 and they go with it.
 
 The catalogs fare no better. calibre-web puts the book's description in
@@ -33,7 +33,7 @@ then stores.
 The device knows a few things no server does: the watched folder tree a
 local book was found under, what the file weighs, when it arrived, when
 it was downloaded, and when it was last modified. It knows the two
-hashes as well, but only for books something has already asked about —
+hashes as well, but only for books something has already asked about;
 `BookFingerprintStore` reads the whole file to compute them and does it
 lazily, for sync.
 
@@ -47,12 +47,12 @@ first chapter.
 
 ## Decision
 
-**A screen, not a bigger sheet.** The actions sheet is a column of
+A screen, not a bigger sheet. The actions sheet is a column of
 conditional rows that has grown once per verb the app learned, and
 details are not a verb: they are somewhere to stay, scroll, and come
 back to. So a full screen, routed from `MainActivity` beside
 `Screen.BOOK_STATS`, with the same `returnsTo` treatment, reachable from
-the actions sheet wherever that sheet already opens — the library and
+the actions sheet wherever that sheet already opens: the library and
 the series screen. The sheet gains one row and loses the pressure to
 become a details view itself.
 
@@ -61,29 +61,29 @@ that does not host the actions sheet and does not route through
 `MainActivity.Screen`, so an entry point there is an activity contract,
 not a row: a separate decision, and not this one.
 
-**Read-only.** Correcting what a book says about itself is a different
+Read-only. Correcting what a book says about itself is a different
 feature with a different shape. An edit has to survive every catalog
-refresh and every re-index, which means a third precedence layer — the
+refresh and every re-index, which means a third precedence layer: the
 one the series columns already carry in `user_series_name`, with its
 own conflict rules. Series editing exists and stays where it is. This
 screen displays.
 
-**Five bands, and a field with nothing behind it is not drawn.**
+Five bands, and a field with nothing behind it is not drawn.
 
-- *The book* — cover, title, subtitle, contributors with their roles,
+- *The book*: cover, title, subtitle, contributors with their roles,
   series and position.
-- *About* — description, subjects.
-- *Publication* — publishers, imprints, publication date, languages,
+- *About*: description, subjects.
+- *Publication*: publishers, imprints, publication date, languages,
   identifiers, page count, and the accessibility record when the file
   declares one.
-- *This copy* — format, size, where it came from, added, downloaded and
+- *This copy*: format, size, where it came from, added, downloaded and
   file-modified dates, and the two hashes when they have already been
   computed. Nothing here computes a hash: reading a whole book off a
   document provider to fill in a row the reader did not ask for is the
   wrong trade, and `BookFingerprintStore` will fill it in the first time
   sync needs it. A book with no file on this device shows no hash, even
   if a row survives from a copy that used to be here.
-- *Reading* — progress, time left, finished and archived state,
+- *Reading*: progress, time left, finished and archived state,
   annotation counts, and a way into `BookReadingStatsScreen`.
 
 A screen of em dashes says less than a short screen, so an absent field
@@ -94,7 +94,7 @@ and that is an honest answer.
 The reading band links rather than repeats. Everything on it is one
 line; the moment it wants a chart it is the stats screen, which exists.
 
-**Stored, with a backfill pass, not read while the reader waits.**
+Stored, with a backfill pass, not read while the reader waits.
 Mounting a document provider, opening a container and parsing an OPF is
 the work the indexing pass already does, and it is not work to start
 inside a navigation. The larger reason is that a book in
@@ -102,7 +102,7 @@ inside a navigation. The larger reason is that a book in
 can only ever be what the catalog said and what was written down at the
 time.
 
-**One row per source, not one column per field.** `books` keeps
+One row per source, not one column per field. `books` keeps
 `file_series_name` apart from `catalog_series_name` precisely so a
 catalog refresh cannot overwrite what the file said, and that reasoning
 holds for every field here. Doing it the same way would add fourteen
@@ -113,10 +113,10 @@ that each source's contribution is a *snapshot* that has to be replaced
 whole: when a catalog refresh no longer mentions a description, the
 right answer is that the server no longer has one, and paired columns
 make that an update per field where a row makes it one write. A
-`book_metadata` table keyed by `(book_url, source)` holds exactly that —
+`book_metadata` table keyed by `(book_url, source)` holds exactly that:
 one row per source, replaced atomically, resolved by one pure function.
 
-**Derived state dies with the book.** `book_metadata` is the one table
+Derived state dies with the book. `book_metadata` is the one table
 in this schema that should cascade, and it gets this schema's first
 foreign key: `book_url` references `books.url` `ON DELETE CASCADE`.
 `reading_progress`, `annotations` and `annotation_sync` have no foreign
@@ -151,19 +151,19 @@ book_metadata(
 ```
 
 Lists are JSON in a column, which is what `reading_progress.locator_json`
-already does. Child tables would buy queries nobody has asked for — the
-screen reads a book's rows and renders them — and cost three more tables
+already does. Child tables would buy queries nobody has asked for; the
+screen reads a book's rows and renders them, and they cost three more tables
 and three more cascades.
 
 There is no `updated_at`. A row is replaced whole and precedence never
 asks when either source last spoke, so a timestamp here would be a
-column that decides nothing — the same reason `client_ts` decides
+column that decides nothing: the same reason `client_ts` decides
 nothing in annotation sync.
 
 `file_size_bytes` is the size the device measured, and it is deliberately
 not `books.size_bytes`, which is the catalog's claim and is treated as
 untrusted wherever it is added up. The screen labels the two differently
-— what the file weighs here, and what the server says it weighs —
+(what the file weighs here, and what the server says it weighs)
 because when they disagree that is worth knowing rather than worth
 hiding.
 
@@ -172,8 +172,8 @@ scan already has the number: `findEpubs()` runs a projection per
 directory, so `COLUMN_SIZE` joins `COLUMN_LAST_MODIFIED` in it at no
 extra round trip, and the scanned size is carried on `ScannedEpub`. A
 downloaded book is a `File` in `booksDir()` with a `length()`. Anything
-else — a single book imported through the picker, and every old book
-`backfillMetadata()` walks, where no scan is in flight — is one
+else (a single book imported through the picker, and every old book
+`backfillMetadata()` walks, where no scan is in flight) is one
 `ContentResolver.query()` for `COLUMN_SIZE` against that document URI.
 A provider that answers null, or that will not answer at all because the
 permission was never persisted, leaves the size unknown, which is a
@@ -197,14 +197,14 @@ blurb.
 
 Scalars coalesce, catalog first: description, subtitle, published date,
 page count. This is the way round the series columns
-already resolve — `COALESCE(:catalogSeriesName, file_series_name)` — and
+already resolve (`COALESCE(:catalogSeriesName, file_series_name)`), and
 for descriptions in particular it is right on its own merits: a calibre
 library has usually been curated, and the blurb a reader put on the
 server is the blurb they want to see, while the OPF's is whatever the
 retailer shipped.
 
 Collections merge and deduplicate: contributors, subjects, languages,
-identifiers. Coalescing them would lose data the screen exists to show —
+identifiers. Coalescing them would lose data the screen exists to show:
 a catalog author would hide the file's translator and illustrator, a
 catalog ISBN would hide the EPUB's UUID, and a subject list from either
 side would silently replace the other's. Order is catalog first, then
@@ -233,13 +233,13 @@ is the direction, not the machinery.
 
 ### Where each source is written
 
-The file snapshot is written wherever a publication is already open —
-`indexBook()`, `reindexBook()`, `indexDownloadedFile()` — in the same
+The file snapshot is written wherever a publication is already open
+(`indexBook()`, `reindexBook()`, `indexDownloadedFile()`), in the same
 write that stores the book, and marked with `file_metadata_checked`.
 
 `reindexBook()` needs its order fixed to survive this. It writes the
 book through `refreshIndexedFile()` and only then, on a `work_id` that
-does not match, calls `contentReplaced()` — so under these rules it
+does not match, calls `contentReplaced()`. So under these rules it
 would write the new file's snapshot and delete it a line later. The
 replacement case becomes one transaction that clears first and writes
 second: the old reading, sync, fingerprint, metadata, remote, catalog
@@ -271,8 +271,8 @@ off a copy that is no longer here.
 
 It drops the book's `book_fingerprint` row in the same breath, which is
 a hole this ADR inherits rather than opens. `BookFingerprintStore`
-caches on `file_modified_at`, and a downloaded book has none —
-`indexDownloadedFile()` never sets one — so a retained row's null
+caches on `file_modified_at`, and a downloaded book has none
+(`indexDownloadedFile()` never sets one), so a retained row's null
 matches the null of whatever is downloaded next. A server that replaced
 the file behind the same UUID would then be told the old hash, and the
 reading state would be filed against the wrong bytes. Removing the file
@@ -283,14 +283,14 @@ existing transaction, and unlinks the whole remote and catalog
 association with them: `remote_uuid`, `remote_book_id`, `download_href`,
 `cover_url`, `remote_updated_at`, `remote_page_count`, `size_bytes`,
 `catalog_series_name`, `catalog_series_index`, `catalog_folder_id`,
-`catalog_series_source` and `catalog_missing_since` — after which the
+`catalog_series_source` and `catalog_missing_since`, after which the
 effective series is resolved again from the file's own columns.
 
 Clearing the catalog snapshot alone is treating the symptom, and
 clearing only the `remote_*` fields is treating half of it.
 `clearSeriesForReplacedWork()` today drops `series_id` and the user
 layer, then sets `series_name = COALESCE(catalog_series_name,
-file_series_name)` — so a replaced file stays filed under the old work's
+file_series_name)`. So a replaced file stays filed under the old work's
 catalog series even with `remote_uuid` gone. And for a row that was
 adopted after an upload, which keeps its local `url` and gains only
 `remote_uuid` and `download_href` per `BookDao.linkToRemote`, the new
@@ -305,7 +305,7 @@ to be true of every column that says otherwise, in one transaction.
 `RemoteBook` gains subtitle, description, publishers, imprints,
 published date, languages, subjects, identifiers and
 contributors-with-roles. The rule
-is not that two servers must supply a field — `calibreBookId`,
+is not that two servers must supply a field: `calibreBookId`,
 `pageCount`, `seriesId` and `sha256` are each one server's and each on
 the contract already. It is that provider-neutral catalog data with a
 common destination belongs on the contract, and everything here has one:
@@ -324,13 +324,13 @@ book has passed through no server at all. So the stripping and the
 bounds below apply to both sources, on the way in, without exception.
 
 The stripper is `HtmlCompat.fromHtml(…).toString()`, which is AndroidX
-and therefore lives in `data/`, not in `domain/MetadataSanitizer.kt` —
+and therefore lives in `data/`, not in `domain/MetadataSanitizer.kt`;
 the domain layer is pure Kotlin so it stays testable without Robolectric,
 and dragging an Android dependency into it to save an import is the
 wrong trade.
 
 calibre-web's `<content>` is not a description with tags in it. It mixes
-generated labels — `SERIES:`, ratings, tags — with the actual blurb, and
+generated labels, `SERIES:`, ratings, and tags, with the actual blurb, and
 `OpdsParser.directText()` skips nested paragraphs deliberately for that
 reason. Flattening the element wholesale would put catalog boilerplate
 on screen as the book's description, so the description is taken from
@@ -351,9 +351,9 @@ nobody can read is still a row every query carries:
 - contributors: at most 64; name at most 256 characters, role at most 64;
 - identifiers: at most 8; scheme at most 64 characters, value at most 256;
 - languages: at most 8, each tag at most 64 characters;
-- accessibility: the typed fields Readium parses — conformance profiles,
+- accessibility: the typed fields Readium parses: conformance profiles,
   access modes, sufficient access modes, features, hazards, the summary,
-  the certification and the exemptions — and nothing else. Each list at
+  the certification, and the exemptions, and nothing else. Each list at
   most 32 entries of at most 64 characters; the summary and the
   certifier's report at most 1,000. A value the enumerations do not
   cover is dropped rather than shown, because an unrecognised access
@@ -363,15 +363,15 @@ nobody can read is still a row every query carries:
 - series position: finite, non-negative, at most 10,000;
 - `file_size_bytes`: a measured `Long` from `Cursor.getLong()` or
   `File.length()`, kept only within `0..2^53` and discarded otherwise.
-  There is no parsing here — the value never was text.
+  There is no parsing here. The value never was text.
 
 Numbers are checked here because `size_bytes` is barely checked today.
 `OpdsParser` reads the `length` attribute with `toLongOrNull()` and
 accepts whatever comes back, negatives included; `KomgaBooks` and
 `LiseurSyncCatalogClient` keep a size only when it is `> 0`, with no
-ceiling on either. This ADR does not fix that column — that is a change
-to what every catalog refresh writes, and it belongs to whoever makes it
-— so the screen validates it on the way out instead, against the same
+ceiling on either. This ADR does not fix that column. That is a change
+to what every catalog refresh writes, and it belongs to whoever makes it,
+so the screen validates it on the way out instead, against the same
 `0..2^53` window. Outside it, the catalog's size is not formatted and
 not shown, which is the answer the reader would have got if the server
 had said nothing. The new column has the rule the old one lacks, and the
@@ -392,8 +392,8 @@ limited to the configured book server and opt-in dictionary lookups.
 A publication date is often a year, sometimes a year and month.
 Converting it to epoch milliseconds invents a timezone and a precision
 the book never claimed, so it is stored as ISO-8601 text that keeps
-whatever precision arrived — a bare `1962` is not `1962-01-01T00:00:00Z`
-— and rendered at the precision it has.
+whatever precision arrived. A bare `1962` is not
+`1962-01-01T00:00:00Z`, and it is rendered at the precision it has.
 
 For the catalog sources that is achievable, because their parsers hold
 the server's own string and can normalise it without widening it. For
@@ -404,7 +404,7 @@ that said `1962` has already become a full instant before
 recover the year would mean reading the package document a second way,
 past the API that exists to read it, and that is a larger cost than the
 month it buys. So the file source stores the date derived from that
-instant, and the column's contract is the precision of what arrived —
+instant, and the column's contract is the precision of what arrived,
 not a promise that the book only claimed that much.
 
 Languages are plural in EPUB metadata and all valid tags are kept.
@@ -435,8 +435,8 @@ The fields here are chosen; the bag is not.
 now. For a local book it is `books.source`, the watched folder tree.
 That column holds a tree URI and nothing stores its display name, so the
 name is asked of the document provider when the screen opens and falls
-back to a string resource — not to the raw URI, which is a
-percent-encoded document id no reader should be shown — when the
+back to a string resource (not to the raw URI, which is a
+percent-encoded document id no reader should be shown) when the
 provider is gone or the permission was revoked. For a book that arrived
 from a catalog it is the provider kind, recovered from `books.url`
 through `ServerKind.urlPrefix`, which is already how the app tells a
@@ -452,7 +452,7 @@ guess.
 The route carries `book.url` and nothing else. The screen observes the
 `Book` and its metadata rows through a view model, the way every other
 screen here does, rather than being handed a `Book` that was current
-when the sheet opened — a catalog refresh during a long read of the
+when the sheet opened; a catalog refresh during a long read of the
 description would otherwise show yesterday's row. Progress, time left
 and annotation counts come from that same model, not from DAO calls in
 a composable. If the book disappears while the screen is open, because
@@ -461,7 +461,7 @@ sitting on a row that no longer exists.
 
 ### Migration
 
-Room goes to 43 → 44: a hand-written `MIGRATION_43_44` creating the
+Room goes to 43 -> 44: a hand-written `MIGRATION_43_44` creating the
 table and adding `file_metadata_checked`, registered in `MIGRATIONS`,
 with `app/schemas/…/44.json` exported and `MigrationTest` replaying it.
 There is nothing to backfill in SQL; the pass fills the rows from the
@@ -475,7 +475,7 @@ that the fingerprint goes with it; content replacement, including the
 remote unlink, that the replaced file is no longer filed under the old
 work's catalog series, and that a reindex which replaces the work ends
 with the new file's snapshot rather than none; and the sanitiser at its
-boundaries — an oversized description, a subject list past its cap, a
+boundaries: an oversized description, a subject list past its cap, a
 negative size, a page count of zero, an unparseable date, an `xhtml`
 summary, and a calibre
 `<content>` block whose `SERIES:` label must not become the
@@ -489,7 +489,7 @@ same cost and the same pacing: a big library takes a while, and the
 shelf is drawn and usable throughout.
 
 A catalog-only book shows what the server said and no more, and that
-looks thin beside a downloaded one. It is thin — nothing has read the
+looks thin beside a downloaded one. It is thin. Nothing has read the
 file, because there is no file.
 
 This schema now has a foreign key. It is one table and the right table,

--- a/docs/adr/0017-go-to-page.md
+++ b/docs/adr/0017-go-to-page.md
@@ -30,13 +30,13 @@ numbers onto points in the text, which is exactly the number a citation
 quotes and exactly the number written on the paper note. Readium parses
 it, and `Publication.pageList` in `readium-shared` 3.3.0 hands it over
 as links. Liseur reads past it, and the page number in its footer is
-Readium's synthetic position — stable, layout-independent, and unrelated
-to what the paper book called that page.
+Readium's synthetic position, which is stable, layout-independent, and
+unrelated to what the paper book called that page.
 
 ## Decision
 
-The page readout already printed under the scrubber — "Page 142 of 517"
-— becomes tappable, and opens a small dialog asking for a page. Typing
+The page readout already printed under the scrubber, "Page 142 of 517",
+becomes tappable, and opens a small dialog asking for a page. Typing
 one moves the book there.
 
 Where a book declares a `page-list`, the dialog asks for and accepts the
@@ -56,7 +56,7 @@ and behind a tab strip, for an answer the scrubber row is already
 displaying. A long-press on the scrubber has no affordance and would go
 undiscovered. The footer's own page number is tempting and wrong: footer
 taps already cycle the middle slot, a quiet gesture worth leaving alone,
-and the footer is the page the reader is trying to read past — putting a
+and the footer is the page the reader is trying to read past; putting a
 dialog under it makes the text itself a control.
 
 ## Design
@@ -64,7 +64,7 @@ dialog under it makes the text itself a control.
 `ReadingScrubber` in `reader/chrome/ReadingProgressUi.kt` draws the
 readout as a `FooterHint` in the row beneath the slider. It gains an
 `onGoToPage` callback and `clickableWithoutRipple`, which the file
-already defines for exactly this — chrome that must swallow a tap
+already defines for exactly this: chrome that must swallow a tap
 without turning the page and without a ripple.
 
 This composes with [ADR 7](0007-scrubber-page-peek.md), which stops a
@@ -90,9 +90,9 @@ speed estimator is already told not to count the jump as reading.
 
 The resolving is pure and lives in `reader/progress/`, beside
 `BookPositions`, so it is testable on the JVM without an emulator. It
-answers two questions — what to ask for, and what a typed answer means —
-from a `page-list` index built once when the publication opens, the same
-moment `BookPositions.of()` is built.
+answers two questions from a `page-list` index built once when the
+publication opens, the same moment `BookPositions.of()` is built: what
+to ask for, and what a typed answer means.
 
 The index is not an integer range, and the design must not pretend
 otherwise. A `page-list` label is a string: roman numerals across front
@@ -101,8 +101,8 @@ followed by 1 through 480 is neither sorted nor contiguous as a number.
 Labels can also repeat across volumes and can be absent entirely for
 stretches of a book. So the index is a map from label to `Link`, an
 ordered list of the labels for range hints, and nothing more. A label
-the book does not carry is refused — the field says so, and the dialog
-does not move the book — rather than rounded to the nearest thing, which
+the book does not carry is refused; the field says so, and the dialog
+does not move the book, rather than rounded to the nearest thing, which
 would silently answer a different question from the one asked.
 
 `publication.locatorFromLink(link)` turns the chosen `page-list` link
@@ -131,8 +131,8 @@ the lesser of the two costs: the alternative is to keep asking for a
 number nobody outside the app has ever seen. The dialog naming what it
 wants, and the chapter hint confirming where that lands, is what carries
 the difference. Renumbering the footer to the printed page is a much
-larger change — the scrubber, time-left, sync progressions and every
-stored annotation position hang off the synthetic ones — and is
+larger change: the scrubber, time-left, sync progressions and every
+stored annotation position hang off the synthetic ones, and it is
 deliberately not proposed here.
 
 Books with a `page-list` are a minority, and the ones that have it are

--- a/docs/adr/0018-period-over-period-reading-comparison.md
+++ b/docs/adr/0018-period-over-period-reading-comparison.md
@@ -54,7 +54,7 @@ period's final day is today, counted only as far as *now*, while the
 baseline's is a complete twenty-four hours. Without the second bound a
 Tuesday afternoon is measured against the whole of the Tuesday before,
 evening included, so the sentence slides towards "less than last week" as
-every day wears on and springs back at midnight — a change in the
+every day wears on and springs back at midnight. That is a change in the
 arithmetic, reported to the reader as a change in their habits.
 
 The bound is named as a wall-clock time rather than as an instant exactly
@@ -72,8 +72,8 @@ A sitting still running at that moment is counted for the share of its
 length that had elapsed. Everywhere else a sitting belongs whole to the
 day it ended on, and midnight still divides nothing: the rule is there so
 that this device, the headline above and liseur-sync all agree which day
-reading happened on. The cutoff answers a different question — how much
-had been read by now — and the sitting on the other side of the
+reading happened on. The cutoff answers a different question, how much
+had been read by now, and the sitting on the other side of the
 comparison is the one open on the reader's screen, which is itself only
 recorded as far as its last checkpoint. Counted whole it would be an
 evening measured against an afternoon; dropped whole it would be an
@@ -102,7 +102,7 @@ every entry but "All time" carries a comparison. `ALL_TIME` has no period
 before it and shows none.
 
 A saved range id is what is on disk, so the three withdrawn ids stay
-resolvable forever — they are simply no longer `StatsRange` entries, and
+resolvable forever: they are simply no longer `StatsRange` entries, and
 nothing can select them again. `StatsRange.fromId()` maps each to the
 nearest surviving span rather than dropping the reader to the current week
 without telling them:
@@ -137,7 +137,7 @@ Midnight still divides nothing: a sitting belongs whole to the day it ended
 on, here as in the headline and on liseur-sync, so the two halves of a
 comparison still add up to a total over both. The proration exists because
 the sitting on the other side is the one open on the reader's screen, which
-is itself only recorded as far as its last checkpoint — counted whole the
+is itself only recorded as far as its last checkpoint; counted whole, the
 older one would be an evening against an afternoon, dropped whole it would
 be an afternoon against nothing.
 
@@ -163,15 +163,15 @@ no server can answer for; the only way to use a server at all would be to
 add its whole days to this device's part-day, and that sum is unsound twice
 over:
 
-- Its days are the *server's* calendar days — `InsightDay` is documented as
-  such — while this device splits by its own zone. An offset between the
+- Its days are the *server's* calendar days (`InsightDay` is documented as
+  such), while this device splits by its own zone. An offset between the
   two leaves the server's final whole day overlapping the device's partial
   day, so uploaded reading is counted by the server and again locally; a
   westward offset leaves a gap instead. The server does not declare its
   timezone, so the app cannot align the split.
 - The two requests fail independently. One succeeding and the other timing
   out would leave one side counting every device and the other counting
-  one — an evening on a laptop appearing in one half of the comparison and
+  one, with an evening on a laptop appearing in one half of the comparison and
   vanishing from the other, which is exactly the false report of a changed
   habit this whole decision exists to prevent. `summary()` also folds a
   genuinely empty period into the same `null` as a failure, so the two
@@ -216,7 +216,7 @@ figure is which.
 
 Naming the scope is not politeness, it is the claim being made. Leaving
 both devices out of both halves does not preserve the all-device
-percentage — a laptop that did four hours last week and none this week
+percentage. A laptop that did four hours last week and none this week
 would still show "more than last week" on a phone that read a little more
 than it did before. What the line reports is a trend *on this device*, and
 that is a true and useful thing to report; reporting it as a trend in the
@@ -230,7 +230,7 @@ The range menu loses three entries and gains one, which is the cost of the
 comparison applying everywhere it is offered. A reader who used "Last 90
 days" loses a span; the year is what they are moved to, and it is the only
 survivor that does not show them less than they had. In exchange nothing
-in the menu is a window whose caption has to be read arithmetically —
+in the menu is a window whose caption has to be read arithmetically:
 "This year" now says so rather than reading "In the last 227 days".
 
 `THIS_YEAR` and `THIS_MONTH` also gain proper captions, which fixes a

--- a/docs/adr/0019-go-to-percentage.md
+++ b/docs/adr/0019-go-to-percentage.md
@@ -6,8 +6,8 @@ GitHub issue: [#126](https://github.com/chmouel/liseur/issues/126)
 ## Context
 
 [ADR 17](0017-go-to-page.md) made the page readout under the scrubber a
-button. It left the readout beside it — the percentage, on the left of
-the same row — a label, and it left both halves of the question it
+button. It left the readout beside it, the percentage on the left of
+the same row, as a label, and it left both halves of the question it
 answers unfinished.
 
 The percentage is the number the rest of the app already speaks. It is
@@ -23,8 +23,8 @@ The percentage is also the only number that always exists. A printed
 private to the app. The percentage is on every book, in every server,
 and on the shelf.
 
-The second gap is in the dialog ADR 17 shipped. It names the endpoints —
-"Enter a page from 1 to 517" — and not the present. A reader typing an
+The second gap is in the dialog ADR 17 shipped. It names the endpoints
+and not the present: "Enter a page from 1 to 517". A reader typing an
 absolute number is very often moving relative to somewhere: back to the
 start of the chapter, on thirty pages, to the other side of a scene
 break. The number they need for that arithmetic is the one number the
@@ -76,26 +76,26 @@ only needed label to `Link`.
 are still per-book and computed once; only the starting point moves with
 the reader.
 
-The printed index — each `page-list` mark resolved through
-`locatorFromLink` and `BookPositions.resolve()` into a position, sorted,
-one label per position — is built lazily, on first use. A page list runs
-to one mark per printed page, and paying for all of them belongs to the
-moment the reader opens the dialog rather than to every book that is
-merely opened.
+The printed index is built lazily, on first use. Each `page-list` mark
+is resolved through `locatorFromLink` and `BookPositions.resolve()` into
+a position; the result is sorted, one label per position. A page list
+runs to one mark per printed page, and paying for all of them belongs
+to the moment the reader opens the dialog rather than to every book
+that is merely opened.
 
 A page list whose marks land nowhere in the reading order is not a
 numbering at all, whatever the file declares: every label it offered
 would be refused, and the reader would be left with a dialog that cannot
 answer. Such a book falls back to the page the footer shows. The
 endpoints of a real one are still read off the document rather than the
-index, because a page list is not sorted by position — roman numerals
+index, because a page list is not sorted by position; roman numerals
 through the front matter is the ordinary case.
 
 Two rules in the index are deliberate. Marks landing on the same position keep
 the *earliest* label, because a chapter whose marks all resolve to its
 first position should read as the page it starts on, not the page it
-ends on. And a reader ahead of no mark at all — in the cover and the
-title page, before the book prints a number — is told the first number
+ends on. And a reader ahead of no mark at all, in the cover and the
+title page before the book prints a number, is told the first number
 the book does print, rather than an empty field.
 
 The percentage resolver is a function, not a class: there is no per-book
@@ -104,10 +104,11 @@ index to hold, only `BookPositions`.
 It maps a percentage to the *first* position the footer would call that
 percentage, in integer arithmetic, because that boundary is the whole
 point: 7% of a hundred steps is 7.000000000000001 in binary floating
-point, and rounding that up steps a page past the page being asked for. That is the only mapping that keeps the promise the feature
-is for: type the number the footer is showing and the footer still shows
-it. Rounding the other way — flooring, which is what
-`locatorAtOrBeforeProgression()` does for sync — lands a page short, and
+point, and rounding that up steps a page past the page being asked for.
+That is the only mapping that keeps the promise the feature is for:
+type the number the footer is showing and the footer still shows it.
+Rounding the other way, flooring as
+`locatorAtOrBeforeProgression()` does for sync, lands a page short, and
 since the footer truncates rather than rounds, typing 70 leaves 69% on
 screen. A reader can only read that as a refusal, and retype it forever.
 It was written that way first and caught on a device, which is the
@@ -137,8 +138,8 @@ return one.
 
 Every absolute move the reader can name now has a way in, and the two
 they can name sit next to each other in the row that displays them. A
-book with no `page-list` and a reader who thinks in percentages — the
-common case, twice over — is no longer served worst.
+book with no `page-list` and a reader who thinks in percentages (the
+common case, twice over) is no longer served worst.
 
 The percentage is coarse on a long book: one percent of a nine hundred
 page book is nine pages. That is the honest resolution of the number,

--- a/docs/adr/0020-fixed-layout-reading-settings.md
+++ b/docs/adr/0020-fixed-layout-reading-settings.md
@@ -12,7 +12,7 @@ it reflows, and Readium honours no reflowable-text setting inside one:
 [ADR 2](0002-typography-fine-tuning.md) disabled the six rows it added
 when the open book is fixed-layout, and said so in a line above them.
 The rows that were already there were left alone, deliberately, to keep
-that change reviewable — and its consequences say as much. So today the
+that change reviewable, and its consequences say as much. So today the
 reader opening a fixed-layout book gets a menu where alignment is greyed
 out and font size is not, though neither one does anything. Dragging the
 size slider reflows nothing, changes nothing, and gives no reason why.
@@ -52,10 +52,10 @@ Two rows in that table are worth arguing about.
 **`backgroundColor` carries no layout gate at all.** Readium's `theme`
 is reflowable-only, so the obvious reading is that the theme swatches
 belong in the disabled set with everything else. They do not. Liseur
-does not rely on `theme` for its colours — it passes explicit
+does not rely on `theme` for its colours; it passes explicit
 `backgroundColor` and `textColor`, because Readium's own palette is
 close to ours but not identical and the difference shows as bands above
-and below the text — and `EpubNavigatorFragment` calls
+and below the text, and `EpubNavigatorFragment` calls
 `resourcePager.setBackgroundColor(settings.effectiveBackgroundColor)`
 whatever the layout. So the swatches visibly change the letterbox around
 a fixed page, in every theme, and disabling them would take away the one
@@ -79,7 +79,7 @@ own and know nothing about layout.
 The same answer ADR 2 gave, for the same reason: the value is not lost,
 it is waiting for the next book that can use it. A reader who has settled
 on 120% and a wide margin should find both still set when they close the
-comic and go back to the novel — and should be able to see, while the
+comic and go back to the novel, and should be able to see, while the
 comic is open, that the app has not forgotten them.
 
 Hiding the rows instead would also make the two sheets change shape
@@ -95,8 +95,8 @@ and the scrolling joining them, a per-group note would print the same
 sentence three times on one sheet.
 
 So it is hoisted to the top of each sheet, above everything it applies
-to, and reworded. The current wording — "so its text cannot be reshaped"
-— was true of the six spacing and alignment rows; it is not what a
+to, and reworded. The current wording, "so its text cannot be reshaped",
+was true of the six spacing and alignment rows; it is not what a
 reader needs to be told when the size slider and the font picker are
 greyed out as well.
 
@@ -104,7 +104,7 @@ greyed out as well.
 
 `ReadingCss.honoursAnything` already answers this. It is false for
 `Unsupported` and true for `Unknown`, which is precisely what the two
-surfaces need: nothing is disabled on Settings → Reading appearance,
+surfaces need: nothing is disabled on Settings -> Reading appearance,
 where no book is open and the reader is choosing a default for every
 book they will open.
 
@@ -118,8 +118,8 @@ enum gains no member.
 It asks what the reader chose and whether the book runs down the page;
 it never asks whether the book can scroll at all.
 
-Three things hang off it — the tap zones, the footer, and whether the
-sheet offers auto-scroll or a page-turn animation — so a reader who left
+Three things hang off it: the tap zones, the footer, and whether the
+sheet offers auto-scroll or a page-turn animation. So a reader who left
 scroll mode on and then opens a fixed-layout book gets scroll-flavoured
 chrome over a page Readium is paginating regardless: tap zones that
 scroll a page that turns, no footer, and an auto-scroll switch that moves
@@ -137,27 +137,27 @@ would cost a reader their place to no effect.
 ### Everything is still sent
 
 No change to `toEpubPreferences`. Every preference keeps going to Readium
-exactly as before, whatever the layout — what the layout decides is
+exactly as before, whatever the layout; what the layout decides is
 whether a value *counts*, not whether it is stored. This is the rule ADR
 2 set for the stylesheet variants, and a fixed layout is the same rule
 one step further.
 
 ## Consequences
 
-- **The inconsistency ADR 2 recorded closes.** A fixed-layout book
+- The inconsistency ADR 2 recorded closes. A fixed-layout book
   presents one state instead of two: everything that cannot work is
   greyed, and the sheet says why once.
-- **The reading theme and the brightness stay enabled**, and the audit
+- The reading theme and the brightness stay enabled, and the audit
   above is the reason. Anyone reading `EpubPreferencesEditor` alone will
   conclude the theme belongs in the disabled set; it does not, because
   Liseur passes its own colours and Readium paints the pager with them
   in every layout.
-- **A stored value survives a fixed-layout book**, because nothing about
+- A stored value survives a fixed-layout book, because nothing about
   what is sent changes.
-- **`spread` remains unreachable.** A fixed-layout book gets a more
+- `spread` remains unreachable. A fixed-layout book gets a more
   honest menu out of this change and no new capability; the one setting
   it actually has is left to its own issue.
-- **The demo shelf has no fixed-layout book**, so this cannot be checked
+- The demo shelf has no fixed-layout book, so this cannot be checked
   by running `hack/screenshots`. Verifying it means building a
   pre-paginated EPUB by hand and side-loading it.
 - No new dependency, no new stored state, no migration, and no new

--- a/docs/adr/0021-cross-device-reading-statistics.md
+++ b/docs/adr/0021-cross-device-reading-statistics.md
@@ -32,8 +32,8 @@ request succeeded, failed, or was never made.
 
 The list beneath it is bounded by the local shelf. Per-book aggregates
 arrive keyed by the server's `work_id` and are mapped onto local book
-URLs through `work_alias`; a work with no usable alias here — a book
-read only on the other device, or one this device has never resolved —
+URLs through `work_alias`; a work with no usable alias here (a book
+read only on the other device, or one this device has never resolved)
 contributes nothing. `booksRead` and `booksFinished` are then counted
 off those rows, so they cannot exceed what is in this library. A reader
 who did a year on a laptop sees the year in the total and not one book
@@ -50,7 +50,7 @@ And the scope is the one thing never written down.
 `library-manage`, `library-upload`, `library-delete` and `admin` into
 `ServerCapabilities`; `read-insights` is not among them. The app's own
 pairing mints it, so this is invisible until somebody pastes in a token
-minted elsewhere — and liseur-sync's own token form leaves that box
+minted elsewhere, and liseur-sync's own token form leaves that box
 unticked. Such a reader gets a 403 on every insights call for the life
 of the account and is never told.
 
@@ -61,7 +61,7 @@ stand as they are:
 
 Both sides are asked about the same window, and an answer to a different
 one is refused. The two are merged by maximum and never by sum. A
-failure produces no error state — the local figures are a complete
+failure produces no error state; the local figures are a complete
 screen on their own. The period-over-period comparison stays local on
 both sides, for the reasons ADR-0018 gives: a relationship only holds
 between two figures gathered the same way, and half a comparison
@@ -74,7 +74,7 @@ the list stops being smaller than the total above it.
 Record `read-insights` as a stored capability, alongside the five scopes
 already read at connect time. A token that lacks it is then a fact the
 app holds rather than a silence it repeats, and the one reader who has
-to do something about it — re-pair, or tick the box — can be told so.
+to do something about it (re-pair, or tick the box) can be told so.
 
 Say on the screen where the figures came from: this device, or every
 device. One line, and only ever a statement of provenance. It must not
@@ -107,7 +107,7 @@ account paired before the column existed defaults to the pessimistic
 value and is corrected the next time it is introspected.
 
 `LiseurSyncInsights` keeps returning null on every failure. Provenance
-is a separate question from the figures and is answered separately —
+is a separate question from the figures and is answered separately:
 whether an answer arrived for the window on screen, which the view model
 already knows, since refusing a stale one is exactly what
 `forWindow` does. Nothing in the merge needs to change to know it.
@@ -127,8 +127,8 @@ and the honesty is the point: the same blank meaning "you are offline"
 and "your token cannot ask" was worse than either message.
 
 The dashboard's list stops being a subset of its own headline. That is
-the visible change, and it brings a new kind of row with it — a book
-this device does not have — which every consumer of `BookReadingStats`
+the visible change, and it brings a new kind of row with it (a book
+this device does not have), which every consumer of `BookReadingStats`
 has to tolerate rather than assume away.
 
 The scope becomes visible at the moment it can still be fixed, when an

--- a/hack/README.md
+++ b/hack/README.md
@@ -1,10 +1,10 @@
 # hack/
 
 Scripts used to build, test, and release Liseur. Most have a `make`
-target wrapping them — run `make help` for the short list. See
+target wrapping them. Run `make help` for the short list. See
 `DEVELOPER.md` for the full release workflow.
 
-- **`screenshots`** — Captures the screenshots used by the README,
+- `screenshots`: Captures the screenshots used by the README,
   `docs/SCREENSHOTS.md` and the F-Droid listing. `--setup` builds a demo
   shelf first (downloads a set of Standard Ebooks EPUBs, pushes them to
   the device, grants the library folder, seeds a highlight/note/bookmark
@@ -14,106 +14,105 @@ target wrapping them — run `make help` for the short list. See
   `--no-dictionary` skips the definition card, which is the one capture
   that needs the device to reach a site. `hack/screenshots --help` for
   the rest of the flags.
-- **`reset-books`** — Wipes the app's storage and the device's `Books`
+- `reset-books`: Wipes the app's storage and the device's `Books`
   folder on a connected device/emulator, then reseeds it with the same
   demo book shelf as `screenshots --setup`, without capturing anything.
   Backs `make reset`. Downloaded books are cached under `tmp/books`,
   shared with `screenshots`.
-- **`e2e-upload`** / **`e2e-delete`** — End-to-end checks of the two
+- `e2e-upload` / `e2e-delete`: End-to-end checks of the two
   actions that reach a liseur-sync server's disk. Both drive the app
   through its own screens against a real server and then read that
   server's folder and the app's database to see what happened, so
   neither can pass on a mock. `e2e-delete -o DIR` also writes
   screenshots of the sheet and the confirmation, which is where the
   pictures in a pull request come from. `--help` for the flags.
-- **`e2e-open-external`** — End-to-end check that a book handed over by
+- `e2e-open-external`: End-to-end check that a book handed over by
   another app lands on the shelf. Pushes an EPUB somewhere nothing
   watches, opens it through the same `VIEW` intent a file manager
   sends, and then asserts against the app's database that the book was
   shelved, that the reading position hangs off that shelved row, that a
   second handover of the same file does not shelve it twice, and that
   the upload offer can reach it. It runs under the "keep them here"
-  upload policy — which it sets through the settings screen and puts
-  back afterwards — so it also proves that shelving a book and sending
-  it are separate: the book reaches the shelf while not one upload is
-  attempted. Pass `-u URL` to name the liseur-sync server. `--help` for
-  the flags.
-- **`lib/demo-books.sh`** — Library sourced by `screenshots`,
+  upload policy. The script sets it through the settings screen and puts
+  it back afterwards. This also proves that shelving a book and sending
+  it are separate: the book reaches the shelf while no upload is attempted.
+  Pass `-u URL` to name the liseur-sync server. `--help` for the flags.
+- `lib/demo-books.sh`: Library sourced by `screenshots`,
   `reset-books` and the `e2e-*` scripts: the demo book list, the uiautomator-driven UI helpers,
   and the fetch/push/grant-folder logic. Not meant to be run directly.
-- **`grimmory-dev`** — Brings up a throwaway
+- `grimmory-dev`: Brings up a throwaway
   [Grimmory](https://github.com/grimmory-tools/grimmory) server
   in containers, seeded and ready for Liseur to connect to, so the
   Grimmory client is developed against the real thing rather than a
   reading of its source. `--up` starts and seeds it, `--down` deletes it
   and everything it held, `--reset` does both, `--info` reprints the
   credentials. Grimmory hides its Komga compatibility shim behind an
-  admin setting *and* behind a separate set of credentials — an "OPDS
-  user", not the browser login — and the script sets up both, because
-  either one missed fails in a way that does not say so. The image tag in
+  admin setting and a separate set of credentials, an "OPDS user" rather
+  than the browser login. The script sets up both because either missing
+  one fails in a way that does not say so. The image tag in
   `hack/grimmory/docker-compose.yml` is pinned deliberately: a
   compatibility shim is exactly the thing that moves under you. The
   seeded shelf is larger than one catalog page on purpose, and holds one
   CBZ, so paging and the EPUB-only filter both have something real to
-  work on. Everything lives under `tmp/`. Developer tooling only —
-  nothing in Gradle, CI or the release path may depend on it.
-- **`grimmory/seed-books.py`** — Generates the books `grimmory-dev`
+  work on. Everything lives under `tmp/`. This is developer tooling only.
+  Nothing in Gradle, CI or the release path may depend on it.
+- `grimmory/seed-books.py`: Generates the books `grimmory-dev`
   seeds: filler EPUBs, each with a cover, plus one CBZ. Everything is
   generated, so no downloads and nothing copyrighted. Not meant to be run
   directly.
-- **`install`** — Builds a release-signed APK (key fetched from `pass`)
+- `install`: Builds a release-signed APK (key fetched from `pass`)
   and installs it in place over the device's existing release install,
   keeping its data. A debug build can't do this: Android refuses an
   update whose signature doesn't match.
-- **`install-release`** — Builds the release APK, signs it with the
+- `install-release`: Builds the release APK, signs it with the
   release key from `pass`, and installs it on a device picked via `fzf`.
-- **`release`** — Runs the release process: bumps `versionCode`/
+- `release`: Runs the release process: bumps `versionCode`/
   `versionName`, checks that F-Droid will see final tags but not test tags,
   tags, builds, publishes the GitHub release, and submits the F-Droid
   update. See `DEVELOPER.md` for the full workflow and flags.
-- **`verify-fdroid-tags`** — Reads the live F-Droid metadata and fails closed
+- `verify-fdroid-tags`: Reads the live F-Droid metadata and fails closed
   unless a plain `vX.Y.Z` tag is discoverable and the supplied non-final tags
   are not. The release script runs it before pushing or submitting a tag.
-- **`test-fdroid-tags`** — Runs the deterministic fixture-based tests for the
+- `test-fdroid-tags`: Runs the deterministic fixture-based tests for the
   tag-policy verifier. It does not contact F-Droid and is part of `make check`
   and CI.
-- **`generate-release-notes`** — Writes the GitHub release notes for a
+- `generate-release-notes`: Writes the GitHub release notes for a
   tag by asking Gemini to turn the commits since the previous tag into
   prose. It also reads the pull requests associated with those commits,
   links each described change back to its PR, and carries over a relevant
   screenshot from the PR body when one is present. It falls back to the
   F-Droid changelog if generation fails.
-- **`store-status`** — Answers "where is Liseur published?" for all
+- `store-status`: Answers "where is Liseur published?" for all
   three channels at once: the last GitHub releases, what F-Droid has
   published and how old its index is, what its last build run did with
   the app, the fdroiddata metadata, any open merge request with its
   pipeline state, and what sits on each Google Play track. It also says
   when the closed track that testers are recruited into falls behind
-  internal, who may install from it — which countries it reaches, and
-  whether its testers come from a Google Group or from an email list the
-  API cannot read — and prints the opt-in link they are handed.
+  internal, who may install from it, which countries it reaches, and
+  whether its testers come from a Google Group or an email list the API
+  cannot read. It also prints the opt-in link they are handed.
   Everything but the Play section reads public sources; Play has no
   public answer while the app is in testing, so that one signs a token
   with the service account from `pass` and is skipped with a line when it
   cannot. Backs `make store-status`.
-- **`verify-reproducible`** — Builds the release APK twice from two
+- `verify-reproducible`: Builds the release APK twice from two
   independent clean checkouts and diffs them byte for byte, the check
   F-Droid's reproducible-builds requirement demands before submission.
-- **`verify-wide-content`** — Checks that content wider than the page is
+- `verify-wide-content`: Checks that content wider than the page is
   measured and constrained rather than painted over the page after it
   (issue #67). The fix is JavaScript that runs inside the book's own
   document, and none of what it has to get right is visible from the
-  JVM, so the script is lifted straight out of `WideContentFit.kt` —
-  never a copy — and run against Readium's own stylesheets in headless
-  Chrome, in a frame the size of a phone. Needs Chrome or Chromium and a
-  prior `./gradlew assembleDebug` (Readium's CSS is unpacked from the
-  AAR by the build), so it is a check to run by hand when that script
+  JVM. The script is lifted straight out of `WideContentFit.kt`, never a
+  copy, and run against Readium's own stylesheets in headless Chrome, in a
+  frame the size of a phone. Needs Chrome or Chromium and a prior
+  `./gradlew assembleDebug` (Readium's CSS is unpacked from the AAR by the
+  build), so it is a check to run by hand when that script
   changes, not part of `make check`. `PORT=` picks another port.
-- **`icon`** — Renders the adaptive launcher icon (two vector drawables)
+- `icon`: Renders the adaptive launcher icon (two vector drawables)
   to a flat PNG for the F-Droid listing and the README.
-- **`feature-graphic`** — Renders the 1024x500 store feature graphic
+- `feature-graphic`: Renders the 1024x500 store feature graphic
   from the app's own emblem.
 
 See also `tests/`, which holds the headless, assertion-shaped end-to-end
-scenarios — the ones that measure behaviour rather than walk the screen.
+scenarios. They measure behaviour rather than walk the screen.
 The `e2e-*` scripts here drive the UI and need a visible device.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,9 +1,9 @@
 # tests/
 
 End-to-end scenarios that run against a real device or emulator over
-`adb`. They exist for the behaviour that only shows up on a device —
-timing, connectivity, the reader actually appearing — which is
-everything the JVM unit tests in `app/src/test` cannot see.
+`adb`. They cover behaviour that only shows up on a device: timing,
+connectivity, and the reader actually appearing. JVM unit tests in
+`app/src/test` cannot see those things.
 
 They are meant to be run by a person or by an agent, unattended:
 
@@ -23,9 +23,9 @@ as a device that passed.
 
 | Scenario | What it proves |
 | --- | --- |
-| `offline-open` | A book opens promptly with no network, and — the case that regressed — with a network whose server is unroutable. |
+| `offline-open` | A book opens promptly with no network and with a network whose server is unroutable, the case that regressed. |
 | `bench-open` | Not pass/fail: prints how long a book takes to open under each network condition. |
-| `grimmory-connect` | Liseur reaches a [Grimmory](https://github.com/grimmory-tools/grimmory) server through its Komga-compatibility API: an OPDS user signs in, the shelf fills from more than one HTTP page, comics stay off it, a second walk prunes nothing, covers load, a book downloads and opens, and nothing offers to keep the reader's place. Needs a server — `hack/grimmory-dev --up` — and skips itself without one. |
+| `grimmory-connect` | Liseur reaches a [Grimmory](https://github.com/grimmory-tools/grimmory) server through its Komga-compatibility API: an OPDS user signs in, the shelf fills from more than one HTTP page, comics stay off it, a second walk prunes nothing, covers load, a book downloads and opens, and nothing offers to keep the reader's place. Needs a server, `hack/grimmory-dev --up`; skips itself without one. |
 
 ## Preconditions
 
@@ -65,62 +65,63 @@ report
 ```
 
 `--help` prints the header comment, so the documentation cannot drift
-away from the code. Make the file executable — `run-all` picks up
+away from the code. Make the file executable: `run-all` picks up
 whatever is executable in this directory.
 
 ### What `lib/device.sh` gives you
 
 - `die`, `step`, `note` for output; `ok`, `bad`, `skip`, `report` for
   results. `report` exits non-zero if anything called `bad`.
-- `adb` — a wrapper pinned to the chosen serial. Always use it.
-- `query "<sql>"` — SQL against the app's database, and `sql_quote` to
+- `adb`: a wrapper pinned to the chosen serial. Always use it.
+- `query "<sql>"`: SQL against the app's database, and `sql_quote` to
   build a literal. Use it for anything that came off the device: a
   configured server address is text the reader typed, and one
   apostrophe pasted straight into a statement ends the string and runs
   whatever follows.
-- `shell_quote` — the same care for the *device's* shell. Everything
+- `shell_quote`: the same care for the *device's* shell. Everything
   handed to `adb shell` is re-parsed there, so a book title with an
   apostrophe in its file name would otherwise end the argument and run
   the rest as the shell user.
-- `set_server_url "<url>"` — points the connected server somewhere,
+- `set_server_url "<url>"`: points the connected server somewhere,
   with the app stopped first and the result checked afterwards.
-- `airplane_mode_state` — `on` or `off`, to read before you change it.
-- `device_now_ms` — the *device's* clock, so adb round-trips are not
+- `airplane_mode_state`: `on` or `off`, to read before you change it.
+- `device_now_ms`: the *device's* clock, so adb round-trips are not
   counted as time the app spent working.
-- `pick_downloaded_book` — sets `BOOK_URL` and `BOOK_LOCAL_URI`.
-- `time_book_open URL LOCAL_URI [CAP_MS]` — milliseconds, or `timeout`.
+- `pick_downloaded_book`: sets `BOOK_URL` and `BOOK_LOCAL_URI`.
+- `time_book_open URL LOCAL_URI [CAP_MS]`: milliseconds, or `timeout`.
 - `expect_open_under LABEL MEASURED BUDGET_MS`.
 - `airplane_mode on|off`.
 
-### Two things to get right
+### Use the database as the oracle
 
-**Use the database as the oracle.** Screen scraping is slow and lies.
+Screen scraping is slow and lies.
 Book-open timing keys off `books.last_opened_at`, which the reader
 writes one line before it shows the page, so it is the honest end of
 "the book opened".
 
-**Restore what you changed, from a trap.** These run against a device
-someone else will use next. Anything a scenario sets — airplane mode, a
-server address, app data — is put back on the way out, however the
-script leaves:
+### Restore what you changed from a trap
+
+Someone else will use the device after the scenario. Anything a scenario
+sets, such as airplane mode, a server address, or app data, is put back on
+the way out:
 
 ```bash
 trap restore EXIT
 ```
 
-Put back what was *there*, not what you assume: read airplane mode
-before turning it on, so a device that had it on keeps it. Stop the app
-before writing to its database, and check the value afterwards rather
-than announcing success — leaving a blackhole address behind quietly
-breaks the next thing anyone does with the device. `set_server_url`
-does all three.
+Put back what was *there*, not what you assume. Read airplane mode before
+turning it on, so a device that had it on keeps it. Stop the app before
+writing to its database, then check the value afterwards. Leaving a
+blackhole address behind breaks the next thing anyone does with the device.
+`set_server_url` does all three.
 
-**Point a server nowhere real.** To make a server unreachable these
-scenarios change only its address, so the app keeps the credentials it
-had and sends them to whatever answers. Use `192.0.2.1` (TEST-NET-1,
-reserved by RFC 5737 and routed nowhere), never a private `10.x` or
-`192.168.x` address, which on somebody's network is perfectly capable
-of answering.
+### Use a reserved address for unreachable-server tests
+
+To make a server unreachable, these scenarios change only its address, so
+the app keeps its existing credentials and sends them to whatever answers.
+Use `192.0.2.1` (TEST-NET-1, reserved by RFC 5737 and routed nowhere).
+Avoid private `10.x` or `192.168.x` addresses, which may answer on
+somebody's network.
 
 ## Related
 


### PR DESCRIPTION
## Summary

This documentation-only change removes repetitive AI-style prose patterns from the repository's Markdown, with the largest pass covering the ADRs. It keeps the technical decisions and instructions intact while making the writing more direct and easier to scan.

## Changes

- Revised prose across all tracked Markdown files that needed cleanup, including 20 ADRs, contributor documentation, privacy and roadmap pages, server capability documentation, and tooling READMEs.
- Replaced avoidable em-dash clauses, Unicode arrows, bold-first bullet labels, and formulaic transitions with clearer sentences or small structural changes.
- Preserved commands, links, inline code, fenced code blocks, identifiers, ADR metadata, table content, and required template fields. The GitHub issue and pull request templates were reviewed and did not need wording changes.
- Kept `AGENTS.md` and the `CLAUDE.md` symlink content identical.

## Testing

- [ ] `./gradlew testDebugUnitTest` (not run; documentation-only change)
- [ ] `./gradlew lintDebug` (not run; documentation-only change)
- [ ] `./gradlew assembleDebug` (not run; documentation-only change)
- [x] Documentation checks: `git diff --check`, fenced-code and inline-code comparisons, link-destination comparison, table integrity checks, and heading review
- [ ] Manually tested on a device or emulator (not applicable)

## Screenshots or recordings

Not applicable; this change does not modify the app UI.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed; no code behavior changed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
