### PR TITLE
Keep reader search and contents clear of the keyboard and the notch

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -416,6 +416,60 @@ java -jar pepk.jar --keystore="$d/release.p12" \
 `pepk.jar` and `encryption_public_key.pem` are downloaded from the
 console, and the temporary directory goes away afterwards.
 
+### The two edge-to-edge advisories
+
+Every release raises the same pair of warnings on the Play Console, and
+neither is a defect report:
+
+> Edge-to-edge may not display for all users.
+
+> Your app uses deprecated APIs or parameters for edge-to-edge.
+
+The first is attached to every app targeting SDK 35 or later. It asks us
+to test, not to change anything. The app has drawn edge-to-edge since it
+started targeting 35: `MainActivity` and `ReaderActivity` both call the
+no-argument `enableEdgeToEdge()`, no theme sets `android:statusBarColor`
+or `android:navigationBarColor`, and the manifest carries no opt-out.
+
+The second is static analysis of the bundle's bytecode, and it does not
+say whose bytecode. Ours calls none of the deprecated setters. Every
+flagged reference belongs to androidx:
+
+| Artifact | `setStatusBarColor` | `setNavigationBarColor` | `setDecorFitsSystemWindows` | `setSystemUiVisibility` |
+| --- | --- | --- | --- | --- |
+| `androidx.activity:activity` | 4 | 4 | 4 | 0 |
+| `androidx.core:core` | 1 | 1 | 4 | 7 |
+
+They are the version-guarded backports inside androidx's own
+`EdgeToEdge`, `WindowCompat` and `WindowInsetsControllerCompat`, which
+are the classes Google's own migration guide sends apps *to*. There is
+nothing to migrate away from, and hand-rolling around them to quieten a
+console page would be strictly worse. The warning stays until androidx
+changes, so treat it as noise rather than as something to fix before a
+release.
+
+Re-check the claim, rather than trusting this table, if androidx moves:
+
+```bash
+unzip -p "$(find ~/.gradle/caches/modules-2 -name 'activity-*.aar' | head -1)" \
+  classes.jar > /tmp/a.jar
+unzip -p /tmp/a.jar '*.class' | grep -ac setStatusBarColor
+```
+
+What the first advisory *is* good for is prompting an actual look. Doing
+that once turned up two real inset bugs the console never mentioned:
+the reader's search results were laid out 820px beneath the keyboard
+where nothing could reach them, and neither the search nor the contents
+screen kept clear of a display cutout in landscape. Both screens pinned
+`contentWindowInsets` to `WindowInsets.systemBars`, which omits the IME
+and the cutout; `safeDrawing` covers all three. An emulator with a cutout
+is the way to see it:
+
+```bash
+adb shell cmd overlay enable com.android.internal.display.cutout.emulation.tall
+adb reboot   # the display picks the cutout up on boot, not on enable
+```
+
 ### Release notes
 
 Two things are written for every release, and they are not the same

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -451,9 +451,10 @@ release.
 Re-check the claim, rather than trusting this table, if androidx moves:
 
 ```bash
-unzip -p "$(find ~/.gradle/caches/modules-2 -name 'activity-*.aar' | head -1)" \
-  classes.jar > /tmp/a.jar
-unzip -p /tmp/a.jar '*.class' | grep -ac setStatusBarColor
+activity_version=$(sed -n 's/^activityCompose = "\(.*\)"/\1/p' gradle/libs.versions.toml)
+unzip -p "$(find ~/.gradle/caches/modules-2/files-2.1/androidx.activity/activity/"$activity_version" \
+  -name '*.aar' -print -quit)" classes.jar > /tmp/a.jar
+unzip -p /tmp/a.jar '*.class' | grep -ao setStatusBarColor | wc -l
 ```
 
 What the first advisory *is* good for is prompting an actual look. Doing

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ContentsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ContentsScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -122,7 +122,10 @@ fun ContentsScreen(
     Scaffold(
         modifier = modifier.fillMaxSize(),
         containerColor = theme.background,
-        contentWindowInsets = WindowInsets.systemBars,
+        // safeDrawing, not systemBars: a landscape display cutout falls on
+        // the side edges, where there is no status bar to stand in for it,
+        // and would otherwise cut into the chapter and annotation rows.
+        contentWindowInsets = WindowInsets.safeDrawing,
         topBar = {
             Column {
                 TopAppBar(

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/search/SearchScreen.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardActions
@@ -85,7 +85,11 @@ fun SearchScreen(
     Scaffold(
         modifier = modifier.fillMaxSize(),
         containerColor = theme.background,
-        contentWindowInsets = WindowInsets.systemBars,
+        // safeDrawing, not systemBars: the field takes focus the moment the
+        // screen opens, so the keyboard is up before the first hit lands and
+        // the last results would sit under it. It also keeps the query and
+        // the hit text clear of a display cutout in landscape.
+        contentWindowInsets = WindowInsets.safeDrawing,
         topBar = {
             Column {
                 TopAppBar(


### PR DESCRIPTION
## Summary

Searching inside a book laid the results list out underneath the on-screen keyboard. The last few hits sat in a strip nothing could scroll to, so they could not be reached without dismissing the keyboard first. In landscape on a phone with a notch, the search and contents screens ran under it as well, cutting into chapter titles and result text.

Both screens now leave room for the keyboard and the notch alongside the status and navigation bars.

This came out of investigating the two edge-to-edge warnings the Play Console raises on every release. Neither warning needed acting on, but looking properly turned up these two bugs, which the console never mentioned.

## Changes

- Reader search and contents now reserve space for the keyboard and a display cutout, not just the status and navigation bars.
- `DEVELOPER.md` records why the Play Console's two edge-to-edge warnings appear on every release and why neither needs a fix. The deprecated calls they flag belong to androidx's own compatibility helpers, which are what Google's migration guide points apps at.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

Checked on an Android 16 emulator with a simulated notch, in portrait and landscape.

Measuring the search results list against the top of the keyboard, at 1517px down a 2400px screen:

| | Results list | Keyboard starts at |
| --- | --- | --- |
| Before | ends at 2337 | 1517 |
| After | ends at 1517 | 1517 |

820px of results, roughly two and a half rows, were being drawn where nothing could reach them.

## Screenshots or recordings

Searching Moby Dick for "pyramid", 12 results, scrolled as far down as the list will go in both cases. Before, it stops mid-sentence on "The Whale as a Dish" and the last four results cannot be reached. After, it reaches the real last result.

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/c6cfdf8a-b5b3-4796-8fda-dfd7ab74d9ea" width="340"> | <img src="https://github.com/user-attachments/assets/f0ccce39-4a95-43c6-a211-945f479092f1" width="340"> |

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
