### PR TITLE
feat: Implement cross-device reading statistics (ADR-0021)

### DIFF
--- a/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/45.json
+++ b/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/45.json
@@ -1,0 +1,1365 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 45,
+    "identityHash": "75330bc5a69d60ed586f3e38dc70e09c",
+    "entities": [
+      {
+        "tableName": "reading_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `total_progression` REAL, `reading_speed` REAL, `reading_seconds_per_position` REAL, `reading_pace_samples` INTEGER NOT NULL DEFAULT 0, `reading_pace_elapsed_ms` INTEGER NOT NULL DEFAULT 0, `reading_pace_evidence` REAL NOT NULL DEFAULT 0, `updated_at` INTEGER NOT NULL, `status` TEXT, `synced_at` INTEGER, `local_revision` INTEGER NOT NULL DEFAULT 0, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `agreed_account` TEXT, `pending_progression` REAL, `pending_locator_json` TEXT, `pending_status` TEXT, `pending_updated_at` INTEGER, `pending_account` TEXT, `owner_account` TEXT, `remote_updated_at` INTEGER, `finished_override` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSpeed",
+            "columnName": "reading_speed",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSecondsPerPosition",
+            "columnName": "reading_seconds_per_position",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingPaceSamples",
+            "columnName": "reading_pace_samples",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceElapsedMs",
+            "columnName": "reading_pace_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceEvidence",
+            "columnName": "reading_pace_evidence",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localRevision",
+            "columnName": "local_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "agreedAccount",
+            "columnName": "agreed_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingLocatorJson",
+            "columnName": "pending_locator_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingAccount",
+            "columnName": "pending_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ownerAccount",
+            "columnName": "owner_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "finishedOverride",
+            "columnName": "finished_override",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `cover_path` TEXT, `source` TEXT, `added_at` INTEGER NOT NULL, `last_opened_at` INTEGER, `local_uri` TEXT, `remote_uuid` TEXT, `remote_book_id` INTEGER, `cover_url` TEXT, `download_href` TEXT, `download_state` TEXT NOT NULL, `remote_updated_at` INTEGER, `downloaded_at` INTEGER, `file_modified_at` INTEGER, `work_id` TEXT, `finished_at` INTEGER, `archived_at` INTEGER, `remote_page_count` INTEGER, `size_bytes` INTEGER, `series_name` TEXT, `series_index` REAL, `file_series_name` TEXT, `file_series_index` REAL, `series_id` TEXT, `series_checked` INTEGER NOT NULL, `catalog_series_name` TEXT, `catalog_series_index` REAL, `catalog_folder_id` TEXT, `catalog_series_source` TEXT, `user_series_name` TEXT, `user_series_index` REAL, `series_override` INTEGER NOT NULL, `user_series_updated_at` INTEGER, `series_claim_pending` INTEGER NOT NULL, `series_claim_reset` INTEGER NOT NULL, `personal_series_updated_at` INTEGER, `series_index_override` INTEGER NOT NULL, `catalog_missing_since` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "last_opened_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localUri",
+            "columnName": "local_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUuid",
+            "columnName": "remote_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteBookId",
+            "columnName": "remote_book_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadHref",
+            "columnName": "download_href",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadState",
+            "columnName": "download_state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloaded_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finished_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archived_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remotePageCount",
+            "columnName": "remote_page_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "size_bytes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fileSeriesName",
+            "columnName": "file_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileSeriesIndex",
+            "columnName": "file_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesChecked",
+            "columnName": "series_checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSeriesName",
+            "columnName": "catalog_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesIndex",
+            "columnName": "catalog_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "catalogFolderId",
+            "columnName": "catalog_folder_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesSource",
+            "columnName": "catalog_series_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesName",
+            "columnName": "user_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesIndex",
+            "columnName": "user_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesOverridden",
+            "columnName": "series_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userSeriesUpdatedAt",
+            "columnName": "user_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesClaimPending",
+            "columnName": "series_claim_pending",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesClaimReset",
+            "columnName": "series_claim_reset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personalSeriesUpdatedAt",
+            "columnName": "personal_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "indexOverridden",
+            "columnName": "series_index_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogMissingSince",
+            "columnName": "catalog_missing_since",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_books_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_books_url` ON `${TABLE_NAME}` (`url`)"
+          },
+          {
+            "name": "index_books_series_name",
+            "unique": false,
+            "columnNames": [
+              "series_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_series_name` ON `${TABLE_NAME}` (`series_name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "library_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `added_at` INTEGER NOT NULL, PRIMARY KEY(`url`))",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "url"
+          ]
+        }
+      },
+      {
+        "tableName": "remote_server",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `kind` TEXT NOT NULL, `base_url` TEXT NOT NULL, `catalog_url` TEXT, `username` TEXT, `password_cipher` TEXT, `api_key_cipher` TEXT, `account_id` TEXT, `user_id` INTEGER, `kobo_token` TEXT, `can_download` INTEGER NOT NULL, `can_manage_library` INTEGER NOT NULL, `can_upload` INTEGER NOT NULL, `can_delete` INTEGER NOT NULL, `can_read_insights` INTEGER NOT NULL, `can_admin` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `catalog_synced_at` INTEGER, `position_synced_at` INTEGER, `sync_token` TEXT, `liseur_token_cipher` TEXT, `liseur_account_id` TEXT, `sync_cursor_seq` INTEGER NOT NULL DEFAULT 0, `annotation_cursor_seq` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogUrl",
+            "columnName": "catalog_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "passwordCipher",
+            "columnName": "password_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiKeyCipher",
+            "columnName": "api_key_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "koboTokenCipher",
+            "columnName": "kobo_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "canDownload",
+            "columnName": "can_download",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canManageLibrary",
+            "columnName": "can_manage_library",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canUpload",
+            "columnName": "can_upload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canDelete",
+            "columnName": "can_delete",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canReadInsights",
+            "columnName": "can_read_insights",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canAdmin",
+            "columnName": "can_admin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSyncedAt",
+            "columnName": "catalog_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "positionSyncedAt",
+            "columnName": "position_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncToken",
+            "columnName": "sync_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurTokenCipher",
+            "columnName": "liseur_token_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurAccountId",
+            "columnName": "liseur_account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncCursorSeq",
+            "columnName": "sync_cursor_seq",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "annotationCursorSeq",
+            "columnName": "annotation_cursor_seq",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `book_id` TEXT NOT NULL, `kind` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `text` TEXT, `note` TEXT, `tint` TEXT, `chapter` TEXT, `position` INTEGER, `total_progression` REAL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tint",
+            "columnName": "tint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapter",
+            "columnName": "chapter",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_typography",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `font` TEXT NOT NULL, `font_size` REAL NOT NULL, `line_height` REAL, `page_margins` REAL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "font",
+            "columnName": "font",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "font_size",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineHeight",
+            "columnName": "line_height",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pageMargins",
+            "columnName": "page_margins",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_screen",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `keep_screen_on` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keepScreenOn",
+            "columnName": "keep_screen_on",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_reading_mode",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `scroll` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scroll",
+            "columnName": "scroll",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `book_url` TEXT NOT NULL, `started_at` INTEGER NOT NULL, `ended_at` INTEGER, `last_checkpoint_at` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `start_progression` REAL, `end_progression` REAL, `idle_ms` INTEGER, `uploaded_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "ended_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastCheckpointAt",
+            "columnName": "last_checkpoint_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startProgression",
+            "columnName": "start_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "endProgression",
+            "columnName": "end_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "idleMs",
+            "columnName": "idle_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "uploadedAt",
+            "columnName": "uploaded_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_sessions_book_url",
+            "unique": false,
+            "columnNames": [
+              "book_url"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_book_url` ON `${TABLE_NAME}` (`book_url`)"
+          },
+          {
+            "name": "index_reading_sessions_started_at",
+            "unique": false,
+            "columnNames": [
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_started_at` ON `${TABLE_NAME}` (`started_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_peer_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `pending_progression` REAL, `pending_locator_json` TEXT, `pending_edition_sha` TEXT, `pending_status` TEXT, `pending_updated_at` INTEGER, `has_pending` INTEGER NOT NULL DEFAULT 0, `remote_updated_at` INTEGER, `synced_at` INTEGER, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingLocatorJson",
+            "columnName": "pending_locator_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingEditionSha",
+            "columnName": "pending_edition_sha",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasPending",
+            "columnName": "has_pending",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_peer_state_peer_id",
+            "unique": false,
+            "columnNames": [
+              "peer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_peer_state_peer_id` ON `${TABLE_NAME}` (`peer_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_fingerprint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `sha256` TEXT NOT NULL, `partial_md5` TEXT NOT NULL, `file_size` INTEGER NOT NULL, `file_modified_at` INTEGER, `computed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256",
+            "columnName": "sha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partialMd5",
+            "columnName": "partial_md5",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "computedAt",
+            "columnName": "computed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "work_alias",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_id` TEXT NOT NULL, `confidence` TEXT NOT NULL, `confirmed` INTEGER NOT NULL, `seeded` INTEGER NOT NULL DEFAULT 0, `source_sent` INTEGER NOT NULL DEFAULT 0, `edition_sha` TEXT, `annotations_reconciled_at` INTEGER NOT NULL DEFAULT 0, `resolved_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confirmed",
+            "columnName": "confirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seeded",
+            "columnName": "seeded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceSent",
+            "columnName": "source_sent",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "editionSha",
+            "columnName": "edition_sha",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "annotationsReconciledAt",
+            "columnName": "annotations_reconciled_at",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "resolvedAt",
+            "columnName": "resolved_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "work_ambiguity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_ids` TEXT NOT NULL, `noticed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workIds",
+            "columnName": "work_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noticedAt",
+            "columnName": "noticed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_extra",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`series_id` TEXT NOT NULL, `summary` TEXT, `status` TEXT, `total_book_count` INTEGER, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`series_id`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalBookCount",
+            "columnName": "total_book_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "series_id"
+          ]
+        }
+      },
+      {
+        "tableName": "annotation_sync",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `book_id` TEXT NOT NULL, `work_id` TEXT NOT NULL, `rev` INTEGER NOT NULL, `seq` INTEGER NOT NULL, `acked_fingerprint` TEXT, `pending_kind` TEXT, `pending_json` TEXT, `pending_rev` INTEGER NOT NULL, `pending_fingerprint` TEXT, `rejected_fingerprint` TEXT, `retry_not_before` INTEGER NOT NULL, PRIMARY KEY(`id`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rev",
+            "columnName": "rev",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seq",
+            "columnName": "seq",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ackedFingerprint",
+            "columnName": "acked_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingKind",
+            "columnName": "pending_kind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingJson",
+            "columnName": "pending_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingRev",
+            "columnName": "pending_rev",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pendingFingerprint",
+            "columnName": "pending_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "rejectedFingerprint",
+            "columnName": "rejected_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "retryNotBefore",
+            "columnName": "retry_not_before",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotation_sync_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotation_sync_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          },
+          {
+            "name": "index_annotation_sync_work_id",
+            "unique": false,
+            "columnNames": [
+              "work_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotation_sync_work_id` ON `${TABLE_NAME}` (`work_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kosync_peer",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `base_url` TEXT NOT NULL, `username` TEXT NOT NULL, `key_cipher` TEXT NOT NULL, `added_at` INTEGER NOT NULL, `position_synced_at` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keyCipher",
+            "columnName": "key_cipher",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSyncedAt",
+            "columnName": "position_synced_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "upload_refusal",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `account_key` TEXT NOT NULL, `refused_at` INTEGER NOT NULL, `kind` TEXT NOT NULL, `reason` TEXT, `content_sha256` TEXT, `seen_at` INTEGER, PRIMARY KEY(`book_url`, `account_key`), FOREIGN KEY(`book_url`) REFERENCES `books`(`url`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountKey",
+            "columnName": "account_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "refusedAt",
+            "columnName": "refused_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reason",
+            "columnName": "reason",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentSha256",
+            "columnName": "content_sha256",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seenAt",
+            "columnName": "seen_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "account_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_upload_refusal_account_key_seen_at",
+            "unique": false,
+            "columnNames": [
+              "account_key",
+              "seen_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_upload_refusal_account_key_seen_at` ON `${TABLE_NAME}` (`account_key`, `seen_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "book_url"
+            ],
+            "referencedColumns": [
+              "url"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '75330bc5a69d60ed586f3e38dc70e09c')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -220,9 +220,15 @@ private fun LiseurApp(settings: AppSettings) {
             ReadingStatsScreen(
                 state = statsState,
                 onOpenBook = { book ->
-                    statsBook = StatsTarget(book.bookUrl, book.title)
-                    bookStatsReturnsTo = Screen.STATS
-                    screen = Screen.BOOK_STATS
+                    // Only a book this device has can be opened. A row
+                    // the server counted and this library has no file
+                    // for carries no tap target at all (ADR-0021), so
+                    // this is belt and braces rather than a path taken.
+                    book.bookUrl?.let { url ->
+                        statsBook = StatsTarget(url, book.title)
+                        bookStatsReturnsTo = Screen.STATS
+                        screen = Screen.BOOK_STATS
+                    }
                 },
                 onBack = { screen = Screen.LIBRARY },
                 onSelectRange = model::selectRange,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
@@ -27,7 +27,7 @@ import androidx.sqlite.execSQL
         KosyncPeer::class,
         UploadRefusal::class,
     ],
-    version = 44,
+    version = 45,
     exportSchema = true,
 )
 abstract class LiseurDatabase : RoomDatabase() {
@@ -1126,6 +1126,23 @@ abstract class LiseurDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Records whether the connected token may ask for reading
+         * statistics (ADR-0021). Off for every existing row, and for the
+         * same reason as [MIGRATION_35_36]: a token minted before the
+         * scope existed does not carry it, and the app cannot widen one
+         * without an account password it never keeps. The next
+         * introspection corrects a token that does hold it.
+         */
+        val MIGRATION_44_45 = object : Migration(44, 45) {
+            override fun migrate(connection: SQLiteConnection) {
+                connection.execSQL(
+                    "ALTER TABLE `remote_server` ADD COLUMN `can_read_insights` " +
+                        "INTEGER NOT NULL DEFAULT 0",
+                )
+            }
+        }
+
         val MIGRATION_39_40 = object : Migration(39, 40) {
             override fun migrate(connection: SQLiteConnection) {
                 connection.execSQL(
@@ -1243,6 +1260,7 @@ abstract class LiseurDatabase : RoomDatabase() {
             MIGRATION_41_42,
             MIGRATION_42_43,
             MIGRATION_43_44,
+            MIGRATION_44_45,
         )
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/RemoteServer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/RemoteServer.kt
@@ -66,6 +66,17 @@ data class RemoteServer(
      * this column existed.
      */
     @ColumnInfo(name = "can_delete") val canDelete: Boolean = false,
+    /**
+     * Whether this connection's token may ask for reading statistics
+     * (ADR-0021). liseur-sync only, and false for every account paired
+     * before the column existed: a token minted without the scope
+     * cannot be widened from here, so the pessimistic value is the
+     * honest one until the account is introspected again — or until the
+     * first insights request answers with a body, which is proof enough
+     * on its own and corrects the value immediately rather than waiting
+     * for the next introspection.
+     */
+    @ColumnInfo(name = "can_read_insights") val canReadInsights: Boolean = false,
     @ColumnInfo(name = "can_admin") val canAdmin: Boolean = false,
     @ColumnInfo(name = "added_at") val addedAt: Long,
     @ColumnInfo(name = "catalog_synced_at") val catalogSyncedAt: Long?,
@@ -251,6 +262,33 @@ interface RemoteServerDao {
 
     @Query("UPDATE remote_server SET can_upload = :allowed WHERE id = :id")
     suspend fun setCanUpload(allowed: Boolean, id: Long = RemoteServer.SINGLE_ID)
+
+    /**
+     * Records what the server actually said about statistics — but only
+     * if [tokenCipher] is still the token the row holds.
+     *
+     * The column is written at connect from the token's scopes and
+     * corrected here from the answers: an account paired before the
+     * column existed starts pessimistic, and the first summary that
+     * arrives is proof enough that the token may ask (ADR-0021). The
+     * permission belongs to the token, not the account — [RemoteServer.accountKey]
+     * deliberately survives a token rotation, so it cannot be what
+     * guards this write. Folding the check into the `WHERE` clause makes
+     * the read-then-write one atomic statement: a reconnect that swaps
+     * in a new token between a request going out and its answer coming
+     * back leaves this a no-op, rather than a late answer for the old
+     * token overwriting the new one's permission. The row count returned
+     * says whether it landed.
+     */
+    @Query(
+        "UPDATE remote_server SET can_read_insights = :allowed " +
+            "WHERE id = :id AND liseur_token_cipher = :tokenCipher",
+    )
+    suspend fun setCanReadInsights(
+        allowed: Boolean,
+        tokenCipher: String?,
+        id: Long = RemoteServer.SINGLE_ID,
+    ): Int
 
     /**
      * Moves the liseur-sync cursor, touching nothing else.

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncInsights.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncInsights.kt
@@ -1,9 +1,13 @@
 package com.chmouel.liseur.data.liseursync
 
 import android.util.Log
+import com.chmouel.liseur.data.db.RemoteServer
 import com.chmouel.liseur.data.db.RemoteServerDao
-import com.chmouel.liseur.data.remote.ServerKind
 import com.chmouel.liseur.data.db.WorkIdentityDao
+import com.chmouel.liseur.data.remote.RemoteCredentials
+import com.chmouel.liseur.data.remote.RemoteHttpFailure
+import com.chmouel.liseur.data.remote.ServerKind
+import com.chmouel.liseur.data.remote.SyncFailure
 import com.chmouel.liseur.domain.StatsRange
 import java.io.IOException
 import java.time.DayOfWeek
@@ -47,10 +51,50 @@ data class WorkInsights(
      * the reader twice for one evening.
      */
     val workId: String = "",
+    /**
+     * What the server calls the book, when it says.
+     *
+     * The only thing needed to list a work this device has no file for
+     * (ADR-0021). Empty from a server too old to send it, which is a
+     * work that cannot be shown rather than one shown nameless.
+     */
+    val title: String = "",
+    val author: String? = null,
+    /**
+     * Where the reader is in the book, by the newest position any device
+     * sent; null when no position has ever reached the server.
+     *
+     * Never windowed: a place in a book is true now, whatever span the
+     * figures beside it cover. Read for a book this device has no file
+     * for and nothing else (ADR-0021): for a book that is here the
+     * local position is fresher than anything a server can relay, but
+     * for one that is not, this is the only account of it there is.
+     */
+    val currentProgression: Double? = null,
 )
 
 /** One server-timezone calendar day, added up across every device. */
 data class InsightDay(val date: LocalDate, val activeMinutes: Double)
+
+/**
+ * Every book the server counted for one window, sorted by whether this
+ * device has a file for it.
+ *
+ * [byBookUrl] is what the dashboard can put a cover, a progression and a
+ * tap target against. [elsewhere] is the rest: works read on another
+ * device, or ones this device has never resolved. They used to be
+ * dropped at the mapping, which left the list under the headline smaller
+ * than the headline itself and gave no reason for the difference
+ * (ADR-0021).
+ */
+data class WorkTotals(
+    val byBookUrl: Map<String, WorkInsights>,
+    val elsewhere: List<WorkInsights>,
+) {
+    companion object {
+        val Empty = WorkTotals(emptyMap(), emptyList())
+    }
+}
 
 /**
  * Statistics from a liseur-sync server, when there are any.
@@ -63,7 +107,9 @@ data class InsightDay(val date: LocalDate, val activeMinutes: Double)
  * on a train should see their own figures rather than a complaint.
  *
  * The token needs the `read-insights` scope; one minted without it is
- * refused, which lands in the same silent null as being offline.
+ * refused, which lands in the same silent null as being offline — but
+ * the refusal is written down on the account, so the reader can be told
+ * where it can still be fixed (ADR-0021).
  */
 class LiseurSyncInsights(
     private val serverDao: RemoteServerDao,
@@ -89,15 +135,9 @@ class LiseurSyncInsights(
     suspend fun summary(from: LocalDate?, to: LocalDate): InsightsSummary? {
         val account = account() ?: return null
         val credentials = account.credentials ?: return null
-        val answer = try {
-            http.get(
-                LiseurSyncApi.insightsSummary(account.baseUrl, from, to),
-                credentials,
-            )
-        } catch (e: IOException) {
-            Log.i(TAG, "No statistics from the server this time", e)
-            return null
-        }
+        val answer = ask("No statistics from the server this time") {
+            fetch(account, credentials, LiseurSyncApi.insightsSummary(account.baseUrl, from, to))
+        } ?: return null
         if (!answer.covers(from, to)) return null
         return InsightsSummary(
             activeMinutes = answer.optDouble("total_active_minutes", 0.0),
@@ -120,12 +160,9 @@ class LiseurSyncInsights(
         val account = account() ?: return null
         val credentials = account.credentials ?: return null
         val alias = identityDao.alias(bookUrl, account.accountKey)?.takeIf { it.usable } ?: return null
-        val answer = try {
-            http.get(LiseurSyncApi.workInsights(account.baseUrl, alias.workId), credentials)
-        } catch (e: IOException) {
-            Log.i(TAG, "No statistics for this book", e)
-            return null
-        }
+        val answer = ask("No statistics for this book") {
+            fetch(account, credentials, LiseurSyncApi.workInsights(account.baseUrl, alias.workId))
+        } ?: return null
         return parseWork(answer)?.takeIf { it.sessions > 0 || it.etaSeconds != null }
     }
 
@@ -142,22 +179,26 @@ class LiseurSyncInsights(
     suspend fun calendar(from: LocalDate, to: LocalDate): List<InsightDay>? {
         val account = account() ?: return null
         val credentials = account.credentials ?: return null
-        val answers = try {
-            val bounded = http.get(
-                LiseurSyncApi.insightsCalendar(account.baseUrl, from, to),
+        val answers = mutableListOf<JSONObject>()
+        ask("No reading calendar from the server this time") {
+            val bounded = fetch(
+                account,
                 credentials,
+                LiseurSyncApi.insightsCalendar(account.baseUrl, from, to),
             )
             if (bounded.covers(from, to)) {
-                listOf(bounded)
+                answers += bounded
             } else {
-                (from.year..to.year).map { year ->
-                    http.get(LiseurSyncApi.insightsCalendar(account.baseUrl, year), credentials)
+                for (year in from.year..to.year) {
+                    answers += fetch(
+                        account,
+                        credentials,
+                        LiseurSyncApi.insightsCalendar(account.baseUrl, year),
+                    )
                 }
             }
-        } catch (e: IOException) {
-            Log.i(TAG, "No reading calendar from the server this time", e)
-            return null
-        }
+            bounded
+        } ?: return null
         return runCatching {
             answers.flatMap { answer ->
                 val days = answer.getJSONArray("days")
@@ -179,8 +220,8 @@ class LiseurSyncInsights(
     }
 
     /**
-     * Per-book aggregates for [range], keyed by this device's permanent
-     * book URL.
+     * Per-book aggregates for [range]: those this device has a book for,
+     * keyed by its permanent book URL, and those it has not.
      *
      * The same window the dashboard's headline uses, so the rows below it
      * add up to the figure above them — and the same check, so a server
@@ -192,48 +233,53 @@ class LiseurSyncInsights(
      * a file move); each usable alias receives the same aggregate, and
      * carries the work id so that a caller adding rows up can tell that
      * it is looking at one book twice. Doubtful aliases stay excluded
-     * until the reader confirms them, just like position sync.
+     * until the reader confirms them, just like position sync — and a
+     * work excluded that way is a work read elsewhere as far as this is
+     * concerned, which is the honest answer: its time is in the total
+     * either way, and this device cannot say which of its files it is.
+     *
+     * A work with no name is dropped rather than listed blank. The
+     * figures are already counted in the headline, so what a nameless
+     * row would add is a line the reader cannot identify.
      */
     suspend fun allBooks(
         range: StatsRange = StatsRange.Default,
         today: LocalDate,
         weekStart: DayOfWeek = WeekFields.ISO.firstDayOfWeek,
-    ): Map<String, WorkInsights>? {
+    ): WorkTotals? {
         val account = account() ?: return null
         val credentials = account.credentials ?: return null
         val aliases = identityDao.aliasesFor(account.accountKey).filter { it.usable }
-        if (aliases.isEmpty()) return emptyMap()
         val from = range.startDate(today, weekStart)
-        val answer = try {
-            http.get(
-                LiseurSyncApi.allWorkInsights(account.baseUrl, from, today),
-                credentials,
-            )
-        } catch (e: IOException) {
-            Log.i(TAG, "No per-book statistics from the server this time", e)
-            return null
-        }
+        val answer = ask("No per-book statistics from the server this time") {
+            fetch(account, credentials, LiseurSyncApi.allWorkInsights(account.baseUrl, from, today))
+        } ?: return null
         if (!answer.covers(from, today)) return null
         return runCatching {
             val byWork = aliases.groupBy { it.workId }
             val works = answer.getJSONArray("works")
-            buildMap {
-                for (index in 0 until works.length()) {
-                    val item = works.optJSONObject(index) ?: continue
-                    val workId = item.getString("work_id")
-                    val insight = parseWork(item)?.copy(workId = workId) ?: continue
-                    for (alias in byWork[workId].orEmpty()) {
-                        put(alias.bookUrl, insight)
-                    }
+            val known = mutableMapOf<String, WorkInsights>()
+            val elsewhere = mutableListOf<WorkInsights>()
+            for (index in 0 until works.length()) {
+                val item = works.optJSONObject(index) ?: continue
+                val workId = item.getString("work_id")
+                val insight = parseWork(item)?.copy(workId = workId) ?: continue
+                val here = byWork[workId].orEmpty()
+                if (here.isEmpty()) {
+                    if (insight.title.isNotEmpty()) elsewhere += insight
+                    continue
                 }
+                for (alias in here) known[alias.bookUrl] = insight
             }
+            WorkTotals(byBookUrl = known, elsewhere = elsewhere)
         }.getOrElse {
             Log.i(TAG, "The server returned malformed per-book statistics", it)
             null
         }
     }
 
-    private fun parseWork(answer: JSONObject): WorkInsights? = runCatching {        WorkInsights(
+    private fun parseWork(answer: JSONObject): WorkInsights? = runCatching {
+        WorkInsights(
             sessions = answer.optInt("sessions"),
             activeMinutes = answer.optDouble("total_active_minutes", 0.0)
                 .takeIf { it.isFinite() && it >= 0 } ?: 0.0,
@@ -245,8 +291,90 @@ class LiseurSyncInsights(
             lastReadAt = answer.optString("last_read_at")
                 .takeIf { it.isNotEmpty() }
                 ?.let { Instant.parse(it).toEpochMilli() },
+            title = answer.optString("title"),
+            author = answer.optString("author").takeIf { it.isNotEmpty() },
+            currentProgression = answer.optDouble("current_progression")
+                .takeIf { it.isFinite() && it > 0.0 }
+                ?.coerceAtMost(1.0),
         )
     }.getOrNull()
+
+    /**
+     * Runs one request and writes down what its answer proved about the
+     * token.
+     *
+     * `can_read_insights` is read off the token's scopes at connect and
+     * nowhere else, so an account paired before the column existed
+     * would carry its pessimistic default for good, and the account
+     * screen would go on saying statistics are refused to a reader
+     * whose statistics work. The answers settle it: a body is proof the
+     * token may ask, a 403 is proof it may not, and either is written
+     * down so the screen says what is true. Any other failure — offline,
+     * a server too old, a malformed body — says nothing about the token
+     * and changes nothing (ADR-0021).
+     *
+     * Conditional on the account, as every write from a background
+     * answer is: a reply to a question asked of an account the reader
+     * has since left must not describe the one they are on.
+     */
+    private suspend fun ask(
+        whenRefused: String,
+        request: suspend () -> JSONObject,
+    ): JSONObject? = try {
+        request()
+    } catch (e: RemoteHttpFailure) {
+        Log.i(TAG, whenRefused, e)
+        null
+    } catch (e: IOException) {
+        Log.i(TAG, whenRefused, e)
+        null
+    }
+
+    /**
+     * One HTTP call, with the capability column corrected from its own
+     * outcome alone.
+     *
+     * A multi-request caller such as [calendar] can have an early call
+     * prove the token capable and a later one fail outright; recording
+     * only once the whole caller returns would lose that proof the
+     * moment anything after it throws. Wrapping each call here instead
+     * means a body updates the column the instant it arrives, no matter
+     * what any later call in the same caller does.
+     */
+    private suspend fun fetch(
+        account: RemoteServer,
+        credentials: RemoteCredentials,
+        url: String,
+    ): JSONObject {
+        try {
+            val answer = http.get(url, credentials)
+            if (!account.canReadInsights) record(account, allowed = true)
+            return answer
+        } catch (e: RemoteHttpFailure) {
+            if (e.reason == SyncFailure.Forbidden && account.canReadInsights) {
+                record(account, allowed = false)
+            }
+            throw e
+        }
+    }
+
+    /**
+     * Writes [allowed] for the token that made the request, and only
+     * that token.
+     *
+     * [RemoteServer.accountKey] deliberately survives a token rotation
+     * (a re-pasted token for the same account keeps it), so it cannot
+     * guard this: the permission belongs to the token, not the account.
+     * Keying the update on the token cipher instead — and folding the
+     * check into the `WHERE` clause of that one statement — closes the
+     * gap a separate read-then-write would leave open, where a
+     * reconnect replaces the row between the request going out and its
+     * answer coming back, and the late answer for the old token would
+     * otherwise overwrite the new one's permission.
+     */
+    private suspend fun record(account: RemoteServer, allowed: Boolean) {
+        serverDao.setCanReadInsights(allowed, account.liseurTokenCipher)
+    }
 
     /**
      * The connected liseur-sync account, or null when the server is of

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncServerSetup.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncServerSetup.kt
@@ -106,6 +106,7 @@ class LiseurSyncServerSetup(
             canManageLibrary = LiseurSyncApi.SCOPE_LIBRARY_MANAGE in scopes || isAdmin,
             canUpload = LiseurSyncApi.SCOPE_LIBRARY_UPLOAD in scopes || isAdmin,
             canDelete = LiseurSyncApi.SCOPE_LIBRARY_DELETE in scopes || isAdmin,
+            canReadInsights = LiseurSyncApi.SCOPE_INSIGHTS in scopes || isAdmin,
             canAdmin = isAdmin,
             accountId = answer.optString("device_id").takeIf { it.isNotEmpty() },
             displayName = answer.optString("name").ifEmpty { "liseur-sync" },

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepository.kt
@@ -571,6 +571,7 @@ class RemoteAccountRepository(
                 canManageLibrary = capabilities.canManageLibrary,
                 canUpload = capabilities.canUpload,
                 canDelete = capabilities.canDelete,
+                canReadInsights = capabilities.canReadInsights,
                 canAdmin = capabilities.canAdmin,
                 addedAt = existing?.addedAt ?: System.currentTimeMillis(),
                 catalogSyncedAt = existing?.catalogSyncedAt,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteSources.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteSources.kt
@@ -112,6 +112,18 @@ data class ServerCapabilities(
      * server decides per folder too — so this says "worth offering".
      */
     val canDelete: Boolean = false,
+    /**
+     * Whether the account may ask liseur-sync for reading statistics
+     * (ADR-0021).
+     *
+     * Half an answer like [canUpload] and [canDelete]: it says the token
+     * may ask, not that the server has anything to say. Recorded because
+     * the alternative was silence — a token minted without
+     * `read-insights` is refused on every statistics call for the life
+     * of the account, and a reader who is never told cannot re-pair to
+     * fix it.
+     */
+    val canReadInsights: Boolean = false,
     /** Whether the account can also write the shared catalog layer. */
     val canAdmin: Boolean = false,
     /** Who the server says we are, for telling two logins apart. */

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/ReadingStats.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/ReadingStats.kt
@@ -13,7 +13,17 @@ import kotlin.math.roundToLong
 
 /** What one book's reading adds up to. */
 data class BookReadingStats(
-    val bookUrl: String,
+    /**
+     * The book on this device, or null for one only a server knows.
+     *
+     * A work read on another phone, or one this device has never
+     * resolved, is still the reader's reading and is still in the total
+     * above the list (ADR-0021). It has no file here, so it has no
+     * cover and nothing to open — but it can still carry [progression]
+     * and [finished], read off the server's own `current_progression`
+     * for that work, and nothing that reads a row must assume otherwise.
+     */
+    val bookUrl: String?,
     val title: String,
     val author: String?,
     val totalMs: Long,
@@ -35,7 +45,15 @@ data class BookReadingStats(
      * Null only for a book this device never recorded a sitting for.
      */
     val firstReadAt: Long? = null,
-    /** Where the reader is in it, if known. */
+    /**
+     * Where the reader is in it, if known.
+     *
+     * For a local book, this is what the reader's own device knows. For
+     * a [bookUrl]-less row it comes from the server instead — its
+     * `current_progression` for that work — since this device has no
+     * file to read a locator off; null there means the server itself had
+     * nothing recent enough to say.
+     */
     val progression: Double?,
     val finished: Boolean,
     /** How many separate sittings it took, in the window being counted. */
@@ -44,7 +62,21 @@ data class BookReadingStats(
     val pendingSessions: Int = 0,
     val coverPath: String? = null,
     val coverUrl: String? = null,
-)
+    /**
+     * The server's name for the work, when this row came from one.
+     *
+     * Only ever set on a row with no [bookUrl], where it is the row's
+     * whole identity: a list needs a stable key, and a book this device
+     * does not have has no URL to be keyed by.
+     */
+    val workId: String? = null,
+) {
+    /** A stable identity for a list, whichever kind of row this is. */
+    val key: String get() = bookUrl ?: "work:${workId.orEmpty()}"
+
+    /** Whether the book is on this device, and so can be opened. */
+    val isLocal: Boolean get() = bookUrl != null
+}
 
 /** How much was read on one day. */
 data class ReadingDay(

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountScreen.kt
@@ -1071,6 +1071,18 @@ private fun ConnectedCard(
         )
     }
 
+    // The same for statistics (ADR-0021), and said here because this is
+    // the one place it can still be fixed. Left unsaid, a token without
+    // the scope is refused on every insights call for the life of the
+    // account, and the dashboard shows the same blank as being offline.
+    if (server.kind == ServerKind.LISEUR_SYNC && !server.canReadInsights) {
+        Text(
+            text = stringResource(R.string.server_insights_needs_reconnect),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+
     // The Kobo token is a calibre-web notion; the others have nothing like it.
     if (server.kind == ServerKind.CALIBRE) {        AdvancedSection(server = server, onKoboToken = onKoboToken)
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
@@ -31,6 +31,8 @@ import androidx.compose.material.icons.outlined.AutoStories
 import androidx.compose.material.icons.outlined.CalendarMonth
 import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.DateRange
+import androidx.compose.material.icons.outlined.Devices
+import androidx.compose.material.icons.outlined.PhoneAndroid
 import androidx.compose.material.icons.outlined.Remove
 import androidx.compose.material.icons.outlined.Speed
 import androidx.compose.material.icons.outlined.Timer
@@ -181,14 +183,20 @@ fun ReadingStatsScreen(
                     BentoHero(stats, ready.headline, ready.range)
                 }
                 item {
+                    ProvenanceLine(ready.provenance)
+                }
+                item {
                     ActivityCard(stats = stats, range = ready.range)
                 }
                 if (stats.books.isNotEmpty()) {
                     item {
                         BooksSectionHeader(count = stats.books.size)
                     }
-                    items(stats.books, key = { it.bookUrl }) { book ->
-                        BookStatCard(book = book, onClick = { onOpenBook(book) })
+                    items(stats.books, key = { it.key }) { book ->
+                        BookStatCard(
+                            book = book,
+                            onClick = if (book.isLocal) ({ onOpenBook(book) }) else null,
+                        )
                     }
                 }
             }
@@ -355,6 +363,44 @@ private fun BentoHero(stats: ReadingStats, headline: StatsHeadline, range: Stats
 
 /** One figure and what it counts. */
 private data class Tally(val icon: ImageVector, val value: String, val label: String)
+
+/**
+ * Where the figures above came from: this device, or all of them.
+ *
+ * A statement of provenance and nothing more (ADR-0021). Not a warning,
+ * not an error, and nothing to dismiss: a reader offline on a train is
+ * looking at their own reading, which is not a fault, and the screen
+ * saying so is the difference between a number they can trust and one
+ * they cannot place.
+ */
+@Composable
+private fun ProvenanceLine(provenance: StatsProvenance) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Icon(
+            imageVector = when (provenance) {
+                StatsProvenance.THIS_DEVICE -> Icons.Outlined.PhoneAndroid
+                StatsProvenance.ALL_DEVICES -> Icons.Outlined.Devices
+            },
+            contentDescription = null,
+            modifier = Modifier.size(14.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = stringResource(
+                when (provenance) {
+                    StatsProvenance.THIS_DEVICE -> R.string.reading_stats_from_this_device
+                    StatsProvenance.ALL_DEVICES -> R.string.reading_stats_from_all_devices
+                },
+            ),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
 
 /** How many tallies share a row. */
 private const val TILES_PER_ROW = 2
@@ -653,15 +699,21 @@ private fun BooksSectionHeader(count: Int) {
 
 /**
  * Editorial card for an individual book's reading breakdown.
+ *
+ * [onClick] is null for a book only another device has (ADR-0021).
+ * There is no file here to open, so the card is not made to look like
+ * something that would open one: no ripple, no cover, and a line saying
+ * where it was read. Its place in the book is the server's and is drawn
+ * like any other, so a book finished elsewhere reads as finished.
  */
 @Composable
-private fun BookStatCard(book: BookReadingStats, onClick: () -> Unit) {
+private fun BookStatCard(book: BookReadingStats, onClick: (() -> Unit)?) {
     Surface(
         shape = RoundedCornerShape(14.dp),
         color = MaterialTheme.colorScheme.surfaceContainerLow,
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick),
+            .let { if (onClick == null) it else it.clickable(onClick = onClick) },
     ) {
         Row(
             modifier = Modifier.padding(12.dp),
@@ -699,6 +751,18 @@ private fun BookStatCard(book: BookReadingStats, onClick: () -> Unit) {
                     )
                 }
                 Spacer(Modifier.height(6.dp))
+                if (!book.isLocal) {
+                    // Why this row has no cover and nothing to open. Said
+                    // plainly rather than left to be inferred from what
+                    // is missing; the place in the book beneath it is the
+                    // server's, and is shown the same way as any other.
+                    Text(
+                        text = stringResource(R.string.reading_stats_book_elsewhere),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(4.dp))
+                }
                 if (book.finished) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
@@ -14,12 +14,14 @@ import com.chmouel.liseur.data.liseursync.InsightDay
 import com.chmouel.liseur.data.liseursync.InsightsSummary
 import com.chmouel.liseur.data.liseursync.LiseurSyncInsights
 import com.chmouel.liseur.data.liseursync.WorkInsights
+import com.chmouel.liseur.data.liseursync.WorkTotals
 import com.chmouel.liseur.data.settings.AppSettingsRepository
 import com.chmouel.liseur.domain.BookReadingStats
 import com.chmouel.liseur.domain.ComparisonSpans
 import com.chmouel.liseur.domain.ReadingComparison
 import com.chmouel.liseur.domain.ReadingDay
 import com.chmouel.liseur.domain.ReadingStats
+import com.chmouel.liseur.domain.ReadingStatus
 import com.chmouel.liseur.domain.SessionSpan
 import com.chmouel.liseur.domain.StatsBook
 import com.chmouel.liseur.domain.StatsRange
@@ -28,6 +30,7 @@ import com.chmouel.liseur.domain.displayAuthor
 import com.chmouel.liseur.domain.displayTitle
 import com.chmouel.liseur.domain.localeWeekStart
 import com.chmouel.liseur.domain.readingStats
+import com.chmouel.liseur.domain.readingStatusFor
 import com.chmouel.liseur.domain.readingTotals
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -53,7 +56,25 @@ sealed interface ReadingStatsUiState {
         val stats: ReadingStats,
         val headline: StatsHeadline,
         val range: StatsRange,
+        val provenance: StatsProvenance = StatsProvenance.THIS_DEVICE,
     ) : ReadingStatsUiState
+}
+
+/**
+ * Which devices the figures on screen counted (ADR-0021).
+ *
+ * A statement, never a warning. The screen has always been one or the
+ * other and never said which, so the same blank meant "you are offline",
+ * "your token cannot ask" and "the server agreed with this device" — and
+ * a reader had no way to tell them apart. It must not become an error or
+ * anything to dismiss: reading on one phone is not a fault.
+ */
+enum class StatsProvenance {
+    /** No server answered for this window, so these are local sums. */
+    THIS_DEVICE,
+
+    /** liseur-sync answered for the span on screen. */
+    ALL_DEVICES,
 }
 
 /**
@@ -186,7 +207,7 @@ class ReadingStatsViewModel(
 
     private val _acrossDevices = MutableStateFlow<Answered<InsightsSummary?>?>(null)
     private val _recentAcrossDevices = MutableStateFlow<Answered<List<InsightDay>?>?>(null)
-    private val _booksAcrossDevices = MutableStateFlow<Answered<Map<String, WorkInsights>?>?>(null)
+    private val _booksAcrossDevices = MutableStateFlow<Answered<WorkTotals?>?>(null)
 
     /**
      * The same reading, counted on every device rather than this one.
@@ -326,7 +347,7 @@ class ReadingStatsViewModel(
      */
     fun serverEstimateFor(bookUrl: String): StateFlow<WorkInsights?> =
         combine(booksAcrossDevices, _window) { answered, window ->
-            answered.forWindow(window)?.get(bookUrl)
+            answered.forWindow(window)?.byBookUrl?.get(bookUrl)
         }.stateIn(
             viewModelScope,
             SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS),
@@ -440,11 +461,14 @@ class ReadingStatsViewModel(
     ) { local, server, recent, serverBooks ->
 
         val window = local.window
+        val summary = server.forWindow(window)
+        val recentDays = recent.forWindow(window)
+        val bookTotals = serverBooks.forWindow(window)
         val merged = mergeDashboard(
             local.stats,
             local.books,
-            recent.forWindow(window),
-            serverBooks.forWindow(window),
+            recentDays,
+            bookTotals,
             local.firstReadAtByUrl,
         )
         ReadingStatsUiState.Ready(
@@ -452,12 +476,13 @@ class ReadingStatsViewModel(
             headline = mergeHeadline(
                 merged = merged,
                 local = local.stats,
-                server = server.forWindow(window),
+                server = summary,
                 spans = local.spans,
                 currentMs = local.currentMs,
                 previousMs = local.previousMs,
             ),
             range = window.range,
+            provenance = provenanceOf(summary, recentDays, bookTotals),
         )
     }.stateIn(
         viewModelScope,
@@ -507,6 +532,33 @@ class ReadingStatsViewModel(
          * plausible limit for good.
          */
         private const val CALENDAR_HORIZON_DAYS = 3650L
+
+        /**
+         * Which devices the figures on screen counted.
+         *
+         * Any answer to the question the screen is asking means every
+         * device: the summary carries the headline, the per-book totals
+         * carry the list and the calendar carries the chart, and each is
+         * the same reading counted everywhere. All three refused is this
+         * device alone, and it makes no difference which of offline, a
+         * token without the scope or a server that has nothing to say
+         * produced the refusal — the figures are the same either way,
+         * and it is the reader's word for them that was missing.
+         *
+         * Not "is a server connected". That would claim a merge that did
+         * not happen: connected and unreachable is exactly the case the
+         * line exists to name.
+         */
+        internal fun provenanceOf(
+            summary: InsightsSummary?,
+            recent: List<InsightDay>?,
+            books: WorkTotals?,
+        ): StatsProvenance =
+            if (summary != null || recent != null || books != null) {
+                StatsProvenance.ALL_DEVICES
+            } else {
+                StatsProvenance.THIS_DEVICE
+            }
 
         /**
          * The one headline, from both sources.
@@ -607,65 +659,142 @@ class ReadingStatsViewModel(
          * becomes one row rather than two. The server counts it once, so
          * showing it twice would both charge the reader twice in the
          * total and present one book as two.
+         *
+         * A work the server knows and this library does not becomes a
+         * row of its own (ADR-0021). Its time is in the headline whether
+         * it is listed or not, so leaving it out is what made the list
+         * smaller than the total above it and gave no reason for the
+         * difference. It carries the server's name and the server's
+         * place in the book, and nothing else: there is no file here to
+         * open and no cover to draw, and nothing downstream may assume
+         * otherwise. The place is read because the server is the only
+         * one who has it, and it is what lets a book finished on the
+         * laptop be counted as finished here rather than left forever
+         * unread in the figure above the list.
          */
         internal fun mergeDashboard(
             local: ReadingStats,
             knownBooks: Map<String, StatsBook>,
             serverRecent: List<InsightDay>?,
-            serverBooks: Map<String, WorkInsights>?,
+            serverBooks: WorkTotals?,
             firstReadAtByUrl: Map<String, Long> = emptyMap(),
         ): ReadingStats {
-            val mergedBooks = local.books.associateBy { it.bookUrl }.toMutableMap()
-            serverBooks.orEmpty().entries
-                .filter { knownBooks.containsKey(it.key) }
+            val mergedBooks = local.books
+                .mapNotNull { row -> row.bookUrl?.let { it to row } }
+                .toMap()
+                .toMutableMap()
+            // A URL this device can put a row against: a book on the
+            // shelf, or one with sittings recorded here even though it
+            // never had a library row (opened straight from Android).
+            // The second matters as much as the first — a server figure
+            // for such a URL has a local row to merge into, and listing
+            // it a second time as read elsewhere would charge the
+            // reader twice.
+            fun here(url: String) = knownBooks.containsKey(url) || mergedBooks.containsKey(url)
+            // An alias can outlive the book it named — a file removed
+            // from the library leaves one behind. Such a work is one
+            // this device has no book for, whatever the alias says, and
+            // it belongs with the rest of them rather than in the gap
+            // between the two.
+            val (aliased, orphaned) = serverBooks?.byBookUrl.orEmpty().entries
                 .groupBy { it.value.workId }
-                .forEach { (_, entries) ->
-                    val urls = entries.map { it.key }
-                    val insight = entries.first().value
-                    val rows = urls.mapNotNull { mergedBooks[it] }
-                    // The row the reader has put the most time into is
-                    // the one the merged figure belongs on; the rest are
-                    // the same book under a URL it used to have.
-                    val canonical = rows.maxWithOrNull(
-                        compareBy<BookReadingStats> { it.totalMs }.thenByDescending { it.bookUrl },
-                    )?.bookUrl ?: urls.min()
-                    val metadata = knownBooks[canonical] ?: return@forEach
-                    val serverMs = insight.activeMinutes.minutesAsMillis()
-                    val localMs = rows.sumOf { it.totalMs }
-                    val pendingMs = rows.sumOf { it.pendingMs }
-                    val lastReadAt = maxOf(
-                        insight.lastReadAt ?: 0L,
-                        rows.maxOfOrNull { it.lastReadAt } ?: 0L,
-                    )
-                    if (lastReadAt <= 0L) return@forEach
-                    if (serverMs <= 0L && rows.isEmpty()) return@forEach
-                    urls.forEach { mergedBooks.remove(it) }
-                    mergedBooks[canonical] = BookReadingStats(
-                        bookUrl = canonical,
-                        title = metadata.title,
-                        author = metadata.author,
-                        totalMs = maxOf(localMs, serverMs + pendingMs),
-                        pendingMs = pendingMs,
-                        lastReadAt = lastReadAt,
-                        // The server has no started-at; the earliest local
-                        // start across the work's URLs is the only source.
-                        // Read from the all-time map first: a URL whose
-                        // reading all predates the window has no row to
-                        // carry its date.
-                        firstReadAt = urls.mapNotNull { firstReadAtByUrl[it] }.minOrNull()
-                            ?: rows.mapNotNull { it.firstReadAt }.minOrNull(),
-                        progression = metadata.progression,
-                        finished = metadata.finished,
-                        sessions = maxOf(
-                            rows.sumOf { it.sessions },
-                            insight.sessions + rows.sumOf { it.pendingSessions },
-                        ),
-                        pendingSessions = rows.sumOf { it.pendingSessions },
-                        coverPath = metadata.coverPath,
-                        coverUrl = metadata.coverUrl,
+                .entries
+                .partition { (_, entries) -> entries.any { here(it.key) } }
+            aliased.forEach { (_, allEntries) ->
+                val entries = allEntries.filter { here(it.key) }
+                val urls = entries.map { it.key }
+                val insight = entries.first().value
+                val rows = urls.mapNotNull { mergedBooks[it] }
+                // The row the reader has put the most time into is
+                // the one the merged figure belongs on; the rest are
+                // the same book under a URL it used to have.
+                val canonical = rows.maxWithOrNull(
+                    compareBy<BookReadingStats> { it.totalMs }
+                        .thenByDescending { it.bookUrl.orEmpty() },
+                )?.bookUrl ?: urls.min()
+                // A row with no library entry keeps what its sittings
+                // already said about it, which is all this device knows.
+                val metadata = knownBooks[canonical]
+                    ?: mergedBooks[canonical]?.let { row ->
+                        StatsBook(
+                            bookUrl = canonical,
+                            title = row.title,
+                            author = row.author,
+                            progression = row.progression,
+                            finished = row.finished,
+                            coverPath = row.coverPath,
+                            coverUrl = row.coverUrl,
+                        )
+                    }
+                    ?: return@forEach
+                val serverMs = insight.activeMinutes.minutesAsMillis()
+                val localMs = rows.sumOf { it.totalMs }
+                val pendingMs = rows.sumOf { it.pendingMs }
+                val lastReadAt = maxOf(
+                    insight.lastReadAt ?: 0L,
+                    rows.maxOfOrNull { it.lastReadAt } ?: 0L,
+                )
+                if (lastReadAt <= 0L) return@forEach
+                if (serverMs <= 0L && rows.isEmpty()) return@forEach
+                urls.forEach { mergedBooks.remove(it) }
+                mergedBooks[canonical] = BookReadingStats(
+                    bookUrl = canonical,
+                    title = metadata.title,
+                    author = metadata.author,
+                    totalMs = maxOf(localMs, serverMs + pendingMs),
+                    pendingMs = pendingMs,
+                    lastReadAt = lastReadAt,
+                    // The server has no started-at; the earliest local
+                    // start across the work's URLs is the only source.
+                    // Read from the all-time map first: a URL whose
+                    // reading all predates the window has no row to
+                    // carry its date.
+                    firstReadAt = urls.mapNotNull { firstReadAtByUrl[it] }.minOrNull()
+                        ?: rows.mapNotNull { it.firstReadAt }.minOrNull(),
+                    progression = metadata.progression,
+                    finished = metadata.finished,
+                    sessions = maxOf(
+                        rows.sumOf { it.sessions },
+                        insight.sessions + rows.sumOf { it.pendingSessions },
+                    ),
+                    pendingSessions = rows.sumOf { it.pendingSessions },
+                    coverPath = metadata.coverPath,
+                    coverUrl = metadata.coverUrl,
+                )
+            }
+            val elsewhere = (
+                serverBooks?.elsewhere.orEmpty() +
+                    orphaned.map { (_, entries) -> entries.first().value }
+                )
+                .filter { it.title.isNotEmpty() }
+                // A work whose whole span is nought minutes is a work
+                // with nothing to say for this window; the server sends
+                // one when the reading it has is all outside the span.
+                .filter { it.activeMinutes > 0 || it.sessions > 0 }
+                .map { insight ->
+                    BookReadingStats(
+                        bookUrl = null,
+                        workId = insight.workId,
+                        title = insight.title,
+                        author = insight.author,
+                        totalMs = insight.activeMinutes.minutesAsMillis(),
+                        lastReadAt = insight.lastReadAt ?: 0L,
+                        // Nothing local to draw on: no file, no cover and
+                        // no first sitting on record here. The place in
+                        // the book is the server's, because nobody else
+                        // has one, and whether that place is the end is
+                        // decided by the one threshold position sync
+                        // applies when the same reading arrives as a
+                        // peer's position — so a book finished on the
+                        // laptop is finished here too, and by the same
+                        // rule.
+                        progression = insight.currentProgression,
+                        finished = readingStatusFor(insight.currentProgression) ==
+                            ReadingStatus.FINISHED,
+                        sessions = insight.sessions,
                     )
                 }
-            val books = mergedBooks.values.sortedWith(
+            val books = (mergedBooks.values + elsewhere).sortedWith(
                 compareByDescending<BookReadingStats> { it.totalMs }.thenBy { it.title },
             )
             val recent = if (serverRecent == null) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -426,6 +426,7 @@
     <string name="delete_from_server_forget_reading">Also delete my reading history on the server</string>
     <string name="delete_from_server_forget_reading_hint">Your position and reading time are kept on the server so another device can pick them up. This only affects your own reading, never anyone else\'s.</string>
     <string name="server_delete_needs_reconnect">This connection cannot delete books from the server. Sign in to the server again to ask for that permission.</string>
+    <string name="server_insights_needs_reconnect">This connection cannot read reading statistics from the server, so your statistics only count this device. Sign in to the server again, or add the “read-insights” permission to this token.</string>
     <string name="delete_file_warning">“%1$s” will be permanently deleted from this device, along with its reading history. This cannot be undone.</string>
     <string name="remove_copy_warning">The downloaded copy of “%1$s” will be removed from this device. You can download it again from the server.</string>
     <string name="remove">Remove</string>
@@ -684,6 +685,9 @@
     <string name="reading_stats_books_finished">Books finished</string>
     <string name="reading_stats_recent">This week</string>
     <string name="reading_stats_by_book">By book</string>
+    <string name="reading_stats_from_this_device">Counting this device only</string>
+    <string name="reading_stats_from_all_devices">Counting all your devices</string>
+    <string name="reading_stats_book_elsewhere">Read on another device</string>
     <string name="reading_stats_empty_title">Nothing recorded yet.</string>
     <string name="reading_stats_empty_detail">Liseur starts counting from the moment you open a book. Reading you did before this arrived is not here, because there is no honest way to work out how long it took.</string>
     <string name="reading_stats_book_empty">You have not read any of this one yet.</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
@@ -940,10 +940,47 @@ class MigrationTest {
             }
     }
 
+    /**
+     * A phone paired before the scope was recorded arrives pessimistic
+     * (ADR-0021). It has to: a token minted without `read-insights`
+     * cannot be widened from here, and assuming it holds the scope would
+     * put the statistics screen back where it was — asking, being
+     * refused, and saying nothing about it.
+     */
+    @Test
+    fun `an upgraded phone is not assumed to hold the statistics scope`() {
+        helper.createDatabase(TEST_DB, 44).use { old ->
+            old.execSQL(
+                """
+                INSERT INTO remote_server (
+                    id, kind, base_url, catalog_url, username, password_cipher,
+                    api_key_cipher, account_id, user_id, kobo_token, can_download,
+                    can_manage_library, can_upload, can_delete, can_admin, added_at,
+                    catalog_synced_at, position_synced_at, sync_token,
+                    liseur_token_cipher, sync_cursor_seq, annotation_cursor_seq
+                ) VALUES (
+                    1, 'LISEUR_SYNC', 'https://sync.example', 'https://sync.example',
+                    'me', NULL, NULL, 'dev', NULL, NULL, 1, 0, 0, 0, 0, 1,
+                    NULL, NULL, NULL, NULL, 0, 0
+                )
+                """.trimIndent(),
+            )
+        }
+
+        helper.runMigrationsAndValidate(TEST_DB, LATEST, true, *LiseurDatabase.MIGRATIONS)
+            .use { db ->
+                db.query("SELECT can_read_insights FROM remote_server WHERE id = 1")
+                    .use { cursor ->
+                        assertTrue(cursor.moveToFirst())
+                        assertEquals(0, cursor.getInt(0))
+                    }
+            }
+    }
+
     private companion object {
         const val TEST_DB = "migration-test.db"
 
         /** Kept in step with the `version` on [LiseurDatabase]. */
-        const val LATEST = 44
+        const val LATEST = 45
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncInsightsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncInsightsTest.kt
@@ -165,7 +165,7 @@ class LiseurSyncInsightsTest {
             ),
         )
 
-        val book = insights().allBooks(today = TODAY)!![BOOK]!!
+        val book = insights().allBooks(today = TODAY)!!.byBookUrl[BOOK]!!
 
         assertEquals(8, book.sessions)
         assertEquals(106.25, book.activeMinutes, 0.001)
@@ -188,7 +188,10 @@ class LiseurSyncInsightsTest {
         alias()
         server.enqueue(ok("""{"range_days":0,"works":[]}"""))
 
-        assertEquals(emptyMap<String, WorkInsights>(), insights().allBooks(StatsRange.ALL_TIME, TODAY))
+        assertEquals(
+            WorkTotals.Empty,
+            insights().allBooks(StatsRange.ALL_TIME, TODAY),
+        )
 
         assertEquals("/v1/insights/works?range=all", server.takeRequest().target)
     }
@@ -253,6 +256,83 @@ class LiseurSyncInsightsTest {
                 from = LocalDate.of(2026, 7, 1),
                 to = LocalDate.of(2026, 7, 11),
             ),
+        )
+    }
+
+    /**
+     * A work the server counted and this device has no book for is
+     * carried rather than dropped (ADR-0021). Dropping it at the mapping
+     * is what left a reader who did a year on a laptop seeing the year
+     * in the total and not one book of it in the list.
+     */
+    @Test
+    fun `a work with no local book is kept and named`() = runTest {
+        connect()
+        alias()
+        server.enqueue(
+            ok(
+                """{"from":"2026-08-10","to":"2026-08-11","works":[""" +
+                    """{"work_id":"w-1","sessions":2,"total_active_minutes":10},""" +
+                    """{"work_id":"w-2","sessions":5,"total_active_minutes":50,""" +
+                    """"title":"Dune","author":"Frank Herbert"}]}""",
+            ),
+        )
+
+        val totals = insights().allBooks(today = TODAY)!!
+
+        assertEquals(setOf(BOOK), totals.byBookUrl.keys)
+        assertEquals(1, totals.elsewhere.size)
+        val other = totals.elsewhere.single()
+        assertEquals("w-2", other.workId)
+        assertEquals("Dune", other.title)
+        assertEquals("Frank Herbert", other.author)
+        assertEquals(5, other.sessions)
+    }
+
+    /**
+     * A nameless work is not listed. Its minutes are in the headline
+     * either way, and a row the reader cannot identify buys nothing —
+     * which is all an older server, or one whose work record has gone,
+     * has to offer.
+     */
+    @Test
+    fun `a work the server will not name is not listed`() = runTest {
+        connect()
+        alias()
+        server.enqueue(
+            ok(
+                """{"from":"2026-08-10","to":"2026-08-11","works":[""" +
+                    """{"work_id":"w-9","sessions":5,"total_active_minutes":50}]}""",
+            ),
+        )
+
+        assertEquals(emptyList<WorkInsights>(), insights().allBooks(today = TODAY)!!.elsewhere)
+    }
+
+    /**
+     * A device with nothing resolved still asks. Every work is then one
+     * it has no book for, which is exactly the reader this is for: the
+     * app newly installed beside a laptop that has been reading for a
+     * year.
+     */
+    @Test
+    fun `a device with no aliases still asks for the works`() = runTest {
+        connect()
+        server.enqueue(
+            ok(
+                """{"from":"2026-08-10","to":"2026-08-11","works":[""" +
+                    """{"work_id":"w-2","sessions":5,"total_active_minutes":50,""" +
+                    """"title":"Dune"}]}""",
+            ),
+        )
+
+        val totals = insights().allBooks(today = TODAY)!!
+
+        assertEquals(emptyMap<String, WorkInsights>(), totals.byBookUrl)
+        assertEquals("Dune", totals.elsewhere.single().title)
+        assertEquals(
+            "/v1/insights/works?from=2026-08-10&to=2026-08-11",
+            server.takeRequest().target,
         )
     }
 
@@ -350,6 +430,83 @@ class LiseurSyncInsightsTest {
         )
 
         assertNull(insights().summary(StatsRange.THIS_WEEK, TODAY))
+    }
+
+    /**
+     * The scope is read off the token at connect and nowhere else, so an
+     * account paired before it was recorded would carry its pessimistic
+     * default for good — and the account screen would go on telling a
+     * reader whose statistics work that they are refused (ADR-0021). An
+     * answer with a body is proof the token may ask; write it down.
+     */
+    @Test
+    fun `a body from the server proves the token may read statistics`() = runTest {
+        connect()
+        assertEquals(false, db.remoteServerDao().get()!!.canReadInsights)
+        server.enqueue(
+            ok("""{"from":"2026-08-10","to":"2026-08-11","total_active_minutes":30,"sessions":1}"""),
+        )
+
+        insights().summary(today = TODAY)
+
+        assertEquals(true, db.remoteServerDao().get()!!.canReadInsights)
+    }
+
+    /** A 403 is the server saying the token may not ask; write that down too. */
+    @Test
+    fun `a refusal proves the token may not read statistics`() = runTest {
+        connect()
+        db.remoteServerDao().setCanReadInsights(true, db.remoteServerDao().get()!!.liseurTokenCipher)
+        server.enqueue(MockResponse(code = 403, body = """{"error":"insufficient scope"}"""))
+
+        assertNull(insights().summary(today = TODAY))
+
+        assertEquals(false, db.remoteServerDao().get()!!.canReadInsights)
+    }
+
+    /**
+     * Offline, a server too old, a malformed body: none of these says
+     * anything about the token, so none of them may change the record.
+     */
+    @Test
+    fun `a failure that is not a refusal leaves the record alone`() = runTest {
+        connect()
+        db.remoteServerDao().setCanReadInsights(true, db.remoteServerDao().get()!!.liseurTokenCipher)
+        server.enqueue(MockResponse(code = 500, body = ""))
+        assertNull(insights().summary(today = TODAY))
+        assertEquals(true, db.remoteServerDao().get()!!.canReadInsights)
+
+        // An answer about the wrong span is a body all the same: the
+        // token was allowed to ask, the server just did not understand.
+        db.remoteServerDao().setCanReadInsights(false, db.remoteServerDao().get()!!.liseurTokenCipher)
+        server.enqueue(ok("""{"total_active_minutes":30,"sessions":1}"""))
+        assertNull(insights().summary(today = TODAY))
+        assertEquals(true, db.remoteServerDao().get()!!.canReadInsights)
+    }
+
+    /**
+     * The server's place in a book is carried for a work this device has
+     * no file for, since nobody else has one (ADR-0021). It is the one
+     * figure that lets a book finished on the laptop count as finished
+     * here. Nought is no place at all.
+     */
+    @Test
+    fun `a work read elsewhere carries the server's place in it`() = runTest {
+        connect()
+        server.enqueue(
+            ok(
+                """{"from":"2026-08-10","to":"2026-08-11","works":[""" +
+                    """{"work_id":"w-9","title":"Dune","sessions":3,"total_active_minutes":50,""" +
+                    """"current_progression":0.985},""" +
+                    """{"work_id":"w-8","title":"Emma","sessions":1,"total_active_minutes":5,""" +
+                    """"current_progression":0}]}""",
+            ),
+        )
+
+        val elsewhere = insights().allBooks(today = TODAY)!!.elsewhere.associateBy { it.workId }
+
+        assertEquals(0.985, elsewhere.getValue("w-9").currentProgression!!, 0.0001)
+        assertNull(elsewhere.getValue("w-8").currentProgression)
     }
 
     private fun insights() = LiseurSyncInsights(

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncServerSetupTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncServerSetupTest.kt
@@ -74,6 +74,7 @@ class LiseurSyncServerSetupTest {
         assertTrue(capabilities.canManageLibrary)
         assertTrue(capabilities.canUpload)
         assertTrue(capabilities.canDelete)
+        assertTrue(capabilities.canReadInsights)
         assertEquals("ada", capabilities.displayName)
 
         // The password went to the login route and nowhere else, and
@@ -116,6 +117,10 @@ class LiseurSyncServerSetupTest {
         // not get the permission by being old. The action stays hidden
         // rather than being offered and refused.
         assertFalse(capabilities.canUpload)
+        // Nor does it get to read statistics by being old (ADR-0021).
+        // Recorded as a fact rather than found out one 403 at a time on
+        // a screen that says nothing about it.
+        assertFalse(capabilities.canReadInsights)
         val asked = server.takeRequest()
         assertTrue(asked.target!!.endsWith("/v1/token"))
         assertEquals("Bearer pasted-secret", asked.headers["Authorization"])
@@ -148,6 +153,7 @@ class LiseurSyncServerSetupTest {
         assertTrue(capabilities.canAdmin)
         assertTrue(capabilities.canManageLibrary)
         assertTrue(capabilities.canDownload)
+        assertTrue(capabilities.canReadInsights)
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModelTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModelTest.kt
@@ -12,6 +12,7 @@ import com.chmouel.liseur.data.db.ReadingSession
 import com.chmouel.liseur.data.liseursync.InsightDay
 import com.chmouel.liseur.data.liseursync.InsightsSummary
 import com.chmouel.liseur.data.liseursync.WorkInsights
+import com.chmouel.liseur.data.liseursync.WorkTotals
 import com.chmouel.liseur.domain.BookReadingStats
 import com.chmouel.liseur.domain.ComparisonDirection
 import com.chmouel.liseur.domain.ComparisonPeriod
@@ -329,13 +330,16 @@ class ReadingStatsViewModelTest {
             local = local,
             knownBooks = known,
             serverRecent = listOf(InsightDay(monday, 23.5), InsightDay(tuesday, 137.0)),
-            serverBooks = mapOf(
-                "book" to WorkInsights(
-                    sessions = 98,
-                    activeMinutes = 160.5,
-                    etaSeconds = null,
-                    lastReadAt = 200,
+            serverBooks = WorkTotals(
+                byBookUrl = mapOf(
+                    "book" to WorkInsights(
+                        sessions = 98,
+                        activeMinutes = 160.5,
+                        etaSeconds = null,
+                        lastReadAt = 200,
+                    ),
                 ),
+                elsewhere = emptyList(),
             ),
         )
 
@@ -386,14 +390,17 @@ class ReadingStatsViewModelTest {
             local = local,
             knownBooks = known,
             serverRecent = listOf(InsightDay(monday, 90.0)),
-            serverBooks = mapOf(
-                "book" to WorkInsights(
-                    workId = "w-1",
-                    sessions = 5,
-                    activeMinutes = 90.0,
-                    etaSeconds = null,
-                    lastReadAt = 200,
+            serverBooks = WorkTotals(
+                byBookUrl = mapOf(
+                    "book" to WorkInsights(
+                        workId = "w-1",
+                        sessions = 5,
+                        activeMinutes = 90.0,
+                        etaSeconds = null,
+                        lastReadAt = 200,
+                    ),
                 ),
+                elsewhere = emptyList(),
             ),
         )
 
@@ -447,14 +454,17 @@ class ReadingStatsViewModelTest {
             local = local,
             knownBooks = known,
             serverRecent = null,
-            serverBooks = mapOf(
-                "book" to WorkInsights(
-                    workId = "w-1",
-                    sessions = 10,
-                    activeMinutes = 100.0,
-                    etaSeconds = null,
-                    lastReadAt = 200,
+            serverBooks = WorkTotals(
+                byBookUrl = mapOf(
+                    "book" to WorkInsights(
+                        workId = "w-1",
+                        sessions = 10,
+                        activeMinutes = 100.0,
+                        etaSeconds = null,
+                        lastReadAt = 200,
+                    ),
                 ),
+                elsewhere = emptyList(),
             ),
         )
 
@@ -462,6 +472,250 @@ class ReadingStatsViewModelTest {
         assertEquals(
             11,
             ReadingStatsViewModel.mergeHeadline(merged, local, server).sessions,
+        )
+    }
+
+    /**
+     * A book only the server knows about is a row, not a rounding
+     * difference (ADR-0021). Its minutes are in the headline whether it
+     * is listed or not, so dropping it is what made the list smaller
+     * than the total above it.
+     */
+    @Test
+    fun `a book only the server knows about is listed and counted`() {
+        val local = ReadingStats(
+            totalMs = 20 * 60_000L,
+            booksRead = 1,
+            booksFinished = 0,
+            books = listOf(
+                BookReadingStats(
+                    bookUrl = "book",
+                    title = "A book",
+                    author = "An author",
+                    totalMs = 20 * 60_000L,
+                    lastReadAt = 100,
+                    progression = 0.5,
+                    finished = false,
+                    sessions = 1,
+                ),
+            ),
+            recent = emptyList(),
+        )
+
+        val merged = ReadingStatsViewModel.mergeDashboard(
+            local = local,
+            knownBooks = mapOf(
+                "book" to StatsBook("book", "A book", "An author", 0.5, finished = false),
+            ),
+            serverRecent = null,
+            serverBooks = WorkTotals(
+                byBookUrl = emptyMap(),
+                elsewhere = listOf(
+                    WorkInsights(
+                        workId = "w-2",
+                        sessions = 4,
+                        activeMinutes = 50.0,
+                        etaSeconds = null,
+                        lastReadAt = 900,
+                        title = "Dune",
+                        author = "Frank Herbert",
+                    ),
+                ),
+            ),
+        )
+
+        assertEquals(2, merged.books.size)
+        assertEquals(2, merged.booksRead)
+        assertEquals(70 * 60_000L, merged.totalMs)
+        val elsewhere = merged.books.first { it.bookUrl == null }
+        assertEquals("Dune", elsewhere.title)
+        assertEquals("Frank Herbert", elsewhere.author)
+        assertEquals(50 * 60_000L, elsewhere.totalMs)
+        assertEquals(4, elsewhere.sessions)
+        // Nothing to open, nothing to draw, and nowhere in the book to
+        // report: there is no file here.
+        assertEquals(false, elsewhere.isLocal)
+        assertNull(elsewhere.progression)
+        assertNull(elsewhere.coverPath)
+        assertEquals(false, elsewhere.finished)
+        assertEquals("work:w-2", elsewhere.key)
+    }
+
+    /**
+     * A book finished on the laptop is finished (ADR-0021). The server's
+     * place in it is the only one there is for a work with no local
+     * file, and the same threshold that position sync applies decides
+     * whether that place is the end — so `booksFinished` counts it, and
+     * a book merely begun elsewhere stays a book in progress.
+     */
+    @Test
+    fun `a book finished on another device counts as finished`() {
+        val merged = ReadingStatsViewModel.mergeDashboard(
+            local = ReadingStats.Empty,
+            knownBooks = emptyMap(),
+            serverRecent = null,
+            serverBooks = WorkTotals(
+                byBookUrl = emptyMap(),
+                elsewhere = listOf(
+                    WorkInsights(
+                        workId = "w-done",
+                        sessions = 9,
+                        activeMinutes = 300.0,
+                        etaSeconds = null,
+                        lastReadAt = 900,
+                        title = "Dune",
+                        currentProgression = 0.99,
+                    ),
+                    WorkInsights(
+                        workId = "w-going",
+                        sessions = 1,
+                        activeMinutes = 10.0,
+                        etaSeconds = null,
+                        lastReadAt = 800,
+                        title = "Emma",
+                        currentProgression = 0.4,
+                    ),
+                ),
+            ),
+        )
+
+        assertEquals(2, merged.booksRead)
+        assertEquals(1, merged.booksFinished)
+        val done = merged.books.first { it.workId == "w-done" }
+        assertTrue(done.finished)
+        assertEquals(0.99, done.progression!!, 0.0001)
+        val going = merged.books.first { it.workId == "w-going" }
+        assertEquals(false, going.finished)
+        assertEquals(0.4, going.progression!!, 0.0001)
+    }
+
+    /**
+     * A book opened straight from Android has sittings here and no
+     * library row. A server figure for its URL has a local row to merge
+     * into, and must go there rather than be listed a second time as
+     * read elsewhere — that would charge the reader twice for one book.
+     */
+    @Test
+    fun `a book with sittings but no library row is merged, not listed twice`() {
+        val local = ReadingStats(
+            totalMs = 20 * 60_000L,
+            booksRead = 1,
+            booksFinished = 0,
+            books = listOf(
+                BookReadingStats(
+                    bookUrl = "content://opened/book.epub",
+                    title = "book.epub",
+                    author = null,
+                    totalMs = 20 * 60_000L,
+                    lastReadAt = 100,
+                    progression = null,
+                    finished = false,
+                    sessions = 1,
+                ),
+            ),
+            recent = emptyList(),
+        )
+
+        val merged = ReadingStatsViewModel.mergeDashboard(
+            local = local,
+            knownBooks = emptyMap(),
+            serverRecent = null,
+            serverBooks = WorkTotals(
+                byBookUrl = mapOf(
+                    "content://opened/book.epub" to WorkInsights(
+                        workId = "w-1",
+                        sessions = 3,
+                        activeMinutes = 60.0,
+                        etaSeconds = null,
+                        lastReadAt = 500,
+                        title = "Dune",
+                    ),
+                ),
+                elsewhere = emptyList(),
+            ),
+        )
+
+        assertEquals(1, merged.books.size)
+        val row = merged.books.single()
+        assertEquals("content://opened/book.epub", row.bookUrl)
+        assertEquals("book.epub", row.title)
+        assertEquals(60 * 60_000L, row.totalMs)
+        assertEquals(60 * 60_000L, merged.totalMs)
+    }
+
+    /**
+     * An alias outlives the book it named: removing a file from the
+     * library leaves the work resolved against a URL nothing answers
+     * to. Such a work is one this device has no book for, whatever the
+     * alias says, and it belongs on the list with the others rather
+     * than in the gap between a matched row and an unmatched one.
+     */
+    @Test
+    fun `a work aliased to a book no longer in the library is listed as elsewhere`() {
+        val merged = ReadingStatsViewModel.mergeDashboard(
+            local = ReadingStats(
+                totalMs = 0,
+                booksRead = 0,
+                booksFinished = 0,
+                books = emptyList(),
+                recent = emptyList(),
+            ),
+            knownBooks = emptyMap(),
+            serverRecent = null,
+            serverBooks = WorkTotals(
+                byBookUrl = mapOf(
+                    "gone" to WorkInsights(
+                        workId = "w-3",
+                        sessions = 2,
+                        activeMinutes = 30.0,
+                        etaSeconds = null,
+                        lastReadAt = 400,
+                        title = "Dune",
+                        author = "Frank Herbert",
+                    ),
+                ),
+                elsewhere = emptyList(),
+            ),
+        )
+
+        assertEquals(1, merged.books.size)
+        val row = merged.books.single()
+        assertEquals("Dune", row.title)
+        assertEquals(30 * 60_000L, row.totalMs)
+        assertEquals(false, row.isLocal)
+        assertEquals(30 * 60_000L, merged.totalMs)
+    }
+
+    /**
+     * The screen has always been one device's or every device's and
+     * never said which, so the same blank meant "you are offline", "your
+     * token cannot ask" and "the server agreed" (ADR-0021). An answer to
+     * the question on screen is what makes it all of them; no answer at
+     * all is this device, whatever the reason.
+     */
+    @Test
+    fun `provenance follows whether an answer arrived, not whether a server exists`() {
+        assertEquals(
+            StatsProvenance.THIS_DEVICE,
+            ReadingStatsViewModel.provenanceOf(null, null, null),
+        )
+        assertEquals(
+            StatsProvenance.ALL_DEVICES,
+            ReadingStatsViewModel.provenanceOf(
+                InsightsSummary(activeMinutes = 10.0, sessions = 1, streakDays = 1),
+                null,
+                null,
+            ),
+        )
+        // The headline can have nothing to report for a span the list and
+        // the chart still answered for. That is still every device.
+        assertEquals(
+            StatsProvenance.ALL_DEVICES,
+            ReadingStatsViewModel.provenanceOf(null, emptyList(), null),
+        )
+        assertEquals(
+            StatsProvenance.ALL_DEVICES,
+            ReadingStatsViewModel.provenanceOf(null, null, WorkTotals.Empty),
         )
     }
 
@@ -489,7 +743,7 @@ class ReadingStatsViewModelTest {
                 InsightDay(monday.minusDays(1), 30.0),
                 InsightDay(monday, 45.0),
             ),
-            serverBooks = emptyMap(),
+            serverBooks = WorkTotals.Empty,
         )
 
         assertEquals(2, merged.recent.size)
@@ -532,14 +786,17 @@ class ReadingStatsViewModelTest {
             knownBooks = known,
             // The server has heard about Monday and nothing since.
             serverRecent = listOf(InsightDay(monday, 30.0)),
-            serverBooks = mapOf(
-                "book" to WorkInsights(
-                    sessions = 2,
-                    activeMinutes = 30.0,
-                    etaSeconds = null,
-                    lastReadAt = 100,
-                    workId = "w-1",
+            serverBooks = WorkTotals(
+                byBookUrl = mapOf(
+                    "book" to WorkInsights(
+                        sessions = 2,
+                        activeMinutes = 30.0,
+                        etaSeconds = null,
+                        lastReadAt = 100,
+                        workId = "w-1",
+                    ),
                 ),
+                elsewhere = emptyList(),
             ),
         )
 
@@ -592,7 +849,7 @@ class ReadingStatsViewModelTest {
             local = local,
             knownBooks = known,
             serverRecent = null,
-            serverBooks = mapOf("old" to one, "new" to one),
+            serverBooks = WorkTotals(mapOf("old" to one, "new" to one), emptyList()),
             // The old URL was begun before the window the rows describe;
             // only the all-time map remembers it.
             firstReadAtByUrl = mapOf("old" to 5L, "new" to 300L),

--- a/docs/adr/0021-cross-device-reading-statistics.md
+++ b/docs/adr/0021-cross-device-reading-statistics.md
@@ -87,10 +87,17 @@ disagree, and `booksRead` and `booksFinished` follow from the merged set
 rather than from the local rows. A book with no local file cannot be
 opened from the dashboard and must not pretend otherwise.
 
-Leave `total_pages` and `current_progression` unread. Both are in every
-answer and neither has a home: pages are a KOReader notion that a
-reflowable EPUB does not have, and this device knows its own progression
-better than the server does. They are not an oversight.
+Leave `total_pages` unread, and `current_progression` unread for any
+book this device has. Pages are a KOReader notion that a reflowable EPUB
+does not have, and for a book that is here the local position is fresher
+than anything a server can relay. Neither is an oversight. The one row
+that does read `current_progression` is the one with no local book,
+because there the server's is the only account of the reader's place
+there is, and without it a book finished on the laptop would sit in the
+list forever unread and never reach `booksFinished`. Whether that place
+is the end is decided by the same threshold position sync applies when
+the same reading arrives as a peer's position, so the two cannot
+disagree about one book.
 
 Two things are deliberately not decided here. The timezone difference
 between the server's day buckets, which follow the account's configured
@@ -104,7 +111,13 @@ change. And nothing here alters how sessions reach the server.
 `can_upload` and `can_delete`. Like those two it is half an answer: it
 says the token may ask, not that the server has anything to say. An
 account paired before the column existed defaults to the pessimistic
-value and is corrected the next time it is introspected.
+value. Introspection happens only at connect, so waiting for the next
+one would leave every upgraded phone telling its reader that statistics
+are refused while the statistics work. The answers correct it instead:
+`LiseurSyncInsights` writes the column from what the server actually
+said, true on any body and false on a 403, guarded on the account being
+the one the question was asked of. Offline, a server too old and a
+malformed body prove nothing about the token and change nothing.
 
 `LiseurSyncInsights` keeps returning null on every failure. Provenance
 is a separate question from the figures and is answered separately:
@@ -117,7 +130,9 @@ mapping them onto local URLs, which is what stops one file counted under
 two names being charged twice. A work with no alias falls out at that
 mapping, and it is there that it has to be kept instead: the row it
 becomes has the server's title and no local book behind it, so it
-carries no cover, no progression and no tap target.
+carries no cover and no tap target — but it does carry the same
+`current_progression`-derived progression and finished state described
+above, since that is the one figure this device has for it.
 
 ## Consequences
 
@@ -140,8 +155,13 @@ reading client.
 Nothing here makes statistics load-bearing. Every one of these is still
 a screen that has to work with the network off.
 
-*Where (when built):* `data/liseursync/LiseurSyncServerSetup.kt`,
+*Where:* `data/liseursync/LiseurSyncServerSetup.kt`,
 `data/liseursync/LiseurSyncInsights.kt`, `data/remote/RemoteSources.kt`,
-`data/db/RemoteServer.kt`, `data/db/LiseurDatabase.kt`,
+`data/remote/RemoteAccountRepository.kt`, `data/db/RemoteServer.kt`,
+`data/db/LiseurDatabase.kt`, `domain/ReadingStats.kt`,
 `ui/stats/ReadingStatsViewModel.kt`, `ui/stats/ReadingStatsScreen.kt`,
-`res/values/strings.xml`.
+`ui/settings/ServerAccountScreen.kt`, `res/values/strings.xml`.
+
+The server names each work in `GET /v1/insights/works`, which is what
+lets a book with no local file be listed at all: liseur-sync's
+`internal/api/insights.go`, `docs/openapi.yaml` and `docs/integrating.md`.


### PR DESCRIPTION
## Summary

Implements [ADR-0021](docs/adr/0021-cross-device-reading-statistics.md). Depends on the server side, chmouel/liseur-sync#14.

The dashboard has always merged this device's sessions with what a liseur-sync server counts, but never told the reader which figures they were looking at, and its per-book list was bounded by the local shelf even though the headline above it counted every device.

## Changes

- **`read-insights` recorded as a stored capability.** `ServerCapabilities.canReadInsights`, persisted on `remote_server.can_read_insights` (Room migration 44→45). Read from the token's scopes at connect, and corrected afterwards from what the server's answers actually prove: a body means the token may ask, a 403 means it may not. Neither offline nor an old server changes it. The account screen tells the reader to reconnect when it is false.
- **The screen says whose figures these are.** A line under the headline: "Counting this device only" or "Counting all your devices" — decided by whether any server answer arrived for the window on screen, not by whether a server is configured (connected-but-unreachable is exactly the case this exists to name).
- **The per-book list stops being smaller than its own headline.** A work the server knows and this library does not is now listed with the server's title. Its place in the book is the server's too, since nobody else has one, decided by the same threshold used elsewhere for "is this finished" — so a book finished on another device counts as finished here. A stale alias pointing at a since-removed book is handled the same way.

## Screenshot

Reading stats screen with a liseur-sync-shaped merge but no server connected, showing the new provenance line ("Counting this device only"):

![reading-stats-provenance.png](https://github.com/user-attachments/assets/b129cf35-938d-45fa-b4e8-5ba90e4820b3)

## Testing

```
./gradlew testDebugUnitTest lintDebug assembleDebug
```
All pass (0 lint errors). New/updated tests: `LiseurSyncInsightsTest`, `ReadingStatsViewModelTest`, `MigrationTest`, `LiseurSyncServerSetupTest`.

No deployment from this PR.


