### PR TITLE
fix: stop one file being shelved twice, and let entries be removed

### DIFF
--- a/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/46.json
+++ b/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/46.json
@@ -1,0 +1,1370 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 46,
+    "identityHash": "ec5a2722e80b4835d62b5d7b91ee4f3a",
+    "entities": [
+      {
+        "tableName": "reading_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `total_progression` REAL, `reading_speed` REAL, `reading_seconds_per_position` REAL, `reading_pace_samples` INTEGER NOT NULL DEFAULT 0, `reading_pace_elapsed_ms` INTEGER NOT NULL DEFAULT 0, `reading_pace_evidence` REAL NOT NULL DEFAULT 0, `updated_at` INTEGER NOT NULL, `status` TEXT, `synced_at` INTEGER, `local_revision` INTEGER NOT NULL DEFAULT 0, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `agreed_account` TEXT, `pending_progression` REAL, `pending_locator_json` TEXT, `pending_status` TEXT, `pending_updated_at` INTEGER, `pending_account` TEXT, `owner_account` TEXT, `remote_updated_at` INTEGER, `finished_override` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSpeed",
+            "columnName": "reading_speed",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSecondsPerPosition",
+            "columnName": "reading_seconds_per_position",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingPaceSamples",
+            "columnName": "reading_pace_samples",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceElapsedMs",
+            "columnName": "reading_pace_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceEvidence",
+            "columnName": "reading_pace_evidence",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localRevision",
+            "columnName": "local_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "agreedAccount",
+            "columnName": "agreed_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingLocatorJson",
+            "columnName": "pending_locator_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingAccount",
+            "columnName": "pending_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ownerAccount",
+            "columnName": "owner_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "finishedOverride",
+            "columnName": "finished_override",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `cover_path` TEXT, `source` TEXT, `added_at` INTEGER NOT NULL, `last_opened_at` INTEGER, `local_uri` TEXT, `remote_uuid` TEXT, `remote_book_id` INTEGER, `cover_url` TEXT, `download_href` TEXT, `download_state` TEXT NOT NULL, `remote_updated_at` INTEGER, `downloaded_at` INTEGER, `file_modified_at` INTEGER, `work_id` TEXT, `finished_at` INTEGER, `archived_at` INTEGER, `remote_page_count` INTEGER, `size_bytes` INTEGER, `series_name` TEXT, `series_index` REAL, `file_series_name` TEXT, `file_series_index` REAL, `series_id` TEXT, `series_checked` INTEGER NOT NULL, `catalog_series_name` TEXT, `catalog_series_index` REAL, `catalog_folder_id` TEXT, `catalog_series_source` TEXT, `user_series_name` TEXT, `user_series_index` REAL, `series_override` INTEGER NOT NULL, `user_series_updated_at` INTEGER, `series_claim_pending` INTEGER NOT NULL, `series_claim_reset` INTEGER NOT NULL, `personal_series_updated_at` INTEGER, `series_index_override` INTEGER NOT NULL, `catalog_missing_since` INTEGER, `hidden_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "last_opened_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localUri",
+            "columnName": "local_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUuid",
+            "columnName": "remote_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteBookId",
+            "columnName": "remote_book_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadHref",
+            "columnName": "download_href",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadState",
+            "columnName": "download_state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloaded_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finished_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archived_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remotePageCount",
+            "columnName": "remote_page_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "size_bytes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fileSeriesName",
+            "columnName": "file_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileSeriesIndex",
+            "columnName": "file_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesChecked",
+            "columnName": "series_checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSeriesName",
+            "columnName": "catalog_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesIndex",
+            "columnName": "catalog_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "catalogFolderId",
+            "columnName": "catalog_folder_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesSource",
+            "columnName": "catalog_series_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesName",
+            "columnName": "user_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesIndex",
+            "columnName": "user_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesOverridden",
+            "columnName": "series_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userSeriesUpdatedAt",
+            "columnName": "user_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesClaimPending",
+            "columnName": "series_claim_pending",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesClaimReset",
+            "columnName": "series_claim_reset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personalSeriesUpdatedAt",
+            "columnName": "personal_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "indexOverridden",
+            "columnName": "series_index_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogMissingSince",
+            "columnName": "catalog_missing_since",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hiddenAt",
+            "columnName": "hidden_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_books_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_books_url` ON `${TABLE_NAME}` (`url`)"
+          },
+          {
+            "name": "index_books_series_name",
+            "unique": false,
+            "columnNames": [
+              "series_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_series_name` ON `${TABLE_NAME}` (`series_name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "library_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `added_at` INTEGER NOT NULL, PRIMARY KEY(`url`))",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "url"
+          ]
+        }
+      },
+      {
+        "tableName": "remote_server",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `kind` TEXT NOT NULL, `base_url` TEXT NOT NULL, `catalog_url` TEXT, `username` TEXT, `password_cipher` TEXT, `api_key_cipher` TEXT, `account_id` TEXT, `user_id` INTEGER, `kobo_token` TEXT, `can_download` INTEGER NOT NULL, `can_manage_library` INTEGER NOT NULL, `can_upload` INTEGER NOT NULL, `can_delete` INTEGER NOT NULL, `can_read_insights` INTEGER NOT NULL, `can_admin` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `catalog_synced_at` INTEGER, `position_synced_at` INTEGER, `sync_token` TEXT, `liseur_token_cipher` TEXT, `liseur_account_id` TEXT, `sync_cursor_seq` INTEGER NOT NULL DEFAULT 0, `annotation_cursor_seq` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogUrl",
+            "columnName": "catalog_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "passwordCipher",
+            "columnName": "password_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiKeyCipher",
+            "columnName": "api_key_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "koboTokenCipher",
+            "columnName": "kobo_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "canDownload",
+            "columnName": "can_download",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canManageLibrary",
+            "columnName": "can_manage_library",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canUpload",
+            "columnName": "can_upload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canDelete",
+            "columnName": "can_delete",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canReadInsights",
+            "columnName": "can_read_insights",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canAdmin",
+            "columnName": "can_admin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSyncedAt",
+            "columnName": "catalog_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "positionSyncedAt",
+            "columnName": "position_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncToken",
+            "columnName": "sync_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurTokenCipher",
+            "columnName": "liseur_token_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurAccountId",
+            "columnName": "liseur_account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncCursorSeq",
+            "columnName": "sync_cursor_seq",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "annotationCursorSeq",
+            "columnName": "annotation_cursor_seq",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `book_id` TEXT NOT NULL, `kind` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `text` TEXT, `note` TEXT, `tint` TEXT, `chapter` TEXT, `position` INTEGER, `total_progression` REAL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tint",
+            "columnName": "tint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapter",
+            "columnName": "chapter",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_typography",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `font` TEXT NOT NULL, `font_size` REAL NOT NULL, `line_height` REAL, `page_margins` REAL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "font",
+            "columnName": "font",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "font_size",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineHeight",
+            "columnName": "line_height",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pageMargins",
+            "columnName": "page_margins",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_screen",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `keep_screen_on` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keepScreenOn",
+            "columnName": "keep_screen_on",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_reading_mode",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `scroll` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scroll",
+            "columnName": "scroll",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `book_url` TEXT NOT NULL, `started_at` INTEGER NOT NULL, `ended_at` INTEGER, `last_checkpoint_at` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `start_progression` REAL, `end_progression` REAL, `idle_ms` INTEGER, `uploaded_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "ended_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastCheckpointAt",
+            "columnName": "last_checkpoint_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startProgression",
+            "columnName": "start_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "endProgression",
+            "columnName": "end_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "idleMs",
+            "columnName": "idle_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "uploadedAt",
+            "columnName": "uploaded_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_sessions_book_url",
+            "unique": false,
+            "columnNames": [
+              "book_url"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_book_url` ON `${TABLE_NAME}` (`book_url`)"
+          },
+          {
+            "name": "index_reading_sessions_started_at",
+            "unique": false,
+            "columnNames": [
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_started_at` ON `${TABLE_NAME}` (`started_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_peer_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `pending_progression` REAL, `pending_locator_json` TEXT, `pending_edition_sha` TEXT, `pending_status` TEXT, `pending_updated_at` INTEGER, `has_pending` INTEGER NOT NULL DEFAULT 0, `remote_updated_at` INTEGER, `synced_at` INTEGER, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingLocatorJson",
+            "columnName": "pending_locator_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingEditionSha",
+            "columnName": "pending_edition_sha",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasPending",
+            "columnName": "has_pending",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_peer_state_peer_id",
+            "unique": false,
+            "columnNames": [
+              "peer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_peer_state_peer_id` ON `${TABLE_NAME}` (`peer_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_fingerprint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `sha256` TEXT NOT NULL, `partial_md5` TEXT NOT NULL, `file_size` INTEGER NOT NULL, `file_modified_at` INTEGER, `computed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256",
+            "columnName": "sha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partialMd5",
+            "columnName": "partial_md5",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "computedAt",
+            "columnName": "computed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "work_alias",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_id` TEXT NOT NULL, `confidence` TEXT NOT NULL, `confirmed` INTEGER NOT NULL, `seeded` INTEGER NOT NULL DEFAULT 0, `source_sent` INTEGER NOT NULL DEFAULT 0, `edition_sha` TEXT, `annotations_reconciled_at` INTEGER NOT NULL DEFAULT 0, `resolved_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confirmed",
+            "columnName": "confirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seeded",
+            "columnName": "seeded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceSent",
+            "columnName": "source_sent",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "editionSha",
+            "columnName": "edition_sha",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "annotationsReconciledAt",
+            "columnName": "annotations_reconciled_at",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "resolvedAt",
+            "columnName": "resolved_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "work_ambiguity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_ids` TEXT NOT NULL, `noticed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workIds",
+            "columnName": "work_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noticedAt",
+            "columnName": "noticed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_extra",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`series_id` TEXT NOT NULL, `summary` TEXT, `status` TEXT, `total_book_count` INTEGER, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`series_id`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalBookCount",
+            "columnName": "total_book_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "series_id"
+          ]
+        }
+      },
+      {
+        "tableName": "annotation_sync",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `book_id` TEXT NOT NULL, `work_id` TEXT NOT NULL, `rev` INTEGER NOT NULL, `seq` INTEGER NOT NULL, `acked_fingerprint` TEXT, `pending_kind` TEXT, `pending_json` TEXT, `pending_rev` INTEGER NOT NULL, `pending_fingerprint` TEXT, `rejected_fingerprint` TEXT, `retry_not_before` INTEGER NOT NULL, PRIMARY KEY(`id`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rev",
+            "columnName": "rev",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seq",
+            "columnName": "seq",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ackedFingerprint",
+            "columnName": "acked_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingKind",
+            "columnName": "pending_kind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingJson",
+            "columnName": "pending_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingRev",
+            "columnName": "pending_rev",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pendingFingerprint",
+            "columnName": "pending_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "rejectedFingerprint",
+            "columnName": "rejected_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "retryNotBefore",
+            "columnName": "retry_not_before",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotation_sync_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotation_sync_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          },
+          {
+            "name": "index_annotation_sync_work_id",
+            "unique": false,
+            "columnNames": [
+              "work_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotation_sync_work_id` ON `${TABLE_NAME}` (`work_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kosync_peer",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `base_url` TEXT NOT NULL, `username` TEXT NOT NULL, `key_cipher` TEXT NOT NULL, `added_at` INTEGER NOT NULL, `position_synced_at` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keyCipher",
+            "columnName": "key_cipher",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSyncedAt",
+            "columnName": "position_synced_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "upload_refusal",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `account_key` TEXT NOT NULL, `refused_at` INTEGER NOT NULL, `kind` TEXT NOT NULL, `reason` TEXT, `content_sha256` TEXT, `seen_at` INTEGER, PRIMARY KEY(`book_url`, `account_key`), FOREIGN KEY(`book_url`) REFERENCES `books`(`url`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountKey",
+            "columnName": "account_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "refusedAt",
+            "columnName": "refused_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reason",
+            "columnName": "reason",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentSha256",
+            "columnName": "content_sha256",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seenAt",
+            "columnName": "seen_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "account_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_upload_refusal_account_key_seen_at",
+            "unique": false,
+            "columnNames": [
+              "account_key",
+              "seen_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_upload_refusal_account_key_seen_at` ON `${TABLE_NAME}` (`account_key`, `seen_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "book_url"
+            ],
+            "referencedColumns": [
+              "url"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ec5a2722e80b4835d62b5d7b91ee4f3a')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -116,6 +116,18 @@ class AppContainer(context: Context) {
         inTransaction = { work -> database.withTransaction { work() } },
     )
 
+    /**
+     * What a book's file hashes to, worked out on demand.
+     *
+     * Lazily, and never during a library scan: hashing a large EPUB on a
+     * memory card is slow enough to be felt, and nothing needs the
+     * answer until a book is named to a server.
+     */
+    val bookFingerprints = BookFingerprintStore(
+        context = context.applicationContext,
+        dao = database.workIdentityDao(),
+    )
+
     val libraryRepository = LocalLibraryRepository(
         context = context.applicationContext,
         assetRetriever = assetRetriever,
@@ -123,6 +135,7 @@ class AppContainer(context: Context) {
         bookDao = database.bookDao(),
         folderDao = database.libraryFolderDao(),
         bookRemoval = bookRemoval,
+        fingerprints = bookFingerprints,
     )
 
     /** Highlights and notes written to a file, and read back on another device. */
@@ -227,18 +240,6 @@ class AppContainer(context: Context) {
         reporting = syncReporting,
         networkAvailability = networkAvailability,
         inTransaction = { work -> database.withTransaction { work() } },
-    )
-
-    /**
-     * What a book's file hashes to, worked out on demand.
-     *
-     * Lazily, and never during a library scan: hashing a large EPUB on a
-     * memory card is slow enough to be felt, and nothing needs the
-     * answer until a book is named to a server.
-     */
-    val bookFingerprints = BookFingerprintStore(
-        context = context.applicationContext,
-        dao = database.workIdentityDao(),
     )
 
     /** What a liseur-sync server calls each book, cached per account. */

--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -586,26 +586,24 @@ private fun LibraryRoute(
     }
 
     // A book that really was new: opened where the library now keeps it.
-    LaunchedEffect(viewModel) {
-        viewModel.openImported.collect { open ->
-            context.startActivity(
-                ReaderActivity.intent(context, open.url, open.bookUrl ?: open.url),
-            )
-        }
+    val openImported by viewModel.openImported.collectAsStateWithLifecycle()
+    LaunchedEffect(openImported) {
+        val open = openImported ?: return@LaunchedEffect
+        viewModel.openImportedHandled()
+        context.startActivity(
+            ReaderActivity.intent(context, open.url, open.bookUrl ?: open.url),
+        )
     }
 
-    var alreadyShelved by remember { mutableStateOf<com.chmouel.liseur.data.db.Book?>(null) }
-    LaunchedEffect(viewModel) {
-        viewModel.alreadyShelved.collect { alreadyShelved = it }
-    }
+    val alreadyShelved by viewModel.alreadyShelved.collectAsStateWithLifecycle()
     alreadyShelved?.let { book ->
         AlertDialog(
-            onDismissRequest = { alreadyShelved = null },
+            onDismissRequest = { viewModel.alreadyShelvedHandled() },
             title = { Text(stringResource(R.string.already_shelved_title)) },
             text = { Text(stringResource(R.string.already_shelved_message, book.title)) },
             confirmButton = {
                 TextButton(onClick = {
-                    alreadyShelved = null
+                    viewModel.alreadyShelvedHandled()
                     book.openableUrl?.let {
                         context.startActivity(ReaderActivity.intent(context, it, book.url))
                     }
@@ -614,7 +612,7 @@ private fun LibraryRoute(
                 }
             },
             dismissButton = {
-                TextButton(onClick = { alreadyShelved = null }) {
+                TextButton(onClick = { viewModel.alreadyShelvedHandled() }) {
                     Text(stringResource(R.string.cancel))
                 }
             },

--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -9,6 +9,9 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.compose.BackHandler
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -20,6 +23,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.platform.LocalLocale
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -46,6 +50,7 @@ import com.chmouel.liseur.ui.stats.ReadingStatsViewModel
 import com.chmouel.liseur.ui.library.BookActionsSheet
 import com.chmouel.liseur.ui.library.ConfirmLocalDeleteDialog
 import com.chmouel.liseur.ui.library.ConfirmRemoveDownloadDialog
+import com.chmouel.liseur.ui.library.ConfirmRemoveFromLibraryDialog
 import com.chmouel.liseur.ui.library.ConfirmServerDeleteDialog
 import com.chmouel.liseur.ui.library.LibraryScreen
 import com.chmouel.liseur.ui.library.SeriesPickerSheet
@@ -57,6 +62,7 @@ import com.chmouel.liseur.ui.settings.AboutScreen
 import com.chmouel.liseur.ui.settings.LicencesScreen
 import com.chmouel.liseur.ui.settings.SettingsScreen
 import com.chmouel.liseur.ui.settings.ReadingAppearanceScreen
+import com.chmouel.liseur.ui.settings.HiddenBooksScreen
 import com.chmouel.liseur.ui.settings.ReadingNavigationScreen
 import com.chmouel.liseur.ui.settings.AnnotationBackupUi
 import com.chmouel.liseur.ui.LocalEInk
@@ -153,6 +159,7 @@ private enum class Screen {
     SETTINGS,
     READING_APPEARANCE,
     READING_NAVIGATION,
+    HIDDEN_BOOKS,
     SERVER_ACCOUNT,
     LICENCES,
     ABOUT,
@@ -286,10 +293,23 @@ private fun LiseurApp(settings: AppSettings) {
                 },
                 onOpenReadingAppearance = { screen = Screen.READING_APPEARANCE },
                 onOpenReadingNavigation = { screen = Screen.READING_NAVIGATION },
+                onOpenHiddenBooks = { screen = Screen.HIDDEN_BOOKS },
                 backup = annotationBackup,
                 connections = context.container.connections,
                 onOpenAbout = { screen = Screen.ABOUT },
                 onBack = { screen = Screen.LIBRARY },
+            )
+        }
+
+        Screen.HIDDEN_BOOKS -> {
+            val back = { screen = Screen.SETTINGS }
+            BackHandler { back() }
+            val library: LibraryViewModel = viewModel(factory = LibraryViewModel.Factory)
+            val hidden by library.hidden.collectAsStateWithLifecycle(emptyList())
+            HiddenBooksScreen(
+                hidden = hidden,
+                onUnhide = { library.unhide(it.url) },
+                onBack = back,
             )
         }
 
@@ -556,9 +576,49 @@ private fun LibraryRoute(
                     Intent.FLAG_GRANT_READ_URI_PERMISSION,
                 )
             }
+            // The reader is not opened here any more. What was picked
+            // may be a book the library already has under the other
+            // spelling SAF gives one file, and opening the URI that was
+            // picked recorded the reading against an entry the shelf
+            // could not show (issue #147). The answer comes back below.
             viewModel.importBook(uri)
-            context.startActivity(ReaderActivity.intent(context, uri.toString()))
         }
+    }
+
+    // A book that really was new: opened where the library now keeps it.
+    LaunchedEffect(viewModel) {
+        viewModel.openImported.collect { open ->
+            context.startActivity(
+                ReaderActivity.intent(context, open.url, open.bookUrl ?: open.url),
+            )
+        }
+    }
+
+    var alreadyShelved by remember { mutableStateOf<com.chmouel.liseur.data.db.Book?>(null) }
+    LaunchedEffect(viewModel) {
+        viewModel.alreadyShelved.collect { alreadyShelved = it }
+    }
+    alreadyShelved?.let { book ->
+        AlertDialog(
+            onDismissRequest = { alreadyShelved = null },
+            title = { Text(stringResource(R.string.already_shelved_title)) },
+            text = { Text(stringResource(R.string.already_shelved_message, book.title)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    alreadyShelved = null
+                    book.openableUrl?.let {
+                        context.startActivity(ReaderActivity.intent(context, it, book.url))
+                    }
+                }) {
+                    Text(stringResource(R.string.already_shelved_open))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { alreadyShelved = null }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            },
+        )
     }
 
     val addFolder = rememberLauncherForActivityResult(
@@ -621,6 +681,9 @@ private fun LibraryRoute(
     var seriesServerDelete by remember { mutableStateOf<com.chmouel.liseur.data.db.Book?>(null) }
     var seriesLocalDelete by remember { mutableStateOf<com.chmouel.liseur.data.db.Book?>(null) }
     var seriesRemoveDownload by remember { mutableStateOf<com.chmouel.liseur.data.db.Book?>(null) }
+    var seriesRemoveFromLibrary by remember {
+        mutableStateOf<com.chmouel.liseur.data.db.Book?>(null)
+    }
     var seriesSheetRefile by remember { mutableStateOf<com.chmouel.liseur.data.db.Book?>(null) }
     val seriesExtras by viewModel.openSeriesExtras.collectAsStateWithLifecycle()
 
@@ -686,6 +749,10 @@ private fun LibraryRoute(
                 // offered here as well as on the shelf.
                 onEditSeries = { seriesSheetRefile = book; seriesSheetBook = null },
                 onDeleteLocal = { seriesLocalDelete = book; seriesSheetBook = null },
+                onRemoveFromLibrary = {
+                    seriesRemoveFromLibrary = book
+                    seriesSheetBook = null
+                },
                 // The same warning the shelf puts in front of it. An
                 // action offered here and answered nowhere would be a
                 // button that quietly does nothing.
@@ -740,6 +807,16 @@ private fun LibraryRoute(
                 onDismiss = { seriesLocalDelete = null },
             )
         }
+        seriesRemoveFromLibrary?.let { book ->
+            ConfirmRemoveFromLibraryDialog(
+                book = book,
+                onConfirm = {
+                    viewModel.removeFromLibrary(book)
+                    seriesRemoveFromLibrary = null
+                },
+                onDismiss = { seriesRemoveFromLibrary = null },
+            )
+        }
         seriesRemoveDownload?.let { book ->
             ConfirmRemoveDownloadDialog(
                 book = book,
@@ -772,6 +849,9 @@ private fun LibraryRoute(
         onSetFinished = viewModel::setFinished,
         onSetArchived = viewModel::setArchived,
         onDeleteLocal = viewModel::deleteLocalBook,
+        onRemoveFromLibrary = viewModel::removeFromLibrary,
+        onUnhide = viewModel::unhide,
+        hiddenBooks = viewModel.hiddenBooks,
         onDeleteFromServer = viewModel::deleteFromServer,
         onUploadToServer = viewModel::uploadToServer,
         onUploadPending = viewModel::uploadPending,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/AnnotationSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/AnnotationSync.kt
@@ -125,6 +125,9 @@ interface AnnotationSyncDao {
      * their highlights, and pushing tombstones because a file went away
      * would empty a library from the one device that lost it.
      */
+    @Query("SELECT COUNT(*) FROM annotation_sync WHERE book_id = :bookId")
+    suspend fun countForBook(bookId: String): Int
+
     @Query("DELETE FROM annotation_sync WHERE book_id = :bookId")
     suspend fun forgetBook(bookId: String)
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/Book.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/Book.kt
@@ -186,10 +186,26 @@ data class Book(
      * fell out of sight. Nothing decides anything by its value.
      */
     @ColumnInfo(name = "catalog_missing_since") val catalogMissingSince: Long? = null,
+    /**
+     * When the reader took the book off the shelf without deleting its
+     * file, and null while it is on the shelf.
+     *
+     * Not archiving, which puts a book on a shelf of its own and is
+     * about having finished with it. This is about the entry being
+     * wrong: the same file shelved twice, which is what one file with
+     * two SAF spellings used to produce (issue #147). The row stays
+     * exactly as it was — the reader's place, their marks, their time,
+     * what a server was told — because the only thing being taken away
+     * is the entry, and putting it back has to give all of it back.
+     */
+    @ColumnInfo(name = "hidden_at") val hiddenAt: Long? = null,
 ) {
     val finished: Boolean get() = finishedAt != null
 
     val archived: Boolean get() = archivedAt != null
+
+    /** Off the shelf, file and all its history kept. */
+    val hidden: Boolean get() = hiddenAt != null
 
     /**
      * The series id worth asking a server about.
@@ -609,6 +625,31 @@ interface BookDao {
     @Query("UPDATE books SET cover_path = :coverPath WHERE url = :url")
     suspend fun setCoverPath(url: String, coverPath: String)
 
+    /**
+     * Files an existing entry under a library folder.
+     *
+     * A book picked by hand has no folder, and a folder scan that later
+     * meets the same file keeps that entry rather than making a second
+     * one. It has to join the folder to be looked after by it: pruned
+     * when the file goes, and removed when the folder is.
+     */
+    @Query("UPDATE books SET source = :source WHERE url = :url")
+    suspend fun setSource(url: String, source: String)
+
+    /**
+     * Takes a book off the shelf, or puts it back.
+     *
+     * The whole of the removal, and the whole of the way back. Nothing
+     * else on the row is touched, which is what lets *Put back* return
+     * the book as it was rather than as a stranger, and what makes both
+     * directions a single indivisible write.
+     */
+    @Query("UPDATE books SET hidden_at = :at WHERE url = :url")
+    suspend fun setHiddenAt(url: String, at: Long?)
+
+    @Query("SELECT * FROM books WHERE hidden_at IS NOT NULL ORDER BY hidden_at DESC")
+    fun observeHidden(): Flow<List<Book>>
+
     @Query("SELECT * FROM books WHERE local_uri IS NOT NULL")
     fun observeDownloaded(): Flow<List<Book>>
 
@@ -814,6 +855,7 @@ interface BookDao {
             SELECT books.* FROM books
             LEFT JOIN reading_progress ON reading_progress.book_url = books.url
             WHERE books.archived_at IS NULL
+              AND books.hidden_at IS NULL
               AND (
                   books.last_opened_at IS NOT NULL
                   OR reading_progress.total_progression IS NOT NULL

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
@@ -27,7 +27,7 @@ import androidx.sqlite.execSQL
         KosyncPeer::class,
         UploadRefusal::class,
     ],
-    version = 45,
+    version = 46,
     exportSchema = true,
 )
 abstract class LiseurDatabase : RoomDatabase() {
@@ -1213,9 +1213,18 @@ abstract class LiseurDatabase : RoomDatabase() {
         }
 
         /**
-         * Every migration, in order, as one list so that what the app
-         * runs and what the tests replay cannot drift apart.
+         * Remembers a book taken off the shelf whose file was kept.
+         *
+         * Without this the only way to be rid of a duplicate entry was
+         * to delete the book itself (issue #147), because anything left
+         * in a watched folder comes back on the next scan.
          */
+        val MIGRATION_45_46 = object : Migration(45, 46) {
+            override fun migrate(connection: SQLiteConnection) {
+                connection.execSQL("ALTER TABLE books ADD COLUMN hidden_at INTEGER")
+            }
+        }
+
         val MIGRATIONS: Array<Migration> get() = arrayOf(
             MIGRATION_1_2,
             MIGRATION_2_3,
@@ -1261,6 +1270,7 @@ abstract class LiseurDatabase : RoomDatabase() {
             MIGRATION_42_43,
             MIGRATION_43_44,
             MIGRATION_44_45,
+            MIGRATION_45_46,
         )
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/ReadingSession.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/ReadingSession.kt
@@ -193,6 +193,9 @@ interface ReadingSessionDao {
     @Query("UPDATE reading_sessions SET uploaded_at = NULL")
     suspend fun forgetUploads()
 
+    @Query("SELECT COUNT(*) FROM reading_sessions WHERE book_url = :bookUrl")
+    suspend fun countForBook(bookUrl: String): Int
+
     @Query("DELETE FROM reading_sessions WHERE book_url = :bookUrl")
     suspend fun deleteForBook(bookUrl: String)
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/SyncPeerState.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/SyncPeerState.kt
@@ -73,6 +73,10 @@ abstract class SyncPeerStateDao {
     @Query("SELECT COUNT(*) FROM sync_peer_state WHERE peer_id = :peerId AND has_pending = 1")
     abstract suspend fun countPending(peerId: String): Int
 
+    /** How much a partner has agreed about one book, settled or not. */
+    @Query("SELECT COUNT(*) FROM sync_peer_state WHERE book_url = :bookUrl")
+    abstract suspend fun countForBook(bookUrl: String): Int
+
     @Upsert
     abstract suspend fun upsert(state: SyncPeerState)
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/WorkIdentity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/WorkIdentity.kt
@@ -241,6 +241,15 @@ interface WorkIdentityDao {
     @Query("DELETE FROM work_alias WHERE book_url IN (:bookUrls)")
     suspend fun forgetAliases(bookUrls: List<String>)
 
+    /** How much a sync server has been persuaded to call one book, settled or not. */
+    @Query(
+        """
+        SELECT (SELECT COUNT(*) FROM work_alias WHERE book_url = :bookUrl) +
+               (SELECT COUNT(*) FROM work_ambiguity WHERE book_url = :bookUrl)
+        """,
+    )
+    suspend fun namingCountForBook(bookUrl: String): Int
+
     @Query("DELETE FROM work_ambiguity WHERE book_url IN (:bookUrls)")
     suspend fun forgetAmbiguities(bookUrls: List<String>)
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/library/BookFingerprintStore.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/library/BookFingerprintStore.kt
@@ -48,7 +48,7 @@ class BookFingerprintStore(
             return cached.fingerprint
         }
 
-        val fresh = compute(url) ?: return null
+        val fresh = read(url) ?: return null
         dao.upsert(
             BookFingerprintRow(
                 bookUrl = book.url,
@@ -62,7 +62,17 @@ class BookFingerprintStore(
         return fresh
     }
 
-    private suspend fun compute(url: String): BookFingerprint? = withContext(Dispatchers.IO) {
+    /**
+     * The fingerprint of a file that has no library row yet.
+     *
+     * Nothing is cached, because there is nothing to cache it against:
+     * this answers for a file the reader has only just picked, which
+     * may turn out to be a book the library already has and may never
+     * be shelved at all.
+     */
+    suspend fun compute(url: String): BookFingerprint? = read(url)
+
+    private suspend fun read(url: String): BookFingerprint? = withContext(Dispatchers.IO) {
         try {
             context.contentResolver.openInputStream(Uri.parse(url))?.use(BookFingerprints::of)
         } catch (e: IOException) {

--- a/app/src/main/kotlin/com/chmouel/liseur/data/library/BookRemoval.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/library/BookRemoval.kt
@@ -1,6 +1,7 @@
 package com.chmouel.liseur.data.library
 
 import com.chmouel.liseur.data.db.AnnotationSyncDao
+import com.chmouel.liseur.data.db.Book
 import com.chmouel.liseur.data.db.BookAnnotationDao
 import com.chmouel.liseur.data.db.BookDao
 import com.chmouel.liseur.data.db.ReadingProgressDao
@@ -77,6 +78,69 @@ class BookRemoval(
             bookDao.clearSeriesForReplacedWork(bookUrl)
         }
     }
+
+    /**
+     * Drops entries that are a second name for a book already on the
+     * shelf, and only those with nothing on them worth keeping.
+     *
+     * Earlier versions shelved one file twice whenever it was picked by
+     * hand as well as found by a folder scan (issue #147), and those
+     * duplicates are still there. A scan can now recognise them, but
+     * recognising is not licence to delete: the reader may well have
+     * been reading the duplicate — that is where a position opened
+     * through `+ -> Add Book` was recorded — and quietly discarding
+     * where someone had got to is worse than the duplicate itself. So a
+     * row goes only when it holds no reading position, no marks, no
+     * agreement with a server about marks, no reading time, and nothing
+     * on the row itself either. Anything else is left for the reader to
+     * remove by hand.
+     *
+     * Returns what was actually removed.
+     */
+    suspend fun dropUntouchedDuplicates(bookUrls: List<String>): List<String> {
+        if (bookUrls.isEmpty()) return emptyList()
+        val removable = mutableListOf<String>()
+        inTransaction {
+            for (url in bookUrls.distinct()) {
+                val book = bookDao.getByUrl(url) ?: continue
+                if (blank(book) && untouched(url)) removable += url
+            }
+            if (removable.isNotEmpty()) forget(removable)
+        }
+        return removable
+    }
+
+    /**
+     * Whether the row itself says nothing that the other one will not.
+     *
+     * Reading history is not the only thing a duplicate can be carrying.
+     * A row that has been uploaded holds the `remote_uuid` that is the
+     * only reason the book is not sent a second time; one that was
+     * opened, finished, archived or filed into a series by hand holds a
+     * decision the reader made. None of that is on the entry this would
+     * keep, so none of it may be dropped on the quiet.
+     */
+    private fun blank(book: Book): Boolean =
+        book.remoteUuid == null &&
+            book.remoteBookId == null &&
+            book.lastOpenedAt == null &&
+            book.finishedAt == null &&
+            book.archivedAt == null &&
+            book.seriesName == book.fileSeriesName &&
+            book.seriesIndex == book.fileSeriesIndex
+
+    private suspend fun untouched(bookUrl: String): Boolean =
+        progressDao.get(bookUrl) == null &&
+            annotationDao.count(bookUrl) == 0 &&
+            annotationSyncDao.countForBook(bookUrl) == 0 &&
+            sessionDao.countForBook(bookUrl) == 0 &&
+            // What a sync partner has agreed about this entry is state
+            // too, and `forget` below would take it with the row.
+            peerStateDao.countForBook(bookUrl) == 0 &&
+            // So is what a server was persuaded to call it. A rejected
+            // low-confidence match is a decision the reader made, and
+            // nothing here could work it out again.
+            identityDao.namingCountForBook(bookUrl) == 0
 
     /**
      * Everything keyed by a book URL, in one place.

--- a/app/src/main/kotlin/com/chmouel/liseur/data/library/BookRemoval.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/library/BookRemoval.kt
@@ -126,6 +126,17 @@ class BookRemoval(
             book.lastOpenedAt == null &&
             book.finishedAt == null &&
             book.archivedAt == null &&
+            // A book the reader took off the shelf is a decision of its
+            // own, and the one entry they can still act on.
+            book.hiddenAt == null &&
+            // The flags, not only what they currently produce. Filing a
+            // book by hand under the series its file already names looks
+            // like nothing was said, and a claim still waiting on a
+            // server is a decision even when it has changed nothing yet.
+            !book.seriesOverridden &&
+            !book.indexOverridden &&
+            !book.seriesClaimPending &&
+            !book.seriesClaimReset &&
             book.seriesName == book.fileSeriesName &&
             book.seriesIndex == book.fileSeriesIndex
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/library/DocumentIdentity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/library/DocumentIdentity.kt
@@ -1,0 +1,99 @@
+package com.chmouel.liseur.data.library
+
+
+/**
+ * What a document *is*, rather than what it happens to be called.
+ *
+ * One file inside a folder the reader granted has two spellings, and
+ * which one is written down depends only on how the book got here. A
+ * folder scan builds its URI against the tree it walked, so it reads
+ * `content://authority/tree/<tree>/document/<doc>`; the single-file
+ * picker behind `+ -> Add Book` hands back the bare
+ * `content://authority/document/<doc>`. Both name the same bytes on
+ * disk, and comparing them as strings says they are different books —
+ * which is exactly how the same EPUB ended up on the shelf twice
+ * (issue #147).
+ *
+ * The document id is what the provider actually keys on, so authority
+ * plus document id is the identity. It is read off the URL by hand
+ * rather than through `DocumentsContract`, because a plain string
+ * function can be tested on the JVM without an emulator, and because
+ * the answer must not depend on whether the provider is installed.
+ *
+ * Null for anything that is not a content URI naming a document — a
+ * `file:` URL, an `http:` URL, a copy in the app's own storage. Those
+ * have only ever had one spelling, so the exact URL is already their
+ * identity and inventing a second one for them could only make two
+ * different books look alike.
+ */
+internal fun documentIdentity(url: String): String? {
+    if (!url.startsWith("content://", ignoreCase = true)) return null
+
+    val afterScheme = url.substringAfter("://")
+    val authority = afterScheme.substringBefore('/', missingDelimiterValue = "")
+    if (authority.isEmpty()) return null
+
+    // The path, without a query or fragment: neither is part of what the
+    // document is, and the picker is free to add either.
+    val path = afterScheme.substring(authority.length)
+        .substringBefore('?')
+        .substringBefore('#')
+
+    // The last one wins: a tree URI carries the tree's own id in an
+    // earlier `/document/` segment on some providers, and it is the
+    // trailing one that names the file.
+    val marker = path.lastIndexOf(DOCUMENT_SEGMENT)
+    if (marker < 0) return null
+
+    val documentId = path.substring(marker + DOCUMENT_SEGMENT.length)
+        .trimEnd('/')
+        .ifEmpty { return null }
+
+    // Percent-encoding is the provider's business and not always
+    // spelled the same way twice, so identity is compared decoded.
+    return authority + '\u0000' + percentDecode(documentId)
+}
+
+/**
+ * Whether two URLs name the same document.
+ *
+ * Falls back to comparing the URLs when neither has an identity, so a
+ * caller can use this alone rather than remembering which URLs the
+ * identity applies to.
+ */
+internal fun sameDocument(url: String, other: String): Boolean {
+    if (url == other) return true
+    val identity = documentIdentity(url) ?: return false
+    return identity == documentIdentity(other)
+}
+
+/**
+ * Decodes `%xx` escapes, leaving anything malformed exactly as it was.
+ *
+ * `URLDecoder` is not used because it also turns `+` into a space,
+ * which in a document id is a literal plus, and because it throws on
+ * a trailing `%`.
+ */
+private fun percentDecode(value: String): String {
+    if (!value.contains('%')) return value
+    val out = StringBuilder(value.length)
+    var i = 0
+    while (i < value.length) {
+        val c = value[i]
+        val hex = if (c == '%' && i + 2 < value.length) {
+            value.substring(i + 1, i + 3).toIntOrNull(16)
+        } else {
+            null
+        }
+        if (hex == null) {
+            out.append(c)
+            i++
+        } else {
+            out.append(hex.toChar())
+            i += 3
+        }
+    }
+    return out.toString()
+}
+
+private const val DOCUMENT_SEGMENT = "/document/"

--- a/app/src/main/kotlin/com/chmouel/liseur/data/library/LocalLibraryRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/library/LocalLibraryRepository.kt
@@ -21,6 +21,8 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.services.cover
@@ -29,6 +31,24 @@ import org.readium.r2.shared.util.asset.AssetRetriever
 import org.readium.r2.shared.util.getOrElse
 import org.readium.r2.shared.util.toAbsoluteUrl
 import org.readium.r2.streamer.PublicationOpener
+
+/**
+ * What became of a book the reader picked by hand.
+ *
+ * Shelving one is not always adding one: the same file can already be
+ * on the shelf under another name, and the reader should be told that
+ * rather than shown a second copy of a book they already have.
+ */
+sealed interface ImportResult {
+    /** A book that was not here before, now indexed. */
+    data class Added(val book: Book) : ImportResult
+
+    /** The library entry this file already has. Nothing was added. */
+    data class AlreadyShelved(val book: Book) : ImportResult
+
+    /** The file could not be read as a book at all. */
+    data object Failed : ImportResult
+}
 
 /**
  * Indexes EPUBs into the library: from SAF folders the user picked
@@ -41,10 +61,22 @@ class LocalLibraryRepository(
     private val bookDao: BookDao,
     private val folderDao: LibraryFolderDao,
     private val bookRemoval: BookRemoval,
+    private val fingerprints: BookFingerprintStore,
 ) {
     val books: Flow<List<Book>> = bookDao.observeAll()
     val mostRecent: Flow<Book?> = bookDao.observeMostRecent()
     val folders: Flow<List<LibraryFolder>> = folderDao.observeAll()
+
+    /**
+     * Held by everything that can put a local book on the shelf.
+     *
+     * Recognising a file and inserting it are two steps, and a folder
+     * scan runs itself on every cold start while the reader is free to
+     * pick a file by hand at the same moment. Both would look, both
+     * would find nothing, and both would insert — the very duplicate
+     * this class now exists to prevent, only harder to reproduce.
+     */
+    private val importLock = Mutex()
 
     suspend fun addFolder(treeUri: Uri) {
         runCatching {
@@ -71,10 +103,44 @@ class LocalLibraryRepository(
         scanFolder(treeUri)
     }
 
-    suspend fun removeFolder(url: String) {
+    suspend fun removeFolder(url: String) = importLock.withLock {
         folderDao.delete(url)
         bookRemoval.deleteByUrls(bookDao.urlsForSource(url))
     }
+
+    /**
+     * Takes a book off the shelf and leaves its file alone.
+     *
+     * The other way out of the library deletes the file first, which is
+     * far too much to ask of someone who only wanted to be rid of a
+     * duplicate entry (issue #147).
+     *
+     * The row is marked, not deleted. The reader's place, their marks,
+     * the time they spent, what a server has been told about it and
+     * where they filed it by hand all hang off this row, and all of it
+     * is theirs whether the entry is showing or not. Marking is also the
+     * whole of the removal and the whole of the way back: one write
+     * each, so there is no moment where the book is neither on the shelf
+     * nor on the list of what was taken off it.
+     */
+    suspend fun removeFromLibrary(book: Book) {
+        bookDao.setHiddenAt(book.url, System.currentTimeMillis())
+    }
+
+    /**
+     * Puts a hidden book back on the shelf.
+     *
+     * Nothing is read and nothing is rebuilt: the entry was never taken
+     * apart, so showing it again is all there is to do. A file that has
+     * gone missing in the meantime is pruned by the next scan of its
+     * folder, exactly as it would have been had it never been hidden.
+     */
+    suspend fun unhide(bookUrl: String) {
+        bookDao.setHiddenAt(bookUrl, null)
+    }
+
+    /** Every book taken off the shelf, most recently taken off first. */
+    val hidden: Flow<List<Book>> = bookDao.observeHidden()
 
     /** Rescans every library folder, adding new books and pruning deleted files. */
     suspend fun rescanAll() {
@@ -83,11 +149,97 @@ class LocalLibraryRepository(
         }
     }
 
-    /** Adds a single, individually picked book to the library. */
-    suspend fun importBook(uri: Uri): Book? {
-        val url = uri.toAbsoluteUrl() ?: return null
-        bookDao.getByUrl(url.toString())?.let { return it }
-        return indexBook(url, source = null)
+    /**
+     * Adds a single, individually picked book to the library.
+     *
+     * The file may well be one the library already has. A folder scan
+     * writes the URI it built against the tree it was walking, and the
+     * single-file picker hands back a bare document URI, so one EPUB in
+     * a watched folder has two spellings and matching on the URL alone
+     * shelved it twice (issue #147). What it is, rather than what it is
+     * called, decides.
+     */
+    suspend fun importBook(uri: Uri): ImportResult = importLock.withLock {
+        val url = uri.toAbsoluteUrl() ?: return@withLock ImportResult.Failed
+        alreadyShelved(url)?.let { return@withLock shelveAgainOrReport(it) }
+        indexBook(url, source = null)
+            ?.let { ImportResult.Added(it) }
+            ?: ImportResult.Failed
+    }
+
+    /**
+     * What to answer about a file the library already has an entry for.
+     *
+     * Picking a book that was taken off the shelf is asking for it back,
+     * so it comes back rather than being reported as already there —
+     * under the URL it has always had, which is where its place and its
+     * marks are.
+     *
+     * The caller holds [importLock].
+     */
+    private suspend fun shelveAgainOrReport(book: Book): ImportResult =
+        if (book.hidden) {
+            unhide(book.url)
+            ImportResult.Added(bookDao.getByUrl(book.url) ?: book)
+        } else {
+            ImportResult.AlreadyShelved(book)
+        }
+
+    /**
+     * The library entry that already stands for this file, or null.
+     *
+     * Three questions, cheapest first, because the last one reads the
+     * whole file:
+     *
+     * 1. The same URL, which is all this used to ask.
+     * 2. The same document: authority and document id, which sees
+     *    through the two spellings SAF gives one file.
+     * 3. The same bytes, for a genuine second copy sitting somewhere
+     *    else. Hashing is confined to books that already claim to be
+     *    the same work, so the usual answer costs one metadata read and
+     *    no hashing at all, and a matching work id on its own is never
+     *    enough — two editions of one book are two books.
+     */
+    private suspend fun alreadyShelved(url: AbsoluteUrl): Book? {
+        val urlText = url.toString()
+        bookDao.getByUrl(urlText)?.let { return it }
+
+        val shelf = bookDao.allOnce()
+        documentIdentity(urlText)?.let { identity ->
+            shelf.firstOrNull { it.url != urlText && documentIdentity(it.url) == identity }
+                ?.let { return it }
+        }
+        return sameContentOnShelf(url, shelf)
+    }
+
+    private suspend fun sameContentOnShelf(url: AbsoluteUrl, shelf: List<Book>): Book? {
+        val workId = workIdOfFile(url) ?: return null
+        val candidates = shelf.filter {
+            it.workId == workId && it.url != url.toString() && it.openableUrl != null
+        }
+        if (candidates.isEmpty()) return null
+
+        val sha256 = fingerprints.compute(url.toString())?.sha256 ?: return null
+        return candidates.firstOrNull { fingerprints.of(it)?.sha256 == sha256 }
+    }
+
+    /** What work a file holds, without shelving it. */
+    private suspend fun workIdOfFile(url: AbsoluteUrl): String? {
+        val asset = assetRetriever.retrieve(url).getOrElse { return null }
+        val publication = publicationOpener.open(asset, allowUserInteraction = false)
+            .getOrElse {
+                asset.close()
+                return null
+            }
+        return try {
+            workIdOf(
+                publication.metadata.identifier,
+                publication.metadata.title,
+                publication.metadata.authors.joinToString(", ") { it.name }.ifBlank { null },
+            )
+        } finally {
+            publication.close()
+        }
     }
 
     /**
@@ -109,22 +261,30 @@ class LocalLibraryRepository(
      * given, because failing to file a book is no reason to refuse to
      * show it.
      */
-    suspend fun importExternalBook(uri: Uri): Book? {
-        val incoming = uri.toAbsoluteUrl() ?: return null
-        bookDao.getByUrl(incoming.toString())?.let { return it }
+    suspend fun importExternalBook(uri: Uri): Book? = importLock.withLock {
+        val incoming = uri.toAbsoluteUrl() ?: return@withLock null
+        // A book arriving from a file manager is very often one the
+        // library already has under the spelling a folder scan gave it,
+        // so ask what the file is and not only what it is called.
+        alreadyShelved(incoming)?.let {
+            // Sharing in a book that was taken off the shelf asks for it
+            // back just as plainly as picking it does.
+            if (it.hidden) unhide(it.url)
+            return@withLock bookDao.getByUrl(it.url) ?: it
+        }
 
         // A real file is already as permanent as the library is, and a
         // grant that survives is just as good. Either way the book is
         // indexed where it lies rather than copied.
         val keepsWorking = incoming.toString().startsWith("file:") || persistPermission(uri)
-        if (keepsWorking) return indexBook(incoming, source = null)
+        if (keepsWorking) return@withLock indexBook(incoming, source = null)
 
-        val copied = copyIntoLibrary(uri) ?: return null
+        val copied = copyIntoLibrary(uri) ?: return@withLock null
         // Content addressing makes this idempotent: the same file opened
         // twice lands on the same path, so the second time finds the row
         // the first one made instead of shelving the book again.
-        bookDao.getByUrl(copied.toString())?.let { return it }
-        return indexBook(copied, source = null)
+        bookDao.getByUrl(copied.toString())?.let { return@withLock it }
+        indexBook(copied, source = null)
     }
 
     /**
@@ -210,26 +370,90 @@ class LocalLibraryRepository(
 
     private suspend fun scanFolder(treeUri: Uri) = withContext(Dispatchers.IO) {
         val found = findEpubs(treeUri) ?: return@withContext
+        importLock.withLock {
+            // Walking the folder takes long enough for it to have been
+            // removed in the meantime, and shelving the walk's results
+            // then would file books under a folder nothing watches any
+            // more: never scanned again, and never pruned.
+            if (folderDao.getAll().none { it.url == treeUri.toString() }) return@withLock
+            shelve(treeUri, found)
+        }
+    }
+
+    private suspend fun shelve(treeUri: Uri, found: List<ScannedEpub>) {
         val knownUrls = bookDao.urlsForSource(treeUri.toString()).toMutableSet()
         // Everything on the shelf, read once. Looking each file up as it
         // was met meant a query per book per scan, on every cold start.
-        val knownBooks = bookDao.allOnce().associateBy { it.url }
+        val shelf = bookDao.allOnce()
+        val knownBooks = shelf.associateBy { it.url }
+        // The same file under its other spelling: what a duplicate entry
+        // made by an older version looks like.
+        val byIdentity = shelf.groupBy { documentIdentity(it.url) }
         val foundUrls = mutableSetOf<String>()
+        val duplicates = mutableListOf<String>()
 
         for (file in found) {
             val url = file.uri.toAbsoluteUrl() ?: continue
-            foundUrls += url.toString()
-            val existing = knownBooks[url.toString()]
+            val urlText = url.toString()
+            val identity = documentIdentity(urlText)
+            foundUrls += urlText
+            val aliases = identity
+                ?.let { id -> byIdentity[id].orEmpty().filter { it.url != urlText } }
+                .orEmpty()
+            // A row under the file's other spelling must survive this
+            // scan whatever its source says, or adopting it below would
+            // hand the book to a row that the pruning then deletes.
+            aliases.forEach { foundUrls += it.url }
+            val existing = knownBooks[urlText]
             when {
-                existing == null -> indexBook(url, source = treeUri.toString(), file.modifiedAt)
-                // The path is the same but the file behind it is not, so the
-                // title and cover we cached are no longer the book's.
-                file.modifiedAt != null && existing.fileModifiedAt != file.modifiedAt ->
-                    reindexBook(url, file.modifiedAt, existing.workId)
+                existing != null -> {
+                    // Any other spelling of a file the shelf already has
+                    // under this one is a duplicate an older version left.
+                    // Not one the reader took off the shelf, though:
+                    // that entry is theirs to put back, and deleting it
+                    // here would take it off the hidden list too.
+                    aliases.filterNot { it.hidden }.forEach { duplicates += it.url }
+                    // The path is the same but the file behind it is not, so the
+                    // title and cover we cached are no longer the book's.
+                    if (file.modifiedAt != null && existing.fileModifiedAt != file.modifiedAt) {
+                        reindexBook(url, file.modifiedAt, existing.workId)
+                    }
+                }
+                // The file is on the shelf already, under the name the
+                // single-file picker gave it. That row *is* the book —
+                // its URL is what the reader's place, marks and time all
+                // hang off — so the scan takes it as the entry for this
+                // file instead of adding a second one. Shelving the
+                // scanned spelling and then tidying up afterwards would
+                // only work while the picked entry had nothing on it,
+                // which is exactly the entry that has been read.
+                aliases.isNotEmpty() -> {
+                    val alias = aliases.first()
+                    // The entry keeps its URL but joins the folder, so
+                    // that it is pruned when the file goes and goes with
+                    // the folder when that is removed. A book picked by
+                    // hand belongs to nothing and would otherwise be
+                    // left behind by both.
+                    //
+                    // Only when it belongs to nothing. Two watched
+                    // folders can hold the same file — one inside the
+                    // other, most obviously — and taking the book off
+                    // whichever scanned first would let removing that
+                    // folder delete a book the other still holds.
+                    if (alias.source == null) {
+                        bookDao.setSource(alias.url, treeUri.toString())
+                    }
+                    if (file.modifiedAt != null && alias.fileModifiedAt != file.modifiedAt) {
+                        Uri.parse(alias.url).toAbsoluteUrl()
+                            ?.let { reindexBook(it, file.modifiedAt, alias.workId) }
+                    }
+                }
+                else -> indexBook(url, source = treeUri.toString(), file.modifiedAt)
             }
         }
 
         bookRemoval.deleteByUrls((knownUrls - foundUrls).toList())
+        bookRemoval.dropUntouchedDuplicates(duplicates)
     }
 
     private class ScannedEpub(val uri: Uri, val modifiedAt: Long?)

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/LibraryFilters.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/LibraryFilters.kt
@@ -133,6 +133,11 @@ data class LibraryFilters(
      * finished ones — see [hidesFinished].
      */
     fun accepts(book: Book, progression: Double? = null): Boolean {
+        // A book taken off the shelf is off it, whatever else is ticked
+        // — including the archived box, which is a different wish.
+        // Settings -> Hidden books is the one place it appears, and that
+        // list does not come through here.
+        if (book.hidden) return false
         // Checked before anything else, and never as one condition among
         // the rest: an archived book is out of every view but its own,
         // however well it matches the others.

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -241,7 +241,9 @@ class ReaderViewModel(
 
     val continuation: StateFlow<EndpaperContinuation?> = combine(
         combine(
-            bookDao.observeAll(),
+            // A book taken off the shelf is not offered as what to read
+            // next: the reader put it away.
+            bookDao.observeAll().map { books -> books.filterNot { it.hidden } },
             progressDao.observeProgressions(),
             dismissedNextUp,
             endpaperReached,
@@ -823,7 +825,10 @@ class ReaderViewModel(
             bookDao.observeAll()
                 .map { books ->
                     val current = books.firstOrNull { it.url == bookId } ?: return@map null
-                    seriesIdForExtras(current, books)
+                    // The book being read is what it is even if it has
+                    // been taken off the shelf elsewhere; its siblings
+                    // are only the ones still on it.
+                    seriesIdForExtras(current, books.filterNot { it.hidden })
                 }
                 .distinctUntilChanged()
                 .collect { seriesId ->

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
@@ -91,6 +91,7 @@ import kotlinx.coroutines.flow.Flow
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -170,6 +171,9 @@ fun LibraryScreen(
     onSetFinished: (Book, Boolean) -> Unit,
     onSetArchived: (Book, Boolean) -> Unit,
     onDeleteLocal: (Book) -> Unit,
+    onRemoveFromLibrary: (Book) -> Unit,
+    onUnhide: (String) -> Unit,
+    hiddenBooks: Flow<Book>,
     onDeleteFromServer: (Book, Boolean) -> Unit,
     onUploadToServer: (Book) -> Unit,
     onUploadPending: () -> Unit,
@@ -217,6 +221,7 @@ fun LibraryScreen(
     var sheetBook by remember { mutableStateOf<Book?>(null) }
     var confirmServerDelete by remember { mutableStateOf<Book?>(null) }
     var confirmLocalDelete by remember { mutableStateOf<Book?>(null) }
+    var confirmRemoveFromLibrary by remember { mutableStateOf<Book?>(null) }
     var confirmRemoveDownload by remember { mutableStateOf<Book?>(null) }
     var editSeriesOf by remember { mutableStateOf<Book?>(null) }
     val scope = rememberCoroutineScope()
@@ -231,6 +236,23 @@ fun LibraryScreen(
         deleteFailures.collect { failure ->
             val message = if (failure.onServer) serverDeleteFailed else localDeleteFailed
             snackbarHost.showSnackbar(message.format(failure.book.title))
+        }
+    }
+    // Removing a book from the library is quiet and easy to do by
+    // accident, and the entry it took away may be the one being read,
+    // so the way back is offered on the spot rather than only in
+    // Settings.
+    val hiddenMessage = stringResource(R.string.book_hidden)
+    val undoLabel = stringResource(R.string.undo)
+    LaunchedEffect(hiddenBooks) {
+        hiddenBooks.collect { book ->
+            val result = snackbarHost.showSnackbar(
+                message = hiddenMessage.format(book.title),
+                actionLabel = undoLabel,
+            )
+            if (result == SnackbarResult.ActionPerformed) {
+                onUnhide(book.url)
+            }
         }
     }
     LaunchedEffect(failedOpens) {
@@ -745,6 +767,17 @@ fun LibraryScreen(
         )
     }
 
+    confirmRemoveFromLibrary?.let { book ->
+        ConfirmRemoveFromLibraryDialog(
+            book = book,
+            onConfirm = {
+                onRemoveFromLibrary(book)
+                confirmRemoveFromLibrary = null
+            },
+            onDismiss = { confirmRemoveFromLibrary = null },
+        )
+    }
+
     confirmRemoveDownload?.let { book ->
         ConfirmRemoveDownloadDialog(
             book = book,
@@ -797,6 +830,7 @@ fun LibraryScreen(
             onOpenStats = { onOpenBookStats(book); sheetBook = null },
             onEditSeries = { editSeriesOf = book; sheetBook = null },
             onDeleteLocal = { confirmLocalDelete = book; sheetBook = null },
+            onRemoveFromLibrary = { confirmRemoveFromLibrary = book; sheetBook = null },
             onDeleteFromServer = { confirmServerDelete = book; sheetBook = null },
             onUploadToServer = { onUploadToServer(book); sheetBook = null },
         )
@@ -952,6 +986,29 @@ internal fun ConfirmLocalDeleteDialog(
     )
 }
 
+/**
+ * The check in front of taking a book off the shelf and keeping it.
+ *
+ * Not destructive, and said so: the whole point of the action is that
+ * the file survives it, and a reader who has just been warned about
+ * deleting one needs to see that this is the other thing.
+ */
+@Composable
+internal fun ConfirmRemoveFromLibraryDialog(
+    book: Book,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ConfirmBookActionDialog(
+        title = stringResource(R.string.remove_from_library),
+        warning = stringResource(R.string.remove_from_library_warning, book.title),
+        confirmLabel = stringResource(R.string.remove),
+        destructive = false,
+        onConfirm = onConfirm,
+        onDismiss = onDismiss,
+    )
+}
+
 /** The check in front of throwing away a copy the server can send again. */
 @Composable
 internal fun ConfirmRemoveDownloadDialog(
@@ -1026,6 +1083,7 @@ internal fun BookActionsSheet(
     onOpenStats: () -> Unit,
     onEditSeries: () -> Unit,
     onDeleteLocal: () -> Unit,
+    onRemoveFromLibrary: () -> Unit,
     onDeleteFromServer: () -> Unit,
     onUploadToServer: () -> Unit,
 ) {
@@ -1072,6 +1130,13 @@ internal fun BookActionsSheet(
                 else -> Unit
             }
             if (book.remoteUuid == null) {
+                Spacer(Modifier.height(8.dp))
+                // Above deleting, and deliberately: the gentler of the
+                // two is the one most people reaching here actually
+                // want, and it used not to exist at all (issue #147).
+                OutlinedButton(onClick = onRemoveFromLibrary, modifier = Modifier.fillMaxWidth()) {
+                    Text(stringResource(R.string.remove_from_library))
+                }
                 Spacer(Modifier.height(8.dp))
                 OutlinedButton(onClick = onDeleteLocal, modifier = Modifier.fillMaxWidth()) {
                     Text(stringResource(R.string.delete_file))

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
@@ -1129,14 +1129,20 @@ internal fun BookActionsSheet(
 
                 else -> Unit
             }
-            if (book.remoteUuid == null) {
+            // A book with a file of its own here, whether or not a
+            // server also knows about it. Uploading one keeps its local
+            // URL and its file, so it is still a shelf entry the reader
+            // may want gone without losing the file (issue #147).
+            if (book.openableUrl != null) {
                 Spacer(Modifier.height(8.dp))
                 // Above deleting, and deliberately: the gentler of the
                 // two is the one most people reaching here actually
-                // want, and it used not to exist at all (issue #147).
+                // want, and it used not to exist at all.
                 OutlinedButton(onClick = onRemoveFromLibrary, modifier = Modifier.fillMaxWidth()) {
                     Text(stringResource(R.string.remove_from_library))
                 }
+            }
+            if (book.remoteUuid == null) {
                 Spacer(Modifier.height(8.dp))
                 OutlinedButton(onClick = onDeleteLocal, modifier = Modifier.fillMaxWidth()) {
                     Text(stringResource(R.string.delete_file))

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryViewModel.kt
@@ -1474,5 +1474,12 @@ internal fun List<Book>.awaitingUpload(
     return filter { it.mayGoUp() && it.url !in refused }
 }
 
-/** Whether a book is one the server has not got and would be given. */
-internal fun Book.mayGoUp(): Boolean = livesOnlyOnThisDevice() && archivedAt == null
+/**
+ * Whether a book is one the server has not got and would be given.
+ *
+ * A book the reader has put away or taken off the shelf is not offered
+ * up. Sending it would put it on their other devices, which is the
+ * opposite of what they asked for.
+ */
+internal fun Book.mayGoUp(): Boolean =
+    livesOnlyOnThisDevice() && archivedAt == null && hiddenAt == null

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryViewModel.kt
@@ -62,6 +62,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
@@ -386,13 +387,30 @@ class LibraryViewModel(
     /** Deletions that did not happen, so the library can say so. */
     val deleteFailures: Flow<DeleteFailure> = _deleteFailures
 
-    private val _openImported = MutableSharedFlow<ImportedOpen>(extraBufferCapacity = 1)
-    /** A freshly shelved book, ready to be opened where it now lives. */
-    val openImported: Flow<ImportedOpen> = _openImported
+    private val _openImported = MutableStateFlow<ImportedOpen?>(null)
 
-    private val _alreadyShelved = MutableSharedFlow<Book>(extraBufferCapacity = 1)
+    /**
+     * A freshly shelved book, ready to be opened where it now lives.
+     *
+     * Held rather than announced once. Shelving a picked file reads its
+     * metadata and may hash it, which is long enough for the screen to
+     * be rebuilt underneath — a rotation, or coming back from the
+     * background — and an answer sent while nothing was listening left
+     * the reader with a picker that had apparently done nothing.
+     */
+    val openImported: StateFlow<ImportedOpen?> = _openImported.asStateFlow()
+
+    fun openImportedHandled() {
+        _openImported.value = null
+    }
+
+    private val _alreadyShelved = MutableStateFlow<Book?>(null)
     /** A picked file the library already had, for the reader to decide about. */
-    val alreadyShelved: Flow<Book> = _alreadyShelved
+    val alreadyShelved: StateFlow<Book?> = _alreadyShelved.asStateFlow()
+
+    fun alreadyShelvedHandled() {
+        _alreadyShelved.value = null
+    }
 
     private val _hiddenBook = MutableSharedFlow<Book>(extraBufferCapacity = 1)
     /** A book just taken off the shelf, so the removal can be undone. */
@@ -501,7 +519,11 @@ class LibraryViewModel(
             prompts.answered,
         ) { baseValues, query, searchActive, promptDismissed, answered ->
             @Suppress("UNCHECKED_CAST")
-            val books = baseValues[0] as List<Book>
+            // Taken out here rather than at each view, so that a book
+            // off the shelf is off every part of it: not counted, not
+            // filtered into anything, and not left inside a series pile
+            // whose other volumes are still showing.
+            val books = (baseValues[0] as List<Book>).filterNot { it.hidden }
             val recent = baseValues[1] as ContinueReading?
             val catalogStatus = baseValues[2] as CatalogStatus
             @Suppress("UNCHECKED_CAST")
@@ -1212,14 +1234,14 @@ class LibraryViewModel(
                     // reading position is keyed to the row, and opening
                     // under any other name records it where the shelf
                     // will never look.
-                    _openImported.emit(ImportedOpen(it, result.book.url))
+                    _openImported.value = ImportedOpen(it, result.book.url)
                 }
-                is ImportResult.AlreadyShelved -> _alreadyShelved.emit(result.book)
+                is ImportResult.AlreadyShelved -> _alreadyShelved.value = result.book
                 // Nothing readable came back, so the reader is left with
                 // the file they picked: opening it is still worth a try,
                 // and failing to shelve a book is no reason to refuse to
                 // show it.
-                ImportResult.Failed -> _openImported.emit(ImportedOpen(uri.toString(), null))
+                ImportResult.Failed -> _openImported.value = ImportedOpen(uri.toString(), null)
             }
         }
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryViewModel.kt
@@ -30,6 +30,7 @@ import com.chmouel.liseur.data.db.RefusedBytes
 import com.chmouel.liseur.data.db.UploadRefusal
 import com.chmouel.liseur.data.db.UploadRefusalDao
 import com.chmouel.liseur.data.library.FinishedState
+import com.chmouel.liseur.data.library.ImportResult
 import com.chmouel.liseur.data.library.LocalLibraryRepository
 import com.chmouel.liseur.data.settings.AppSettings
 import com.chmouel.liseur.data.settings.UploadPolicy
@@ -294,6 +295,13 @@ data class LibraryUiState(
  */
 data class DeleteFailure(val book: Book, val onServer: Boolean)
 
+/**
+ * A book to open after it was picked by hand: where its bytes are, and
+ * what the library calls it. The two differ for a book copied into the
+ * app's own storage, and the reading position follows the second.
+ */
+data class ImportedOpen(val url: String, val bookUrl: String?)
+
 @OptIn(ExperimentalCoroutinesApi::class)
 class LibraryViewModel(
     private val library: LocalLibraryRepository,
@@ -377,6 +385,18 @@ class LibraryViewModel(
     private val _deleteFailures = MutableSharedFlow<DeleteFailure>(extraBufferCapacity = 1)
     /** Deletions that did not happen, so the library can say so. */
     val deleteFailures: Flow<DeleteFailure> = _deleteFailures
+
+    private val _openImported = MutableSharedFlow<ImportedOpen>(extraBufferCapacity = 1)
+    /** A freshly shelved book, ready to be opened where it now lives. */
+    val openImported: Flow<ImportedOpen> = _openImported
+
+    private val _alreadyShelved = MutableSharedFlow<Book>(extraBufferCapacity = 1)
+    /** A picked file the library already had, for the reader to decide about. */
+    val alreadyShelved: Flow<Book> = _alreadyShelved
+
+    private val _hiddenBook = MutableSharedFlow<Book>(extraBufferCapacity = 1)
+    /** A book just taken off the shelf, so the removal can be undone. */
+    val hiddenBooks: Flow<Book> = _hiddenBook
 
     /**
      * What the connected account has refused, and whether it still would.
@@ -1173,10 +1193,52 @@ class LibraryViewModel(
         viewModelScope.launch { library.addFolder(treeUri) }
     }
 
-    /** Index a single picked file; the reader can open it right away. */
+    /**
+     * Indexes a single picked file, and says which book it turned out
+     * to be.
+     *
+     * A file picked by hand is very often one the library already has:
+     * the folder scan and the file picker spell the same document
+     * differently, and until this was resolved the book was shelved
+     * twice (issue #147). The reader is told rather than silently sent
+     * to the entry they already had, because being handed a book they
+     * did not think they owned is confusing in the other direction.
+     */
     fun importBook(uri: Uri) {
-        viewModelScope.launch { library.importBook(uri) }
+        viewModelScope.launch {
+            when (val result = library.importBook(uri)) {
+                is ImportResult.Added -> result.book.openableUrl?.let {
+                    // Named by its library row, not by the file: the
+                    // reading position is keyed to the row, and opening
+                    // under any other name records it where the shelf
+                    // will never look.
+                    _openImported.emit(ImportedOpen(it, result.book.url))
+                }
+                is ImportResult.AlreadyShelved -> _alreadyShelved.emit(result.book)
+                // Nothing readable came back, so the reader is left with
+                // the file they picked: opening it is still worth a try,
+                // and failing to shelve a book is no reason to refuse to
+                // show it.
+                ImportResult.Failed -> _openImported.emit(ImportedOpen(uri.toString(), null))
+            }
+        }
     }
+
+    /** Takes a book off the shelf without touching its file. */
+    fun removeFromLibrary(book: Book) {
+        viewModelScope.launch {
+            library.removeFromLibrary(book)
+            _hiddenBook.emit(book)
+        }
+    }
+
+    /** Puts a book back, from the undo notice or the hidden list alike. */
+    fun unhide(bookUrl: String) {
+        viewModelScope.launch { library.unhide(bookUrl) }
+    }
+
+    /** Books taken off the shelf, with their files left where they are. */
+    val hidden: Flow<List<Book>> = library.hidden
 
     /**
      * Sends one book the reader added here up to the server.

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/HiddenBooksScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/HiddenBooksScreen.kt
@@ -1,0 +1,108 @@
+package com.chmouel.liseur.ui.settings
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.chmouel.liseur.R
+import com.chmouel.liseur.data.db.Book
+import com.chmouel.liseur.ui.contentWidthCap
+import com.chmouel.liseur.ui.windowWidth
+
+/**
+ * Books taken off the shelf whose files were kept, and the way back.
+ *
+ * Taking an entry off the shelf leaves no trace anywhere else, and a
+ * removal a reader cannot see is one they cannot undo once the snackbar
+ * has gone. So the list is here, and so is the only thing anyone comes
+ * here to do.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HiddenBooksScreen(
+    hidden: List<Book>,
+    onUnhide: (Book) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    Scaffold(
+        modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        topBar = {
+            LargeTopAppBar(
+                title = { Text(stringResource(R.string.hidden_books)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.Outlined.ArrowBack,
+                            contentDescription = stringResource(R.string.back),
+                        )
+                    }
+                },
+                scrollBehavior = scrollBehavior,
+            )
+        },
+    ) { padding ->
+        Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.TopCenter) {
+            Column(
+                Modifier
+                    .widthIn(max = contentWidthCap(windowWidth()))
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 20.dp)
+                    .padding(bottom = 32.dp),
+            ) {
+                if (hidden.isEmpty()) {
+                    Text(
+                        text = stringResource(R.string.hidden_books_empty),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(vertical = 24.dp),
+                    )
+                } else {
+                    SettingsGroup(stringResource(R.string.hidden_books)) {
+                        hidden.forEachIndexed { index, book ->
+                            if (index > 0) RowDivider()
+                            ListItem(
+                                headlineContent = { Text(book.title) },
+                                supportingContent = book.author?.let { { Text(it) } },
+                                trailingContent = {
+                                    TextButton(onClick = { onUnhide(book) }) {
+                                        Text(stringResource(R.string.hidden_books_put_back))
+                                    }
+                                },
+                                colors = ListItemDefaults.colors(
+                                    containerColor = Color.Transparent,
+                                ),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.outlined.FileOpen
 import androidx.compose.material.icons.outlined.FileUpload
 import androidx.compose.material.icons.outlined.CloudDownload
 import androidx.compose.material.icons.outlined.TextFormat
+import androidx.compose.material.icons.outlined.VisibilityOff
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
@@ -75,6 +76,7 @@ fun SettingsScreen(
     onOpenAccount: () -> Unit,
     onOpenReadingAppearance: () -> Unit,
     onOpenReadingNavigation: () -> Unit,
+    onOpenHiddenBooks: () -> Unit,
     backup: AnnotationBackupUi,
     connections: ConnectionsState,
     onOpenAbout: () -> Unit,
@@ -234,6 +236,17 @@ fun SettingsScreen(
                         subtitle = stringResource(R.string.settings_group_series_detail),
                         checked = settings.libraryFilters.groupBySeries,
                         onCheckedChange = onGroupSeries,
+                    )
+                    ConnectionRow(
+                        icon = {
+                            Icon(
+                                Icons.Outlined.VisibilityOff,
+                                contentDescription = null,
+                            )
+                        },
+                        title = stringResource(R.string.hidden_books),
+                        subtitle = stringResource(R.string.hidden_books_summary),
+                        onClick = onOpenHiddenBooks,
                     )
                 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -434,6 +434,18 @@
     <string name="delete_local_failed">Could not delete the file for “%1$s”. Liseur may only be allowed to read that folder — add it again to grant deletion.</string>
     <string name="delete">Delete</string>
 
+    <string name="remove_from_library">Remove from library</string>
+    <string name="remove_from_library_warning">“%1$s” will be taken off the shelf. The file stays on this device, and you can put the book back from Settings → Hidden books.</string>
+    <string name="book_hidden">“%1$s” removed from the library.</string>
+    <string name="undo">Undo</string>
+    <string name="already_shelved_title">Already in your library</string>
+    <string name="already_shelved_message">“%1$s” is already on your shelf, so it was not added again.</string>
+    <string name="already_shelved_open">Open</string>
+    <string name="hidden_books">Hidden books</string>
+    <string name="hidden_books_summary">Books taken off the shelf whose files were kept</string>
+    <string name="hidden_books_empty">Nothing is hidden. Books you remove from the library without deleting their file are listed here.</string>
+    <string name="hidden_books_put_back">Put back</string>
+
     <string name="upload_to_server">Upload to server</string>
     <string name="upload_offer_title">Send to the server?</string>
     <plurals name="upload_offer_message">

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
@@ -977,10 +977,42 @@ class MigrationTest {
             }
     }
 
+    /**
+     * Upgrading does not take anything off the shelf. Every book that
+     * was showing before is still showing after, because being off the
+     * shelf is a thing the reader does and nothing else.
+     */
+    @Test
+    fun `a book from before is still on the shelf after upgrading`() {
+        helper.createDatabase(TEST_DB, 45).use { old ->
+            old.execSQL(
+                """
+                INSERT INTO books (
+                    url, title, author, cover_path, source, added_at, last_opened_at,
+                    download_state, series_checked, series_override, series_claim_pending,
+                    series_claim_reset, series_index_override
+                ) VALUES (
+                    'file:///kept', 'Golden Son', 'Pierce Brown', NULL, NULL, 1, 2,
+                    'LOCAL', 0, 0, 0, 0, 0
+                )
+                """.trimIndent(),
+            )
+        }
+
+        helper.runMigrationsAndValidate(TEST_DB, LATEST, true, *LiseurDatabase.MIGRATIONS)
+            .use { db ->
+                db.query("SELECT hidden_at FROM books WHERE url = 'file:///kept'")
+                    .use { cursor ->
+                        assertTrue(cursor.moveToFirst())
+                        assertTrue(cursor.isNull(0))
+                    }
+            }
+    }
+
     private companion object {
         const val TEST_DB = "migration-test.db"
 
         /** Kept in step with the `version` on [LiseurDatabase]. */
-        const val LATEST = 45
+        const val LATEST = 46
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/library/BookRemovalTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/library/BookRemovalTest.kt
@@ -9,8 +9,11 @@ import com.chmouel.liseur.data.db.AnnotationKind
 import com.chmouel.liseur.data.db.BookAnnotation
 import com.chmouel.liseur.data.db.DownloadState
 import com.chmouel.liseur.data.db.LiseurDatabase
+import com.chmouel.liseur.data.db.ReadingProgress
 import com.chmouel.liseur.data.db.ReadingSession
 import com.chmouel.liseur.data.db.WorkAlias
+import com.chmouel.liseur.domain.LibraryFilterOption
+import com.chmouel.liseur.domain.LibraryFilters
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -162,6 +165,134 @@ class BookRemovalTest {
         // contained them.
         assertNull(db.workIdentityDao().alias("gone", "peer"))
         assertNull(db.workIdentityDao().fingerprint("gone"))
+    }
+
+    @Test
+    fun `a duplicate entry with nothing on it goes`() = runTest {
+        // Issue #147: the same file shelved twice, once by the folder
+        // scan and once by the file picker, and the second entry never
+        // opened.
+        db.bookDao().upsert(book("tree"))
+        db.bookDao().upsert(book("picked"))
+
+        assertEquals(listOf("picked"), removal.dropUntouchedDuplicates(listOf("picked")))
+
+        assertNull(db.bookDao().getByUrl("picked"))
+        assertNotNull(db.bookDao().getByUrl("tree"))
+    }
+
+    @Test
+    fun `a duplicate that was read is left alone`() = runTest {
+        // Reading through Add Book recorded the position against the
+        // duplicate, so dropping it would throw away where someone had
+        // got to. Better a duplicate than that; the reader can remove
+        // it themselves.
+        db.bookDao().upsert(book("picked"))
+        db.readingProgressDao().upsert(
+            ReadingProgress(
+                bookUrl = "picked",
+                locatorJson = "{}",
+                totalProgression = 0.42,
+                updatedAt = 1L,
+            ),
+        )
+
+        assertEquals(emptyList<String>(), removal.dropUntouchedDuplicates(listOf("picked")))
+        assertNotNull(db.bookDao().getByUrl("picked"))
+    }
+
+    @Test
+    fun `a duplicate that was marked, synced or timed is left alone`() = runTest {
+        db.bookDao().upsert(book("marked"))
+        db.bookDao().upsert(book("synced"))
+        db.bookDao().upsert(book("timed"))
+        db.annotationDao().upsert(mark().copy(id = "mark-2", bookId = "marked"))
+        db.annotationSyncDao().upsert(syncRow().copy(id = "mark-3", bookId = "synced"))
+        db.readingSessionDao().insert(session("timed"))
+
+        assertEquals(
+            emptyList<String>(),
+            removal.dropUntouchedDuplicates(listOf("marked", "synced", "timed")),
+        )
+        assertNotNull(db.bookDao().getByUrl("marked"))
+        assertNotNull(db.bookDao().getByUrl("synced"))
+        assertNotNull(db.bookDao().getByUrl("timed"))
+    }
+
+    @Test
+    fun `a duplicate carrying something only it knows is left alone`() = runTest {
+        // None of this is on the entry that would be kept, so none of it
+        // can be dropped quietly: the uuid is the only reason an
+        // uploaded book is not sent again, and the rest are decisions
+        // the reader made.
+        db.bookDao().upsert(book("uploaded", remoteUuid = "uuid-1"))
+        db.bookDao().upsert(book("opened").copy(lastOpenedAt = 1_700_000_000))
+        db.bookDao().upsert(book("finished").copy(finishedAt = 1_700_000_000))
+        db.bookDao().upsert(book("archived").copy(archivedAt = 1_700_000_000))
+        db.bookDao().upsert(book("refiled").copy(seriesName = "By hand"))
+
+        val urls = listOf("uploaded", "opened", "finished", "archived", "refiled")
+        assertEquals(emptyList<String>(), removal.dropUntouchedDuplicates(urls))
+        urls.forEach { assertNotNull(db.bookDao().getByUrl(it)) }
+    }
+
+    @Test
+    fun `taking a book off the shelf keeps every part of it`() = runTest {
+        // The reader is told the book can be put back, so putting it
+        // back has to give them all of it, not a stranger with the same
+        // title: their place in it, their marks, their time, and every
+        // decision they made about where it was filed.
+        db.bookDao().upsert(
+            book("hidden").copy(
+                addedAt = 5,
+                lastOpenedAt = 1_700_000_000,
+                finishedAt = 1_700_000_001,
+                seriesName = "By hand",
+                seriesIndex = 3.0,
+            ),
+        )
+        db.readingProgressDao().upsert(
+            ReadingProgress(
+                bookUrl = "hidden",
+                locatorJson = """{"href":"one"}""",
+                totalProgression = 0.5,
+                updatedAt = 1,
+            ),
+        )
+        db.annotationDao().upsert(mark().copy(id = "mark-4", bookId = "hidden"))
+        db.readingSessionDao().insert(session("hidden"))
+        val was = db.bookDao().getByUrl("hidden")!!
+
+        db.bookDao().setHiddenAt("hidden", 42)
+
+        val whileHidden = db.bookDao().getByUrl("hidden")!!
+        assertEquals(true, whileHidden.hidden)
+        assertNotNull(db.readingProgressDao().get("hidden"))
+        assertEquals(1, db.annotationDao().count("hidden"))
+        assertEquals(1, db.readingSessionDao().countForBook("hidden"))
+
+        db.bookDao().setHiddenAt("hidden", null)
+
+        assertEquals(was, db.bookDao().getByUrl("hidden"))
+    }
+
+    @Test
+    fun `a book taken off the shelf is out of every view of it`() = runTest {
+        // Not archiving, which has a shelf of its own: this one is
+        // nowhere, including on the shelf the archived box shows.
+        val hidden = book("hidden").copy(hiddenAt = 42)
+        assertEquals(false, LibraryFilters().accepts(hidden))
+        assertEquals(
+            false,
+            LibraryFilters(setOf(LibraryFilterOption.ARCHIVED)).accepts(hidden),
+        )
+        assertEquals(true, LibraryFilters().accepts(hidden.copy(hiddenAt = null)))
+    }
+
+    @Test
+    fun `a url with no book behind it is not an error`() = runTest {
+        assertEquals(emptyList<String>(), removal.dropUntouchedDuplicates(listOf("nothing")))
+        assertEquals(emptyList<String>(), removal.dropUntouchedDuplicates(emptyList()))
     }
 
     private fun mark() = BookAnnotation(

--- a/app/src/test/kotlin/com/chmouel/liseur/data/library/DocumentIdentityTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/library/DocumentIdentityTest.kt
@@ -1,0 +1,89 @@
+package com.chmouel.liseur.data.library
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DocumentIdentityTest {
+
+    private val tree =
+        "content://com.android.externalstorage.documents/tree/" +
+            "primary%3ADocuments%2Fmybooks/document/" +
+            "primary%3ADocuments%2Fmybooks%2Fbook.epub"
+
+    private val picked =
+        "content://com.android.externalstorage.documents/document/" +
+            "primary%3ADocuments%2Fmybooks%2Fbook.epub"
+
+    @Test
+    fun `a scanned file and the same file picked by hand agree`() {
+        // Issue #147: one EPUB, two spellings, two shelf entries.
+        assertEquals(documentIdentity(tree), documentIdentity(picked))
+        assertTrue(sameDocument(tree, picked))
+    }
+
+    @Test
+    fun `different files in the same folder differ`() {
+        val other = picked.replace("book.epub", "other.epub")
+        assertNotEquals(documentIdentity(picked), documentIdentity(other))
+        assertFalse(sameDocument(tree, other))
+    }
+
+    @Test
+    fun `the same document id under another provider differs`() {
+        val elsewhere = picked.replace(
+            "com.android.externalstorage.documents",
+            "com.android.providers.downloads.documents",
+        )
+        assertNotEquals(documentIdentity(picked), documentIdentity(elsewhere))
+    }
+
+    @Test
+    fun `a query or fragment is not part of what the document is`() {
+        assertEquals(documentIdentity(picked), documentIdentity("$picked?page=3"))
+        assertEquals(documentIdentity(picked), documentIdentity("$picked#chapter"))
+    }
+
+    @Test
+    fun `escaping is compared decoded`() {
+        val decoded =
+            "content://com.android.externalstorage.documents/document/" +
+                "primary:Documents/mybooks/book.epub"
+        assertEquals(documentIdentity(picked), documentIdentity(decoded))
+    }
+
+    @Test
+    fun `a malformed escape is left alone rather than losing the id`() {
+        val trailing = "content://authority/document/book%"
+        assertEquals("authority\u0000book%", documentIdentity(trailing))
+    }
+
+    @Test
+    fun `a plus stays a plus`() {
+        // URLDecoder would read this as a space and merge two documents.
+        assertNotEquals(
+            documentIdentity("content://authority/document/a+b.epub"),
+            documentIdentity("content://authority/document/a b.epub"),
+        )
+    }
+
+    @Test
+    fun `urls with no document have no identity`() {
+        assertNull(documentIdentity("file:///storage/emulated/0/Books/book.epub"))
+        assertNull(documentIdentity("https://example.org/book.epub"))
+        assertNull(documentIdentity("content://com.example.provider/books/7"))
+        assertNull(documentIdentity("content:///document/x"))
+        assertNull(documentIdentity("content://authority/document/"))
+        assertNull(documentIdentity(""))
+    }
+
+    @Test
+    fun `urls without an identity fall back to being compared as strings`() {
+        val file = "file:///storage/emulated/0/Books/book.epub"
+        assertTrue(sameDocument(file, file))
+        assertFalse(sameDocument(file, "file:///storage/emulated/0/Books/other.epub"))
+    }
+}


### PR DESCRIPTION
## Summary

Adding an EPUB with **+ → Add Book** shelved it a second time when the file
was already in a watched folder. Android hands the same document out under
two names — one built against the folder tree, one from the single-file
picker — and `books.url` was the only thing anyone compared, so the second
name looked like a new book. The reporter was then stuck with it: the only
way out of the library was **Delete file**.

Fixes #147.

## Changes

- **Add Book recognises the file.** It matches on what the document *is*
  (authority plus document id) before what it is called, and falls back to
  the file's contents for a genuine second copy at another path. Hashing is
  confined to rows that already claim to be the same work, so the usual
  answer costs one metadata read.
- **It says so.** A known book raises *Already in your library* with **Open**
  — which opens the entry that is already there, so the reading position
  lands where the shelf can see it — rather than silently shelving or
  silently opening a new row.
- **Remove from library.** A gentler action above *Delete file* that takes the
  entry off the shelf and leaves the file where it is, with an undo snackbar
  and a **Settings → Library → Hidden books** list to put anything back later.
- **Nothing is lost by removing an entry.** The row is marked with `hidden_at`
  rather than deleted, so the reader's place, their highlights and notes, the
  time they spent and everything a sync server has been told about the book
  all come back untouched. Hiding and restoring are one write each, so there
  is no moment where a book is neither on the shelf nor on the hidden list.
- **Duplicates earlier versions made** are cleared by the next folder scan,
  but only rows with no progress, no annotations, no sync state and no
  reading sessions on them. A duplicate that has been read is left alone —
  the reader can now remove it by hand.
- Schema 45 → 46 adds one nullable column to `books`.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

On `emulator-5554`, against a fresh install and a 16-book demo shelf:

1. **+ → Add Book** on a file already in the watched folder → the dialog
   below, shelf still 16 books, no second row.
2. Long-press → **Remove from library** → shelf 15, the `books` row still
   there with `hidden_at` set, the file still on disk, undo offered.
3. Pull-to-refresh → the book stays off the shelf.
4. **Settings → Hidden books → Put back** → back to 16, with its original
   `added_at` and folder source intact.
5. **Add Book** on a book that had been removed → it comes back and opens,
   rather than being reported as already there.

## Screenshots or recordings

Already in your library, and the actions sheet with the new entry:

<img src="https://github.com/user-attachments/assets/a305d5f8-925f-4334-b1ff-f897fc7e1fa0" width="300"> <img src="https://github.com/user-attachments/assets/d8dd05fd-dfae-4d5d-88f2-2853a211128a" width="300">

Confirming the removal, the undo, and the way back:

<img src="https://github.com/user-attachments/assets/a45abb82-8bcd-40fa-a510-fd4c4068f5b8" width="250"> <img src="https://github.com/user-attachments/assets/aad99e12-9783-4955-9bf2-79c2773da128" width="250"> <img src="https://github.com/user-attachments/assets/e2c97bf7-4bd4-40c6-a54f-3cb9743b9a3a" width="250">

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
