### PR TITLE
fix(reader): disable reading settings a fixed-layout book cannot use

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -342,8 +342,19 @@ fun ReaderScreen(
     // "is this book scrolled" has to ask it this way, or a vertical book
     // gets tap zones that turn pages it has not got.
     var verticalText by remember { mutableStateOf(false) }
-    val effectiveScrolling = scrollMode || verticalText
+    // A fixed-layout book places everything by absolute coordinates:
+    // nothing reflows, so measuring what "fits" means nothing, and the
+    // document does not move under the viewport, so a fraction of its
+    // length says nothing about where the reader is either. Readium
+    // paginates it whatever the scrolling preference says, too.
+    val reflowableText = remember(publication) {
+        publication.metadata.layout != Layout.FIXED
+    }
+    // The chrome's answer, and the container's, which are not the same
+    // one and must not be merged: see [chromeScrolls]/[containerScrolls].
+    val effectiveScrolling = chromeScrolls(reflowableText, scrollMode, verticalText)
     val effectiveScrollingNow by rememberUpdatedState(effectiveScrolling)
+    val pageContainerScrolls = containerScrolls(reflowableText, scrollMode)
     var autoScrollArmed by remember { mutableStateOf(false) }
     val columnMode = prefs.columnMode.effectiveFor(widthClass())
 
@@ -426,14 +437,6 @@ fun ReaderScreen(
     // See ReflowScope: a locator nobody has claimed while this is open is the
     // layout moving, not the reader.
     val reflow = remember { ReflowScope() }
-
-    // A fixed-layout book places everything by absolute coordinates: nothing
-    // reflows, so measuring what "fits" means nothing, and the document does
-    // not move under the viewport, so a fraction of its length says nothing
-    // about where the reader is either.
-    val reflowableText = remember(publication) {
-        publication.metadata.layout != Layout.FIXED
-    }
 
     // Which of Readium's four stylesheets this book will be rendered
     // with, and so which of the fine typography settings it can honour.
@@ -852,6 +855,12 @@ fun ReaderScreen(
         // dusk has chosen nothing, and the open book should still follow.
         combine(
             prefsFlow,
+            // The reader's raw scrolling preference, not [containerScrolls]
+            // or [effectiveScrolling]. What is sent to Readium has to be
+            // byte-identical to the initialPreferences the activity built,
+            // or `dropWhile` below lets a value through on open and the
+            // book reflows for nothing. Readium renders a fixed-layout
+            // book paginated whatever this says.
             snapshotFlow { Triple(readingThemeNow, columnMode, scrollMode) },
         ) { p, (theme, columns, scrolling) ->
             p.toEpubPreferences(theme, columns, scrolling, readingCss)
@@ -1525,6 +1534,14 @@ fun ReaderScreen(
         // stop turning them when the pages become one long column.
         // And on the imported fonts, third of the three, because a
         // font family is declared at construction as well.
+        //
+        // This is the reader's raw preference, not [containerScrolls]:
+        // the key's job is to say what this fragment was *built* with,
+        // and the activity builds it — the factory, the initial
+        // preferences and the restore target all hang off the raw value
+        // there. The two halves have to flip together, and a `scroll`
+        // that differs between them invalidates Readium's view pager
+        // even in a fixed-layout book, where nothing renders from it.
         key(columnMode, scrollMode, fontKey) {
             // Derived, not measured: the reservation must exist before
             // the page lays out, or the last line is cut in half. The
@@ -1555,7 +1572,7 @@ fun ReaderScreen(
                 modifier = Modifier
                     .fillMaxSize()
                     .then(
-                        if (scrollMode) {
+                        if (pageContainerScrolls) {
                             Modifier.windowInsetsPadding(
                                 WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal),
                             )
@@ -1969,6 +1986,7 @@ fun ReaderScreen(
         TypographySheet(
             prefs = prefs,
             readingTheme = readingTheme,
+            readingCss = readingCss,
             onFontSelected = onPrefsAction.setFont,
             onFontSizeChanged = onPrefsAction.setFontSize,
             onThemeSelected = onPrefsAction.setTheme,
@@ -1986,7 +2004,8 @@ fun ReaderScreen(
         AdvancedSheet(
             prefs = prefs,
             // Not the reader's own answer but the page's: vertical text
-            // runs rather than turns whatever the setting says.
+            // runs rather than turns whatever the setting says, and a
+            // fixed-layout book turns rather than runs whatever it says.
             scrolling = effectiveScrolling,
             autoScrolling = autoScrollArmed,
             autoScrollSpeed = prefs.autoScrollSpeed,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ScrolledPage.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ScrolledPage.kt
@@ -1,0 +1,44 @@
+package com.chmouel.liseur.reader
+
+/**
+ * Whether a book is being read by scrolling — asked twice, because the
+ * two askers need different answers.
+ *
+ * Three things decide it. What the reader chose (`scrollMode`), what the
+ * book's lines do (`verticalText`: Readium cannot paginate text that
+ * runs down the page, so such a book scrolls whatever the setting says),
+ * and whether the book has anything to scroll at all (`reflowable`: a
+ * fixed-layout book is placed page by page and Readium paginates it
+ * whatever the setting says).
+ *
+ * See `docs/adr/0020-fixed-layout-reading-settings.md`.
+ */
+
+/**
+ * What the reader sees around the page: the tap zones, the footer, the
+ * edge turner, auto-scroll, and which rows the sheets offer.
+ *
+ * This is the full answer, [verticalText] included, because the chrome
+ * has to describe the page that is actually there.
+ */
+fun chromeScrolls(reflowable: Boolean, scrollMode: Boolean, verticalText: Boolean): Boolean =
+    reflowable && (scrollMode || verticalText)
+
+/**
+ * What the navigator fragment is laid out inside: the insets it is given
+ * and the band reserved under it for the footer.
+ *
+ * **Deliberately without [chromeScrolls]'s `verticalText` term, and not
+ * to be merged back into it.** Whether a book's text is vertical is only
+ * known once the navigator has read the publication, so it arrives false
+ * and turns true a moment later; a container that followed it would take
+ * the footer's band back out from under a book that had already been
+ * laid out with it, reflowing the page under the reader on open. The
+ * comment on the fragment's padding says the same thing from the other
+ * side: an unused 38dp is the cheaper of the two.
+ *
+ * Both terms here are settled before the navigator exists, so this
+ * answer never changes while a book is open.
+ */
+fun containerScrolls(reflowable: Boolean, scrollMode: Boolean): Boolean =
+    reflowable && scrollMode

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
@@ -33,6 +33,7 @@ import com.chmouel.liseur.data.settings.ReadingCss
 import com.chmouel.liseur.ui.LiseurModalBottomSheet
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.reading.FineTypographyActions
+import com.chmouel.liseur.ui.reading.FixedLayoutNotice
 import com.chmouel.liseur.ui.reading.ReadingFineTypographyControls
 import com.chmouel.liseur.ui.reading.ReadingFooterModeDropdown
 import com.chmouel.liseur.ui.reading.ReadingLayoutControls
@@ -59,10 +60,18 @@ import com.chmouel.liseur.ui.windowWidth
  *
  * [scrolling] is whether the text runs rather than turns, which is not
  * only the reader's own choice: vertical text is laid out that way
- * whatever the setting says. Three rows turn on it, and they are the
- * same question asked once — a page that scrolls has no columns to
- * count and no turn to animate, and is the only kind that can be
- * scrolled along on its own.
+ * whatever the setting says, and a fixed-layout book is paginated
+ * whatever it says. Three rows turn on it, and they are the same
+ * question asked once — a page that scrolls has no columns to count and
+ * no turn to animate, and is the only kind that can be scrolled along on
+ * its own.
+ *
+ * [readingCss] is what this book can honour. A fixed-layout book greys
+ * the line spacing, the margins and the columns along with the fine
+ * typography rows, under the one line at the top. The footer, the
+ * page-turn animation and "just this book" are Liseur's own and know
+ * nothing about layout, so they stay live. See
+ * `docs/adr/0020-fixed-layout-reading-settings.md`.
  *
  * See `docs/adr/0001-advanced-reading-menu.md`.
  */
@@ -96,6 +105,8 @@ fun AdvancedSheet(
                 .padding(bottom = 24.dp),
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
+            val reshapeable = readingCss.honoursAnything
+            if (!reshapeable) FixedLayoutNotice()
             ReadingLayoutControls(
                 lineHeight = prefs.lineHeight,
                 pageMargins = prefs.pageMargins,
@@ -104,6 +115,7 @@ fun AdvancedSheet(
                 // has nothing to divide and the control would take a tap
                 // and change nothing.
                 showColumns = !scrolling,
+                enabled = reshapeable,
                 onLineHeightChanged = onLineHeightChanged,
                 onPageMarginsChanged = onPageMarginsChanged,
                 onColumnModeChanged = onColumnModeChanged,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/TypographySheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/TypographySheet.kt
@@ -28,8 +28,10 @@ import com.chmouel.liseur.data.settings.ReadingFont
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.ReaderTheme
 import com.chmouel.liseur.data.settings.ReaderThemeChoice
+import com.chmouel.liseur.data.settings.ReadingCss
 import com.chmouel.liseur.ui.LiseurModalBottomSheet
 import com.chmouel.liseur.ui.contentWidthCap
+import com.chmouel.liseur.ui.reading.FixedLayoutNotice
 import com.chmouel.liseur.ui.reading.ReadingBrightnessSlider
 import com.chmouel.liseur.ui.reading.ReadingFontDropdown
 import com.chmouel.liseur.ui.reading.rememberFontLibrary
@@ -50,12 +52,22 @@ import com.chmouel.liseur.ui.windowWidth
  * It is deliberately short. Everything a reader sets once, if ever, is a
  * tap further in, behind the Advanced row at the bottom — see
  * `docs/adr/0001-advanced-reading-menu.md`.
+ *
+ * [readingCss] is what this book can honour. A fixed-layout book greys
+ * the size, the face and the scrolling toggle, because Readium gates all
+ * three on a reflowable publication, and the line at the top says so
+ * once for the three of them. The theme and the brightness stay live:
+ * the brightness is the screen's, and Liseur passes its own
+ * `backgroundColor`, which Readium paints the pager with whatever the
+ * layout — so the swatches still change the surround of a fixed page.
+ * See `docs/adr/0020-fixed-layout-reading-settings.md`.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TypographySheet(
     prefs: ReaderPrefs,
     readingTheme: ReaderTheme,
+    readingCss: ReadingCss,
     onFontSelected: (ReadingFont) -> Unit,
     onFontSizeChanged: (Double) -> Unit,
     onThemeSelected: (ReaderThemeChoice) -> Unit,
@@ -77,23 +89,31 @@ fun TypographySheet(
                 .padding(bottom = 24.dp),
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
+            val reshapeable = readingCss.honoursAnything
+            if (!reshapeable) FixedLayoutNotice()
             ReadingThemeRow(
                 selected = prefs.themeChoice,
                 resolved = readingTheme,
                 onSelected = onThemeSelected,
             )
-            ReadingFontSizeSlider(value = prefs.fontSize, onChanged = onFontSizeChanged)
+            ReadingFontSizeSlider(
+                value = prefs.fontSize,
+                enabled = reshapeable,
+                onChanged = onFontSizeChanged,
+            )
             ReadingBrightnessSlider(value = prefs.brightness, onChanged = onBrightnessChanged)
             val fontLibrary = rememberFontLibrary(onSelected = onFontSelected)
             ReadingFontDropdown(
                 selected = prefs.font,
                 imported = fontLibrary.fonts,
+                enabled = reshapeable,
                 onSelected = onFontSelected,
                 onImport = fontLibrary.pick,
                 onRemove = fontLibrary.remove,
             )
             ScrollModeToggle(
-                enabled = scrollMode,
+                checked = scrollMode,
+                enabled = reshapeable,
                 onChanged = onScrollModeChanged,
             )
             KeepScreenOnToggle(
@@ -144,15 +164,23 @@ private fun AdvancedRow(onClick: () -> Unit) {
  * starts from; flipping it here sets this book apart for good, the same
  * way the screen switch below does, so a later change in Settings leaves
  * this book where it was put.
+ *
+ * [enabled] is false in a fixed-layout book, which Readium paginates
+ * whatever this says.
  */
 @Composable
-private fun ScrollModeToggle(enabled: Boolean, onChanged: (Boolean) -> Unit) {
+private fun ScrollModeToggle(
+    checked: Boolean,
+    enabled: Boolean,
+    onChanged: (Boolean) -> Unit,
+) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
             .toggleable(
-                value = enabled,
+                value = checked,
+                enabled = enabled,
                 role = Role.Switch,
                 onValueChange = onChanged,
             ),
@@ -163,7 +191,7 @@ private fun ScrollModeToggle(enabled: Boolean, onChanged: (Boolean) -> Unit) {
                 style = MaterialTheme.typography.bodyLarge,
             )
         }
-        Switch(checked = enabled, onCheckedChange = null)
+        Switch(checked = checked, enabled = enabled, onCheckedChange = null)
     }
 }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/reading/ReadingAppearanceControls.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/reading/ReadingAppearanceControls.kt
@@ -85,6 +85,33 @@ fun ReadingSectionLabel(text: String) {
     )
 }
 
+/** A line under a control, saying what it cannot do or will do anyway. */
+@Composable
+fun ReadingSupportingText(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(top = 2.dp),
+    )
+}
+
+/**
+ * The one line a fixed-layout book gets, at the top of a sheet.
+ *
+ * A fixed-layout EPUB is placed by the publisher, page by page, and
+ * Readium honours no reflowable-text preference inside one. Several rows
+ * on each sheet are greyed because of it, and a note under each would
+ * print the same sentence three times, so it is said once, above
+ * everything it answers for.
+ *
+ * See `docs/adr/0020-fixed-layout-reading-settings.md`.
+ */
+@Composable
+fun FixedLayoutNotice() {
+    ReadingSupportingText(stringResource(R.string.reader_typography_fixed_layout))
+}
+
 /**
  * The reading themes, as swatches of themselves.
  *
@@ -159,11 +186,21 @@ fun ReadingThemeRow(
     }
 }
 
+/**
+ * The reading face, bundled and imported alike.
+ *
+ * [enabled] is false in a fixed-layout book, whose pages carry their own
+ * typesetting: Readium gates `fontFamily` on a reflowable publication,
+ * so opening this menu there would take a tap and change nothing. The
+ * chosen face still shows, because it has not been lost — the next book
+ * that can be set in it will be.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ReadingFontDropdown(
     selected: ReadingFont,
     imported: List<UserFont>,
+    enabled: Boolean,
     onSelected: (ReadingFont) -> Unit,
     onImport: () -> Unit,
     onRemove: (UserFont) -> Unit,
@@ -171,29 +208,35 @@ fun ReadingFontDropdown(
     val context = LocalContext.current
     var expanded by remember { mutableStateOf(false) }
     var pendingRemoval by remember { mutableStateOf<UserFont?>(null) }
+    val open = expanded && enabled
 
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         ReadingSectionLabel(stringResource(R.string.reader_font))
         ExposedDropdownMenuBox(
-            expanded = expanded,
-            onExpandedChange = { expanded = it },
+            expanded = open,
+            onExpandedChange = { if (enabled) expanded = it },
         ) {
             OutlinedTextField(
                 value = selected.displayName(imported),
                 onValueChange = {},
                 readOnly = true,
                 singleLine = true,
+                enabled = enabled,
                 textStyle = LocalTextStyle.current.copy(
                     fontFamily = selected.readingFamily(imported),
                     fontSize = 18.sp,
                 ),
-                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = open) },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                    // The anchor takes the same answer, not just the
+                    // field. Without it the node keeps its `expandable`
+                    // semantics and a screen reader announces a menu
+                    // that can be opened, which this one cannot.
+                    .menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled),
             )
             ExposedDropdownMenu(
-                expanded = expanded,
+                expanded = open,
                 onDismissRequest = { expanded = false },
             ) {
                 ReaderFont.entries.forEach { font ->
@@ -382,8 +425,16 @@ fun ReadingFooterModeDropdown(selected: FooterMode, onSelected: (FooterMode) -> 
     }
 }
 
+/**
+ * How big the text is set.
+ *
+ * [enabled] is false in a fixed-layout book: Readium gates `fontSize` on
+ * a reflowable publication, so the thumb would slide and the page would
+ * not move. The stored size still shows, and comes back with the next
+ * book that can be resized.
+ */
 @Composable
-fun ReadingFontSizeSlider(value: Double, onChanged: (Double) -> Unit) {
+fun ReadingFontSizeSlider(value: Double, enabled: Boolean, onChanged: (Double) -> Unit) {
     var sliderValue by remember(value) { mutableFloatStateOf(value.toFloat()) }
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         ReadingSectionLabel(stringResource(R.string.reader_size))
@@ -391,6 +442,7 @@ fun ReadingFontSizeSlider(value: Double, onChanged: (Double) -> Unit) {
             Text("A", fontSize = 14.sp)
             Slider(
                 value = sliderValue,
+                enabled = enabled,
                 onValueChange = { sliderValue = it },
                 onValueChangeFinished = { onChanged(sliderValue.toDouble()) },
                 valueRange = ReaderPrefs.MIN_FONT_SIZE.toFloat()..ReaderPrefs.MAX_FONT_SIZE.toFloat(),
@@ -446,12 +498,22 @@ fun ReadingBrightnessSlider(value: Float?, onChanged: (Float?) -> Unit) {
     }
 }
 
+/**
+ * The shape of the text block: line spacing, margins and columns.
+ *
+ * [showColumns] hides the column count where it cannot apply — a
+ * scrolled chapter is one running column, and a phone has no room for
+ * two. [enabled] is a different question: all three rules are gated on a
+ * reflowable publication, so in a fixed-layout book every row here is
+ * greyed and goes on showing what the reader chose.
+ */
 @Composable
 fun ReadingLayoutControls(
     lineHeight: Double?,
     pageMargins: Double?,
     columnMode: ColumnMode,
     showColumns: Boolean,
+    enabled: Boolean,
     onLineHeightChanged: (Double?) -> Unit,
     onPageMarginsChanged: (Double?) -> Unit,
     onColumnModeChanged: (ColumnMode) -> Unit,
@@ -472,6 +534,7 @@ fun ReadingLayoutControls(
             options.forEachIndexed { index, (label, v) ->
                 SegmentedButton(
                     selected = lineHeight == v,
+                    enabled = enabled,
                     onClick = { onLineHeightChanged(v) },
                     shape = SegmentedButtonDefaults.itemShape(index, options.size),
                 ) { Text(stringResource(label)) }
@@ -487,6 +550,7 @@ fun ReadingLayoutControls(
             options.forEachIndexed { index, (label, v) ->
                 SegmentedButton(
                     selected = pageMargins == v,
+                    enabled = enabled,
                     onClick = { onPageMarginsChanged(v) },
                     shape = SegmentedButtonDefaults.itemShape(index, options.size),
                 ) { Text(stringResource(label)) }
@@ -502,6 +566,7 @@ fun ReadingLayoutControls(
                 options.forEachIndexed { index, mode ->
                     SegmentedButton(
                         selected = columnMode == mode,
+                        enabled = enabled,
                         onClick = { onColumnModeChanged(mode) },
                         shape = SegmentedButtonDefaults.itemShape(index, options.size),
                     ) { Text(stringResource(mode.label)) }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/reading/ReadingFineTypography.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/reading/ReadingFineTypography.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.outlined.Restore
@@ -83,6 +82,11 @@ data class FineTypographyActions(
  * It keeps showing its stored value while disabled: the setting has not
  * been lost, it is waiting for a book that can use it.
  *
+ * A fixed-layout book disables every row here, and says so nowhere: the
+ * sheet above says it once at the top, for these rows and for the size,
+ * the face, the margins and the columns alike. See
+ * [com.chmouel.liseur.ui.reading.FixedLayoutNotice].
+ *
  * [ReadingCss.Unknown] is the settings screen, where no book is open.
  * Nothing is disabled there — the reader is choosing a default for every
  * book they will open, not for this one — and the wording names the
@@ -95,10 +99,7 @@ fun ReadingFineTypographyControls(
     actions: FineTypographyActions,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        if (css == ReadingCss.Unsupported) {
-            ReadingSupportingText(stringResource(R.string.reader_typography_fixed_layout))
-        }
-        val enabled = css != ReadingCss.Unsupported
+        val enabled = css.honoursAnything
 
         AlignmentRow(
             value = prefs.textAlign,
@@ -397,14 +398,4 @@ private fun spacingLabel(value: Double?): String {
         value == 0.0 -> stringResource(R.string.reader_spacing_value_none)
         else -> stringResource(R.string.reader_spacing_value, format.format(value))
     }
-}
-
-@Composable
-private fun ReadingSupportingText(text: String) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.bodySmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(top = 2.dp),
-    )
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
@@ -130,11 +130,18 @@ fun ReadingAppearanceScreen(
                     resolved = resolved,
                     onSelected = onTheme,
                 )
-                ReadingFontSizeSlider(value = prefs.fontSize, onChanged = onFontSize)
+                ReadingFontSizeSlider(
+                    value = prefs.fontSize,
+                    // No book here, so nothing is refused: the reader is
+                    // choosing a default for every book they will open.
+                    enabled = true,
+                    onChanged = onFontSize,
+                )
                 ReadingBrightnessSlider(value = prefs.brightness, onChanged = onBrightness)
                 ReadingFontDropdown(
                     selected = prefs.font,
                     imported = fontLibrary.fonts,
+                    enabled = true,
                     onSelected = onFont,
                     onImport = fontLibrary.pick,
                     onRemove = fontLibrary.remove,
@@ -148,6 +155,7 @@ fun ReadingAppearanceScreen(
                     // check, so the preference is always offered; the
                     // reader surface decides whether to honor it.
                     showColumns = true,
+                    enabled = true,
                     onLineHeightChanged = onLineHeight,
                     onPageMarginsChanged = onPageMargins,
                     onColumnModeChanged = onColumnMode,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -519,7 +519,7 @@
     <string name="reader_spacing_value">+%1$s</string>
     <string name="reader_spacing_customize">Set a value</string>
     <string name="reader_spacing_reset">Back to default</string>
-    <string name="reader_typography_fixed_layout">This book has a fixed layout, so its text cannot be reshaped.</string>
+    <string name="reader_typography_fixed_layout">This book has a fixed layout: its pages are set by the publisher, so these settings do not change them.</string>
     <string name="reader_typography_not_in_cjk">Not applied in Chinese, Japanese, Korean or vertical books.</string>
     <string name="reader_typography_latin_not_in_rtl">Hyphenation and letter and word spacing are not applied in right-to-left books.</string>
     <string name="reader_typography_latin_not_in_cjk">Hyphenation and letter and word spacing are not applied in Chinese, Japanese, Korean or vertical books.</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/settings/ReadingCssTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/settings/ReadingCssTest.kt
@@ -134,6 +134,17 @@ class ReadingCssTest {
     }
 
     @Test
+    fun `a fixed layout book honours nothing at all`() {
+        // The single gate the reading sheets read, for the older rows
+        // and the newer ones alike: size, face, line spacing, margins,
+        // columns and scrolling as well as the six of ADR 2.
+        assertFalse(ReadingCss.Unsupported.honoursAnything)
+        assertTrue(ReadingCss.Default.honoursAnything)
+        assertTrue(ReadingCss.Rtl.honoursAnything)
+        assertTrue(ReadingCss.Cjk.honoursAnything)
+    }
+
+    @Test
     fun `the settings screen claims nothing it cannot know`() {
         // No book is open there, so every row stays usable.
         assertTrue(ReadingCss.Unknown.honoursAnything)

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/ScrolledPageTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/ScrolledPageTest.kt
@@ -1,0 +1,66 @@
+package com.chmouel.liseur.reader
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Whether a book is being read by scrolling.
+ *
+ * Two answers, deliberately, and the point of this class is that they
+ * stay two. [chromeScrolls] follows the book's vertical text;
+ * [containerScrolls] must not, because that arrives after the navigator
+ * has been laid out and following it late reflows the page under the
+ * reader. Anyone tempted to collapse these into one function should fail
+ * `the container ignores vertical text` first.
+ */
+class ScrolledPageTest {
+
+    @Test
+    fun `a reflowable book scrolls when the reader asked it to`() {
+        assertTrue(chromeScrolls(reflowable = true, scrollMode = true, verticalText = false))
+        assertTrue(containerScrolls(reflowable = true, scrollMode = true))
+    }
+
+    @Test
+    fun `a reflowable book left paginated does not`() {
+        assertFalse(chromeScrolls(reflowable = true, scrollMode = false, verticalText = false))
+        assertFalse(containerScrolls(reflowable = true, scrollMode = false))
+    }
+
+    @Test
+    fun `vertical text scrolls the chrome whatever the reader chose`() {
+        // Readium cannot paginate lines that run down the page.
+        assertTrue(chromeScrolls(reflowable = true, scrollMode = false, verticalText = true))
+    }
+
+    @Test
+    fun `the container ignores vertical text`() {
+        // Not an oversight. `verticalText` is false until the navigator
+        // has read the publication, so a container that followed it
+        // would take the footer's reserved band back out from under a
+        // book already laid out with it — a reflow on open, on every
+        // vertical book. Merging this with chromeScrolls reintroduces
+        // exactly that.
+        assertFalse(containerScrolls(reflowable = true, scrollMode = false))
+        assertTrue(chromeScrolls(reflowable = true, scrollMode = false, verticalText = true))
+    }
+
+    @Test
+    fun `a fixed layout book never scrolls, however it is asked`() {
+        // Readium paginates it whatever the preference says, so chrome
+        // that scrolled would sit over a page that turns.
+        for (scroll in listOf(false, true)) {
+            for (vertical in listOf(false, true)) {
+                assertFalse(
+                    "scrollMode=$scroll verticalText=$vertical",
+                    chromeScrolls(reflowable = false, scrollMode = scroll, verticalText = vertical),
+                )
+            }
+            assertFalse(
+                "scrollMode=$scroll",
+                containerScrolls(reflowable = false, scrollMode = scroll),
+            )
+        }
+    }
+}

--- a/docs/adr/0020-fixed-layout-reading-settings.md
+++ b/docs/adr/0020-fixed-layout-reading-settings.md
@@ -1,6 +1,6 @@
 # 20. Settings a fixed-layout book cannot use
 
-Status: proposed
+Status: accepted
 GitHub issue: [#123](https://github.com/chmouel/liseur/issues/123)
 
 ## Context
@@ -69,8 +69,19 @@ change would widen the scope again, which is exactly the move that
 produced this issue, and it has an issue of its own to arrive under.
 
 The rest need no argument. Brightness is the screen's, not the page's.
-The footer, the page-turn animation and "just this book" are Liseur's
-own and know nothing about layout.
+The footer and the page-turn animation are Liseur's own and know nothing
+about layout.
+
+**"Just this book" stays live, and it is not as obvious as the rest.**
+Its subject is precisely the set being greyed — what the book is set in,
+how big, how open, how wide — so a fixed-layout book shows four disabled
+rows above a switch that decides whether those four are the book's own.
+It stays because it is a *filing* decision rather than a typographic
+one: it is answered once, before or after the settings it governs, and
+a reader who sets it while a comic is open has recorded something true
+that takes effect the moment they set anything the comic could use.
+Disabling it would be the one place in this change where a control that
+still does something is taken away.
 
 ## Design
 
@@ -118,21 +129,64 @@ enum gains no member.
 It asks what the reader chose and whether the book runs down the page;
 it never asks whether the book can scroll at all.
 
-Three things hang off it: the tap zones, the footer, and whether the
-sheet offers auto-scroll or a page-turn animation. So a reader who left
-scroll mode on and then opens a fixed-layout book gets scroll-flavoured
-chrome over a page Readium is paginating regardless: tap zones that
-scroll a page that turns, no footer, and an auto-scroll switch that moves
-nothing. It becomes `reflowable && (scrollMode || verticalText)`, which
-widens the derivation [ADR 6](0006-auto-scroll.md) named "effectively
-scrolled" by the one clause it never had: it asks what the reader chose
-and what the book's lines do, and now also whether the book has anything
-to scroll.
+A good deal hangs off it: the tap zones, the footer, whether the sheet
+offers auto-scroll or a page-turn animation, `ScrollEdgeTurner`,
+`canAutoScroll`, the held-place retirement, the loop that measures a
+scrolled place, the bookmark ribbon's scrolled path, and
+`PageTurner.isScrolling`. So a reader who left scroll mode on and then
+opens a fixed-layout book gets scroll-flavoured chrome over a page
+Readium is paginating regardless: tap zones that scroll a page that
+turns, no footer, an auto-scroll switch that moves nothing, and a loop
+reading `scrollY` off a web view that never scrolls. It becomes
+`reflowable && (scrollMode || verticalText)`, which widens the
+derivation [ADR 6](0006-auto-scroll.md) named "effectively scrolled" by
+the one clause it never had: it asks what the reader chose and what the
+book's lines do, and now also whether the book has anything to scroll.
 
-What is *sent* to Readium does not change. `scroll` goes on being passed
-as the reader left it, because Readium ignores it for a fixed layout on
-its own, and rebuilding the navigator fragment over a value it ignores
-would cost a reader their place to no effect.
+### Two answers, and they must stay two
+
+The container the navigator fragment is laid out in — its insets, and
+the band reserved under it for the footer — asks the same question and
+needs a **different** answer: `reflowable && scrollMode`, with no
+`verticalText` term.
+
+`verticalText` is not known until the navigator has read the
+publication. It arrives false and turns true a moment later. The footer
+is guarded by the chrome's answer while its reserved band is set by the
+container's, so the two have to agree about a fixed-layout book or the
+footer prints over the page — but a container that also followed
+`verticalText` would take that band back out from under a book already
+laid out with it, reflowing the page under the reader on open, on every
+vertical book. The existing comment on that padding says as much from
+the other side: an unused 38dp is the cheaper of the two.
+
+Hence `chromeScrolls()` and `containerScrolls()`, pure and unit-tested,
+with a test whose only job is to fail if someone merges them.
+
+### What is sent to Readium does not change, and the fragment key stays raw
+
+`scroll` goes on being passed as the reader left it, and the fragment
+key (`key(columnMode, scrollMode, fontKey)`) goes on being the raw
+preference too.
+
+Not for the reason first written here. It is *not* true that "Readium
+ignores `scroll` for a fixed layout on its own" — that holds for
+rendering only. `EpubSettingsResolver.settings()` resolves `scroll` with
+no layout gate, and `EpubNavigatorViewModel`'s `needsInvalidation`
+compares `oldSettings.scroll != newSettings.scroll` with no layout gate
+either, sending `InvalidateViewPager`: `resetResourcePager()` and a
+`go(locator)`, the whole pager rebuilt. A fixed-layout book renders the
+same whatever `scroll` says and still gets torn down when it changes.
+
+Which is exactly why the key is left alone. It is one half of a two-part
+operation whose other half is in `ReaderActivity`, where the restore
+target, the initial preferences and the fragment factory are all
+remembered on the raw preference. Correcting one half would let a
+changed `scroll` reach `submitPreferences` without the fragment being
+recreated for it, and the reader would lose their place to a value that
+changes nothing they can see. The raw preference is constant while a
+fixed-layout book is open anyway, because the toggle that changes it is
+now disabled.
 
 ### Everything is still sent
 
@@ -150,8 +204,12 @@ one step further.
 - The reading theme and the brightness stay enabled, and the audit
   above is the reason. Anyone reading `EpubPreferencesEditor` alone will
   conclude the theme belongs in the disabled set; it does not, because
-  Liseur passes its own colours and Readium paints the pager with them
-  in every layout.
+  Liseur passes its own `backgroundColor` and Readium paints the pager
+  with it in every layout. `textColor` *is* gated, so what the swatches
+  change in a fixed-layout book is the letterbox around the page and not
+  the page — which is more than nothing, and is why the notice says
+  these settings do not change the *pages* rather than claiming the book
+  cannot be recoloured at all.
 - A stored value survives a fixed-layout book, because nothing about
   what is sent changes.
 - `spread` remains unreachable. A fixed-layout book gets a more
@@ -166,4 +224,5 @@ one step further.
 *Where:* `ui/reading/ReadingFineTypography.kt`,
 `ui/reading/ReadingAppearanceControls.kt`,
 `reader/chrome/TypographySheet.kt`, `reader/chrome/AdvancedSheet.kt`,
-`reader/ReaderScreen.kt`, `res/values/strings.xml`.
+`reader/ReaderScreen.kt`, `reader/ScrolledPage.kt`,
+`res/values/strings.xml`.


### PR DESCRIPTION
## Summary

A fixed-layout EPUB is placed page by page by the publisher. Readium 3.3.0
gates `fontSize`, `fontFamily`, `lineHeight`, `pageMargins`, `columnCount` and
`scroll` on `layout == REFLOWABLE`, so none of them does anything in such a
book. Liseur only greyed out the six rows ADR 2 added, so a reader got a menu
where alignment was disabled and font size was not, and dragging the size
slider changed nothing and said nothing.

This implements `docs/adr/0020-fixed-layout-reading-settings.md`, which was
already written and sitting at *proposed*.

Fixes #123

## Changes

- Every control Readium honours only in a reflowable book is **disabled, still
  showing its stored value**, under **one line per sheet** saying the book
  carries its own layout. Theme, brightness, keep-screen-on, the footer, the
  page-turn animation and the per-book override stay enabled — the theme
  because Liseur passes explicit `backgroundColor`, which carries no layout
  gate, so the swatches still repaint the letterbox.
- The gate is the existing `ReadingCss.honoursAnything`, now used in all three
  places rather than respelled per sheet. `ReadingFineTypography.kt` spelled
  the same question as `css != ReadingCss.Unsupported`; a copy that can drift
  is what produced this bug.
- `ReadingFontSizeSlider`, `ReadingFontDropdown` and `ReadingLayoutControls`
  gain an `enabled` parameter, with no default: both call sites state their
  answer. The dropdown passes `enabled` to `menuAnchor` too, so TalkBack does
  not announce a collapsed dropdown that cannot be opened.
- `ScrollModeToggle`'s parameter was named `enabled` but meant *checked*;
  renamed, with a real `enabled` added.
- Settings → Reading appearance is untouched: no book is open there, and
  `ReadingCss.Unknown` already means nothing is disabled.

### The scrolling correction

`effectiveScrolling` was `scrollMode || verticalText`. It never asked whether
the book could scroll at all, so a reader who left scroll mode on and opened a
fixed-layout book got scroll-flavoured chrome — and the footer drawn across the
page — over something Readium paginates anyway.

It splits into two derived values, in a new `reader/ScrolledPage.kt`, and
**they must not be merged**:

- `chromeScrolls(reflowable, scrollMode, verticalText)` — what the reader sees.
- `containerScrolls(reflowable, scrollMode)` — the container the fragment is
  laid out in. No `verticalText` term: it is only known once the navigator has
  read the publication, so feeding it here would flip the bottom band on open
  and reflow the book under the reader, the exact cost the comment at the
  padding branch says was traded away for an unused 38dp.

The fragment `key` and the preferences flow deliberately keep sending the raw
preference. They are one half of a two-part operation with `ReaderActivity`,
which remembers the restore target, the initial preferences and the fragment
factory on the same raw value. A `scroll` that differs between the halves is
not a no-op in a fixed-layout book: `EpubSettingsResolver` resolves `scroll`
ungated by layout and `needsInvalidation` compares it ungated too, sending
`InvalidateViewPager` — the whole pager rebuilt, and the reader's place gone.
Rendering ignores `scroll` for a fixed layout; invalidation does not.

- `docs/adr/0020-…` moves to *accepted*, with four corrections: the false
  "Readium ignores it on its own" claim, the two derived values, an
  undercounted blast radius for `effectiveScrolling`, and a proper argument for
  leaving "just this book" enabled.

`spread` remains unreachable in a fixed-layout book; that gets its own issue.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

New unit tests, JVM only:

- `ScrolledPageTest` — five cases, including *the container ignores vertical
  text*, whose only job is to fail if someone collapses the two functions back
  into one. Nothing else in this change can catch that regression.
- `ReadingCssTest` — `Unsupported.honoursAnything` is false.

Checked on `liseur_phone_api36` against two purpose-built fixtures (a
pre-paginated EPUB and a Japanese `vertical-rl` one with an RTL spine, which is
what Readium actually reads `verticalText` off — the CSS alone does not do it):

- both sheets grey the right rows and say the line exactly once
- theme swatches and brightness stay live
- with scroll mode **on** globally, the fixed-layout book keeps paged chrome
  and the footer sits below the page rather than across it
- the vertical-text book keeps its scrolled chrome with scroll mode off, so the
  `verticalText` path survives, and opens without a reflow
- a reflowable book is unchanged
- values set in a reflowable book are still shown by the disabled controls, and
  are still there afterwards

## Screenshots or recordings

Same phone, same session, same font size — set in a reflowable book and left
alone. The typography sheet before and after the book changes:

| A reflowable book | A fixed-layout book |
|---|---|
| <img width="360" alt="Typography sheet in Moby Dick: everything live" src="https://github.com/user-attachments/assets/96ed75e1-e023-4346-87f8-6a3e405095f3" /> | <img width="360" alt="Typography sheet in a fixed-layout book: size, font and scrolling greyed under the notice" src="https://github.com/user-attachments/assets/e13ad157-2e68-464f-832d-000cb0a08873" /> |

The size slider keeps the value it was given and shows it greyed; theme and
brightness stay in colour, because they still do something. The scrolling
toggle is greyed in its stored *on* position.

The Advanced sheet, where line spacing and margins now join the six rows ADR 2
had already disabled:

<img width="360" alt="Advanced sheet in a fixed-layout book: line spacing and margins greyed alongside alignment and hyphenation" src="https://github.com/user-attachments/assets/97daef0b-189a-400b-b1ee-84a4686f050b" />

And the reason the scrolling gate is the risky half. Scroll mode is **on**
app-wide here. Before this change the chrome would have gone scrolled and drawn
itself over the page; now the book keeps paged chrome and the footer sits below
it, in the letterbox:

<img width="360" alt="A fixed-layout page with scroll mode on: paged chrome, page counter, footer below the page" src="https://github.com/user-attachments/assets/ce133876-cb5c-4830-8711-f2548d340f0f" />
## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

