### PR TITLE
fix: Bookmark the page while the reading menu is open

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -1474,11 +1474,10 @@ fun ReaderScreen(
      * Marks the page, or unmarks it, from wherever the reader asked.
      *
      * The ribbon in the corner and the button in the chrome are two
-     * doors onto one room: the corner belongs to the app bar while the
-     * chrome is up, which is what took the ribbon's taps for itself, so
-     * the toolbar carries the control there instead. A bookmark has to
-     * land in the same place whichever was used, so neither of them owns
-     * this.
+     * doors onto one room: with the chrome up the app bar is hit before
+     * the ribbon and the corner's taps die on it, so the toolbar carries
+     * the control there instead. A bookmark has to land in the same
+     * place whichever was used, so neither of them owns this.
      *
      * A scrolled page moves under the reader's thumb without Readium
      * saying so: its current locator is debounced, and between two of
@@ -1666,10 +1665,11 @@ fun ReaderScreen(
         PageTurnOverlay(pageTurnEffect)
 
         // The ribbon is the marker for a page with no chrome on it. The
-        // app bar covers this corner and, being a Surface, swallows what
-        // lands there, so while the chrome is up the ribbon would be a
-        // target that ignores every tap. The bookmark button in the bar
-        // is what answers there instead.
+        // app bar is placed over this corner and hit first, and its
+        // pointer input is not shared with the siblings under it
+        // (sharePointerInputWithSiblings), so while the chrome is up a
+        // tap here never reaches the ribbon at all. The bookmark button
+        // in the bar is what answers there instead.
         if (!showingEnd && !chromeVisible) {
             BookmarkRibbon(
                 bookmarked = bookmarked,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -34,6 +34,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.List
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -1468,6 +1470,47 @@ fun ReaderScreen(
     // decides everything else, and this adds nothing once the page stops.
     KeepScreenOn(enabled = keepScreenOn || autoScrollArmed)
 
+    /**
+     * Marks the page, or unmarks it, from wherever the reader asked.
+     *
+     * The ribbon in the corner and the button in the chrome are two
+     * doors onto one room: the corner belongs to the app bar while the
+     * chrome is up, which is what took the ribbon's taps for itself, so
+     * the toolbar carries the control there instead. A bookmark has to
+     * land in the same place whichever was used, so neither of them owns
+     * this.
+     *
+     * A scrolled page moves under the reader's thumb without Readium
+     * saying so: its current locator is debounced, and between two of
+     * those the view model's idea of the place can be a screen or more
+     * behind what is on the page. A bookmark is taken at the moment it
+     * is asked for and has to mean that moment, so the document is asked
+     * where it is now — the same question the reader leaving the book
+     * already asks — and only then is the mark made. It also decides
+     * which mark is being toggled, so asking first is what stops a tap
+     * meant as a new bookmark deleting the one behind it.
+     *
+     * Only a scrolled page is asked. A book set in pages publishes its
+     * place on the turn, long before a finger can reach the corner, and
+     * it does not scroll: `scrolledPlace` would read an offset of
+     * nothing over a screenful and file the reader at the top of the
+     * chapter — the very thing this is here to prevent. Every other
+     * caller guards on the same flag.
+     */
+    fun toggleBookmarkHere() {
+        view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+        effectScope.launch {
+            if (effectiveScrollingNow) {
+                navigatorNow?.let { nav ->
+                    scrolledPlace(nav)?.let {
+                        onLocatorChanged(it, NavigatorPositionEvent.LOCAL_JUMP)
+                    }
+                }
+            }
+            onAnnotationAction.toggleBookmark()
+        }
+    }
+
     Box(
         Modifier
             .fillMaxSize()
@@ -1622,44 +1665,16 @@ fun ReaderScreen(
 
         PageTurnOverlay(pageTurnEffect)
 
-        if (!showingEnd) {
+        // The ribbon is the marker for a page with no chrome on it. The
+        // app bar covers this corner and, being a Surface, swallows what
+        // lands there, so while the chrome is up the ribbon would be a
+        // target that ignores every tap. The bookmark button in the bar
+        // is what answers there instead.
+        if (!showingEnd && !chromeVisible) {
             BookmarkRibbon(
                 bookmarked = bookmarked,
                 theme = readingTheme,
-                onToggle = {
-                    view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
-                    // A scrolled page moves under the reader's thumb
-                    // without Readium saying so: its current locator is
-                    // debounced, and between two of those the view
-                    // model's idea of the place can be a screen or more
-                    // behind what is on the page. A bookmark is taken at
-                    // the moment the ribbon is tapped and has to mean
-                    // that moment, so the document is asked where it is
-                    // now — the same question the reader leaving the
-                    // book already asks — and only then is the mark
-                    // made. It also decides which mark is being toggled,
-                    // so asking first is what stops a tap meant as a new
-                    // bookmark deleting the one behind it.
-                    //
-                    // Only a scrolled page is asked. A book set in pages
-                    // publishes its place on the turn, long before a
-                    // finger can reach the ribbon, and it does not
-                    // scroll: `scrolledPlace` would read an offset of
-                    // nothing over a screenful and file the reader at
-                    // the top of the chapter — the very thing this is
-                    // here to prevent. Every other caller guards on the
-                    // same flag.
-                    effectScope.launch {
-                        if (effectiveScrollingNow) {
-                            navigatorNow?.let { nav ->
-                                scrolledPlace(nav)?.let {
-                                    onLocatorChanged(it, NavigatorPositionEvent.LOCAL_JUMP)
-                                }
-                            }
-                        }
-                        onAnnotationAction.toggleBookmark()
-                    }
-                },
+                onToggle = ::toggleBookmarkHere,
                 modifier = Modifier
                     .align(Alignment.TopEnd)
                     .padding(end = 12.dp),
@@ -1836,6 +1851,25 @@ fun ReaderScreen(
                         Icon(
                             Icons.AutoMirrored.Outlined.List,
                             contentDescription = stringResource(R.string.reader_contents),
+                        )
+                    }
+                    // The bar owns this corner while it is up, ribbon and
+                    // all, so it owns the bookmark with it. Last of the
+                    // actions to keep the mark where the ribbon hangs.
+                    IconButton(onClick = ::toggleBookmarkHere) {
+                        Icon(
+                            if (bookmarked) {
+                                Icons.Filled.Bookmark
+                            } else {
+                                Icons.Outlined.BookmarkBorder
+                            },
+                            contentDescription = stringResource(
+                                if (bookmarked) {
+                                    R.string.reader_remove_bookmark
+                                } else {
+                                    R.string.reader_add_bookmark
+                                },
+                            ),
                         )
                     }
                 },

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -1482,8 +1482,15 @@ fun ReaderScreen(
     LaunchedEffect(chromeVisible) {
         if (chromeVisible && effectiveScrollingNow) {
             navigatorNow?.let { nav ->
+                // Held and published through the one path the scroll
+                // loop uses, or a measurement the loop is still carrying
+                // would come back at pause and walk the reader
+                // backwards over the place this just published.
+                val since = heldPlace.mark()
                 scrolledPlace(nav)?.let {
-                    onLocatorChanged(it, NavigatorPositionEvent.READER_MOVEMENT)
+                    if (heldPlace.hold(it, since)) {
+                        onLocatorChanged(it, NavigatorPositionEvent.READER_MOVEMENT)
+                    }
                 }
             }
         }
@@ -1520,8 +1527,11 @@ fun ReaderScreen(
         effectScope.launch {
             if (effectiveScrollingNow) {
                 navigatorNow?.let { nav ->
+                    val since = heldPlace.mark()
                     scrolledPlace(nav)?.let {
-                        onLocatorChanged(it, NavigatorPositionEvent.LOCAL_JUMP)
+                        if (heldPlace.hold(it, since)) {
+                            onLocatorChanged(it, NavigatorPositionEvent.LOCAL_JUMP)
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -1474,12 +1474,16 @@ fun ReaderScreen(
     // toggle, and a scrolled page can be a screen ahead of the debounced
     // locator the view model last heard about. Ask where it is as the
     // chrome arrives, so the icon and the toggle agree about which mark
-    // that is.
+    // that is. The page really moved under the reader's finger, so the
+    // answer goes as movement: sent as a jump it would land first and
+    // the debounced movement behind it would be dropped as a duplicate,
+    // and with it the pace sample and the reading-time checkpoint the
+    // scroll earned.
     LaunchedEffect(chromeVisible) {
         if (chromeVisible && effectiveScrollingNow) {
             navigatorNow?.let { nav ->
                 scrolledPlace(nav)?.let {
-                    onLocatorChanged(it, NavigatorPositionEvent.LOCAL_JUMP)
+                    onLocatorChanged(it, NavigatorPositionEvent.READER_MOVEMENT)
                 }
             }
         }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -1470,6 +1470,21 @@ fun ReaderScreen(
     // decides everything else, and this adds nothing once the page stops.
     KeepScreenOn(enabled = keepScreenOn || autoScrollArmed)
 
+    // The bar's bookmark button advertises the mark of the page it will
+    // toggle, and a scrolled page can be a screen ahead of the debounced
+    // locator the view model last heard about. Ask where it is as the
+    // chrome arrives, so the icon and the toggle agree about which mark
+    // that is.
+    LaunchedEffect(chromeVisible) {
+        if (chromeVisible && effectiveScrollingNow) {
+            navigatorNow?.let { nav ->
+                scrolledPlace(nav)?.let {
+                    onLocatorChanged(it, NavigatorPositionEvent.LOCAL_JUMP)
+                }
+            }
+        }
+    }
+
     /**
      * Marks the page, or unmarks it, from wherever the reader asked.
      *

--- a/hack/screenshots
+++ b/hack/screenshots
@@ -903,7 +903,26 @@ seed_reading() {
 
     dismiss_popup
     reader_chrome_up
-    tap_if_there "Bookmark this page" && note "bookmarked the page"
+    # The bookmark is the one mark taken from the chrome, and a tap there
+    # that lands on nothing looks exactly like a tap that worked: the
+    # button stays where it was and the run carries on. So the label has
+    # to turn over and the row has to appear. This reported a bookmark it
+    # had never taken, and the demo shelf shipped without one.
+    #
+    # A page already carrying one is left as it is: tapping would take
+    # the mark off, and the shelf would end up as bare as before.
+    if on_screen "Remove bookmark"; then
+        note "the page was already bookmarked"
+    else
+        before=$(annotation_count)
+        tap_on "Bookmark this page"
+        wait_for "Remove bookmark" 10 >/dev/null ||
+            die "the bookmark button did not take the mark"
+        after=$(annotation_count)
+        [[ ${after:-0} -gt ${before:-0} ]] ||
+            die "the bookmark button turned over without writing a mark"
+        note "bookmarked the page"
+    fi
     reader_chrome_down
 
     # Back to a page carrying a highlight, because that is the page the


### PR DESCRIPTION
## Summary

The bookmark ribbon in the top-right corner of the page did nothing whenever the reading menu was open: the menu bar covered that corner and swallowed the tap, so no bookmark was ever written from it. With the menu closed the ribbon worked as before.

The menu bar now carries its own bookmark button, filled in when the page is bookmarked, that toggles the same mark. The ribbon steps aside while the menu is up instead of sitting there ignoring taps. A page mark lands in the same place from either control.

## Changes

- Added a bookmark toggle button to the reading menu bar, sharing the ribbon's toggle.
- Hid the corner ribbon while the menu is open, so no dead target is on screen.
- Hardened the demo-shelf script: its bookmark step used to report a bookmark it never took; it now fails the run when the mark does not land, and leaves an already-bookmarked page alone.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

Tested on an emulator, paged and scrolled, with the annotations table read straight out of the database: the menu button adds and removes one mark per tap, the ribbon still works with the menu closed, and a from-scratch demo-shelf run now leaves a real bookmark behind.

## Screenshots or recordings

Menu open on a bookmarked page, showing the new button filled in:

![Bookmark button in the reading menu](https://github.com/user-attachments/assets/4d34d808-794b-4f85-9c3e-4222cb033a2c)

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

