### PR TITLE
feat: Add a dev build type for side-by-side installation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,24 @@ make stop                            # stop the selected emulator
 make shutdown                        # shut down the selected emulator
 ```
 
+For trying a change on a phone that already has the real app on it,
+there is a second build with its own package name:
+
+```bash
+make dev                             # build the side-by-side APK
+make dev-install                     # install it beside the real app
+make dev-run                         # install it and launch it
+make dev-uninstall                   # remove it
+make dev-logcat                      # tail its logs
+```
+
+It is the debug build in every respect but two: it is
+`com.chmouel.liseur.dev`, and it says "Liseur (dev)" under a differently
+tinted icon. The package name is the point — it gets its own database,
+its own settings and its own folder grant, so it cannot reach the
+installed app's library, and it opens empty the first time. `release` is
+untouched by all of this, so F-Droid's rebuild is unaffected.
+
 The default AVD is `liseur_phone_api36`. Override it when needed:
 
 ```bash
@@ -61,6 +79,12 @@ uninstall the app, clear its storage, or write to its database on a
 real device without asking first.** A reading position, a highlight and
 a half-finished note are not reproducible, and an unlucky
 `adb install -r` takes them.
+
+`make dev-install` is the way to put a change on a phone without asking
+that question: it carries its own package name, so it lands next to the
+real app instead of over it. It is still an install on somebody's
+device, so it is still worth saying you are about to do it — but nothing
+it does can reach the library that matters.
 
 When several devices are attached, always pass `-s` / `SERIAL=` rather
 than letting `adb` choose. `adb devices` reports emulators as

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -18,7 +18,7 @@ Manager package list).
 ./gradlew bundleRelease    # minified release AAB, for Google Play only
 ```
 
-Output APKs land in `app/build/outputs/apk/{debug,release}/`, and the
+Output APKs land in `app/build/outputs/apk/{debug,dev,release}/`, and the
 bundle in `app/build/outputs/bundle/release/`.
 
 The debug build is signed with the standard Android debug key, so
@@ -26,6 +26,52 @@ The debug build is signed with the standard Android debug key, so
 sideloading. The release build is unsigned by default so the project
 builds out of the box on any machine/CI; see below if you want a signed
 release build.
+
+### The dev build, for testing on a phone you use
+
+The debug build carries the production `applicationId`, so installing it
+on a phone that already has Liseur on it *replaces* Liseur. The library
+that goes with it — reading positions, highlights, notes, sessions —
+does not come back.
+
+The `dev` build type exists so that does not have to happen:
+
+```bash
+make dev             # ./gradlew assembleDev
+make dev-install     # adb install -r, beside the real app
+make dev-run         # install and launch
+make dev-uninstall
+make dev-logcat      # logcat filtered to its pid
+```
+
+It is the debug build with two differences, both deliberate:
+
+- `applicationId` is `com.chmouel.liseur.dev`. Android keys an app's
+  storage off that, so the dev build gets its own Room database, its own
+  DataStore and its own SAF grant. It cannot read or damage the real
+  app's library, and the first thing it will ask for is a folder,
+  because it genuinely has none. Connecting a server is likewise a fresh
+  connection, with its own device key.
+- The launcher name is "Liseur (dev)" and the icon field is retinted, so
+  the two are told apart before either is opened. That is the whole of
+  `app/src/dev/res/`.
+
+The APK lands in `app/build/outputs/apk/dev/app-dev.apk`, debug-signed
+like `app-debug.apk`.
+
+`release` is not involved anywhere in this, which is the point: F-Droid
+rebuilds that build type byte for byte from the tag, and nothing here
+changes what it produces. `debug` is not involved either, so
+`make install`, `make run`, `make reset`, `hack/screenshots`,
+`hack/e2e-*` and the scenarios under `tests/` keep the package name they
+hardcode and go on working against the emulator unchanged.
+
+One thing to watch if you drive it by hand: `adb shell am start -n
+com.chmouel.liseur.dev/.MainActivity` does *not* work. The `.Class`
+shorthand is relative to the application id, and the dev build's no
+longer matches the namespace the class lives in, so the component has to
+be spelled `com.chmouel.liseur.dev/com.chmouel.liseur.MainActivity`.
+The Makefile already does.
 
 ### Signing a release build (optional)
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,16 @@ PACKAGE := com.chmouel.liseur
 ACTIVITY := $(PACKAGE)/.MainActivity
 DEBUG_APK := app/build/outputs/apk/debug/app-debug.apk
 
-.PHONY: help build debug release bundle test lint check verify-fdroid-tags e2e clean emulator stop shutdown install run run-bg reset screenshots icon feature-graphic store-status
+# The side-by-side build, for trying a change on a phone that already has
+# the real app on it. The component name is spelled out rather than
+# abbreviated to `.MainActivity`, because that shorthand is relative to
+# the application id and the dev build's no longer matches the namespace
+# the class lives in.
+DEV_PACKAGE := $(PACKAGE).dev
+DEV_ACTIVITY := $(DEV_PACKAGE)/$(PACKAGE).MainActivity
+DEV_APK := app/build/outputs/apk/dev/app-dev.apk
+
+.PHONY: help build debug release bundle test lint check verify-fdroid-tags e2e clean emulator stop shutdown install run run-bg reset screenshots icon feature-graphic store-status dev dev-install dev-run dev-uninstall dev-logcat
 
 help:
 	@printf '%s\n' \
@@ -32,6 +41,11 @@ help:
 		'make run-bg            Start the emulator, install, and launch without scrcpy' \
 		'make reset             Reinstall the app, wipe its storage, and reseed a demo library' \
 		'make clean             Remove build outputs' \
+		'make dev               Build the side-by-side APK ($(DEV_PACKAGE))' \
+		'make dev-install       Build and install it beside the real app' \
+		'make dev-run           Install it and launch it' \
+		'make dev-uninstall     Remove it' \
+		'make dev-logcat        Tail its logs' \
 		'make screenshots       Capture the UI screenshots' \
 		'make icon              Generate the store icon' \
 		'make feature-graphic   Generate the store feature graphic' \
@@ -101,6 +115,33 @@ run: run-bg
 
 reset: run-bg
 	./hack/reset-books -s $(SERIAL)
+
+# The side-by-side build. Everything above installs over whatever carries
+# the production package name, which on a phone is somebody's library; the
+# targets below carry their own package name and cannot reach it. The
+# device is still chosen with SERIAL= like everywhere else, and still
+# defaults to the emulator.
+dev:
+	$(GRADLE) assembleDev
+
+dev-install: dev
+	$(ADB) $(ADB_TARGET) install -r '$(DEV_APK)'
+
+dev-run: dev-install
+	$(ADB) $(ADB_TARGET) shell am start -n '$(DEV_ACTIVITY)'
+
+dev-uninstall:
+	$(ADB) $(ADB_TARGET) uninstall '$(DEV_PACKAGE)'
+
+# Filtered by pid rather than by tag: the app logs under a dozen of them,
+# and the pid is the one thing that says "this build and not the other".
+dev-logcat:
+	@pid=$$($(ADB) $(ADB_TARGET) shell pidof '$(DEV_PACKAGE)' 2>/dev/null | tr -d '\r' | awk '{print $$1}'); \
+	if [ -z "$$pid" ]; then \
+		printf 'error: %s is not running; start it with make dev-run\n' '$(DEV_PACKAGE)' >&2; \
+		exit 1; \
+	fi; \
+	$(ADB) $(ADB_TARGET) logcat --pid="$$pid"
 
 screenshots:
 	./hack/screenshots

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,26 @@ android {
         debug {
             isMinifyEnabled = false
         }
+        // A build that installs *beside* the real app rather than over
+        // it. The debug build carries the production applicationId, so
+        // pushing a work in progress to a phone replaces a library —
+        // reading positions, highlights, notes — that cannot be rebuilt.
+        // The suffix gives this one its own package name, and with it
+        // its own database, DataStore and SAF grant, so the installed
+        // app is never touched.
+        //
+        // Only the id and the label differ: it is the debug build in
+        // every other respect, debug-signed and unminified, so what is
+        // tested here behaves the way `make run` behaves on the
+        // emulator. `release` is deliberately not its base — F-Droid
+        // rebuilds that one byte for byte, and nothing here should be
+        // able to reach it.
+        create("dev") {
+            initWith(getByName("debug"))
+            applicationIdSuffix = ".dev"
+            versionNameSuffix = "-dev"
+            isMinifyEnabled = false
+        }
     }
 
     compileOptions {

--- a/app/src/dev/res/values/colors.xml
+++ b/app/src/dev/res/values/colors.xml
@@ -1,0 +1,7 @@
+<resources>
+    <!-- The field behind the launcher and splash artwork, in a colour
+         the real app never wears. The two icons sit next to each other
+         on the launcher, and a name under an identical mark is not a
+         difference you notice before tapping the wrong one. -->
+    <color name="logo_field">#B7D5E4</color>
+</resources>

--- a/app/src/dev/res/values/strings.xml
+++ b/app/src/dev/res/values/strings.xml
@@ -1,0 +1,5 @@
+<resources>
+    <!-- The name on the launcher, so the build under test and the real
+         app are told apart before either is opened. -->
+    <string name="app_name">Liseur (dev)</string>
+</resources>


### PR DESCRIPTION
Installing the debug build on a personal device replaced the production
app, wiping user reading positions, notes, and local library data.
A dedicated dev build variant was introduced with a distinct package
identifier, updated launcher branding, and developer tooling so test
builds could run safely alongside the real app without risking personal
data.

Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>

## Summary

<!-- What does this change do, and why? Link related issues with "Fixes #123". -->

## Changes

-

## Testing

- [ ] `./gradlew testDebugUnitTest`
- [ ] `./gradlew lintDebug`
- [ ] `./gradlew assembleDebug`
- [ ] Manually tested on a device or emulator, if applicable

## Screenshots or recordings

<!-- Include before/after visuals for UI changes. Remove personal information. -->

## Checklist

- [ ] I have kept this change focused and documented any user-facing behaviour.
- [ ] I have added or updated tests where needed.
- [ ] I have checked that dependencies remain FOSS and available from allowed repositories.
- [ ] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
