### PR TITLE
feat: pinch the page to resize text, or a picture to see it full screen

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -321,6 +321,7 @@ private fun LiseurApp(settings: AppSettings) {
                 vendorName = context.container.eInkDisplay.vendor,
                 onVolumeKeys = { scope.launch { repository.setVolumeKeysTurnPages(it) } },
                 onTapZones = { scope.launch { repository.setTapZones(it) } },
+                onPinchToResize = { scope.launch { repository.setPinchToResize(it) } },
                 onResumeLastBook = { scope.launch { repository.setResumeLastBook(it) } },
                 onScrollMode = { scope.launch { repository.setScrollMode(it) } },
                 onKeepScreenOn = { scope.launch { repository.setKeepScreenOn(it) } },

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
@@ -143,6 +143,11 @@ enum class DefinitionTarget(val id: String) {
  *   what you get back by turning it off, and what older phones always get.
  * @param volumeKeysTurnPages Volume keys page forward and back while reading.
  * @param tapZones Which side of a paginated page turns forward.
+ * @param pinchToResize A two-finger pinch on the page changes the reading
+ *   font size. On by default; it is here for a grip that produces stray
+ *   two-finger touches, since a stray resize changes how every page looks
+ *   from then on. Pinching an image to enlarge it is not covered: that one
+ *   is one visible thing, dismissed with a tap.
  * @param resumeLastBook Opening the app goes back into the book you were in.
  * @param keepScreenOn The screen stays awake while a book is open. Off
  *   until asked for: it costs battery, and it overrides a device setting
@@ -175,6 +180,7 @@ data class AppSettings(
     val dynamicColor: Boolean = true,
     val volumeKeysTurnPages: Boolean = true,
     val tapZones: TapZones = TapZones.Default,
+    val pinchToResize: Boolean = true,
     val resumeLastBook: Boolean = true,
     val keepScreenOn: Boolean = false,
     val scrollMode: Boolean = false,
@@ -224,6 +230,7 @@ class AppSettingsRepository(private val context: Context) {
         val DYNAMIC_COLOR = booleanPreferencesKey("dynamic_color")
         val VOLUME_KEYS = booleanPreferencesKey("volume_keys_turn_pages")
         val TAP_ZONES = stringPreferencesKey("tap_zones")
+        val PINCH_TO_RESIZE = booleanPreferencesKey("pinch_to_resize")
         val RESUME_LAST_BOOK = booleanPreferencesKey("resume_last_book")
         val KEEP_SCREEN_ON = booleanPreferencesKey("keep_screen_on")
         val SCROLL_MODE = booleanPreferencesKey("scroll_mode")
@@ -263,6 +270,7 @@ class AppSettingsRepository(private val context: Context) {
             dynamicColor = p[Keys.DYNAMIC_COLOR] ?: true,
             volumeKeysTurnPages = p[Keys.VOLUME_KEYS] ?: true,
             tapZones = TapZones.fromId(p[Keys.TAP_ZONES]),
+            pinchToResize = p[Keys.PINCH_TO_RESIZE] ?: true,
             resumeLastBook = p[Keys.RESUME_LAST_BOOK] ?: true,
             keepScreenOn = p[Keys.KEEP_SCREEN_ON] ?: false,
             scrollMode = p[Keys.SCROLL_MODE] ?: false,
@@ -308,6 +316,10 @@ class AppSettingsRepository(private val context: Context) {
 
     suspend fun setTapZones(zones: TapZones) {
         context.appSettingsStore.edit { it[Keys.TAP_ZONES] = zones.id }
+    }
+
+    suspend fun setPinchToResize(enabled: Boolean) {
+        context.appSettingsStore.edit { it[Keys.PINCH_TO_RESIZE] = enabled }
     }
 
     suspend fun setResumeLastBook(enabled: Boolean) {

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPrefs.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPrefs.kt
@@ -597,6 +597,19 @@ data class ReaderPrefs(
     companion object {
         const val MIN_FONT_SIZE = 0.6
         const val MAX_FONT_SIZE = 2.5
+
+        /**
+         * How many sizes the reader can actually choose between.
+         *
+         * The Size slider and the pinch gesture must land on the same
+         * values or a book resized by one and then nudged by the other
+         * jumps, so the count lives here and both read it. A `Slider`
+         * counts the notches *between* its ends, hence the two.
+         *
+         * @see FONT_SIZE_SLIDER_STEPS
+         */
+        const val FONT_SIZE_POSITIONS = 19
+        const val FONT_SIZE_SLIDER_STEPS = FONT_SIZE_POSITIONS - 2
     }
 }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ImageAtPoint.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ImageAtPoint.kt
@@ -1,17 +1,22 @@
 package com.chmouel.liseur.reader
 
+import android.webkit.WebView
+import kotlin.coroutines.resume
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.json.JSONObject
-import org.readium.r2.navigator.epub.EpubNavigatorFragment
-import org.readium.r2.shared.ExperimentalReadiumApi
 
 /**
  * What image, if any, is under a point on the page.
  *
- * Injected into the book's own document, the way [WideContentFit] is,
- * because Readium 3.3.0 tells nobody about images: its `InputListener`
- * is `onTap`, `onDrag` and `onKey`, and its navigator listener knows
- * about links and jumps. The only thing that can answer "is that a
- * picture" is the document.
+ * Injected into the book's own document, because Readium 3.3.0 tells
+ * nobody about images: its `InputListener` is `onTap`, `onDrag` and
+ * `onKey`, and its navigator listener knows about links and jumps. The
+ * only thing that can answer "is that a picture" is the document.
+ *
+ * Asked of the web view directly rather than through
+ * `EpubNavigatorFragment.evaluateJavascript`, which answers null on a
+ * fixed-layout book — and a fixed-layout book is very often nothing but
+ * pictures, so that is exactly where the question matters most.
  *
  * See `docs/adr/0022-pinch-on-the-page.md`.
  */
@@ -43,18 +48,30 @@ internal object ImageAtPoint {
     const val MIN_RENDERED_PX = 48
 
     /**
-     * `epub:type` roles that name an image as furniture rather than as
+     * The words a book uses for a picture that is furniture rather than
      * something to look at.
      *
      * Size alone is not enough. The imprint page of every Standard Ebook
      * carries a publisher logo drawn around 76 CSS pixels wide — over any
      * threshold meant to exclude an ornament, and still nothing anyone
-     * wants full screen. The markup says what it is, so it is read.
+     * wants full screen. The title page is worse: its lettering is a
+     * picture the width of the column. The markup says what both are, so
+     * it is read.
+     *
+     * Read off the image and off the few elements above it, because the
+     * word that matters is often on the section rather than on the image:
+     * a title page's `<img>` says nothing, its `<section>` says
+     * `titlepage`.
      */
     private val DECORATIVE = listOf(
         "publisher-logo",
         "ornament",
         "footnote-separator",
+        "titlepage",
+        "halftitlepage",
+        "colophon",
+        "imprint",
+        "copyright-page",
     )
 
     /**
@@ -82,11 +99,39 @@ internal object ImageAtPoint {
      * the element what images it contains. Both are bounded: an unbounded
      * walk ends at `<body>`, which contains every image in the chapter.
      */
-    fun script(x: Float, y: Float): String = """
+    fun script(fx: Float, fy: Float): String = """
         (function () {
           var MIN = $MIN_RENDERED_PX;
+          // The point arrives as a fraction of the web view rather than
+          // in pixels. A fixed-layout page is drawn at whatever scale it
+          // takes to fit the screen, so device pixels divided by the
+          // display density are not CSS pixels there; a fraction of the
+          // viewport is the same fraction in either kind of book.
+          var VW = window.innerWidth || document.documentElement.clientWidth;
+          var VH = window.innerHeight || document.documentElement.clientHeight;
+          var px = $fx * VW;
+          var py = $fy * VH;
           var DECOR = ${DECORATIVE.joinToString(prefix = "[", postfix = "]") { "\"$it\"" }};
-          var el = document.elementFromPoint($x, $y);
+          var OPS = "http://www.idpf.org/2007/ops";
+          // What the book calls this element. The epub:type attribute is
+          // rewritten into a class name by the time the document is on
+          // screen, so both spellings are read and neither is trusted to
+          // be the one that survived.
+          function roleOf(e) {
+            if (!e || !e.getAttribute) return "";
+            var ns = "";
+            try { ns = e.getAttributeNS(OPS, "type") || ""; } catch (err) {}
+            return ((e.getAttribute("epub:type") || "") + " " + ns + " " +
+                    (e.getAttribute("class") || "")).toLowerCase();
+          }
+          function decorative(e) {
+            var role = roleOf(e);
+            for (var d = 0; d < DECOR.length; d++) {
+              if (role.indexOf(DECOR[d]) !== -1) return true;
+            }
+            return false;
+          }
+          var el = document.elementFromPoint(px, py);
           var img = null;
           for (var i = 0; el && i < 4; i++) {
             if (el.tagName && (el.tagName.toLowerCase() === "img" ||
@@ -100,11 +145,8 @@ internal object ImageAtPoint {
           }
           if (!img) return null;
 
-          var role = (img.getAttribute("epub:type") ||
-                      img.getAttributeNS("http://www.idpf.org/2007/ops", "type") ||
-                      "").toLowerCase();
-          for (var d = 0; d < DECOR.length; d++) {
-            if (role.indexOf(DECOR[d]) !== -1) return null;
+          for (var up = img, j = 0; up && j < 5; up = up.parentElement, j++) {
+            if (decorative(up)) return null;
           }
 
           var box = img.getBoundingClientRect();
@@ -145,13 +187,21 @@ internal object ImageAtPoint {
     }
 
     /** True when the resource on screen has an image anywhere in it. */
-    @OptIn(ExperimentalReadiumApi::class)
-    suspend fun hasImages(navigator: EpubNavigatorFragment): Boolean =
-        runCatching { navigator.evaluateJavascript(HAS_IMAGES_SCRIPT) }
-            .getOrNull()?.trim() == "true"
+    suspend fun hasImages(web: WebView): Boolean =
+        eval(web, HAS_IMAGES_SCRIPT)?.trim() == "true"
 
-    /** The image under ([x], [y]), given in the page's own CSS pixels. */
-    @OptIn(ExperimentalReadiumApi::class)
-    suspend fun at(navigator: EpubNavigatorFragment, x: Float, y: Float): Hit? =
-        parse(runCatching { navigator.evaluateJavascript(script(x, y)) }.getOrNull())
+    /**
+     * The image under a point, given as a fraction of [web]'s own width
+     * and height rather than in pixels of either kind.
+     */
+    suspend fun at(web: WebView, fx: Float, fy: Float): Hit? = parse(eval(web, script(fx, fy)))
+
+    private suspend fun eval(web: WebView, js: String): String? =
+        suspendCancellableCoroutine { cont ->
+            try {
+                web.evaluateJavascript(js) { if (cont.isActive) cont.resume(it) }
+            } catch (e: Exception) {
+                if (cont.isActive) cont.resume(null)
+            }
+        }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ImageAtPoint.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ImageAtPoint.kt
@@ -1,0 +1,157 @@
+package com.chmouel.liseur.reader
+
+import org.json.JSONObject
+import org.readium.r2.navigator.epub.EpubNavigatorFragment
+import org.readium.r2.shared.ExperimentalReadiumApi
+
+/**
+ * What image, if any, is under a point on the page.
+ *
+ * Injected into the book's own document, the way [WideContentFit] is,
+ * because Readium 3.3.0 tells nobody about images: its `InputListener`
+ * is `onTap`, `onDrag` and `onKey`, and its navigator listener knows
+ * about links and jumps. The only thing that can answer "is that a
+ * picture" is the document.
+ *
+ * See `docs/adr/0022-pinch-on-the-page.md`.
+ */
+internal object ImageAtPoint {
+
+    /**
+     * An image worth opening full screen.
+     *
+     * @param src The URL the page actually resolved, absolute.
+     * @param alt The book's own caption for it, if it wrote one.
+     * @param width Its natural width in pixels, or zero if unknown.
+     * @param height Its natural height in pixels, or zero if unknown.
+     */
+    data class Hit(
+        val src: String,
+        val alt: String?,
+        val width: Int,
+        val height: Int,
+    )
+
+    /**
+     * The smallest an image can be drawn and still be worth enlarging, in
+     * CSS pixels.
+     *
+     * Below this it is punctuation: a drop cap, an inline rule, the
+     * dingbat between two scenes. Opening a viewer over one of those is a
+     * gesture the reader did not mean.
+     */
+    const val MIN_RENDERED_PX = 48
+
+    /**
+     * `epub:type` roles that name an image as furniture rather than as
+     * something to look at.
+     *
+     * Size alone is not enough. The imprint page of every Standard Ebook
+     * carries a publisher logo drawn around 76 CSS pixels wide — over any
+     * threshold meant to exclude an ornament, and still nothing anyone
+     * wants full screen. The markup says what it is, so it is read.
+     */
+    private val DECORATIVE = listOf(
+        "publisher-logo",
+        "ornament",
+        "footnote-separator",
+    )
+
+    /**
+     * Whether this resource has any image at all.
+     *
+     * Asked once per resource and remembered, because the answer is no
+     * for most pages of most books, and a no means no script runs when
+     * the reader puts two fingers on the page.
+     */
+    const val HAS_IMAGES_SCRIPT: String =
+        "(document.images.length > 0 || !!document.querySelector('svg image'))"
+
+    /**
+     * The hit test itself.
+     *
+     * `currentSrc` before `src`, and this is not a detail. Given
+     * `srcset="logo-2x.png 2x, logo.png 1x"` any screen above 1x displays
+     * the 2x file, and `src` names the 1x one — so a viewer built from
+     * `src` would open a *lower*-resolution copy of the picture the
+     * reader is looking at, which is the exact opposite of the point.
+     *
+     * `elementFromPoint` answers with the topmost element, which over a
+     * picture is often a link or a `<figure>`'s own text node rather than
+     * the image, so it walks up a few levels and then, failing that, asks
+     * the element what images it contains. Both are bounded: an unbounded
+     * walk ends at `<body>`, which contains every image in the chapter.
+     */
+    fun script(x: Float, y: Float): String = """
+        (function () {
+          var MIN = $MIN_RENDERED_PX;
+          var DECOR = ${DECORATIVE.joinToString(prefix = "[", postfix = "]") { "\"$it\"" }};
+          var el = document.elementFromPoint($x, $y);
+          var img = null;
+          for (var i = 0; el && i < 4; i++) {
+            if (el.tagName && (el.tagName.toLowerCase() === "img" ||
+                               el.tagName.toLowerCase() === "image")) {
+              img = el;
+              break;
+            }
+            var inner = el.querySelector ? el.querySelector("img, svg image") : null;
+            if (inner) { img = inner; break; }
+            el = el.parentElement;
+          }
+          if (!img) return null;
+
+          var role = (img.getAttribute("epub:type") ||
+                      img.getAttributeNS("http://www.idpf.org/2007/ops", "type") ||
+                      "").toLowerCase();
+          for (var d = 0; d < DECOR.length; d++) {
+            if (role.indexOf(DECOR[d]) !== -1) return null;
+          }
+
+          var box = img.getBoundingClientRect();
+          if (box.width < MIN || box.height < MIN) return null;
+
+          var src = img.currentSrc || img.src ||
+                    (img.href && img.href.baseVal) ||
+                    img.getAttribute("xlink:href") || "";
+          if (typeof src !== "string" || !src) return null;
+          var abs = src;
+          try { abs = new URL(src, document.baseURI).href; } catch (e) {}
+
+          return {
+            src: abs,
+            alt: img.getAttribute("alt") || "",
+            width: img.naturalWidth || Math.round(box.width),
+            height: img.naturalHeight || Math.round(box.height)
+          };
+        })();
+    """
+
+    /**
+     * `evaluateJavascript` hands back the JSON encoding of the value, so
+     * an object arrives as an object and a miss arrives as the four
+     * characters `null`.
+     */
+    fun parse(result: String?): Hit? {
+        val raw = result?.trim().orEmpty()
+        if (raw.isEmpty() || raw == "null") return null
+        val json = runCatching { JSONObject(raw) }.getOrNull() ?: return null
+        val src = json.optString("src").takeIf { it.isNotBlank() } ?: return null
+        return Hit(
+            src = src,
+            alt = json.optString("alt").takeIf { it.isNotBlank() },
+            width = json.optInt("width"),
+            height = json.optInt("height"),
+        )
+    }
+
+    /** True when the resource on screen has an image anywhere in it. */
+    @OptIn(ExperimentalReadiumApi::class)
+    suspend fun hasImages(navigator: EpubNavigatorFragment): Boolean =
+        runCatching { navigator.evaluateJavascript(HAS_IMAGES_SCRIPT) }
+            .getOrNull()?.trim() == "true"
+
+    /** The image under ([x], [y]), given in the page's own CSS pixels. */
+    @OptIn(ExperimentalReadiumApi::class)
+    suspend fun at(navigator: EpubNavigatorFragment, x: Float, y: Float): Hit? =
+        parse(runCatching { navigator.evaluateJavascript(script(x, y)) }.getOrNull())
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ImageAtPoint.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ImageAtPoint.kt
@@ -27,13 +27,17 @@ internal object ImageAtPoint {
      * An image worth opening full screen.
      *
      * @param src The URL the page actually resolved, absolute.
-     * @param alt The book's own caption for it, if it wrote one.
+     * @param alt What the book says the picture *is*, for a screen
+     *   reader. Not a caption, whatever it reads like.
+     * @param caption The book's own visible caption, taken from a
+     *   `<figcaption>` in the figure the picture sits in, if there is one.
      * @param width Its natural width in pixels, or zero if unknown.
      * @param height Its natural height in pixels, or zero if unknown.
      */
     data class Hit(
         val src: String,
         val alt: String?,
+        val caption: String?,
         val width: Int,
         val height: Int,
     )
@@ -213,9 +217,25 @@ internal object ImageAtPoint {
           var alt = img.getAttribute("alt") || "";
           if (alt.length > MAX_ALT) alt = alt.slice(0, MAX_ALT);
 
+          // The caption the book wrote, which is not the alt text: alt
+          // says what the picture is, for someone who cannot see it, and
+          // a <figcaption> is the line printed under it for everyone.
+          // A book that has both means both, and only one of them is
+          // meant to be read.
+          var caption = "";
+          for (var f = img, g = 0; f && g < 4; f = f.parentElement, g++) {
+            if (f.tagName && f.tagName.toLowerCase() === "figure") {
+              var cap = f.querySelector ? f.querySelector("figcaption") : null;
+              if (cap) caption = (cap.textContent || "").replace(/\s+/g, " ").trim();
+              break;
+            }
+          }
+          if (caption.length > MAX_ALT) caption = caption.slice(0, MAX_ALT);
+
           return {
             src: abs,
             alt: alt,
+            caption: caption,
             width: img.naturalWidth || Math.round(box.width),
             height: img.naturalHeight || Math.round(box.height)
           };
@@ -233,13 +253,14 @@ internal object ImageAtPoint {
     fun parse(result: String?): Hit? {
         val raw = result?.trim().orEmpty()
         if (raw.isEmpty() || raw == "null") return null
-        if (raw.length > MAX_SRC_CHARS + MAX_ALT_CHARS + PARSE_SLACK_CHARS) return null
+        if (raw.length > MAX_SRC_CHARS + MAX_ALT_CHARS * 2 + PARSE_SLACK_CHARS) return null
         val json = runCatching { JSONObject(raw) }.getOrNull() ?: return null
         val src = json.optString("src").takeIf { it.isNotBlank() } ?: return null
         if (src.length > MAX_SRC_CHARS) return null
         return Hit(
             src = src,
             alt = json.optString("alt").takeIf { it.isNotBlank() }?.take(MAX_ALT_CHARS),
+            caption = json.optString("caption").takeIf { it.isNotBlank() }?.take(MAX_ALT_CHARS),
             width = json.optInt("width"),
             height = json.optInt("height"),
         )

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ImageAtPoint.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ImageAtPoint.kt
@@ -3,6 +3,7 @@ package com.chmouel.liseur.reader
 import android.webkit.WebView
 import kotlin.coroutines.resume
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONObject
 
 /**
@@ -77,12 +78,37 @@ internal object ImageAtPoint {
     /**
      * Whether this resource has any image at all.
      *
-     * Asked once per resource and remembered, because the answer is no
-     * for most pages of most books, and a no means no script runs when
-     * the reader puts two fingers on the page.
+     * Asked once per resource, because the answer is no for most pages of
+     * most books, and a no means no script runs when the reader puts two
+     * fingers on the page. Only a *yes* is remembered: see the caller.
      */
     const val HAS_IMAGES_SCRIPT: String =
         "(document.images.length > 0 || !!document.querySelector('svg image'))"
+
+    /**
+     * The longest an address and a caption are allowed to be.
+     *
+     * The document is the book's, so everything it says comes back as
+     * something a file chose. A book that inlines a plate as a `data:`
+     * URL, or writes a novel into an `alt`, would otherwise hand back a
+     * string of that size across the bridge on every touch. Both figures
+     * are far above anything a real address or a real caption reaches.
+     */
+    private const val MAX_SRC_CHARS = 4096
+    private const val MAX_ALT_CHARS = 512
+
+    /** Room for the JSON around the two strings the script may return. */
+    private const val PARSE_SLACK_CHARS = 256
+
+    /**
+     * The longest the document is given to answer.
+     *
+     * A renderer that hangs, or a process that goes away without saying
+     * so, never calls the callback at all — and the touch that asked
+     * would then wait for ever, with its job still in flight when the
+     * next one starts.
+     */
+    private const val EVAL_TIMEOUT_MS = 1500L
 
     /**
      * The hit test itself.
@@ -93,15 +119,20 @@ internal object ImageAtPoint {
      * `src` would open a *lower*-resolution copy of the picture the
      * reader is looking at, which is the exact opposite of the point.
      *
-     * `elementFromPoint` answers with the topmost element, which over a
-     * picture is often a link or a `<figure>`'s own text node rather than
-     * the image, so it walks up a few levels and then, failing that, asks
-     * the element what images it contains. Both are bounded: an unbounded
-     * walk ends at `<body>`, which contains every image in the chapter.
+     * `elementsFromPoint` gives the whole stack under the point, so a
+     * picture beneath a link, a caption's wrapper or a transparent
+     * overlay is found without guessing which of them the browser calls
+     * topmost. Failing that it walks up a few levels and looks *inside*
+     * each ancestor — and anything found that way has to have the point
+     * inside its own box, because an ancestor two levels up is usually
+     * the `<section>`, and a `<section>` contains the chapter's plate
+     * wherever in the chapter that plate happens to be.
      */
     fun script(fx: Float, fy: Float): String = """
         (function () {
           var MIN = $MIN_RENDERED_PX;
+          var MAX_SRC = $MAX_SRC_CHARS;
+          var MAX_ALT = $MAX_ALT_CHARS;
           // The point arrives as a fraction of the web view rather than
           // in pixels. A fixed-layout page is drawn at whatever scale it
           // takes to fit the screen, so device pixels divided by the
@@ -131,16 +162,35 @@ internal object ImageAtPoint {
             }
             return false;
           }
-          var el = document.elementFromPoint(px, py);
+          function isImage(e) {
+            if (!e || !e.tagName) return false;
+            var t = e.tagName.toLowerCase();
+            return t === "img" || t === "image";
+          }
+          // Whether the picture is actually under the finger. Without
+          // this a pinch on a paragraph, or on a plate's own caption,
+          // finds whatever illustration happens to live elsewhere in the
+          // same <section> and opens that instead of resizing the text.
+          function covers(e, x, y) {
+            if (!isImage(e)) return false;
+            var r = e.getBoundingClientRect();
+            return x >= r.left && x <= r.right && y >= r.top && y <= r.bottom;
+          }
           var img = null;
-          for (var i = 0; el && i < 4; i++) {
-            if (el.tagName && (el.tagName.toLowerCase() === "img" ||
-                               el.tagName.toLowerCase() === "image")) {
-              img = el;
-              break;
+          var stack = [];
+          try {
+            if (document.elementsFromPoint) stack = document.elementsFromPoint(px, py) || [];
+          } catch (e) {}
+          for (var s = 0; s < stack.length && s < 8; s++) {
+            if (isImage(stack[s])) { img = stack[s]; break; }
+          }
+          var el = document.elementFromPoint(px, py);
+          for (var i = 0; !img && el && i < 4; i++) {
+            if (isImage(el)) { img = el; break; }
+            var inner = el.querySelectorAll ? el.querySelectorAll("img, svg image") : [];
+            for (var k = 0; k < inner.length && k < 16; k++) {
+              if (covers(inner[k], px, py)) { img = inner[k]; break; }
             }
-            var inner = el.querySelector ? el.querySelector("img, svg image") : null;
-            if (inner) { img = inner; break; }
             el = el.parentElement;
           }
           if (!img) return null;
@@ -158,10 +208,14 @@ internal object ImageAtPoint {
           if (typeof src !== "string" || !src) return null;
           var abs = src;
           try { abs = new URL(src, document.baseURI).href; } catch (e) {}
+          if (abs.length > MAX_SRC) return null;
+
+          var alt = img.getAttribute("alt") || "";
+          if (alt.length > MAX_ALT) alt = alt.slice(0, MAX_ALT);
 
           return {
             src: abs,
-            alt: img.getAttribute("alt") || "",
+            alt: alt,
             width: img.naturalWidth || Math.round(box.width),
             height: img.naturalHeight || Math.round(box.height)
           };
@@ -172,15 +226,20 @@ internal object ImageAtPoint {
      * `evaluateJavascript` hands back the JSON encoding of the value, so
      * an object arrives as an object and a miss arrives as the four
      * characters `null`.
+     *
+     * The script caps what it returns, so anything longer than those caps
+     * did not come from the script and is refused before it is parsed.
      */
     fun parse(result: String?): Hit? {
         val raw = result?.trim().orEmpty()
         if (raw.isEmpty() || raw == "null") return null
+        if (raw.length > MAX_SRC_CHARS + MAX_ALT_CHARS + PARSE_SLACK_CHARS) return null
         val json = runCatching { JSONObject(raw) }.getOrNull() ?: return null
         val src = json.optString("src").takeIf { it.isNotBlank() } ?: return null
+        if (src.length > MAX_SRC_CHARS) return null
         return Hit(
             src = src,
-            alt = json.optString("alt").takeIf { it.isNotBlank() },
+            alt = json.optString("alt").takeIf { it.isNotBlank() }?.take(MAX_ALT_CHARS),
             width = json.optInt("width"),
             height = json.optInt("height"),
         )
@@ -197,11 +256,13 @@ internal object ImageAtPoint {
     suspend fun at(web: WebView, fx: Float, fy: Float): Hit? = parse(eval(web, script(fx, fy)))
 
     private suspend fun eval(web: WebView, js: String): String? =
-        suspendCancellableCoroutine { cont ->
-            try {
-                web.evaluateJavascript(js) { if (cont.isActive) cont.resume(it) }
-            } catch (e: Exception) {
-                if (cont.isActive) cont.resume(null)
+        withTimeoutOrNull(EVAL_TIMEOUT_MS) {
+            suspendCancellableCoroutine { cont ->
+                try {
+                    web.evaluateJavascript(js) { if (cont.isActive) cont.resume(it) }
+                } catch (e: Exception) {
+                    if (cont.isActive) cont.resume(null)
+                }
             }
         }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
@@ -370,6 +370,7 @@ class ReaderActivity : FragmentActivity() {
                                     scrollModeFlow = viewModel.scrollMode,
                                     onScrollModeChanged = viewModel::setScrollMode,
                                     tapZonesFlow = viewModel.tapZones,
+                                    pinchToResizeFlow = viewModel.pinchToResize,
                                     // Dialogs of this activity's own,
                                     // drawn over the reader. The page
                                     // must not carry on scrolling under

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -1102,7 +1102,7 @@ fun ReaderScreen(
             val web = visibleWebView(root) ?: return@collect
             if (web === asked) return@collect
             asked = web
-            touch.resourceHasImages = ImageAtPoint.hasImages(nav)
+            touch.resourceHasImages = ImageAtPoint.hasImages(web)
         }
     }
 
@@ -1635,7 +1635,6 @@ fun ReaderScreen(
      */
     var boxInWindow by remember { mutableStateOf(Offset.Zero) }
     val longPressMs = LocalViewConfiguration.current.longPressTimeoutMillis
-    val pageDensity = LocalDensity.current.density
     val publicationNow by rememberUpdatedState(publication)
 
     /**
@@ -1649,6 +1648,7 @@ fun ReaderScreen(
     fun showImage(hit: ImageAtPoint.Hit) {
         if (touch.opening || viewedImage != null) return
         touch.opening = true
+        touch.claimed = true
         val serial = touch.serial
         effectScope.launch {
             try {
@@ -1684,12 +1684,17 @@ fun ReaderScreen(
             return
         }
         val web = visibleWebView(nav.publicationView) ?: run { touch.answered = true; return }
+        if (web.width <= 0 || web.height <= 0) {
+            touch.answered = true
+            return
+        }
         val origin = IntArray(2)
         web.getLocationInWindow(origin)
-        val cssX = (boxInWindow.x + position.x - origin[0]) / pageDensity
-        val cssY = (boxInWindow.y + position.y - origin[1]) / pageDensity
+        // As a fraction of the web view, not in pixels: see the script.
+        val fx = (boxInWindow.x + position.x - origin[0]) / web.width
+        val fy = (boxInWindow.y + position.y - origin[1]) / web.height
         effectScope.launch {
-            val hit = ImageAtPoint.at(nav, cssX, cssY)
+            val hit = ImageAtPoint.at(web, fx, fy)
             if (touch.serial != serial) return@launch
             touch.hit = hit
             touch.answered = true
@@ -1739,6 +1744,23 @@ fun ReaderScreen(
                         // for it to be lifted, so a reader nudging the
                         // text is not fighting the page for it.
                         fingerDown = event.changes.any { it.pressed }
+
+                        val down = event.changes.filter { it.pressed }
+                        val was = touch.pointers
+                        touch.pointers = down.size
+
+                        // A touch that opened the viewer belongs to the
+                        // viewer until it is lifted. Consuming the rest of
+                        // it is what keeps the long press that opened the
+                        // picture from also being a long press on the web
+                        // view, which answers one with a drag of the image
+                        // or a selection under an overlay nobody can see
+                        // past.
+                        if (touch.claimed) {
+                            event.changes.forEach { it.consume() }
+                            if (down.isEmpty()) touch.claimed = false
+                            continue
+                        }
                         // The card is drawn inside this box, so without this
                         // guard reading a note would move it: every touch on
                         // the card would become the new anchor and the card
@@ -1749,9 +1771,6 @@ fun ReaderScreen(
                         // it is reachable while it is up.
                         if (viewedImage != null) continue
 
-                        val down = event.changes.filter { it.pressed }
-                        val was = touch.pointers
-                        touch.pointers = down.size
                         when {
                             down.isEmpty() -> Unit
 
@@ -2859,6 +2878,16 @@ private class TouchProbe {
     var answered = false
     var opening = false
     var hit: ImageAtPoint.Hit? = null
+
+    /**
+     * Whether this touch has been taken for the viewer.
+     *
+     * A claimed touch is consumed for the rest of its life, which is what
+     * stops the same long press from also reaching the web view, where it
+     * would start a drag of the image or open a selection under a viewer
+     * the reader cannot see past.
+     */
+    var claimed = false
 
     /** Whether the resource on screen has any image in it; see the probe. */
     var resourceHasImages = false

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -1,6 +1,7 @@
 package com.chmouel.liseur.reader
 
 import android.app.Activity
+import android.graphics.BitmapFactory
 import android.view.WindowManager
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
@@ -461,6 +462,11 @@ fun ReaderScreen(
     val setFontSizeNow by rememberUpdatedState(onPrefsAction.setFontSize)
     val touch = remember { TouchProbe() }
     var viewedImage by remember { mutableStateOf<ViewedImage?>(null) }
+    // True from the moment a picture is claimed to the moment it is on
+    // screen. The bytes take a read of an archive entry to arrive, and
+    // the fingers have usually left by then: without this the book turns
+    // or scrolls on in the gap before the overlay covers it.
+    var openingImage by remember { mutableStateOf(false) }
     // The tracker below outlives every recomposition, so it cannot read
     // `footnote` directly — it would keep seeing whatever was true when it
     // started. This gives it a window onto the current value.
@@ -719,6 +725,8 @@ fun ReaderScreen(
     val showingEndNow by rememberUpdatedState(showingEnd)
     var endpaperRtl by remember { mutableStateOf(false) }
     val pageTurnEffect = remember { PageTurnEffectState(effectScope) }
+    val viewedImageNow by rememberUpdatedState(viewedImage)
+    val openingImageNow by rememberUpdatedState(openingImage)
     val pageTurner = remember {
         PageTurner(
             effect = pageTurnEffect,
@@ -737,6 +745,9 @@ fun ReaderScreen(
             isScrolling = { effectiveScrollingNow },
             isVerticalText = { navigatorNow?.settings?.value?.verticalText == true },
             showingEnd = { showingEndNow },
+            // A picture over the page takes the book out of reach of
+            // every way of turning it, keys and volume included.
+            isSuspended = { viewedImageNow != null || openingImageNow },
             onReachedEnd = {
                 endpaperRtl = navigatorNow?.overflow?.value?.readingProgression ==
                     ReadingProgression.RTL
@@ -1240,6 +1251,12 @@ fun ReaderScreen(
         defineWord == null &&
         jumpBack == null &&
         catchUp == null &&
+        // A picture over the page is modal to a finger and to a screen
+        // reader; it has to be modal to the clock as well, or the book
+        // scrolls on underneath it and the reader comes back somewhere
+        // they never asked to be.
+        viewedImage == null &&
+        !openingImage &&
         !blockedByDialog
 
     // Arming is a decision taken in a sheet, and the page it applies to
@@ -1683,6 +1700,7 @@ fun ReaderScreen(
     fun showImage(hit: ImageAtPoint.Hit) {
         if (touch.opening || viewedImage != null) return
         touch.opening = true
+        openingImage = true
         touch.claimed = true
         val serial = touch.serial
         effectScope.launch {
@@ -1716,16 +1734,28 @@ fun ReaderScreen(
                 // The touch that asked may be long over, and the reader
                 // somewhere else entirely.
                 if (touch.serial != serial) return@launch
+                // The size the *file* says, not the size the document
+                // reported. `naturalWidth` is corrected for a `srcset`
+                // descriptor and an SVG's fallback is only the box it is
+                // drawn in, so a document can name a picture far smaller
+                // than it decodes to and walk a huge raster straight past
+                // the pixel budget. Reading the header allocates nothing.
+                val (decodedW, decodedH) = withContext(Dispatchers.Default) {
+                    val header = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+                    BitmapFactory.decodeByteArray(bytes, 0, bytes.size, header)
+                    header.outWidth to header.outHeight
+                }
                 view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
                 viewedImage = ViewedImage(
                     bytes = bytes,
                     alt = hit.alt,
                     caption = hit.caption,
-                    width = hit.width,
-                    height = hit.height,
+                    width = decodedW,
+                    height = decodedH,
                 )
             } finally {
                 touch.opening = false
+                openingImage = false
             }
         }
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -72,6 +72,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextOverflow
@@ -251,6 +252,18 @@ private const val DECIDE_BUDGET_MS = 250L
 
 /** How often the long press looks to see whether the answer has landed. */
 private const val ANSWER_POLL_MS = 20L
+
+/**
+ * The most of a book a picture is allowed to be, before it is refused.
+ *
+ * A reader opens whatever file it is handed, and an archive entry's
+ * declared size is the file's word for it. Without a ceiling a book can
+ * name an illustration large enough to take the heap with it, and a
+ * two-finger touch on a page is all it would take to set that off. The
+ * figure matches the one covers are read under; no illustration a
+ * publisher meant anybody to look at is anywhere near it.
+ */
+private const val MAX_IMAGE_BYTES = 16L * 1024 * 1024
 
 // How often a book scrolled by hand is looked in on, and so the most a
 // place kept for the pause can be behind the reader. The same interval
@@ -1097,12 +1110,29 @@ fun ReaderScreen(
     LaunchedEffect(navigator) {
         val nav = navigator ?: return@LaunchedEffect
         val root = nav.publicationView
-        var asked: WebView? = null
+        var withImages: Pair<WebView, String>? = null
         merge(nav.currentLocator.map { }, layoutPasses(root)).collect {
             val web = visibleWebView(root) ?: return@collect
-            if (web === asked) return@collect
-            asked = web
-            touch.resourceHasImages = ImageAtPoint.hasImages(web)
+            // Keyed by the resource as well as by the view, because the
+            // pager recycles a web view from one chapter into another and
+            // the same instance is then a different document.
+            val key = web to nav.currentLocator.value.href.toString()
+            if (key == withImages) return@collect
+            // Willing to ask until told otherwise. A wrong yes costs one
+            // script evaluation on a touch; a wrong no is the feature
+            // quietly not working, and the gap between a page turn and
+            // this answer is exactly where a reader lands on a plate.
+            touch.resourceHasImages = true
+            val has = ImageAtPoint.hasImages(web)
+            touch.resourceHasImages = has
+            // Only a yes is remembered. A no is either the truth about a
+            // page of plain text or a document that had not finished
+            // loading when it was asked, and from here the two look the
+            // same — so a no is asked again the next time the page moves.
+            // That costs one trivial script per turn, off the touch path,
+            // which is where the cost mattered; a remembered no costs the
+            // whole feature on the chapter it was wrong about.
+            withImages = if (has) key else null
         }
     }
 
@@ -1654,9 +1684,30 @@ fun ReaderScreen(
             try {
                 val href = ResourceAddress.href(hit.src) ?: return@launch
                 val url = Url(href) ?: return@launch
+                // Read a range rather than the whole entry, because the
+                // entry's size is the book's word against the heap: this
+                // reader opens whatever file it is pointed at, and a ZIP
+                // can name a hundred megabytes as easily as one.
+                //
+                // The range is the entry's own length where the container
+                // knows it, because Readium refuses a range that runs off
+                // the end of a compressed entry rather than clamping it.
+                // The declared length is still only the book's word, so
+                // it bounds the range and never the trust: nothing over
+                // the limit is asked for, and what comes back is measured
+                // before it is used.
                 val bytes = withContext(Dispatchers.IO) {
-                    publicationNow.get(url)?.use { it.read().getOrNull() }
-                } ?: return@launch
+                    publicationNow.get(url)?.use {
+                        val declared = it.length().getOrNull()
+                        if (declared != null && declared > MAX_IMAGE_BYTES) {
+                            null
+                        } else {
+                            it.read(0 until (declared ?: (MAX_IMAGE_BYTES + 1))).getOrNull()
+                        }
+                    }
+                }
+                if (bytes == null) return@launch
+                if (bytes.size > MAX_IMAGE_BYTES) return@launch
                 // The touch that asked may be long over, and the reader
                 // somewhere else entirely.
                 if (touch.serial != serial) return@launch
@@ -1667,6 +1718,22 @@ fun ReaderScreen(
             }
         }
     }
+
+    /**
+     * Whether an image under the fingers may still take the gesture.
+     *
+     * The one place that is decided, because it is asked from two: the
+     * coroutine that receives the document's answer, and the pointer loop
+     * on the next event after it was written down. Asked in only one of
+     * them the budget is no budget at all — the reply is stored, and the
+     * next finger movement acts on it regardless.
+     *
+     * A gesture no resize has claimed yet is not on a clock: fingers that
+     * take their time arriving at a picture still get the picture. Once a
+     * resize is under way it is, because changing a gesture's meaning
+     * under fingers already moving to it is worse than getting it wrong.
+     */
+    fun imageMayWin(): Boolean = pinchStart.value == null || touch.undecided()
 
     /**
      * Asks the document what is under the finger, as the finger lands.
@@ -1704,8 +1771,7 @@ fun ReaderScreen(
             // is still young: changing a gesture's meaning under fingers
             // that have been moving for half a second is worse than
             // getting it wrong.
-            val late = SystemClock.uptimeMillis() - touch.startedAt > DECIDE_BUDGET_MS
-            if (hit != null && touch.pointers >= 2 && !late) {
+            if (hit != null && touch.pointers >= 2 && imageMayWin()) {
                 pinchStart.value = null
                 pinchTarget = null
                 pinchRefused = false
@@ -1728,6 +1794,19 @@ fun ReaderScreen(
             touch.hit?.let(::showImage)
         }
     }
+
+    /**
+     * What the page and the chrome become while a picture is full screen.
+     *
+     * The viewer is drawn as the last child of the same box rather than
+     * in a window of its own, so nothing under it is reachable by touch
+     * — the pointer loop stops there. A screen reader is not steered by
+     * the pointer loop, and without this it walks straight past the
+     * picture into a chapter and a row of controls that are not on
+     * screen. See `docs/adr/0022-pinch-on-the-page.md`.
+     */
+    val behindViewer =
+        if (viewedImage != null) Modifier.semantics { hideFromAccessibility() } else Modifier
 
     Box(
         Modifier
@@ -1792,8 +1871,12 @@ fun ReaderScreen(
                                 touch.moved = true
                         }
                         // What is under the fingers decides which gesture
-                        // this is, and holds until they lift.
-                        if (down.size >= 2 && touch.hit != null) {
+                        // this is, and holds until they lift. Asked here
+                        // as well as where the answer lands: an answer
+                        // that came too late to take a running resize is
+                        // written down all the same, and without this the
+                        // next movement would act on it anyway.
+                        if (down.size >= 2 && touch.hit != null && imageMayWin()) {
                             touch.hit?.let(::showImage)
                             event.changes.forEach { it.consume() }
                             continue
@@ -1816,8 +1899,8 @@ fun ReaderScreen(
                                         pinchRefused = !reflowableText
                                     }
                                 if (reflowableText) {
-                                    PinchResize.targetFor(start.size, start.span, span)
-                                        ?.let { pinchTarget = it }
+                                    pinchTarget =
+                                        PinchResize.targetFor(start.size, start.span, span)
                                 }
                                 // Only once a second finger is down.
                                 // Consuming a lone pointer here would take
@@ -1922,6 +2005,7 @@ fun ReaderScreen(
             AndroidFragment<EpubNavigatorFragment>(
                 modifier = Modifier
                     .fillMaxSize()
+                    .then(behindViewer)
                     .then(
                         if (pageContainerScrolls) {
                             Modifier.windowInsetsPadding(
@@ -1999,6 +2083,7 @@ fun ReaderScreen(
             Modifier
                 .align(Alignment.BottomCenter)
                 .fillMaxWidth()
+                .then(behindViewer)
                 .navigationBarsPadding(),
         ) {
             if (!showingEnd) {
@@ -2113,7 +2198,7 @@ fun ReaderScreen(
             visible = chromeVisible && !showingEnd,
             enter = chromeEnter,
             exit = chromeExit,
-            modifier = Modifier.align(Alignment.TopCenter),
+            modifier = Modifier.align(Alignment.TopCenter).then(behindViewer),
         ) {
             TopAppBar(
                 title = {
@@ -2891,4 +2976,18 @@ private class TouchProbe {
 
     /** Whether the resource on screen has any image in it; see the probe. */
     var resourceHasImages = false
+
+    /**
+     * Whether an image answer is still young enough to change what this
+     * touch means.
+     *
+     * Only ever asked of a touch a resize has already got hold of: the
+     * budget exists so that a document which took half a second to answer
+     * cannot yank the gesture out from under fingers that have spent that
+     * half second resizing. A gesture nothing else has claimed is not on
+     * a clock — a long press is deliberately slower than this — so ask
+     * through `imageMayWin` rather than reaching for this directly.
+     */
+    fun undecided(): Boolean =
+        SystemClock.uptimeMillis() - startedAt <= DECIDE_BUDGET_MS
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -1799,6 +1799,12 @@ fun ReaderScreen(
                 waited += ANSWER_POLL_MS
             }
             if (touch.serial != serial || touch.moved || touch.pointers != 1) return@launch
+            // A resize that took this touch keeps it. Without this, a
+            // quick pinch held by a still first finger ends with that
+            // finger alone and unmoved, which is exactly what a long
+            // press looks like — so the size would commit and the
+            // picture would open on top of it.
+            if (!imageMayWin()) return@launch
             touch.hit?.let(::showImage)
         }
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -452,6 +452,10 @@ fun ReaderScreen(
     val pinchSettledAt = remember { mutableLongStateOf(0L) }
     var pinchTarget by remember { mutableStateOf<Double?>(null) }
     var pinchRefused by remember { mutableStateOf(false) }
+    // Two fingers down on a page the document has not answered for yet.
+    // Consumed, so nothing else acts on the touch, but committing
+    // nothing, because what the gesture means is not settled (ADR 22).
+    var pinchHeld by remember { mutableStateOf(false) }
     val pinchToResizeNow by rememberUpdatedState(pinchToResize)
     val fontSizeNow by rememberUpdatedState(prefs.fontSize)
     val setFontSizeNow by rememberUpdatedState(onPrefsAction.setFontSize)
@@ -1543,7 +1547,7 @@ fun ReaderScreen(
         onPageTurnerChanged(if (nav != null) pageTurner else null)
         val listeners = nav?.let {
             val isPinching = {
-                pinchStart.value != null ||
+                pinchStart.value != null || pinchHeld ||
                     SystemClock.uptimeMillis() - pinchSettledAt.longValue < PinchResize.GUARD_MS
             }
             listOf(
@@ -1783,6 +1787,7 @@ fun ReaderScreen(
                 pinchStart.value = null
                 pinchTarget = null
                 pinchRefused = false
+                pinchHeld = false
                 showImage(hit)
             }
         }
@@ -1879,6 +1884,7 @@ fun ReaderScreen(
                                 touch.downAt = down[0].position
                                 touch.startedAt = SystemClock.uptimeMillis()
                                 touch.claim.begin(touch.startedAt)
+                                pinchHeld = false
                                 probeUnderFinger(down[0].position)
                             }
 
@@ -1897,7 +1903,23 @@ fun ReaderScreen(
                             continue
                         }
                         when {
+                            // The document has not said yet what is under
+                            // the fingers, and the budget has not run out.
+                            // Held: consumed so nothing else acts on the
+                            // touch, but starting no resize, so a lift here
+                            // commits no size to a gesture that may yet
+                            // turn out to have been aimed at a picture.
+                            // When the budget does run out the span is
+                            // measured from that moment, so the size does
+                            // not jump (ADR 22).
+                            down.size >= 2 && pinchToResizeNow && !touch.answered &&
+                                touch.claim.undecided(SystemClock.uptimeMillis()) -> {
+                                pinchHeld = true
+                                event.changes.forEach { it.consume() }
+                            }
+
                             down.size >= 2 && pinchToResizeNow -> {
+                                pinchHeld = false
                                 touch.claim.resizeTook()
                                 val span = PinchResize.spanOf(
                                     down[0].position.x, down[0].position.y,
@@ -1931,12 +1953,18 @@ fun ReaderScreen(
                                 event.changes.forEach { it.consume() }
                             }
 
-                            pinchStart.value != null -> {
-                                // One commit, one reflow, one anchor.
+                            pinchStart.value != null || pinchHeld -> {
+                                // One commit, one reflow, one anchor. A
+                                // gesture that was still undecided when the
+                                // fingers left has nothing to commit, but
+                                // it is still swallowed: its fingers were
+                                // consumed all the way, and a page turn
+                                // out of the end of one is not a tap.
                                 pinchTarget?.let { if (it != fontSizeNow) setFontSizeNow(it) }
                                 pinchStart.value = null
                                 pinchTarget = null
                                 pinchRefused = false
+                                pinchHeld = false
                                 pinchSettledAt.longValue = SystemClock.uptimeMillis()
                                 event.changes.forEach { it.consume() }
                             }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -1713,7 +1713,13 @@ fun ReaderScreen(
                 // somewhere else entirely.
                 if (touch.serial != serial) return@launch
                 view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
-                viewedImage = ViewedImage(bytes, hit.alt)
+                viewedImage = ViewedImage(
+                    bytes = bytes,
+                    alt = hit.alt,
+                    caption = hit.caption,
+                    width = hit.width,
+                    height = hit.height,
+                )
             } finally {
                 touch.opening = false
             }
@@ -1895,16 +1901,22 @@ fun ReaderScreen(
                                     .also {
                                         pinchStart.value = it
                                         pinchTarget = null
-                                        // A fixed-layout book places every
-                                        // page itself and Readium honours
-                                        // no font size inside one, so the
-                                        // pinch says so rather than doing
-                                        // nothing at all (ADR 20, ADR 22).
-                                        pinchRefused = !reflowableText
+                                        pinchRefused = false
                                     }
                                 if (reflowableText) {
                                     pinchTarget =
                                         PinchResize.targetFor(start.size, start.span, span)
+                                } else {
+                                    // A fixed-layout book places every page
+                                    // itself and Readium honours no font
+                                    // size inside one, so the pinch says so
+                                    // rather than doing nothing at all (ADR
+                                    // 20, ADR 22) — but only once the
+                                    // fingers have travelled as far as they
+                                    // would have to on a page that can be
+                                    // resized. Resting two fingers is not a
+                                    // pinch on either kind of book.
+                                    pinchRefused = PinchResize.moved(start.span, span)
                                 }
                                 // Only once a second finger is down.
                                 // Consuming a lone pointer here would take
@@ -2031,32 +2043,34 @@ fun ReaderScreen(
         }
 
         if (showingEnd) {
-            Endpaper(
-                title = publication.metadata.title.orEmpty(),
-                author = publication.metadata.authors
-                    .joinToString(", ") { it.name }
-                    .ifBlank { null },
-                theme = readingTheme,
-                finished = continuation?.finished,
-                timeSpentMs = continuation?.timeSpentMs,
-                seriesName = continuation?.seriesName,
-                finishedVolume = continuation?.finishedVolume,
-                next = continuation?.next,
-                missingIndex = continuation?.missingIndex,
-                noNextInLibrary = continuation?.noNextInLibrary == true,
-                seriesCompletion = continuation?.seriesCompletion,
-                rtl = endpaperRtl,
-                swapped = tapZones.swapped,
-                onTurnBack = {
-                    showingEnd = false
-                    onLeftEndpaper()
-                },
-                onLibrary = {
-                    onLeftEndpaper()
-                    onBack()
-                },
-                onOpenNext = onContinueNext,
-            )
+            Box(Modifier.fillMaxSize().then(behindViewer)) {
+                Endpaper(
+                    title = publication.metadata.title.orEmpty(),
+                    author = publication.metadata.authors
+                        .joinToString(", ") { it.name }
+                        .ifBlank { null },
+                    theme = readingTheme,
+                    finished = continuation?.finished,
+                    timeSpentMs = continuation?.timeSpentMs,
+                    seriesName = continuation?.seriesName,
+                    finishedVolume = continuation?.finishedVolume,
+                    next = continuation?.next,
+                    missingIndex = continuation?.missingIndex,
+                    noNextInLibrary = continuation?.noNextInLibrary == true,
+                    seriesCompletion = continuation?.seriesCompletion,
+                    rtl = endpaperRtl,
+                    swapped = tapZones.swapped,
+                    onTurnBack = {
+                        showingEnd = false
+                        onLeftEndpaper()
+                    },
+                    onLibrary = {
+                        onLeftEndpaper()
+                        onBack()
+                    },
+                    onOpenNext = onContinueNext,
+                )
+            }
         }
 
         PageTurnOverlay(pageTurnEffect)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -65,7 +65,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -83,6 +87,8 @@ import android.view.HapticFeedbackConstants
 import android.view.View
 import android.os.SystemClock
 import android.webkit.WebView
+import org.readium.r2.shared.util.Url
+import org.readium.r2.shared.util.use
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.IntOffset
@@ -134,6 +140,8 @@ import com.chmouel.liseur.reader.chrome.Endpaper
 import com.chmouel.liseur.reader.chrome.FixedLayoutPinchHud
 import com.chmouel.liseur.reader.chrome.FontSizeHud
 import com.chmouel.liseur.reader.chrome.FootnoteCard
+import com.chmouel.liseur.reader.chrome.ImageViewer
+import com.chmouel.liseur.reader.chrome.ViewedImage
 import com.chmouel.liseur.reader.chrome.PinchResize
 import com.chmouel.liseur.reader.chrome.PinchStart
 import com.chmouel.liseur.reader.chrome.GoToPageDialog
@@ -161,6 +169,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
@@ -174,6 +183,7 @@ import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.withContext
 import org.readium.r2.navigator.Decoration
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.navigator.epub.EpubPreferences
@@ -226,6 +236,21 @@ private const val MAX_CHAPTER_DWELL_MS = 8_000L
 // loss is a line, long enough that a document round trip every so often
 // costs nothing.
 private const val AUTO_SCROLL_SAVE_NANOS = 2_000_000_000L
+
+/**
+ * How long after a touch lands its meaning is still open to the
+ * document's answer about what is under it.
+ *
+ * The question goes out when the first finger lands, so the answer is
+ * normally back before a second one arrives and this is never reached.
+ * It bounds the case where it is not: past it the gesture is whatever it
+ * has become, because changing what fingers mean while they are already
+ * moving is worse than getting it wrong.
+ */
+private const val DECIDE_BUDGET_MS = 250L
+
+/** How often the long press looks to see whether the answer has landed. */
+private const val ANSWER_POLL_MS = 20L
 
 // How often a book scrolled by hand is looked in on, and so the most a
 // place kept for the pause can be behind the reader. The same interval
@@ -416,6 +441,8 @@ fun ReaderScreen(
     val pinchToResizeNow by rememberUpdatedState(pinchToResize)
     val fontSizeNow by rememberUpdatedState(prefs.fontSize)
     val setFontSizeNow by rememberUpdatedState(onPrefsAction.setFontSize)
+    val touch = remember { TouchProbe() }
+    var viewedImage by remember { mutableStateOf<ViewedImage?>(null) }
     // The tracker below outlives every recomposition, so it cannot read
     // `footnote` directly — it would keep seeing whatever was true when it
     // started. This gives it a window onto the current value.
@@ -1059,6 +1086,26 @@ fun ReaderScreen(
         }
     }
 
+    // Whether this page has a picture on it at all, asked once per
+    // resource that gets laid out — the same prompts, and for the same
+    // reasons, as the fit above.
+    //
+    // Most pages of most books have no image, and this is what keeps a
+    // touch on one of them from running any script at all: the answer is
+    // already no when the finger lands, so the pinch goes straight to
+    // resizing the text.
+    LaunchedEffect(navigator) {
+        val nav = navigator ?: return@LaunchedEffect
+        val root = nav.publicationView
+        var asked: WebView? = null
+        merge(nav.currentLocator.map { }, layoutPasses(root)).collect {
+            val web = visibleWebView(root) ?: return@collect
+            if (web === asked) return@collect
+            asked = web
+            touch.resourceHasImages = ImageAtPoint.hasImages(nav)
+        }
+    }
+
     // Picking the selection up from the navigator when it tells us the
     // reader made one, and turning it into a place to put the action bar.
     //
@@ -1574,11 +1621,116 @@ fun ReaderScreen(
         }
     }
 
+    /*
+     * The image lookup, which the pinch and the long press both wait on.
+     *
+     * Plain fields rather than snapshot state: the pointer loop writes
+     * them and the coroutines below read them, and both run on the main
+     * thread. Only the viewer itself is state, because only the viewer is
+     * drawn.
+     *
+     * [TouchProbe.serial] is what makes an answer belong to a touch: a
+     * finger lifted before the document replied leaves a job in flight
+     * whose answer must not open a viewer over the next page.
+     */
+    var boxInWindow by remember { mutableStateOf(Offset.Zero) }
+    val longPressMs = LocalViewConfiguration.current.longPressTimeoutMillis
+    val pageDensity = LocalDensity.current.density
+    val publicationNow by rememberUpdatedState(publication)
+
+    /**
+     * Opens the picture, having fetched it out of the book.
+     *
+     * The bytes come from the publication rather than from the web view,
+     * because the web view has already thrown away everything above the
+     * size it drew the picture at, and the whole point is to see more
+     * than that.
+     */
+    fun showImage(hit: ImageAtPoint.Hit) {
+        if (touch.opening || viewedImage != null) return
+        touch.opening = true
+        val serial = touch.serial
+        effectScope.launch {
+            try {
+                val href = ResourceAddress.href(hit.src) ?: return@launch
+                val url = Url(href) ?: return@launch
+                val bytes = withContext(Dispatchers.IO) {
+                    publicationNow.get(url)?.use { it.read().getOrNull() }
+                } ?: return@launch
+                // The touch that asked may be long over, and the reader
+                // somewhere else entirely.
+                if (touch.serial != serial) return@launch
+                view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+                viewedImage = ViewedImage(bytes, hit.alt)
+            } finally {
+                touch.opening = false
+            }
+        }
+    }
+
+    /**
+     * Asks the document what is under the finger, as the finger lands.
+     *
+     * Fired on the *first* pointer rather than on the second, so that the
+     * answer is already in hand by the time a second finger turns the
+     * touch into a pinch and something has to be decided. On a resource
+     * with no images in it at all, nothing is asked.
+     */
+    fun probeUnderFinger(position: Offset) {
+        val serial = touch.serial
+        val nav = navigatorNow ?: run { touch.answered = true; return }
+        if (!touch.resourceHasImages) {
+            touch.answered = true
+            return
+        }
+        val web = visibleWebView(nav.publicationView) ?: run { touch.answered = true; return }
+        val origin = IntArray(2)
+        web.getLocationInWindow(origin)
+        val cssX = (boxInWindow.x + position.x - origin[0]) / pageDensity
+        val cssY = (boxInWindow.y + position.y - origin[1]) / pageDensity
+        effectScope.launch {
+            val hit = ImageAtPoint.at(nav, cssX, cssY)
+            if (touch.serial != serial) return@launch
+            touch.hit = hit
+            touch.answered = true
+            // The fingers may already be pinching, undecided, by the time
+            // this lands. An image takes the gesture back off the resize,
+            // which has committed nothing yet — but only while the pinch
+            // is still young: changing a gesture's meaning under fingers
+            // that have been moving for half a second is worse than
+            // getting it wrong.
+            val late = SystemClock.uptimeMillis() - touch.startedAt > DECIDE_BUDGET_MS
+            if (hit != null && touch.pointers >= 2 && !late) {
+                pinchStart.value = null
+                pinchTarget = null
+                pinchRefused = false
+                showImage(hit)
+            }
+        }
+        // A finger that stays put is the other way in. The wait is the
+        // platform's own, so a long press means here what it means
+        // everywhere else on the phone.
+        effectScope.launch {
+            delay(longPressMs)
+            // Almost always already answered, since the question went out
+            // when the finger landed; this is for the page that was busy.
+            var waited = 0L
+            while (!touch.answered && waited < DECIDE_BUDGET_MS) {
+                delay(ANSWER_POLL_MS)
+                waited += ANSWER_POLL_MS
+            }
+            if (touch.serial != serial || touch.moved || touch.pointers != 1) return@launch
+            touch.hit?.let(::showImage)
+        }
+    }
+
     Box(
         Modifier
             .fillMaxSize()
             .background(readingTheme.background)
+            .onGloballyPositioned { boxInWindow = it.positionInWindow() }
             .pointerInput(Unit) {
+                val slop = viewConfiguration.touchSlop
                 awaitPointerEventScope {
                     while (true) {
                         val event = awaitPointerEvent(PointerEventPass.Initial)
@@ -1592,8 +1744,41 @@ fun ReaderScreen(
                         // the card would become the new anchor and the card
                         // would jump out from under the finger scrolling it.
                         if (noteShowing) continue
+                        // The viewer is drawn inside this box and has
+                        // gestures of its own. Nothing on the page below
+                        // it is reachable while it is up.
+                        if (viewedImage != null) continue
 
                         val down = event.changes.filter { it.pressed }
+                        val was = touch.pointers
+                        touch.pointers = down.size
+                        when {
+                            down.isEmpty() -> Unit
+
+                            // A fresh touch. The serial moves here and
+                            // nowhere else: lifting a finger does not make
+                            // the answer to that touch stale, and a long
+                            // press ends with a lift.
+                            was == 0 -> {
+                                touch.serial++
+                                touch.hit = null
+                                touch.answered = false
+                                touch.moved = false
+                                touch.downAt = down[0].position
+                                touch.startedAt = SystemClock.uptimeMillis()
+                                probeUnderFinger(down[0].position)
+                            }
+
+                            (down[0].position - touch.downAt).getDistance() > slop ->
+                                touch.moved = true
+                        }
+                        // What is under the fingers decides which gesture
+                        // this is, and holds until they lift.
+                        if (down.size >= 2 && touch.hit != null) {
+                            touch.hit?.let(::showImage)
+                            event.changes.forEach { it.consume() }
+                            continue
+                        }
                         when {
                             down.size >= 2 && pinchToResizeNow -> {
                                 val span = PinchResize.spanOf(
@@ -2018,6 +2203,11 @@ fun ReaderScreen(
             pinchRefused -> FixedLayoutPinchHud(theme = readingTheme)
             else -> pinchTarget?.let { FontSizeHud(size = it, theme = readingTheme) }
         }
+
+        // Last of all: a picture asked for full screen is the thing the
+        // reader is looking at, and everything else in the box is what
+        // they asked to be shown it over.
+        viewedImage?.let { ImageViewer(image = it, onDismiss = { viewedImage = null }) }
     }
 
     // Letting a selection go from our own bar rather than from the page.
@@ -2645,3 +2835,31 @@ internal fun Locator.restorePoint(exact: Boolean = false) = RestorePoint(
     progression = locations.totalProgression,
     exact = exact,
 )
+
+/**
+ * What the touch on the page is doing, and what the document said was
+ * under it.
+ *
+ * Written by the pointer loop and read by the coroutines that answer for
+ * it, all on the main thread, so plain fields rather than snapshot state:
+ * none of this is drawn, and making it observable would recompose the
+ * reader on every finger that moves.
+ *
+ * [serial] counts touches, and is what makes an answer belong to one.
+ * Asking the document what is under a finger is a round trip, and a
+ * finger lifted before the answer comes back leaves a job in flight whose
+ * answer must not open a picture over whatever the reader did next.
+ */
+private class TouchProbe {
+    var serial = 0
+    var pointers = 0
+    var downAt = Offset.Zero
+    var startedAt = 0L
+    var moved = false
+    var answered = false
+    var opening = false
+    var hit: ImageAtPoint.Hit? = null
+
+    /** Whether the resource on screen has any image in it; see the probe. */
+    var resourceHasImages = false
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -141,6 +141,7 @@ import com.chmouel.liseur.reader.chrome.Endpaper
 import com.chmouel.liseur.reader.chrome.FixedLayoutPinchHud
 import com.chmouel.liseur.reader.chrome.FontSizeHud
 import com.chmouel.liseur.reader.chrome.FootnoteCard
+import com.chmouel.liseur.reader.chrome.GestureClaim
 import com.chmouel.liseur.reader.chrome.ImageViewer
 import com.chmouel.liseur.reader.chrome.ViewedImage
 import com.chmouel.liseur.reader.chrome.PinchResize
@@ -1730,10 +1731,11 @@ fun ReaderScreen(
      *
      * A gesture no resize has claimed yet is not on a clock: fingers that
      * take their time arriving at a picture still get the picture. Once a
-     * resize is under way it is, because changing a gesture's meaning
-     * under fingers already moving to it is worse than getting it wrong.
+     * resize has had hold of it, it is — and that is asked of the touch
+     * rather than of `pinchStart`, which empties as soon as the pinch
+     * drops to one finger while the touch itself runs on.
      */
-    fun imageMayWin(): Boolean = pinchStart.value == null || touch.undecided()
+    fun imageMayWin(): Boolean = touch.claim.imageMayWin(SystemClock.uptimeMillis())
 
     /**
      * Asks the document what is under the finger, as the finger lands.
@@ -1864,6 +1866,7 @@ fun ReaderScreen(
                                 touch.moved = false
                                 touch.downAt = down[0].position
                                 touch.startedAt = SystemClock.uptimeMillis()
+                                touch.claim.begin(touch.startedAt)
                                 probeUnderFinger(down[0].position)
                             }
 
@@ -1883,6 +1886,7 @@ fun ReaderScreen(
                         }
                         when {
                             down.size >= 2 && pinchToResizeNow -> {
+                                touch.claim.resizeTook()
                                 val span = PinchResize.spanOf(
                                     down[0].position.x, down[0].position.y,
                                     down[1].position.x, down[1].position.y,
@@ -2070,6 +2074,7 @@ fun ReaderScreen(
                 onToggle = ::toggleBookmarkHere,
                 modifier = Modifier
                     .align(Alignment.TopEnd)
+                    .then(behindViewer)
                     .padding(end = 12.dp),
             )
         }
@@ -2174,6 +2179,7 @@ fun ReaderScreen(
                 onCycleMode = onProgressAction.cycleFooterMode,
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
+                    .then(behindViewer)
                     .padding(bottom = FooterMetrics.BOTTOM_MARGIN_DP.dp),
             )
         }
@@ -2280,32 +2286,36 @@ fun ReaderScreen(
         // the thing the reader just asked for, and the page, the pills and
         // the chrome are all what they asked to be shown it over.
         footnote?.let { note ->
-            FootnoteCard(
-                html = note.html,
-                theme = readingTheme,
-                anchorY = lastTouchY,
-                onGoToNote = {
-                    onDismissFootnote()
-                    onProgressAction.onJump()
-                    navigator?.let { nav ->
-                        val noteToken = moves.issue(
-                            from = nav.currentLocator.value.restorePoint(),
-                            to = publication.locatorFromLink(note.link)?.destination(),
-                            nowMs = SystemClock.elapsedRealtime(),
-                        )
-                        if (!nav.go(note.link, animated = false)) moves.cancel(noteToken)
-                    }
-                },
-                onDismiss = onDismissFootnote,
-            )
+            Box(Modifier.fillMaxSize().then(behindViewer)) {
+                FootnoteCard(
+                    html = note.html,
+                    theme = readingTheme,
+                    anchorY = lastTouchY,
+                    onGoToNote = {
+                        onDismissFootnote()
+                        onProgressAction.onJump()
+                        navigator?.let { nav ->
+                            val noteToken = moves.issue(
+                                from = nav.currentLocator.value.restorePoint(),
+                                to = publication.locatorFromLink(note.link)?.destination(),
+                                nowMs = SystemClock.elapsedRealtime(),
+                            )
+                            if (!nav.go(note.link, animated = false)) moves.cancel(noteToken)
+                        }
+                    },
+                    onDismiss = onDismissFootnote,
+                )
+            }
         }
 
         // Above the note guard rather than below it, because a pinch is
         // refused outright while a note is open, so the two can never be
         // on screen together.
-        when {
-            pinchRefused -> FixedLayoutPinchHud(theme = readingTheme)
-            else -> pinchTarget?.let { FontSizeHud(size = it, theme = readingTheme) }
+        Box(Modifier.fillMaxSize().then(behindViewer)) {
+            when {
+                pinchRefused -> FixedLayoutPinchHud(theme = readingTheme)
+                else -> pinchTarget?.let { FontSizeHud(size = it, theme = readingTheme) }
+            }
         }
 
         // Last of all: a picture asked for full screen is the thing the
@@ -2329,51 +2339,53 @@ fun ReaderScreen(
     }
 
     selection?.let { active ->
-        SelectionPopup(
-            offset = active.popupOffset(),
-            activeTint = active.existing?.tint?.let(HighlightTint::fromName),
-            actions = remember(active, dictionary) {
-                SelectionActions(
-                    onHighlight = { tint ->
-                        onAnnotationAction.highlight(active.locator, tint, active.existing?.id)
-                        dismissSelection()
-                    },
-                    onNote = {
-                        noteFor = active
-                        dismissSelection()
-                    },
-                    onSearch = {
-                        searchFor = active.text
-                        dismissSelection()
-                    },
-                    onLookUp = {
-                        when (dictionary.target) {
-                            DefinitionTarget.BUILT_IN -> defineWord = active.text
-                            DefinitionTarget.EXTERNAL_APP -> {
-                                context.lookUpExternally(active.text, dictionary.baseUrl)
-                            }
-                        }
-                        dismissSelection()
-                    },
-                    onShare = {
-                        context.shareText(active.text, publication.metadata.title)
-                        dismissSelection()
-                    },
-                    onDelete = active.existing?.let { existing ->
-                        {
-                            onAnnotationAction.remove(existing)
+        Box(Modifier.fillMaxSize().then(behindViewer)) {
+            SelectionPopup(
+                offset = active.popupOffset(),
+                activeTint = active.existing?.tint?.let(HighlightTint::fromName),
+                actions = remember(active, dictionary) {
+                    SelectionActions(
+                        onHighlight = { tint ->
+                            onAnnotationAction.highlight(active.locator, tint, active.existing?.id)
                             dismissSelection()
-                        }
-                    },
-                )
-            },
-            onDismiss = {
-                // The bar and the selection go together: leaving the page
-                // selected keeps the platform's handles alive and drawing
-                // over words the reader has finished with.
-                dismissSelection()
-            },
-        )
+                        },
+                        onNote = {
+                            noteFor = active
+                            dismissSelection()
+                        },
+                        onSearch = {
+                            searchFor = active.text
+                            dismissSelection()
+                        },
+                        onLookUp = {
+                            when (dictionary.target) {
+                                DefinitionTarget.BUILT_IN -> defineWord = active.text
+                                DefinitionTarget.EXTERNAL_APP -> {
+                                    context.lookUpExternally(active.text, dictionary.baseUrl)
+                                }
+                            }
+                            dismissSelection()
+                        },
+                        onShare = {
+                            context.shareText(active.text, publication.metadata.title)
+                            dismissSelection()
+                        },
+                        onDelete = active.existing?.let { existing ->
+                            {
+                                onAnnotationAction.remove(existing)
+                                dismissSelection()
+                            }
+                        },
+                    )
+                },
+                onDismiss = {
+                    // The bar and the selection go together: leaving the page
+                    // selected keeps the platform's handles alive and drawing
+                    // over words the reader has finished with.
+                    dismissSelection()
+                },
+            )
+        }
     }
 
     defineWord?.let { word ->
@@ -2978,16 +2990,11 @@ private class TouchProbe {
     var resourceHasImages = false
 
     /**
-     * Whether an image answer is still young enough to change what this
-     * touch means.
+     * Whether a resize has had hold of this touch at any point.
      *
-     * Only ever asked of a touch a resize has already got hold of: the
-     * budget exists so that a document which took half a second to answer
-     * cannot yank the gesture out from under fingers that have spent that
-     * half second resizing. A gesture nothing else has claimed is not on
-     * a clock — a long press is deliberately slower than this — so ask
-     * through `imageMayWin` rather than reaching for this directly.
+     * Sticky for the life of the whole sequence, and cleared only when a
+     * fresh touch begins; see [GestureClaim] for why the live pinch is
+     * the wrong thing to read.
      */
-    fun undecided(): Boolean =
-        SystemClock.uptimeMillis() - startedAt <= DECIDE_BUDGET_MS
+    val claim = GestureClaim(DECIDE_BUDGET_MS)
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -2338,54 +2338,59 @@ fun ReaderScreen(
         selection = null
     }
 
-    selection?.let { active ->
-        Box(Modifier.fillMaxSize().then(behindViewer)) {
-            SelectionPopup(
-                offset = active.popupOffset(),
-                activeTint = active.existing?.tint?.let(HighlightTint::fromName),
-                actions = remember(active, dictionary) {
-                    SelectionActions(
-                        onHighlight = { tint ->
-                            onAnnotationAction.highlight(active.locator, tint, active.existing?.id)
-                            dismissSelection()
-                        },
-                        onNote = {
-                            noteFor = active
-                            dismissSelection()
-                        },
-                        onSearch = {
-                            searchFor = active.text
-                            dismissSelection()
-                        },
-                        onLookUp = {
-                            when (dictionary.target) {
-                                DefinitionTarget.BUILT_IN -> defineWord = active.text
-                                DefinitionTarget.EXTERNAL_APP -> {
-                                    context.lookUpExternally(active.text, dictionary.baseUrl)
-                                }
+    // Not composed at all while a picture is open, rather than hidden the
+    // way the rest of the chrome is. This one is a `Popup`, which is a
+    // window of its own: a modifier on the box around it reaches neither
+    // its semantics nor its drawing order, so hiding it would leave a bar
+    // of buttons a screen reader could still operate — and draw them over
+    // the picture besides. The selection itself is untouched and comes
+    // back with the bar when the picture is dismissed.
+    selection?.takeIf { viewedImage == null }?.let { active ->
+        SelectionPopup(
+            offset = active.popupOffset(),
+            activeTint = active.existing?.tint?.let(HighlightTint::fromName),
+            actions = remember(active, dictionary) {
+                SelectionActions(
+                    onHighlight = { tint ->
+                        onAnnotationAction.highlight(active.locator, tint, active.existing?.id)
+                        dismissSelection()
+                    },
+                    onNote = {
+                        noteFor = active
+                        dismissSelection()
+                    },
+                    onSearch = {
+                        searchFor = active.text
+                        dismissSelection()
+                    },
+                    onLookUp = {
+                        when (dictionary.target) {
+                            DefinitionTarget.BUILT_IN -> defineWord = active.text
+                            DefinitionTarget.EXTERNAL_APP -> {
+                                context.lookUpExternally(active.text, dictionary.baseUrl)
                             }
+                        }
+                        dismissSelection()
+                    },
+                    onShare = {
+                        context.shareText(active.text, publication.metadata.title)
+                        dismissSelection()
+                    },
+                    onDelete = active.existing?.let { existing ->
+                        {
+                            onAnnotationAction.remove(existing)
                             dismissSelection()
-                        },
-                        onShare = {
-                            context.shareText(active.text, publication.metadata.title)
-                            dismissSelection()
-                        },
-                        onDelete = active.existing?.let { existing ->
-                            {
-                                onAnnotationAction.remove(existing)
-                                dismissSelection()
-                            }
-                        },
-                    )
-                },
-                onDismiss = {
-                    // The bar and the selection go together: leaving the page
-                    // selected keeps the platform's handles alive and drawing
-                    // over words the reader has finished with.
-                    dismissSelection()
-                },
-            )
-        }
+                        }
+                    },
+                )
+            },
+            onDismiss = {
+                // The bar and the selection go together: leaving the page
+                // selected keeps the platform's handles alive and drawing
+                // over words the reader has finished with.
+                dismissSelection()
+            },
+        )
     }
 
     defineWord?.let { word ->

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
@@ -130,7 +131,11 @@ import com.chmouel.liseur.reader.chrome.layoutPasses
 import com.chmouel.liseur.reader.chrome.ReadingScrubber
 import com.chmouel.liseur.reader.chrome.ContentsScreen
 import com.chmouel.liseur.reader.chrome.Endpaper
+import com.chmouel.liseur.reader.chrome.FixedLayoutPinchHud
+import com.chmouel.liseur.reader.chrome.FontSizeHud
 import com.chmouel.liseur.reader.chrome.FootnoteCard
+import com.chmouel.liseur.reader.chrome.PinchResize
+import com.chmouel.liseur.reader.chrome.PinchStart
 import com.chmouel.liseur.reader.chrome.GoToPageDialog
 import com.chmouel.liseur.reader.chrome.GoToPercentDialog
 import com.chmouel.liseur.reader.chrome.TypographySheet
@@ -313,6 +318,7 @@ fun ReaderScreen(
     scrollModeFlow: StateFlow<Boolean>,
     onScrollModeChanged: (Boolean) -> Unit,
     tapZonesFlow: StateFlow<TapZones>,
+    pinchToResizeFlow: StateFlow<Boolean>,
     // The activity draws dialogs of its own over this screen — a link
     // out of the book, a sync, an offer to send the book up — and a tap
     // on a link never reaches the tap zones, so the screen would
@@ -338,6 +344,7 @@ fun ReaderScreen(
     val scrollMode by scrollModeFlow.collectAsStateWithLifecycle()
     val tapZones by tapZonesFlow.collectAsStateWithLifecycle()
     val swappedZonesNow by rememberUpdatedState(tapZones.swapped)
+    val pinchToResize by pinchToResizeFlow.collectAsStateWithLifecycle()
     // Readium reads vertical text off the book rather than off the
     // reader: it cannot paginate lines that run down the page, so such a
     // book is scrolled whatever the setting says. Everything that asks
@@ -387,6 +394,28 @@ fun ReaderScreen(
      */
     var lastTouchY by remember { mutableStateOf<Float?>(null) }
     var fingerDown by remember { mutableStateOf(false) }
+    /*
+     * The pinch on the page, and what it is landing on.
+     *
+     * Nothing here is committed while the fingers move. The size the
+     * gesture is heading for is drawn over the page as a preview and
+     * written once, on the lift, because every intermediate value would
+     * be a reflow and an anchor-and-restore of a book the reader is
+     * holding still — the same reason the Size slider commits on
+     * `onValueChangeFinished` and not on every notch. See
+     * `docs/adr/0022-pinch-on-the-page.md`.
+     *
+     * [pinchStart] and [pinchSettledAt] are held as state objects rather
+     * than through `by`, because the tap zones read them from a lambda
+     * that outlives every recomposition.
+     */
+    val pinchStart = remember { mutableStateOf<PinchStart?>(null) }
+    val pinchSettledAt = remember { mutableLongStateOf(0L) }
+    var pinchTarget by remember { mutableStateOf<Double?>(null) }
+    var pinchRefused by remember { mutableStateOf(false) }
+    val pinchToResizeNow by rememberUpdatedState(pinchToResize)
+    val fontSizeNow by rememberUpdatedState(prefs.fontSize)
+    val setFontSizeNow by rememberUpdatedState(onPrefsAction.setFontSize)
     // The tracker below outlives every recomposition, so it cannot read
     // `footnote` directly — it would keep seeing whatever was true when it
     // started. This gives it a window onto the current value.
@@ -1435,12 +1464,17 @@ fun ReaderScreen(
         pageTurner.publication = publication
         onPageTurnerChanged(if (nav != null) pageTurner else null)
         val listeners = nav?.let {
+            val isPinching = {
+                pinchStart.value != null ||
+                    SystemClock.uptimeMillis() - pinchSettledAt.longValue < PinchResize.GUARD_MS
+            }
             listOf(
                 ReaderTapZones(
                     navigator = it,
                     isChromeVisible = { chromeVisibleNow },
                     isScrolling = { effectiveScrollingNow },
                     isSwapped = { swappedZonesNow },
+                    isPinching = isPinching,
                     onTurnPage = pageTurner::turn,
                     onShowChrome = { chromeVisible = true },
                     onHideChrome = { chromeVisible = false },
@@ -1449,6 +1483,7 @@ fun ReaderScreen(
                     navigator = it,
                     isScrolling = { effectiveScrollingNow },
                     isVerticalText = { it.settings.value.verticalText },
+                    isPinching = isPinching,
                     onStepChapter = { forward -> pageTurner.stepChapter(forward) },
                 ),
             ).onEach(it::addInputListener)
@@ -1557,8 +1592,49 @@ fun ReaderScreen(
                         // the card would become the new anchor and the card
                         // would jump out from under the finger scrolling it.
                         if (noteShowing) continue
-                        event.changes.firstOrNull { it.pressed }
-                            ?.let { lastTouchY = it.position.y }
+
+                        val down = event.changes.filter { it.pressed }
+                        when {
+                            down.size >= 2 && pinchToResizeNow -> {
+                                val span = PinchResize.spanOf(
+                                    down[0].position.x, down[0].position.y,
+                                    down[1].position.x, down[1].position.y,
+                                )
+                                val start = pinchStart.value ?: PinchStart(span, fontSizeNow)
+                                    .also {
+                                        pinchStart.value = it
+                                        pinchTarget = null
+                                        // A fixed-layout book places every
+                                        // page itself and Readium honours
+                                        // no font size inside one, so the
+                                        // pinch says so rather than doing
+                                        // nothing at all (ADR 20, ADR 22).
+                                        pinchRefused = !reflowableText
+                                    }
+                                if (reflowableText) {
+                                    PinchResize.targetFor(start.size, start.span, span)
+                                        ?.let { pinchTarget = it }
+                                }
+                                // Only once a second finger is down.
+                                // Consuming a lone pointer here would take
+                                // the ordinary tap away from the page, and
+                                // the ordinary tap is how the book is read.
+                                event.changes.forEach { it.consume() }
+                            }
+
+                            pinchStart.value != null -> {
+                                // One commit, one reflow, one anchor.
+                                pinchTarget?.let { if (it != fontSizeNow) setFontSizeNow(it) }
+                                pinchStart.value = null
+                                pinchTarget = null
+                                pinchRefused = false
+                                pinchSettledAt.longValue = SystemClock.uptimeMillis()
+                                event.changes.forEach { it.consume() }
+                            }
+
+                            else -> event.changes.firstOrNull { it.pressed }
+                                ?.let { lastTouchY = it.position.y }
+                        }
                     }
                 }
             },
@@ -1933,6 +2009,14 @@ fun ReaderScreen(
                 },
                 onDismiss = onDismissFootnote,
             )
+        }
+
+        // Above the note guard rather than below it, because a pinch is
+        // refused outright while a note is open, so the two can never be
+        // on screen together.
+        when {
+            pinchRefused -> FixedLayoutPinchHud(theme = readingTheme)
+            else -> pinchTarget?.let { FontSizeHud(size = it, theme = readingTheme) }
         }
     }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -809,6 +809,11 @@ class ReaderViewModel(
         .map { it.tapZones }
         .stateIn(viewModelScope, SharingStarted.Eagerly, TapZones.Default)
 
+    /** Whether a two-finger pinch on the page resizes the text, app-wide. */
+    val pinchToResize: StateFlow<Boolean> = appSettings.settings
+        .map { it.pinchToResize }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, true)
+
     /** Most recent position, used to persist progress and to survive recreation. */
     var lastLocator: Locator? = null
         private set

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ResourceAddress.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ResourceAddress.kt
@@ -28,7 +28,21 @@ internal object ResourceAddress {
         return shown == named
     }
 
-    private fun path(raw: String?): String? {
+    /**
+     * The publication-relative href [webUrl] addresses, if any.
+     *
+     * The same origin-stripping [shows] compares by, exposed because
+     * reading a resource the page named — the file behind an `<img>`,
+     * say — has to spell it the way the publication does, and a second
+     * spelling of this is a second thing to get wrong.
+     *
+     * Percent escapes are *kept*, unlike in the comparison below: this
+     * answer is handed back to Readium as a URL, and a book is free to
+     * ship a file with a space in its name.
+     */
+    fun href(webUrl: String?): String? = relative(webUrl)
+
+    private fun relative(raw: String?): String? {
         val address = raw?.substringBefore('#')?.substringBefore('?')?.trim() ?: return null
         if (address.isEmpty()) return null
         val origin = address.indexOf("://")
@@ -37,8 +51,11 @@ internal object ResourceAddress {
         } else {
             address.substring(origin + 3).substringAfter('/', "")
         }
-        return decode(path).trimStart('/').takeIf { it.isNotEmpty() }
+        return path.trimStart('/').takeIf { it.isNotEmpty() }
     }
+
+    private fun path(raw: String?): String? =
+        relative(raw)?.let(::decode)?.trimStart('/')?.takeIf { it.isNotEmpty() }
 
     /**
      * Percent decoding, rather than `URLDecoder`, which reads `+` as a

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/FontSizeHud.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/FontSizeHud.kt
@@ -1,0 +1,105 @@
+package com.chmouel.liseur.reader.chrome
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.chmouel.liseur.R
+import com.chmouel.liseur.data.settings.ReaderTheme
+import com.chmouel.liseur.ui.LocalEInk
+import kotlin.math.roundToInt
+
+/** The base the "Aa" sample is drawn at, before the size multiplier. */
+private const val SAMPLE_BASE_SP = 22f
+
+/**
+ * What a pinch on the page is doing, while it is doing it.
+ *
+ * The reader is not asking "what multiplier is this", they are asking
+ * "can I read that", so the pill answers in the only terms that question
+ * has: the letters "Aa" drawn at the size being landed on. The page
+ * underneath has not moved — nothing commits until the fingers lift (see
+ * `docs/adr/0022-pinch-on-the-page.md`) — so this sample is the whole of
+ * the feedback.
+ *
+ * Painted in the reading theme rather than in Material colours, for the
+ * same reason [FootnoteCard] is: a white card over a black page at night
+ * is a lamp in the face.
+ *
+ * Laid over the page inside the reader's own box, and deliberately not
+ * clickable: the fingers that raised it are already busy, and a target
+ * under them would take the gesture away from the page.
+ */
+@Composable
+fun FontSizeHud(size: Double, theme: ReaderTheme) {
+    // The sample is a picture of a size, not a line of prose: "Aa" read
+    // aloud tells a screen reader nothing, and the percentage does.
+    val spoken = stringResource(R.string.reader_pinch_size, (size * 100).roundToInt())
+    HudPill(theme) {
+        Text(
+            text = stringResource(R.string.reader_pinch_sample),
+            color = theme.foreground,
+            fontSize = (SAMPLE_BASE_SP * size).sp,
+            modifier = Modifier.clearAndSetSemantics { contentDescription = spoken },
+        )
+    }
+}
+
+/**
+ * The same pill, saying why the pinch did nothing.
+ *
+ * A fixed-layout book places every page itself and Readium honours no
+ * font size inside one, so the gesture has nothing to change. Saying so
+ * is the whole point: a gesture that silently does nothing does not read
+ * as "this book carries its own layout", it reads as broken, and worse
+ * than a greyed-out slider does, because the reader cannot even tell
+ * whether the app saw the pinch. Same argument as
+ * `docs/adr/0020-fixed-layout-reading-settings.md`, same wording as the
+ * line the typography sheet already shows.
+ */
+@Composable
+fun FixedLayoutPinchHud(theme: ReaderTheme) {
+    HudPill(theme) {
+        Text(
+            text = stringResource(R.string.reader_typography_fixed_layout),
+            color = theme.foreground,
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+private fun HudPill(theme: ReaderTheme, content: @Composable () -> Unit) {
+    val eInk = LocalEInk.current
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Surface(
+            shape = RoundedCornerShape(20.dp),
+            color = theme.background,
+            contentColor = theme.foreground,
+            border = BorderStroke(1.dp, theme.foreground.copy(alpha = 0.25f)),
+            shadowElevation = if (eInk) 0.dp else 12.dp,
+            modifier = Modifier.widthIn(max = 320.dp),
+        ) {
+            Box(
+                Modifier.padding(horizontal = 28.dp, vertical = 20.dp),
+                contentAlignment = Alignment.Center,
+                content = { content() },
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/GestureClaim.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/GestureClaim.kt
@@ -1,0 +1,49 @@
+package com.chmouel.liseur.reader.chrome
+
+/**
+ * Which of the two pinch gestures a touch belongs to, once the document
+ * has answered late.
+ *
+ * The page is asked what is under the finger as the finger lands, and the
+ * answer arrives whenever it arrives. Usually that is before the second
+ * finger is down and the question never comes up. When it is not, the
+ * answer must not be allowed to yank the gesture out from under fingers
+ * that have spent that time resizing — so a resize that has taken the
+ * touch keeps it, unless the answer is young enough to have been part of
+ * the same decision.
+ *
+ * A touch nothing has taken is deliberately not on a clock. Fingers that
+ * take their time arriving at a picture, and a long press, are both
+ * slower than the budget, and both still get the picture.
+ *
+ * Kept apart from the pointer loop because the interesting case is a
+ * *sequence*: a resize is forgotten the instant it drops to one finger,
+ * while the touch itself runs on until the last finger leaves. Reading
+ * the live pinch there would make a long resize count as unclaimed again
+ * the moment a finger lifted, and a replacement finger landing then would
+ * open the picture the first finger had been over. So the claim is held
+ * here, for the life of the whole touch, and cleared only by a touch that
+ * began with no fingers already down.
+ */
+class GestureClaim(private val budgetMs: Long) {
+    private var startedAt = 0L
+    private var resizeHolds = false
+
+    /** True once a resize has had hold of the touch now in progress. */
+    val claimed: Boolean get() = resizeHolds
+
+    /** A genuinely new touch: every finger had left before this one landed. */
+    fun begin(nowMs: Long) {
+        startedAt = nowMs
+        resizeHolds = false
+    }
+
+    /** A resize has taken this touch, and keeps it until the touch ends. */
+    fun resizeTook() {
+        resizeHolds = true
+    }
+
+    /** Whether an image answer may still decide what this touch means. */
+    fun imageMayWin(nowMs: Long): Boolean =
+        !resizeHolds || nowMs - startedAt <= budgetMs
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/GestureClaim.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/GestureClaim.kt
@@ -16,6 +16,12 @@ package com.chmouel.liseur.reader.chrome
  * take their time arriving at a picture, and a long press, are both
  * slower than the budget, and both still get the picture.
  *
+ * The same budget also decides how long a second finger waits before the
+ * gesture gives up on the document and becomes a resize. Until then the
+ * gesture is held: consumed, so nothing else acts on it, but committing
+ * nothing, so fingers that lift while the answer is still in flight
+ * change no size.
+ *
  * Kept apart from the pointer loop because the interesting case is a
  * *sequence*: a resize is forgotten the instant it drops to one finger,
  * while the touch itself runs on until the last finger leaves. Reading
@@ -42,6 +48,9 @@ class GestureClaim(private val budgetMs: Long) {
     fun resizeTook() {
         resizeHolds = true
     }
+
+    /** Whether the gesture must wait rather than commit to being a resize. */
+    fun undecided(nowMs: Long): Boolean = !resizeHolds && nowMs - startedAt <= budgetMs
 
     /** Whether an image answer may still decide what this touch means. */
     fun imageMayWin(nowMs: Long): Boolean =

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageViewer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageViewer.kt
@@ -1,0 +1,176 @@
+package com.chmouel.liseur.reader.chrome
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.isSpecified
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.chmouel.liseur.R
+
+/** A picture the reader asked to see, with the book's own caption for it. */
+data class ViewedImage(val bytes: ByteArray, val alt: String?) {
+    override fun equals(other: Any?): Boolean =
+        this === other || (other is ViewedImage && bytes === other.bytes && alt == other.alt)
+
+    override fun hashCode(): Int = System.identityHashCode(bytes) * 31 + (alt?.hashCode() ?: 0)
+}
+
+/**
+ * A picture from the book, on the app's own page rather than the book's.
+ *
+ * The alternative was zooming the web view in place, and it does not
+ * work: an enlarged image fights the paginated column layout it sits in,
+ * there is nothing to dismiss, and the reader is left pinching their way
+ * back to exactly 1.0 before the page turns properly again. A full-screen
+ * overlay has none of those problems and is the only place `BackHandler`
+ * means anything. See `docs/adr/0022-pinch-on-the-page.md`.
+ *
+ * Drawn over everything on a black scrim, in Material colours rather than
+ * in the reading theme: this is not the page any more, and a picture is
+ * judged against black in every other viewer the reader owns.
+ */
+@Composable
+fun ImageViewer(image: ViewedImage, onDismiss: () -> Unit) {
+    var scale by remember(image) { mutableFloatStateOf(ImageZoom.MIN_SCALE) }
+    var offsetX by remember(image) { mutableFloatStateOf(0f) }
+    var offsetY by remember(image) { mutableFloatStateOf(0f) }
+    var viewport by remember { mutableStateOf(IntSize.Zero) }
+    // The picture's own size, not the composable's. The image is drawn to
+    // fit inside a box that fills the screen, so the box says nothing
+    // about how far the picture reaches: panning by the box would let the
+    // reader drag the letterbox into view and lose the picture off the
+    // other edge.
+    var natural by remember(image) { mutableStateOf(Size.Unspecified) }
+    val dismissTravel = with(LocalDensity.current) { ImageZoom.DISMISS_TRAVEL_DP.dp.toPx() }
+
+    fun hold() {
+        val (w, h) = ImageZoom.fitted(
+            contentW = natural.takeIf { it.isSpecified }?.width ?: 0f,
+            contentH = natural.takeIf { it.isSpecified }?.height ?: 0f,
+            viewW = viewport.width.toFloat(),
+            viewH = viewport.height.toFloat(),
+        )
+        offsetX = ImageZoom.clampPan(offsetX, viewport.width.toFloat(), w * scale)
+        offsetY = ImageZoom.clampPan(offsetY, viewport.height.toFloat(), h * scale)
+    }
+
+    BackHandler(onBack = onDismiss)
+
+    Box(
+        Modifier
+            .fillMaxSize()
+            .background(Color.Black)
+            .onSizeChanged { viewport = it }
+            .pointerInput(image) {
+                detectTapGestures(
+                    // A tap while zoomed in is how a reader steadies the
+                    // picture, so only a tap at fit is a tap meaning
+                    // "done with this".
+                    onTap = { if (ImageZoom.atFit(scale)) onDismiss() },
+                    onDoubleTap = { point ->
+                        if (ImageZoom.atFit(scale)) {
+                            scale = ImageZoom.DOUBLE_TAP_SCALE
+                            // Zoom towards what was tapped, not towards
+                            // the middle: the reader tapped the corner of
+                            // the map they want to read.
+                            offsetX = (viewport.width / 2f - point.x) * (scale - 1f)
+                            offsetY = (viewport.height / 2f - point.y) * (scale - 1f)
+                        } else {
+                            scale = ImageZoom.MIN_SCALE
+                            offsetX = 0f
+                            offsetY = 0f
+                        }
+                        hold()
+                    },
+                )
+            }
+            .pointerInput(image) {
+                detectTransformGestures { _, pan, zoom, _ ->
+                    val wasAtFit = ImageZoom.atFit(scale)
+                    scale = ImageZoom.clampScale(scale * zoom)
+                    offsetX += pan.x
+                    offsetY += pan.y
+                    // Dragging a picture that already fits has nowhere to
+                    // go, so it means put it away. Downwards only: it is
+                    // the direction every other viewer uses, and it does
+                    // not collide with the sideways pan of a wide plate.
+                    if (wasAtFit && ImageZoom.atFit(scale) && offsetY > dismissTravel) {
+                        onDismiss()
+                    }
+                    hold()
+                }
+            },
+    ) {
+        AsyncImage(
+            model = image.bytes,
+            contentDescription = image.alt,
+            contentScale = ContentScale.Fit,
+            onSuccess = { natural = it.painter.intrinsicSize },
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer {
+                    scaleX = scale
+                    scaleY = scale
+                    translationX = offsetX
+                    translationY = offsetY
+                },
+        )
+
+        image.alt?.let { caption ->
+            Text(
+                text = caption,
+                color = Color.White,
+                style = MaterialTheme.typography.bodySmall,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .safeDrawingPadding()
+                    .padding(horizontal = 24.dp, vertical = 16.dp),
+            )
+        }
+
+        IconButton(
+            onClick = onDismiss,
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .safeDrawingPadding()
+                .padding(8.dp),
+        ) {
+            Icon(
+                Icons.Filled.Close,
+                contentDescription = stringResource(R.string.close),
+                tint = Color.White,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageViewer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageViewer.kt
@@ -34,6 +34,10 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -78,6 +82,7 @@ fun ImageViewer(image: ViewedImage, onDismiss: () -> Unit) {
     // other edge.
     var natural by remember(image) { mutableStateOf(Size.Unspecified) }
     val dismissTravel = with(LocalDensity.current) { ImageZoom.DISMISS_TRAVEL_DP.dp.toPx() }
+    val viewerTitle = image.alt ?: stringResource(R.string.reader_image_viewer)
 
     fun hold() {
         val (w, h) = ImageZoom.fitted(
@@ -96,6 +101,16 @@ fun ImageViewer(image: ViewedImage, onDismiss: () -> Unit) {
         Modifier
             .fillMaxSize()
             .background(Color.Black)
+            // Modal in the way that matters to somebody who cannot see
+            // it: without this the reader's own chrome stays reachable
+            // behind the picture, so a swipe lands on a control that is
+            // not on screen. Nothing under the viewer is addressable
+            // while it is up, which is already true for touch.
+            .semantics {
+                isTraversalGroup = true
+                traversalIndex = -1f
+                paneTitle = viewerTitle
+            }
             .onSizeChanged { viewport = it }
             .pointerInput(image) {
                 detectTapGestures(

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageViewer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageViewer.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
@@ -22,9 +23,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.isSpecified
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
@@ -36,6 +39,9 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.chmouel.liseur.R
+
+/** Enough of the scrim to keep a caption legible over a pale picture. */
+private val CAPTION_BACKING = Color.Black.copy(alpha = 0.66f)
 
 /** A picture the reader asked to see, with the book's own caption for it. */
 data class ViewedImage(val bytes: ByteArray, val alt: String?) {
@@ -143,6 +149,28 @@ fun ImageViewer(image: ViewedImage, onDismiss: () -> Unit) {
                     scaleY = scale
                     translationX = offsetX
                     translationY = offsetY
+                }
+                // Paper under the ink. A great many book illustrations are
+                // black line art on a transparent background — Standard
+                // Ebooks marks them `se:image.color-depth.black-on-transparent`
+                // — and on the scrim those are simply invisible. Drawn to
+                // the picture's own fitted rectangle rather than to the
+                // whole screen, so a photograph covers it completely and
+                // never shows a white border.
+                .drawBehind {
+                    if (!natural.isSpecified) return@drawBehind
+                    val (w, h) = ImageZoom.fitted(
+                        contentW = natural.width,
+                        contentH = natural.height,
+                        viewW = size.width,
+                        viewH = size.height,
+                    )
+                    if (w <= 0f || h <= 0f) return@drawBehind
+                    drawRect(
+                        color = Color.White,
+                        topLeft = Offset((size.width - w) / 2f, (size.height - h) / 2f),
+                        size = Size(w, h),
+                    )
                 },
         )
 
@@ -155,7 +183,12 @@ fun ImageViewer(image: ViewedImage, onDismiss: () -> Unit) {
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .safeDrawingPadding()
-                    .padding(horizontal = 24.dp, vertical = 16.dp),
+                    .padding(horizontal = 24.dp, vertical = 16.dp)
+                    // The caption sits over whatever the picture leaves
+                    // there, which after the paper behind a line drawing
+                    // can be white.
+                    .background(CAPTION_BACKING, RoundedCornerShape(8.dp))
+                    .padding(horizontal = 12.dp, vertical = 6.dp),
             )
         }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageViewer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageViewer.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.isTraversalGroup
@@ -42,17 +43,51 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.size.Size as CoilSize
 import com.chmouel.liseur.R
 
 /** Enough of the scrim to keep a caption legible over a pale picture. */
 private val CAPTION_BACKING = Color.Black.copy(alpha = 0.66f)
 
-/** A picture the reader asked to see, with the book's own caption for it. */
-data class ViewedImage(val bytes: ByteArray, val alt: String?) {
-    override fun equals(other: Any?): Boolean =
-        this === other || (other is ViewedImage && bytes === other.bytes && alt == other.alt)
+/**
+ * The largest picture decoded at its own size rather than the screen's.
+ *
+ * A decoded bitmap costs four bytes a pixel whatever the file weighs, so
+ * eight megapixels is thirty-two megabytes held for as long as the viewer
+ * is open. That is affordable, and it is roughly where book plates stop:
+ * a scan far bigger than this is a page of an atlas, and it goes back to
+ * decoding for the screen rather than risking the process.
+ */
+private const val MAX_DECODE_PIXELS = 8_000_000L
 
-    override fun hashCode(): Int = System.identityHashCode(bytes) * 31 + (alt?.hashCode() ?: 0)
+/** A picture the reader asked to see, with the book's own caption for it. */
+data class ViewedImage(
+    val bytes: ByteArray,
+    val alt: String?,
+    val caption: String?,
+    val width: Int,
+    val height: Int,
+) {
+    /**
+     * The line printed under the picture.
+     *
+     * The book's own caption where it wrote one, and the alternative text
+     * otherwise — which is a description rather than a caption, but a
+     * description of the thing on screen is still better than a blank
+     * strip, and a great many books carry nothing else.
+     */
+    val subtitle: String? get() = caption ?: alt
+
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            (
+                other is ViewedImage && bytes === other.bytes && alt == other.alt &&
+                    caption == other.caption
+                )
+
+    override fun hashCode(): Int =
+        System.identityHashCode(bytes) * 31 + (subtitle?.hashCode() ?: 0)
 }
 
 /**
@@ -82,6 +117,7 @@ fun ImageViewer(image: ViewedImage, onDismiss: () -> Unit) {
     // other edge.
     var natural by remember(image) { mutableStateOf(Size.Unspecified) }
     val dismissTravel = with(LocalDensity.current) { ImageZoom.DISMISS_TRAVEL_DP.dp.toPx() }
+    val context = LocalContext.current
     val viewerTitle = image.alt ?: stringResource(R.string.reader_image_viewer)
 
     fun hold() {
@@ -152,8 +188,24 @@ fun ImageViewer(image: ViewedImage, onDismiss: () -> Unit) {
                 }
             },
     ) {
+        // Decoded at the picture's own size rather than at the size of the
+        // screen, so that zooming in reveals the plate instead of
+        // magnifying a screen-sized copy of it. A book can name any size
+        // it likes, though, and a bitmap costs four bytes a pixel however
+        // little the file weighs, so past a budget it goes back to
+        // decoding for the screen: blurred at six times is a worse
+        // picture, and a dead process is no picture at all.
+        val model = remember(image) {
+            ImageRequest.Builder(context)
+                .data(image.bytes)
+                .apply {
+                    val pixels = image.width.toLong() * image.height.toLong()
+                    if (pixels in 1..MAX_DECODE_PIXELS) size(CoilSize.ORIGINAL)
+                }
+                .build()
+        }
         AsyncImage(
-            model = image.bytes,
+            model = model,
             contentDescription = image.alt,
             contentScale = ContentScale.Fit,
             onSuccess = { natural = it.painter.intrinsicSize },
@@ -189,7 +241,7 @@ fun ImageViewer(image: ViewedImage, onDismiss: () -> Unit) {
                 },
         )
 
-        image.alt?.let { caption ->
+        image.subtitle?.let { caption ->
             Text(
                 text = caption,
                 color = Color.White,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageViewer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageViewer.kt
@@ -2,6 +2,8 @@ package com.chmouel.liseur.reader.chrome
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Box
@@ -29,6 +31,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.isSpecified
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
@@ -116,6 +119,11 @@ fun ImageViewer(image: ViewedImage, onDismiss: () -> Unit) {
     // reader drag the letterbox into view and lose the picture off the
     // other edge.
     var natural by remember(image) { mutableStateOf(Size.Unspecified) }
+    // Counted apart from `offsetY`, which is clamped to nothing at fit
+    // because a fitted picture has nowhere to pan to. Adding the pan to
+    // an offset that is about to be zeroed again measures one frame of
+    // travel rather than a drag, and one frame is never far enough.
+    var dragDown by remember(image) { mutableFloatStateOf(0f) }
     val dismissTravel = with(LocalDensity.current) { ImageZoom.DISMISS_TRAVEL_DP.dp.toPx() }
     val context = LocalContext.current
     val viewerTitle = image.alt ?: stringResource(R.string.reader_image_viewer)
@@ -181,10 +189,29 @@ fun ImageViewer(image: ViewedImage, onDismiss: () -> Unit) {
                     // go, so it means put it away. Downwards only: it is
                     // the direction every other viewer uses, and it does
                     // not collide with the sideways pan of a wide plate.
-                    if (wasAtFit && ImageZoom.atFit(scale) && offsetY > dismissTravel) {
-                        onDismiss()
+                    // Travel back up takes it off again, so a hand that
+                    // wanders down and comes back has not asked.
+                    if (wasAtFit && ImageZoom.atFit(scale)) {
+                        dragDown = ImageZoom.dragTravel(dragDown, pan.y)
+                        if (dragDown > dismissTravel) onDismiss()
+                    } else {
+                        dragDown = 0f
                     }
                     hold()
+                }
+            }
+            // `detectTransformGestures` has no gesture-end callback, and
+            // the travel above needs one: distance covered by two
+            // separate drags is not a drag. Watched on the initial pass
+            // and never consumed, so the detector above still sees
+            // everything.
+            .pointerInput(image) {
+                awaitEachGesture {
+                    awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+                    do {
+                        val event = awaitPointerEvent(PointerEventPass.Initial)
+                    } while (event.changes.any { it.pressed })
+                    dragDown = 0f
                 }
             },
     ) {

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageZoom.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageZoom.kt
@@ -1,0 +1,70 @@
+package com.chmouel.liseur.reader.chrome
+
+/**
+ * The bounds a zoomed image is held inside.
+ *
+ * Pure Kotlin, no Compose types, so the arithmetic that decides whether
+ * a picture can be dragged off the screen is unit-testable. See
+ * `docs/adr/0022-pinch-on-the-page.md`.
+ */
+object ImageZoom {
+    /** Fit: the whole picture on screen, which is where the viewer opens. */
+    const val MIN_SCALE = 1f
+
+    /**
+     * As far in as the reader can go.
+     *
+     * Past this a scanned plate is mostly its own paper grain, and a
+     * vector diagram has long since stopped gaining detail.
+     */
+    const val MAX_SCALE = 6f
+
+    /** Where a double-tap lands, when it is not going back to fit. */
+    const val DOUBLE_TAP_SCALE = 3f
+
+    /** Below this the viewer counts as being at fit, allowing for float drift. */
+    const val FIT_EPSILON = 0.01f
+
+    /** How far the picture is dragged down before it is being dismissed, in dp. */
+    const val DISMISS_TRAVEL_DP = 96f
+
+    fun clampScale(scale: Float): Float = scale.coerceIn(MIN_SCALE, MAX_SCALE)
+
+    /** True when [scale] is close enough to fit that a drag means dismiss. */
+    fun atFit(scale: Float): Boolean = scale <= MIN_SCALE + FIT_EPSILON
+
+    /**
+     * How far the picture may be moved on one axis before it would leave
+     * a gap at the edge of the screen.
+     *
+     * Zero once the drawn size no longer fills the viewport, which is why
+     * a tall picture on a wide screen stays centred sideways however far
+     * in the reader has zoomed.
+     */
+    fun maxPan(viewport: Float, drawn: Float): Float =
+        ((drawn - viewport) / 2f).coerceAtLeast(0f)
+
+    /** [offset] held inside [maxPan]. */
+    fun clampPan(offset: Float, viewport: Float, drawn: Float): Float {
+        val limit = maxPan(viewport, drawn)
+        return offset.coerceIn(-limit, limit)
+    }
+
+    /**
+     * The size a picture of [contentW] by [contentH] is drawn at to fit
+     * inside [viewW] by [viewH], as (width, height).
+     *
+     * A picture smaller than the screen is drawn at the screen's size
+     * rather than at its own: the reader opened the viewer to see it
+     * bigger, and a postage stamp in the middle of a black screen is not
+     * that. Coil is asked to scale it, so the pixels come from the file
+     * rather than from a bitmap already thrown away.
+     */
+    fun fitted(contentW: Float, contentH: Float, viewW: Float, viewH: Float): Pair<Float, Float> {
+        if (contentW <= 0f || contentH <= 0f || viewW <= 0f || viewH <= 0f) {
+            return viewW to viewH
+        }
+        val ratio = minOf(viewW / contentW, viewH / contentH)
+        return contentW * ratio to contentH * ratio
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageZoom.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageZoom.kt
@@ -30,6 +30,20 @@ object ImageZoom {
 
     fun clampScale(scale: Float): Float = scale.coerceIn(MIN_SCALE, MAX_SCALE)
 
+    /**
+     * The travel a downward drag has accumulated, given [travelled] so
+     * far and one frame's [panY].
+     *
+     * Counted here rather than read off the picture's own offset, because
+     * a picture at fit is clamped back to centre after every frame and
+     * so never accumulates anything. Travel back up cancels travel down,
+     * so a hand that wanders and returns has asked for nothing, and it
+     * never goes negative — a drag that started upwards should not need
+     * to be paid back before a later downward one counts.
+     */
+    fun dragTravel(travelled: Float, panY: Float): Float =
+        (travelled + panY).coerceAtLeast(0f)
+
     /** True when [scale] is close enough to fit that a drag means dismiss. */
     fun atFit(scale: Float): Boolean = scale <= MIN_SCALE + FIT_EPSILON
 

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnEffect.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnEffect.kt
@@ -103,6 +103,17 @@ class PageTurner(
     private val isScrolling: () -> Boolean = { false },
     private val isVerticalText: () -> Boolean = { false },
     private val showingEnd: () -> Boolean = { false },
+    /**
+     * Whether the book is behind something and must not be turned.
+     *
+     * Asked of every entry point rather than of every caller, because a
+     * turn arrives from a tap zone, an edge drag, a keyboard and a
+     * volume key, and a modal overlay is modal to all four or to none of
+     * them. A key press is still swallowed: the reader is looking at
+     * something else, and a book turning behind it is worse than a key
+     * that did nothing.
+     */
+    private val isSuspended: () -> Boolean = { false },
     private val onReachedEnd: () -> Unit = {},
     private val onLeaveEnd: () -> Unit = {},
     /**
@@ -144,6 +155,7 @@ class PageTurner(
     private var probeGeneration = 0L
 
     fun turn(forward: Boolean) {
+        if (isSuspended()) return
         if (showingEnd() || pendingEnd) {
             if (!forward && showingEnd()) onLeaveEnd()
             return
@@ -352,6 +364,7 @@ class PageTurner(
      * one that answered when this locator was made.
      */
     fun stepChapter(forward: Boolean): Boolean {
+        if (isSuspended()) return false
         if (showingEnd() || pendingEnd) {
             if (!forward && showingEnd()) onLeaveEnd()
             return false

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PinchResize.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PinchResize.kt
@@ -1,0 +1,107 @@
+package com.chmouel.liseur.reader.chrome
+
+import com.chmouel.liseur.data.settings.ReaderPrefs
+import kotlin.math.abs
+import kotlin.math.hypot
+import kotlin.math.roundToInt
+
+/**
+ * The maths behind pinching the page to change the reading font size.
+ *
+ * Pure Kotlin on purpose: no Android types, no Compose, so the part of
+ * the gesture that can be got wrong is the part that is unit-tested. See
+ * `docs/adr/0022-pinch-on-the-page.md`.
+ *
+ * The size the gesture lands on is one of the positions the Size slider
+ * already offers, derived here from the same range and the same step
+ * count, so the sheet and the gesture cannot drift into offering
+ * different sizes for the same book.
+ */
+object PinchResize {
+    /**
+     * How many sizes the slider offers: its `steps` plus the two ends.
+     *
+     * The slider is declared with `steps = 17` in
+     * `ui/reading/ReadingAppearanceControls.kt`, which Material reads as
+     * seventeen notches *between* the ends.
+     */
+    const val POSITIONS = 18
+
+    /**
+     * How far the fingers must travel before the gesture is a resize.
+     *
+     * A thumb and a finger holding the phone drift against each other by
+     * a few percent without anybody meaning anything by it, and a resize
+     * silently changes how every page looks from then on. Expressed as a
+     * ratio of the span the gesture started with, so it costs the same
+     * movement whether the fingers began an inch apart or a hand's
+     * width.
+     */
+    const val DEAD_ZONE = 0.08
+
+    /** The smallest span worth measuring a ratio against, in pixels. */
+    private const val MIN_START_SPAN = 24f
+
+    private val step: Double
+        get() = (ReaderPrefs.MAX_FONT_SIZE - ReaderPrefs.MIN_FONT_SIZE) / (POSITIONS - 1)
+
+    /** The size at [index], counting from the smallest. */    fun sizeAt(index: Int): Double {
+        val clamped = index.coerceIn(0, POSITIONS - 1)
+        return ReaderPrefs.MIN_FONT_SIZE + clamped * step
+    }
+
+    /** The position [size] belongs to, clamped to the offered range. */
+    fun positionOf(size: Double): Int {
+        val raw = (size - ReaderPrefs.MIN_FONT_SIZE) / step
+        return raw.roundToInt().coerceIn(0, POSITIONS - 1)
+    }
+
+    /** [size] rounded onto the nearest position the slider offers. */
+    fun snap(size: Double): Double = sizeAt(positionOf(size))
+
+    /**
+     * The size a pinch has landed on, or null while it has landed on
+     * nothing.
+     *
+     * Null means "do not commit and do not show a preview": either the
+     * fingers have not left the dead zone yet, or the span is too small
+     * to divide by. It is not the same as landing back on [startSize],
+     * which is a real answer and worth drawing, because a reader who
+     * pinches too far and comes back deserves to see that they are home.
+     *
+     * The ratio is applied to the size the *gesture* started from rather
+     * than to the size the last frame produced, so the value cannot walk
+     * away from the fingers: putting them back where they began puts the
+     * size back where it began.
+     */
+    fun targetFor(startSize: Double, startSpan: Float, currentSpan: Float): Double? {
+        if (startSpan < MIN_START_SPAN || currentSpan <= 0f) return null
+        val ratio = currentSpan / startSpan
+        if (abs(ratio - 1.0) < DEAD_ZONE) return null
+        return snap(startSize * ratio)
+    }
+
+    /** How far apart two fingers are. */
+    fun spanOf(x1: Float, y1: Float, x2: Float, y2: Float): Float =
+        hypot(x2 - x1, y2 - y1)
+
+    /**
+     * How long after the fingers lift a page turn is still refused.
+     *
+     * Lifting out of a pinch releases two pointers a few milliseconds
+     * apart, and the last of them looks exactly like a tap on whichever
+     * side of the page it happened to be on. A gesture should not turn a
+     * page on its way out.
+     */
+    const val GUARD_MS = 350L
+}
+
+/**
+ * What a pinch began with: the gap between the fingers and the size the
+ * page was set in.
+ *
+ * Both are read once, when the second finger lands, and the ratio is
+ * applied to them rather than to the last frame's answer, so putting the
+ * fingers back where they started puts the size back where it started.
+ */
+data class PinchStart(val span: Float, val size: Double)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PinchResize.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PinchResize.kt
@@ -63,11 +63,11 @@ object PinchResize {
      * The size a pinch has landed on, or null while it has landed on
      * nothing.
      *
-     * Null means "do not commit and do not show a preview": either the
-     * fingers have not left the dead zone yet, or the span is too small
-     * to divide by. It is not the same as landing back on [startSize],
-     * which is a real answer and worth drawing, because a reader who
-     * pinches too far and comes back deserves to see that they are home.
+     * Null means "do not commit and do not show a preview". That covers
+     * the whole dead zone, including fingers back at exactly the span
+     * they started from: a pinch that has gone out and come home has
+     * nothing to say, and saying it would leave a panel on screen after
+     * a gesture that changed nothing.
      *
      * The ratio is applied to the size the *gesture* started from rather
      * than to the size the last frame produced, so the value cannot walk
@@ -75,10 +75,21 @@ object PinchResize {
      * size back where it began.
      */
     fun targetFor(startSize: Double, startSpan: Float, currentSpan: Float): Double? {
-        if (startSpan < MIN_START_SPAN || currentSpan <= 0f) return null
-        val ratio = currentSpan / startSpan
-        if (abs(ratio - 1.0) < DEAD_ZONE) return null
-        return snap(startSize * ratio)
+        if (!moved(startSpan, currentSpan)) return null
+        return snap(startSize * (currentSpan / startSpan))
+    }
+
+    /**
+     * Whether the fingers have travelled far enough to have meant it.
+     *
+     * The dead zone, asked on its own so that a book which cannot be
+     * resized can wait for the same travel before saying so. Without it,
+     * resting two fingers on a fixed-layout page raises the refusal at
+     * once, while the same rest on an ordinary page does nothing at all.
+     */
+    fun moved(startSpan: Float, currentSpan: Float): Boolean {
+        if (startSpan < MIN_START_SPAN || currentSpan <= 0f) return false
+        return abs(currentSpan / startSpan - 1.0) >= DEAD_ZONE
     }
 
     /** How far apart two fingers are. */

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PinchResize.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PinchResize.kt
@@ -21,11 +21,11 @@ object PinchResize {
     /**
      * How many sizes the slider offers: its `steps` plus the two ends.
      *
-     * The slider is declared with `steps = 17` in
-     * `ui/reading/ReadingAppearanceControls.kt`, which Material reads as
-     * seventeen notches *between* the ends.
+     * Taken from [ReaderPrefs.FONT_SIZE_POSITIONS] rather than counted
+     * again here, because the whole point of snapping is that the
+     * gesture and the slider land on the *same* sizes.
      */
-    const val POSITIONS = 18
+    const val POSITIONS = ReaderPrefs.FONT_SIZE_POSITIONS
 
     /**
      * How far the fingers must travel before the gesture is a resize.

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReaderTapZones.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReaderTapZones.kt
@@ -59,12 +59,18 @@ class ReaderTapZones(
     private val isChromeVisible: () -> Boolean,
     private val isScrolling: () -> Boolean = { false },
     private val isSwapped: () -> Boolean = { false },
+    private val isPinching: () -> Boolean = { false },
     private val onTurnPage: (forward: Boolean) -> Unit,
     private val onShowChrome: () -> Unit,
     private val onHideChrome: () -> Unit,
 ) : InputListener {
 
     override fun onTap(event: TapEvent): Boolean {
+        // A second finger arriving a beat after the first turns the tap
+        // into a pinch, and lifting out of a pinch releases its pointers
+        // one at a time. Neither is a tap on the page. See
+        // `docs/adr/0022-pinch-on-the-page.md`.
+        if (isPinching()) return true
         if (isChromeVisible()) {
             onHideChrome()
             return true

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ScrollEdgeTurner.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ScrollEdgeTurner.kt
@@ -25,6 +25,7 @@ class ScrollEdgeTurner(
     private val navigator: OverflowableNavigator,
     private val isScrolling: () -> Boolean,
     private val isVerticalText: () -> Boolean = { false },
+    private val isPinching: () -> Boolean = { false },
     private val onStepChapter: (forward: Boolean) -> Unit,
 ) : InputListener {
 
@@ -32,6 +33,13 @@ class ScrollEdgeTurner(
 
     override fun onDrag(event: DragEvent): Boolean {
         if (!isScrolling()) return false
+        // Two fingers converging on a scrolled page read as a drag as
+        // well, and one that reaches the end of the chapter would open
+        // the next one out from under the pinch.
+        if (isPinching()) {
+            pull.reset()
+            return false
+        }
         when (event.type) {
             DragEvent.Type.Start -> pull.reset()
 

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/reading/ReadingAppearanceControls.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/reading/ReadingAppearanceControls.kt
@@ -446,7 +446,7 @@ fun ReadingFontSizeSlider(value: Double, enabled: Boolean, onChanged: (Double) -
                 onValueChange = { sliderValue = it },
                 onValueChangeFinished = { onChanged(sliderValue.toDouble()) },
                 valueRange = ReaderPrefs.MIN_FONT_SIZE.toFloat()..ReaderPrefs.MAX_FONT_SIZE.toFloat(),
-                steps = 17,
+                steps = ReaderPrefs.FONT_SIZE_SLIDER_STEPS,
                 modifier = Modifier
                     .weight(1f)
                     .padding(horizontal = 12.dp),

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingNavigationScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingNavigationScreen.kt
@@ -69,6 +69,7 @@ fun ReadingNavigationScreen(
     vendorName: String?,
     onVolumeKeys: (Boolean) -> Unit,
     onTapZones: (TapZones) -> Unit,
+    onPinchToResize: (Boolean) -> Unit,
     onResumeLastBook: (Boolean) -> Unit,
     onScrollMode: (Boolean) -> Unit,
     onKeepScreenOn: (Boolean) -> Unit,
@@ -127,6 +128,13 @@ fun ReadingNavigationScreen(
                         selected = settings.tapZones,
                         label = { stringResource(it.label) },
                         onSelected = onTapZones,
+                    )
+                    RowDivider()
+                    SwitchRow(
+                        title = stringResource(R.string.settings_pinch_to_resize),
+                        subtitle = stringResource(R.string.settings_pinch_to_resize_detail),
+                        checked = settings.pinchToResize,
+                        onCheckedChange = onPinchToResize,
                     )
                     RowDivider()
                     SwitchRow(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -533,6 +533,7 @@
     <string name="reader_spacing_customize">Set a value</string>
     <string name="reader_spacing_reset">Back to default</string>
     <string name="reader_pinch_sample">Aa</string>
+    <string name="reader_image_viewer">Image</string>
     <string name="reader_pinch_size">Text size %1$d%%</string>
     <string name="reader_typography_fixed_layout">This book has a fixed layout: its pages are set by the publisher, so these settings do not change them.</string>
     <string name="reader_typography_not_in_cjk">Not applied in Chinese, Japanese, Korean or vertical books.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -532,6 +532,8 @@
     <string name="reader_spacing_value">+%1$s</string>
     <string name="reader_spacing_customize">Set a value</string>
     <string name="reader_spacing_reset">Back to default</string>
+    <string name="reader_pinch_sample">Aa</string>
+    <string name="reader_pinch_size">Text size %1$d%%</string>
     <string name="reader_typography_fixed_layout">This book has a fixed layout: its pages are set by the publisher, so these settings do not change them.</string>
     <string name="reader_typography_not_in_cjk">Not applied in Chinese, Japanese, Korean or vertical books.</string>
     <string name="reader_typography_latin_not_in_rtl">Hyphenation and letter and word spacing are not applied in right-to-left books.</string>
@@ -592,6 +594,8 @@
     <string name="settings_tap_zones_detail">Which side of the page turns forward when you tap it. Swapped puts the forward turn under the other thumb, for holding the phone in the other hand: in most books the left of the page goes on and the right goes back, and in a book that reads right to left it is the other way about. The middle still opens the menu, the volume keys are unchanged, and a book read by scrolling has no sides to tap.</string>
     <string name="tap_zones_standard">Standard</string>
     <string name="tap_zones_swapped">Swapped</string>
+    <string name="settings_pinch_to_resize">Pinch to resize text</string>
+    <string name="settings_pinch_to_resize_detail">A two-finger pinch on the page makes the text bigger or smaller, without opening the menu. Turn it off if the way you hold the phone sets it off by accident. Pinching an image to enlarge it still works either way.</string>
     <string name="settings_resume">Open on the book you were reading</string>
     <string name="settings_resume_detail">Skip the library when you left off mid-book.</string>
     <string name="settings_keep_screen_on">Keep the screen on</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/ImageAtPointTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/ImageAtPointTest.kt
@@ -59,8 +59,20 @@ class ImageAtPointTest {
 
     @Test
     fun `the script carries the point it was asked about`() {
-        val script = ImageAtPoint.script(137.5f, 42f)
-        assertTrue(script.contains("elementFromPoint(137.5, 42.0)"))
+        val script = ImageAtPoint.script(0.25f, 0.5f)
+        assertTrue(script.contains("var px = 0.25 * VW"))
+        assertTrue(script.contains("var py = 0.5 * VH"))
+        assertTrue(script.contains("elementFromPoint(px, py)"))
+    }
+
+    @Test
+    fun `the point is a fraction of the viewport, not a pixel count`() {
+        // A fixed-layout page is drawn at whatever scale fits the screen,
+        // so device pixels over the display density are not CSS pixels
+        // there. A fraction is the same fraction in either kind of book.
+        val script = ImageAtPoint.script(0.5f, 0.5f)
+        assertTrue(script.contains("window.innerWidth"))
+        assertTrue(script.contains("document.documentElement.clientWidth"))
     }
 
     @Test
@@ -77,6 +89,17 @@ class ImageAtPointTest {
         val script = ImageAtPoint.script(0f, 0f)
         assertTrue(script.contains("\"publisher-logo\""))
         assertTrue(script.contains("\"ornament\""))
+    }
+
+    @Test
+    fun `an ancestor can say the picture is furniture`() {
+        // A title page's img says nothing; its section says titlepage.
+        val script = ImageAtPoint.script(0f, 0f)
+        assertTrue(script.contains("up.parentElement"))
+        assertTrue(script.contains("\"titlepage\""))
+        // The class matters as much as the attribute: epub:type is
+        // rewritten into a class by the time the document is on screen.
+        assertTrue(script.contains("getAttribute(\"class\")"))
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/ImageAtPointTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/ImageAtPointTest.kt
@@ -1,0 +1,88 @@
+package com.chmouel.liseur.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ImageAtPointTest {
+
+    @Test
+    fun `a miss is nothing`() {
+        assertNull(ImageAtPoint.parse("null"))
+        assertNull(ImageAtPoint.parse(null))
+        assertNull(ImageAtPoint.parse(""))
+        assertNull(ImageAtPoint.parse("   "))
+    }
+
+    @Test
+    fun `a malformed answer is a miss rather than a crash`() {
+        assertNull(ImageAtPoint.parse("not json at all"))
+        assertNull(ImageAtPoint.parse("{"))
+        assertNull(ImageAtPoint.parse("\"a string\""))
+    }
+
+    @Test
+    fun `an answer without a source is a miss`() {
+        assertNull(ImageAtPoint.parse("""{"alt":"a map","width":800,"height":600}"""))
+        assertNull(ImageAtPoint.parse("""{"src":"","alt":"a map"}"""))
+    }
+
+    @Test
+    fun `an image comes back whole`() {
+        val hit = ImageAtPoint.parse(
+            """{"src":"https://readium_package/EPUB/images/map.jpg",
+                "alt":"A map of the island.","width":1600,"height":1200}""",
+        )
+        assertEquals("https://readium_package/EPUB/images/map.jpg", hit?.src)
+        assertEquals("A map of the island.", hit?.alt)
+        assertEquals(1600, hit?.width)
+        assertEquals(1200, hit?.height)
+    }
+
+    @Test
+    fun `a caption the book did not write is absent rather than empty`() {
+        val hit = ImageAtPoint.parse("""{"src":"a.png","alt":"","width":300,"height":300}""")
+        assertNull(hit?.alt)
+    }
+
+    @Test
+    fun `the script reads currentSrc before src`() {
+        // With srcset, any screen above 1x displays the 2x file while src
+        // still names the 1x one, so building a viewer from src would open
+        // a lower-resolution copy of the picture on the page.
+        val script = ImageAtPoint.script(10f, 20f)
+        val current = script.indexOf("currentSrc")
+        val plain = script.indexOf("img.src")
+        assertTrue(current in 0 until plain)
+    }
+
+    @Test
+    fun `the script carries the point it was asked about`() {
+        val script = ImageAtPoint.script(137.5f, 42f)
+        assertTrue(script.contains("elementFromPoint(137.5, 42.0)"))
+    }
+
+    @Test
+    fun `the script refuses images too small to be worth a viewer`() {
+        val script = ImageAtPoint.script(0f, 0f)
+        assertTrue(script.contains("var MIN = ${ImageAtPoint.MIN_RENDERED_PX}"))
+        assertTrue(script.contains("box.width < MIN || box.height < MIN"))
+    }
+
+    @Test
+    fun `the script knows the decorative roles by name`() {
+        // Size alone will not do it: a Standard Ebooks publisher logo is
+        // drawn well above the threshold and is still furniture.
+        val script = ImageAtPoint.script(0f, 0f)
+        assertTrue(script.contains("\"publisher-logo\""))
+        assertTrue(script.contains("\"ornament\""))
+    }
+
+    @Test
+    fun `the walk up from the point is bounded`() {
+        // An unbounded walk ends at body, which contains every image in
+        // the chapter, so every tap would find one.
+        assertTrue(ImageAtPoint.script(0f, 0f).contains("i < 4"))
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/ImageAtPointTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/ImageAtPointTest.kt
@@ -108,4 +108,51 @@ class ImageAtPointTest {
         // the chapter, so every tap would find one.
         assertTrue(ImageAtPoint.script(0f, 0f).contains("i < 4"))
     }
+
+    /**
+     * The guard that keeps a pinch on a paragraph from opening whatever
+     * illustration happens to live elsewhere in the same section.
+     */
+    @Test
+    fun `an image found by searching a container must be under the point`() {
+        val script = ImageAtPoint.script(0.5f, 0.5f)
+        assertTrue(script.contains("function covers("))
+        assertTrue(script.contains("covers(inner[k], px, py)"))
+        assertTrue(script.contains("x >= r.left && x <= r.right && y >= r.top && y <= r.bottom"))
+    }
+
+    /** The whole stack under the point, not a guess at what is on top. */
+    @Test
+    fun `the script reads the hit stack before it walks`() {
+        assertTrue(ImageAtPoint.script(0f, 0f).contains("elementsFromPoint(px, py)"))
+    }
+
+    /**
+     * The document belongs to the book, so everything it hands back is a
+     * length a file chose. An inlined `data:` plate runs to megabytes.
+     */
+    @Test
+    fun `an absurd answer is refused rather than parsed`() {
+        val src = "data:image/png;base64," + "A".repeat(200_000)
+        assertNull(ImageAtPoint.parse("""{"src":"$src","alt":"","width":9,"height":9}"""))
+    }
+
+    @Test
+    fun `an answer far larger than the script can produce is refused`() {
+        val alt = "x".repeat(5_000)
+        assertNull(
+            ImageAtPoint.parse(
+                """{"src":"http://h/i.png","alt":"$alt","width":9,"height":9}""",
+            ),
+        )
+    }
+
+    @Test
+    fun `a long but plausible caption survives`() {
+        val alt = "x".repeat(400)
+        val hit = ImageAtPoint.parse(
+            """{"src":"http://h/i.png","alt":"$alt","width":9,"height":9}""",
+        )
+        assertEquals(alt, hit?.alt)
+    }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/ImageAtPointTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/ImageAtPointTest.kt
@@ -139,7 +139,7 @@ class ImageAtPointTest {
 
     @Test
     fun `an answer far larger than the script can produce is refused`() {
-        val alt = "x".repeat(5_000)
+        val alt = "x".repeat(6_000)
         assertNull(
             ImageAtPoint.parse(
                 """{"src":"http://h/i.png","alt":"$alt","width":9,"height":9}""",
@@ -154,5 +154,31 @@ class ImageAtPointTest {
             """{"src":"http://h/i.png","alt":"$alt","width":9,"height":9}""",
         )
         assertEquals(alt, hit?.alt)
+    }
+
+    @Test
+    fun `the book's own caption is preferred to its alternative text`() {
+        val hit = ImageAtPoint.parse(
+            """{"src":"http://h/i.png","alt":"A photograph of a ship.",""" +
+                """"caption":"Plate IV. The Hispaniola.","width":9,"height":9}""",
+        )
+        assertEquals("Plate IV. The Hispaniola.", hit?.caption)
+        assertEquals("A photograph of a ship.", hit?.alt)
+    }
+
+    @Test
+    fun `a picture with no figure of its own still describes itself`() {
+        val hit = ImageAtPoint.parse(
+            """{"src":"http://h/i.png","alt":"A map.","caption":"","width":9,"height":9}""",
+        )
+        assertNull(hit?.caption)
+        assertEquals("A map.", hit?.alt)
+    }
+
+    @Test
+    fun `the script reads a figcaption out of the figure the picture sits in`() {
+        val js = ImageAtPoint.script(0.5f, 0.5f)
+        assertTrue(js.contains("figcaption"))
+        assertTrue(js.contains("\"figure\""))
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/ResourceAddressTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/ResourceAddressTest.kt
@@ -1,6 +1,8 @@
 package com.chmouel.liseur.reader
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -124,5 +126,35 @@ class ResourceAddressTest {
                 "pub/OPS/book.xhtml",
             ),
         )
+    }
+
+    @Test
+    fun `an image url becomes the href the publication spells it with`() {
+        assertEquals(
+            "EPUB/images/map.jpg",
+            ResourceAddress.href("https://readium_package/EPUB/images/map.jpg"),
+        )
+        assertEquals(
+            "EPUB/images/map.jpg",
+            ResourceAddress.href("https://readium_package/EPUB/images/map.jpg#top"),
+        )
+    }
+
+    @Test
+    fun `an href keeps its escapes, because it is handed back as a url`() {
+        // Comparison decodes them, so that two spellings of one filename
+        // are one resource. Reading the file does not: a url with a raw
+        // space in it does not parse.
+        assertEquals(
+            "EPUB/images/a%20map.jpg",
+            ResourceAddress.href("https://readium_package/EPUB/images/a%20map.jpg"),
+        )
+    }
+
+    @Test
+    fun `nothing addressable is no href`() {
+        assertNull(ResourceAddress.href(null))
+        assertNull(ResourceAddress.href(""))
+        assertNull(ResourceAddress.href("https://readium_package/"))
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/GestureClaimTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/GestureClaimTest.kt
@@ -51,4 +51,21 @@ class GestureClaimTest {
         assertFalse(claim.claimed)
         assertTrue(claim.imageMayWin(10_000 + budget * 10))
     }
+
+    @Test
+    fun `a touch waits for the document before it becomes a resize`() {
+        val claim = GestureClaim(budgetMs = 250L)
+        claim.begin(1_000L)
+        assertTrue(claim.undecided(1_000L))
+        assertTrue(claim.undecided(1_240L))
+        assertFalse(claim.undecided(1_260L))
+    }
+
+    @Test
+    fun `a resize that has taken the touch waits for nothing`() {
+        val claim = GestureClaim(budgetMs = 250L)
+        claim.begin(1_000L)
+        claim.resizeTook()
+        assertFalse(claim.undecided(1_010L))
+    }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/GestureClaimTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/GestureClaimTest.kt
@@ -1,0 +1,54 @@
+package com.chmouel.liseur.reader.chrome
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GestureClaimTest {
+
+    private val budget = 120L
+
+    @Test
+    fun `a touch nothing has taken is never too late for a picture`() {
+        val claim = GestureClaim(budget)
+        claim.begin(0)
+
+        // A long press is deliberately slower than the budget.
+        assertTrue(claim.imageMayWin(5_000))
+    }
+
+    @Test
+    fun `a late answer cannot take a touch a resize is already using`() {
+        val claim = GestureClaim(budget)
+        claim.begin(0)
+        claim.resizeTook()
+
+        assertTrue(claim.imageMayWin(budget))
+        assertFalse(claim.imageMayWin(budget + 1))
+    }
+
+    @Test
+    fun `a finger lifting out of a pinch does not give the touch back`() {
+        val claim = GestureClaim(budget)
+        claim.begin(0)
+        claim.resizeTook()
+
+        // Two fingers become one, then one becomes two again as another
+        // lands. The pinch was forgotten in between; the touch was not.
+        assertTrue(claim.claimed)
+        assertFalse(claim.imageMayWin(budget + 1))
+    }
+
+    @Test
+    fun `a genuinely new touch starts unclaimed and off the clock`() {
+        val claim = GestureClaim(budget)
+        claim.begin(0)
+        claim.resizeTook()
+        assertFalse(claim.imageMayWin(budget + 1))
+
+        claim.begin(10_000)
+
+        assertFalse(claim.claimed)
+        assertTrue(claim.imageMayWin(10_000 + budget * 10))
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/ImageZoomTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/ImageZoomTest.kt
@@ -1,0 +1,64 @@
+package com.chmouel.liseur.reader.chrome
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ImageZoomTest {
+
+    @Test
+    fun `the viewer opens at fit and cannot go further out`() {
+        assertEquals(ImageZoom.MIN_SCALE, ImageZoom.clampScale(0.1f), 1e-6f)
+        assertTrue(ImageZoom.atFit(ImageZoom.MIN_SCALE))
+        assertFalse(ImageZoom.atFit(ImageZoom.DOUBLE_TAP_SCALE))
+    }
+
+    @Test
+    fun `it cannot be zoomed past its ceiling`() {
+        assertEquals(ImageZoom.MAX_SCALE, ImageZoom.clampScale(1000f), 1e-6f)
+    }
+
+    @Test
+    fun `a picture that does not fill the screen cannot be dragged off it`() {
+        // Drawn narrower than the viewport: there is nothing to pan to,
+        // and letting it move would only drag the scrim into view.
+        assertEquals(0f, ImageZoom.maxPan(viewport = 1080f, drawn = 800f), 1e-6f)
+        assertEquals(0f, ImageZoom.clampPan(-500f, viewport = 1080f, drawn = 800f), 1e-6f)
+    }
+
+    @Test
+    fun `a picture wider than the screen pans as far as its own edges`() {
+        assertEquals(460f, ImageZoom.maxPan(viewport = 1080f, drawn = 2000f), 1e-6f)
+        assertEquals(460f, ImageZoom.clampPan(9000f, viewport = 1080f, drawn = 2000f), 1e-6f)
+        assertEquals(-460f, ImageZoom.clampPan(-9000f, viewport = 1080f, drawn = 2000f), 1e-6f)
+        assertEquals(100f, ImageZoom.clampPan(100f, viewport = 1080f, drawn = 2000f), 1e-6f)
+    }
+
+    @Test
+    fun `fitting a wide picture fills the width and letterboxes the height`() {
+        val (w, h) = ImageZoom.fitted(2000f, 1000f, viewW = 1000f, viewH = 1000f)
+        assertEquals(1000f, w, 1e-6f)
+        assertEquals(500f, h, 1e-6f)
+    }
+
+    @Test
+    fun `fitting a tall picture fills the height`() {
+        val (w, h) = ImageZoom.fitted(500f, 2000f, viewW = 1000f, viewH = 1000f)
+        assertEquals(250f, w, 1e-6f)
+        assertEquals(1000f, h, 1e-6f)
+    }
+
+    @Test
+    fun `a picture smaller than the screen is still drawn to the screen`() {
+        val (w, h) = ImageZoom.fitted(100f, 100f, viewW = 1000f, viewH = 800f)
+        assertEquals(800f, w, 1e-6f)
+        assertEquals(800f, h, 1e-6f)
+    }
+
+    @Test
+    fun `an unmeasured picture falls back to the viewport`() {
+        assertEquals(1000f to 800f, ImageZoom.fitted(0f, 0f, 1000f, 800f))
+        assertEquals(0f to 0f, ImageZoom.fitted(100f, 100f, 0f, 0f))
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/ImageZoomTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/ImageZoomTest.kt
@@ -61,4 +61,32 @@ class ImageZoomTest {
         assertEquals(1000f to 800f, ImageZoom.fitted(0f, 0f, 1000f, 800f))
         assertEquals(0f to 0f, ImageZoom.fitted(100f, 100f, 0f, 0f))
     }
+
+    /**
+     * A picture at fit is clamped back to centre after every frame, so
+     * the travel that dismisses it cannot be read off its own offset:
+     * one frame of a drag is never 96dp.
+     */
+    @Test
+    fun `a downward drag accumulates across frames`() {
+        var travelled = 0f
+        repeat(20) { travelled = ImageZoom.dragTravel(travelled, 15f) }
+        assertEquals(300f, travelled, 0.01f)
+    }
+
+    @Test
+    fun `travelling back up takes the drag off again`() {
+        var travelled = ImageZoom.dragTravel(0f, 100f)
+        travelled = ImageZoom.dragTravel(travelled, -40f)
+        assertEquals(60f, travelled, 0.01f)
+    }
+
+    @Test
+    fun `a drag that starts upwards is not a debt to pay back`() {
+        var travelled = 0f
+        repeat(5) { travelled = ImageZoom.dragTravel(travelled, -50f) }
+        assertEquals(0f, travelled, 0.01f)
+        travelled = ImageZoom.dragTravel(travelled, 30f)
+        assertEquals(30f, travelled, 0.01f)
+    }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/PinchResizeTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/PinchResizeTest.kt
@@ -1,6 +1,7 @@
 package com.chmouel.liseur.reader.chrome
 
 import com.chmouel.liseur.data.settings.ReaderPrefs
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -124,5 +125,23 @@ class PinchResizeTest {
     fun `the gap between two fingers is the distance between them`() {
         assertEquals(5f, PinchResize.spanOf(0f, 0f, 3f, 4f), 1e-4f)
         assertEquals(0f, PinchResize.spanOf(7f, 9f, 7f, 9f), 1e-4f)
+    }
+
+    @Test
+    fun `resting two fingers has not moved them`() {
+        assertFalse(PinchResize.moved(startSpan = 300f, currentSpan = 300f))
+        assertFalse(PinchResize.moved(startSpan = 300f, currentSpan = 310f))
+    }
+
+    @Test
+    fun `a real pinch has`() {
+        assertTrue(PinchResize.moved(startSpan = 300f, currentSpan = 400f))
+        assertTrue(PinchResize.moved(startSpan = 400f, currentSpan = 300f))
+    }
+
+    @Test
+    fun `fingers too close together to divide by have not moved`() {
+        assertFalse(PinchResize.moved(startSpan = 1f, currentSpan = 500f))
+        assertFalse(PinchResize.moved(startSpan = 300f, currentSpan = 0f))
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/PinchResizeTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/PinchResizeTest.kt
@@ -1,0 +1,101 @@
+package com.chmouel.liseur.reader.chrome
+
+import com.chmouel.liseur.data.settings.ReaderPrefs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PinchResizeTest {
+
+    @Test
+    fun `the ends of the range are positions`() {
+        assertEquals(ReaderPrefs.MIN_FONT_SIZE, PinchResize.sizeAt(0), 1e-9)
+        assertEquals(
+            ReaderPrefs.MAX_FONT_SIZE,
+            PinchResize.sizeAt(PinchResize.POSITIONS - 1),
+            1e-9,
+        )
+    }
+
+    @Test
+    fun `every position round-trips through its size`() {
+        for (i in 0 until PinchResize.POSITIONS) {
+            assertEquals(i, PinchResize.positionOf(PinchResize.sizeAt(i)))
+        }
+    }
+
+    @Test
+    fun `a size between two positions snaps to the nearer`() {
+        val below = PinchResize.sizeAt(4)
+        val above = PinchResize.sizeAt(5)
+        assertEquals(below, PinchResize.snap(below + (above - below) * 0.2), 1e-9)
+        assertEquals(above, PinchResize.snap(below + (above - below) * 0.8), 1e-9)
+    }
+
+    @Test
+    fun `a snapped size is always one the slider offers`() {
+        var s = ReaderPrefs.MIN_FONT_SIZE - 1.0
+        while (s < ReaderPrefs.MAX_FONT_SIZE + 1.0) {
+            val snapped = PinchResize.snap(s)
+            assertEquals(snapped, PinchResize.sizeAt(PinchResize.positionOf(snapped)), 1e-9)
+            s += 0.017
+        }
+    }
+
+    @Test
+    fun `spreading the fingers makes the text bigger`() {
+        val target = PinchResize.targetFor(startSize = 1.0, startSpan = 200f, currentSpan = 300f)
+        assertTrue(target != null && target > 1.0)
+    }
+
+    @Test
+    fun `pinching the fingers together makes the text smaller`() {
+        val target = PinchResize.targetFor(startSize = 1.0, startSpan = 300f, currentSpan = 200f)
+        assertTrue(target != null && target < 1.0)
+    }
+
+    @Test
+    fun `a rest inside the dead zone lands on nothing`() {
+        val nudge = 1f + (PinchResize.DEAD_ZONE / 2).toFloat()
+        assertNull(PinchResize.targetFor(1.0, 300f, 300f * nudge))
+        assertNull(PinchResize.targetFor(1.0, 300f, 300f / nudge))
+    }
+
+    @Test
+    fun `it never lands outside the range the slider offers`() {
+        assertEquals(
+            ReaderPrefs.MAX_FONT_SIZE,
+            PinchResize.targetFor(2.0, 100f, 4000f)!!,
+            1e-9,
+        )
+        assertEquals(
+            ReaderPrefs.MIN_FONT_SIZE,
+            PinchResize.targetFor(0.8, 4000f, 100f)!!,
+            1e-9,
+        )
+    }
+
+    @Test
+    fun `a span too small to divide by lands on nothing`() {
+        assertNull(PinchResize.targetFor(1.0, 4f, 400f))
+        assertNull(PinchResize.targetFor(1.0, 300f, 0f))
+    }
+
+    @Test
+    fun `bringing the fingers back where they started leaves the size alone`() {
+        // The ratio applies to the size the gesture began with, not to
+        // whatever the last frame produced, so the value cannot walk away:
+        // an excursion out and back lands on nothing at all.
+        val start = PinchResize.sizeAt(6)
+        assertEquals(PinchResize.sizeAt(PinchResize.POSITIONS - 1), PinchResize.targetFor(start, 200f, 900f))
+        assertEquals(PinchResize.sizeAt(0), PinchResize.targetFor(start, 200f, 40f))
+        assertNull(PinchResize.targetFor(start, 200f, 200f))
+    }
+
+    @Test
+    fun `the gap between two fingers is the distance between them`() {
+        assertEquals(5f, PinchResize.spanOf(0f, 0f, 3f, 4f), 1e-4f)
+        assertEquals(0f, PinchResize.spanOf(7f, 9f, 7f, 9f), 1e-4f)
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/PinchResizeTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/PinchResizeTest.kt
@@ -25,6 +25,33 @@ class PinchResizeTest {
         }
     }
 
+    /**
+     * The gesture and the Size slider have to offer the *same* sizes, or
+     * a book resized by one and then nudged by the other jumps. A
+     * `Slider` counts the notches between its ends, so its `steps` is two
+     * fewer than the number of sizes it can actually be left on.
+     */
+    @Test
+    fun `the pinch lands on the sizes the slider offers`() {
+        assertEquals(ReaderPrefs.FONT_SIZE_POSITIONS, PinchResize.POSITIONS)
+        assertEquals(PinchResize.POSITIONS - 2, ReaderPrefs.FONT_SIZE_SLIDER_STEPS)
+    }
+
+    /**
+     * Fingers that spread and then come home again have asked for
+     * nothing. The answer has to be `null` rather than the last target,
+     * because the caller assigns it: a `null` that was merged instead of
+     * assigned would commit whatever the gesture passed through on the
+     * way out.
+     */
+    @Test
+    fun `coming back to the starting span asks for nothing`() {
+        val start = PinchResize.sizeAt(6)
+        assertTrue(PinchResize.targetFor(start, 200f, 320f) != null)
+        assertNull(PinchResize.targetFor(start, 200f, 200f))
+        assertNull(PinchResize.targetFor(start, 200f, 206f))
+    }
+
     @Test
     fun `a size between two positions snaps to the nearer`() {
         val below = PinchResize.sizeAt(4)

--- a/docs/adr/0022-pinch-on-the-page.md
+++ b/docs/adr/0022-pinch-on-the-page.md
@@ -1,0 +1,301 @@
+# 22. Pinch on the page
+
+Status: accepted
+GitHub issues: [#139](https://github.com/chmouel/liseur/issues/139),
+[#110](https://github.com/chmouel/liseur/issues/110)
+
+## Context
+
+Two requests want the same two fingers on the same surface, so neither
+can be answered on its own.
+
+**Font size is a round trip.** It lives on the Size slider in the
+typography sheet and on Settings -> Reading appearance, and both of them
+cover the text in order to offer the control that resizes it. A reader
+who thinks the page is slightly too small has to notice, open the sheet,
+drag a slider they cannot see the effect of, close the sheet, find their
+place again, and then decide whether it was enough. Often it was not.
+
+**Images cannot be enlarged at all.** An EPUB renders a map, a diagram
+or a plate at whatever width the column gives it, and on a phone that is
+frequently too small to read. There is nothing to tap and nothing to
+stretch.
+
+Both are the pinch. Which means the first question is not how to resize
+text or how to zoom an image, it is what a pinch on a page of a book
+*means* — and that has one answer, not two.
+
+The constraint that shapes everything after it: Readium 3.3.0 has no
+pinch. This cannot be a navigator listener, so it is a Compose gesture
+intercepted ahead of the web view, which is a sharper instrument than
+this codebase usually reaches for.
+
+## Decision
+
+A two-finger pinch on the page is a reading gesture, and there are two
+of them.
+
+1. **What is under the fingers when the gesture begins decides which
+   one it is.** If the gesture starts on an image, it zooms that image.
+   Anything else resizes the text.
+2. The rule is settled when the second finger lands and is **not
+   revisited** while the fingers move.
+3. The text size snaps to the positions the Size slider already offers,
+   and commits **once**, when the fingers lift.
+4. During the gesture a small pill shows "Aa" drawn at the size being
+   landed on.
+5. On a fixed-layout book the resize half **refuses out loud**. The
+   image half works there in full.
+6. An image also opens from a long-press on it.
+7. The resize half can be switched off in Settings -> Reading &
+   navigation. The image half cannot.
+
+## What Readium actually does
+
+Read off the shipped Readium 3.3.0 classes and off a running emulator
+rather than off the documentation, the way [ADR 2](0002-typography-fine-tuning.md)
+and [ADR 20](0020-fixed-layout-reading-settings.md) were.
+
+**`InputListener` is three methods.** `onTap(TapEvent)`,
+`onDrag(DragEvent)`, `onKey(KeyEvent)`. There is no pinch and no long
+press, and `EpubNavigatorFragment.Listener` extends only
+`OverflowableNavigator.Listener` and `HyperlinkNavigator.Listener` —
+links and jumps, nothing about images. So neither gesture can be a third
+listener beside `ReaderTapZones` and `ScrollEdgeTurner`, and the Compose
+`pointerInput` over the reading box is the only place a second finger is
+visible at all. `evaluateJavascript` is public and suspending, which is
+the door `WideContentFit` already goes through to ask the book's own
+document a question.
+
+**Readium turns the web view's own zoom on, and then swallows it.**
+`R2EpubPageFragment` calls `setSupportZoom(true)`,
+`setBuiltInZoomControls(true)` and `setDisplayZoomControls(false)`, so
+on paper the pinch is already claimed by the platform. It is not. A
+genuine two-finger pinch injected on an emulator — multitouch protocol B
+through `sendevent`, twenty-four steps, fingers travelling from 200px
+apart to 680px apart across the middle of a page — left the screen
+byte-identical, with a single-finger tap injected the same way as the
+control, and that one turned the page. `R2WebView.onTouchEvent` consumes
+the multi-touch stream before the zoom manager ever sees it.
+
+The gesture is therefore unclaimed and free to take. That is *behaviour*
+rather than a contract, so a Readium upgrade is a thing to re-test, not
+a thing to assume.
+
+**`fontSize.isEffective` is gated on `layout == REFLOWABLE`.** The row
+already in ADR 20's table, and the reason point 5 exists: on a
+fixed-layout book, committing a new size would change nothing at all.
+
+## Design
+
+### The rule is settled at the second finger
+
+A gesture whose meaning changed while the fingers moved is a gesture
+nobody can aim. So the page is asked what is under the centroid once, as
+the pinch begins, and whatever it answers holds until the fingers lift —
+even if they wander off the image, even if the text they wander onto
+would have resized.
+
+### Where the gesture lives, and what it consumes
+
+The existing `pointerInput` at `PointerEventPass.Initial`
+(`ReaderScreen.kt`), which already tracks `fingerDown` for auto-scroll
+and `lastTouchY` for the footnote card, and already bails out while a
+note is showing. `Initial` is ahead of the web view, which is what makes
+the interception possible and also what makes it dangerous: events are
+consumed **only once a second pointer is down**. Consuming earlier would
+take the ordinary tap away from the page, and the ordinary tap is how
+the book is read.
+
+### The size commits when the fingers lift
+
+`ReflowScope` serialises reflows behind a mutex and restores the
+reader's place around each one, which is the machinery that came out of
+#63. Preferences reach it through a `distinctUntilChanged().collect`,
+and the comment there already explains why a slider dragged through its
+notches must not commit per notch: every intermediate value is a reflow
+and an anchor-and-restore of a book the reader is holding still.
+
+A pinch is that slider with no `onValueChangeFinished`, so the commit
+has to be put back by hand. One gesture, one commit, one reflow, one
+anchor. Everything before the lift is a preview drawn by Liseur, and the
+book underneath does not move.
+
+### It snaps to the slider's own positions
+
+The eighteen positions are derived once from `ReaderPrefs.MIN_FONT_SIZE`,
+`ReaderPrefs.MAX_FONT_SIZE` and the slider's step count, in one place
+that the sheet and the gesture both read, so the two cannot drift into
+offering different sizes for the same book. Snapping also bounds how far
+a single gesture can travel and gives the pill something discrete to
+show, instead of a continuously sliding sample that never settles.
+
+A dead zone at the start keeps a two-finger rest — a thumb and a
+finger holding the phone — from being a resize.
+
+### The pill is the text, not a number
+
+"Aa" drawn at the size being landed on, so the reader sees the answer to
+the question they are actually asking, which is not "what multiplier is
+this" but "can I read that". Painted in the reading theme rather than in
+Material colours, for the reason `FootnoteCard` is: a white card over a
+black page at night is a lamp in the face. Animation-free under
+`LocalEInk`.
+
+### A fixed-layout book refuses out loud
+
+ADR 20's argument applied to a gesture. A control that silently does
+nothing does not read as "this book carries its own layout", it reads as
+broken — and a gesture is worse than a slider here, because the reader
+cannot even tell whether the app saw the pinch. So the same pill appears
+carrying the same line the typography sheet already shows, and nothing
+is committed. A pinch on an image in that book still zooms, because
+nothing about a fixed layout stops an image being too small.
+
+### Asking the page what is under the fingers, without stalling them
+
+`document.elementFromPoint` at the gesture's centroid, walking up for an
+`<img>` or an SVG `<image>`, answered as JSON — the shape `WideContentFit`
+established. The point is CSS pixels in the web view's viewport, so the
+Compose position is offset by the web view's screen rect and divided by
+the display density.
+
+`evaluateJavascript` is asynchronous and the fingers are already moving,
+so the answer has to arrive before it is needed. Two things make that
+true. First, a `document.images.length` probe run **once per resource**:
+on a page of plain text, which is most pages of most books, no script
+runs on touch at all and the pinch goes straight to resize. Second,
+where the probe says the resource does have images, the hit test is
+fired on the **first** pointer down, so the answer is usually already in
+hand when the second finger arrives. Only if it is not does the gesture
+hold undecided — consumed, committing nothing — for a short budget, and
+if the budget runs out it falls into resize with the span measured from
+that moment, so the size does not jump.
+
+### Which images count
+
+Two filters, because either alone gets it wrong.
+
+A **minimum rendered size**, which catches the unlabelled ornaments:
+drop caps, inline rules, the 16px dingbat between scenes. And a short
+vocabulary of **decorative `epub:type` roles**, which catches the
+labelled ones. The second exists because of the imprint page of every
+Standard Ebook:
+
+```html
+<img alt="The Standard Ebooks logo."
+     src="../images/logo.png"
+     srcset="../images/logo-2x.png 2x, ../images/logo.png 1x"
+     epub:type="z3998:publisher-logo"/>
+```
+
+That logo renders around 76dp wide — comfortably above any threshold
+meant to exclude an ornament, and still not something anyone wants a
+full-screen viewer for. The markup says outright what it is. Judging an
+element by what it *is* rather than by how big it happens to be is the
+same move `FootnoteResolver` already makes for notes.
+
+The same snippet settles the source attribute. On any screen above 1x
+the browser resolves `srcset` and displays `logo-2x.png`; reading `src`
+would hand the viewer `logo.png`, the *lower*-resolution file, which is
+the exact opposite of what zooming is for. The script reads
+`currentSrc` — the URL the page actually resolved — and falls back to
+`src` only when there is none.
+
+`alt` is a caption the book has already written, so the viewer shows it.
+
+### The viewer is the app's page, not the book's
+
+A full-screen overlay, not an in-place zoom of the web view. An in-place
+zoom fights the paginated column layout, has nothing to dismiss it, and
+leaves the reader pinching their way back to exactly 1.0 before the page
+turns properly again. The overlay is also the only place `BackHandler`
+means anything.
+
+The bytes come from `publication.get(href)?.read()` on
+`Dispatchers.IO`, inside the suspending function that blocks, and Coil
+does the downsampling. `ResourceAddress` gains a public `href()`
+extracted from its existing private `path()`, so the one spelling of
+"turn a `readium_package` URL into a publication href" is shared rather
+than copied.
+
+### Long-press, and why not the web view's own
+
+Detected in the same pointer loop — one pointer, no travel, past
+`viewConfiguration.longPressTimeoutMillis` — rather than through
+`setOnLongClickListener`, which would fight whatever Readium has on the
+web view and would sit in front of text selection. The pointer is
+consumed only once the answer says image, so a long press on text still
+selects it.
+
+### What the other two gestures must not do
+
+`ReaderTapZones` and `ScrollEdgeTurner` read an `isPinching` lambda,
+the same trick [ADR 9](0009-tap-zone-customization.md) used so that
+changing a preference does not tear down and rebuild the navigator's
+input listeners. A second finger arriving a beat late must not turn a
+page on the way in, and lifting out of a pinch must not leave a stray
+tap behind.
+
+### The opt-out covers the resize half only
+
+It is for a grip that produces stray two-finger touches, and the two
+halves fail differently there. A stray resize silently changes how every
+page looks from then on, and the reader has to work out what happened. A
+stray viewer is one visible thing, dismissed with a tap. So the switch
+is named for what it does — "Pinch to resize text" — and sits in
+Settings -> Reading & navigation beside the other rows about how the
+book is turned and held, not in Reading appearance: it is not how the
+page looks, it is what the hands do (ADR 1, ADR 9).
+
+## Ruled out
+
+**Zooming the page of a fixed-layout book.** A pinch there could
+plausibly magnify the publisher's page. That is a different feature
+wearing the same gesture, with its own questions about panning, page
+turns and where the zoom resets, and taking it now would mean the
+gesture means three things instead of two.
+
+**In-place web view zoom for images**, for the reasons above.
+
+**Leaving it on the slider.** It works and it is discoverable. It also
+costs the round trip that is the complaint. The slider stays either way;
+the gesture is an addition, not a replacement.
+
+**A vertical edge drag for size.** Collides with `ScrollEdgeTurner` and
+with scroll mode, and is not the gesture readers reach for.
+
+**Double-tap cycling through preset sizes.** Double-tap is wanted
+elsewhere, and cycling suits a three-way choice, not eighteen steps.
+
+**A per-book pinch preference.** The gesture is about the hand, not the
+book. Per-book typography stays where it is.
+
+## Consequences
+
+A gesture is not discoverable. That is why the slider stays, and why the
+pill has to be legible the first time it appears.
+
+Someone's grip will produce a stray pinch. That is what the opt-out is
+for, and it is also why the dead zone exists.
+
+Consuming at `PointerEventPass.Initial` is ahead of the web view, so a
+mistake there costs ordinary taps rather than degrading gracefully. The
+"only once a second pointer is down" rule is load-bearing.
+
+The undecided window is the one place this can feel like lag, on a
+picture-heavy page where the hit test has not answered yet.
+
+The minimum size will be wrong for somebody's book in one direction or
+the other, and the decorative vocabulary only knows the roles it has
+been told about.
+
+Readium's swallowing of multi-touch is behaviour, not contract. A
+toolkit upgrade is a thing to re-test.
+
+*Where:* `reader/ReaderScreen.kt`, `reader/chrome/PinchResize.kt`,
+`reader/chrome/FontSizeHud.kt`, `reader/chrome/ImageViewer.kt`,
+`reader/ImageAtPoint.kt`, `reader/ResourceAddress.kt`,
+`reader/chrome/ReaderTapZones.kt`, `reader/chrome/ScrollEdgeTurner.kt`,
+`reader/ReaderViewModel.kt`, `data/settings/AppSettings.kt`,
+`ui/settings/ReadingNavigationScreen.kt`.

--- a/docs/adr/0022-pinch-on-the-page.md
+++ b/docs/adr/0022-pinch-on-the-page.md
@@ -91,10 +91,17 @@ fixed-layout book, committing a new size would change nothing at all.
 ### The rule is settled at the second finger
 
 A gesture whose meaning changed while the fingers moved is a gesture
-nobody can aim. So the page is asked what is under the centroid once, as
-the pinch begins, and whatever it answers holds until the fingers lift —
-even if they wander off the image, even if the text they wander onto
-would have resized.
+nobody can aim. So the page is asked what is under the first finger
+once, as the touch begins, and whatever it answers holds until the
+fingers lift — even if they wander off the image, even if the text they
+wander onto would have resized.
+
+The first finger rather than the centroid, because the answer has to be
+in hand *before* the second finger lands, and because a pinch that
+starts on a picture starts with a finger on it: by the time there is a
+centroid to measure, the fingers have already begun to spread, and the
+midpoint between them may be sitting on the margin beside the very image
+the reader is reaching for.
 
 ### Where the gesture lives, and what it consumes
 
@@ -154,11 +161,11 @@ nothing about a fixed layout stops an image being too small.
 
 ### Asking the page what is under the fingers, without stalling them
 
-`document.elementFromPoint` at the gesture's centroid, walking up for an
-`<img>` or an SVG `<image>`, answered as JSON — the shape `WideContentFit`
-established. The point is CSS pixels in the web view's viewport, so the
-Compose position is offset by the web view's screen rect and divided by
-the display density.
+`document.elementFromPoint` where the first finger landed, walking up for
+an `<img>` or an SVG `<image>`, answered as JSON — the shape
+`WideContentFit` established. The point is CSS pixels in the web view's
+viewport, so the Compose position is offset by the web view's screen rect
+and divided by the display density.
 
 `evaluateJavascript` is asynchronous and the fingers are already moving,
 so the answer has to arrive before it is needed. Two things make that

--- a/docs/adr/0022-pinch-on-the-page.md
+++ b/docs/adr/0022-pinch-on-the-page.md
@@ -341,14 +341,23 @@ what it has not revealed, and the overlay carries a pane title.
 
 The cost of drawing it as a sibling rather than in its own window is
 that being hidden has to be *applied*, once per sibling, and a window
-gets it for free. The bookmark ribbon, the footer, the note card, the
-selection bar and the size HUD all carry it for that reason. Anything
-new added to the reading box has to carry it too; a sibling that forgets
-is a control a reader cannot see and can still reach. The trade is
-deliberate — a separate window would mean re-deriving the immersive bar
-handling this screen is careful about — but it is the fragile half of
-this decision, and the place to look first if a control ever turns up
-where it should not.
+gets it for free. The bookmark ribbon, the footer, the note card and the
+size HUD all carry it for that reason. Anything new added to the reading
+box has to carry it too; a sibling that forgets is a control a reader
+cannot see and can still reach. The trade is deliberate — a separate
+window would mean re-deriving the immersive bar handling this screen is
+careful about — but it is the fragile half of this decision, and the
+place to look first if a control ever turns up where it should not.
+
+The selection bar is the exception, and it shows what the fragility
+looks like. It is a `Popup`, so it is already a window of its own: a
+modifier on the box around it reaches neither its semantics nor its
+drawing order, and hiding it would have left a row of buttons a screen
+reader could operate — drawn over the picture besides. It is not
+composed at all while the viewer is up. The selection itself survives,
+so the bar comes back with it when the picture is dismissed. The rule
+that follows: a sibling in a window of its own has to be *removed*, not
+hidden.
 
 ### Long-press, and why not the web view's own
 

--- a/docs/adr/0022-pinch-on-the-page.md
+++ b/docs/adr/0022-pinch-on-the-page.md
@@ -86,6 +86,15 @@ a thing to assume.
 already in ADR 20's table, and the reason point 5 exists: on a
 fixed-layout book, committing a new size would change nothing at all.
 
+**`EpubNavigatorFragment.evaluateJavascript` answers `null` on a
+fixed-layout book.** Not an error and not `"false"` — nothing at all,
+which reads as "this page has no images" and would refuse the viewer on
+every page of a book that is very often nothing but images. So the
+script is put to the web view directly, through
+`WebView.evaluateJavascript`, which the same code already has in hand
+because it needs the view's bounds to place the point anyway. Readium's
+own method is not used here.
+
 ## Design
 
 ### The rule is settled at the second finger
@@ -163,9 +172,14 @@ nothing about a fixed layout stops an image being too small.
 
 `document.elementFromPoint` where the first finger landed, walking up for
 an `<img>` or an SVG `<image>`, answered as JSON — the shape
-`WideContentFit` established. The point is CSS pixels in the web view's
-viewport, so the Compose position is offset by the web view's screen rect
-and divided by the display density.
+`WideContentFit` established.
+
+The point crosses as a **fraction of the web view**, not as a pixel
+count. A reflowable page is drawn at the display density and a fixed-layout
+page is drawn at whatever scale it takes to fit the screen, so device
+pixels over the display density are CSS pixels in one kind of book and
+not the other; the script multiplies the fraction by
+`window.innerWidth`, which is right in both.
 
 `evaluateJavascript` is asynchronous and the fingers are already moving,
 so the answer has to arrive before it is needed. Two things make that
@@ -202,6 +216,14 @@ full-screen viewer for. The markup says outright what it is. Judging an
 element by what it *is* rather than by how big it happens to be is the
 same move `FootnoteResolver` already makes for notes.
 
+The role is read off the picture **and off the few elements above it**,
+because the word that matters is often on the section rather than on the
+image: a title page's `<img>` says nothing, its `<section>` says
+`titlepage`. And it is read from `class` as well as from `epub:type`,
+because by the time the document is on screen the attribute has been
+rewritten into a class name and looking only for the attribute finds
+nothing at all.
+
 The same snippet settles the source attribute. On any screen above 1x
 the browser resolves `srcset` and displays `logo-2x.png`; reading `src`
 would hand the viewer `logo.png`, the *lower*-resolution file, which is
@@ -226,6 +248,16 @@ extracted from its existing private `path()`, so the one spelling of
 "turn a `readium_package` URL into a publication href" is shared rather
 than copied.
 
+**Paper under the ink.** A great many book illustrations are black line
+art on a transparent background — Standard Ebooks marks them
+`se:image.color-depth.black-on-transparent` — and on a black scrim those
+are not dimmed, they are gone. So a white rectangle is drawn behind the
+picture's own fitted rectangle. Behind the fitted rectangle rather than
+behind the screen, so a photograph covers it completely and never shows
+a white border; white rather than the reading theme's paper, because the
+overlay is not the page and because a transparent image in an EPUB is
+ink, not chalk.
+
 ### Long-press, and why not the web view's own
 
 Detected in the same pointer loop — one pointer, no travel, past
@@ -234,6 +266,12 @@ Detected in the same pointer loop — one pointer, no travel, past
 web view and would sit in front of text selection. The pointer is
 consumed only once the answer says image, so a long press on text still
 selects it.
+
+Consumed for the *rest of that touch*, and not only for the event that
+opened the viewer. A long press on an image is also a long press as far
+as the web view is concerned, and the web view answers one by starting a
+drag of the picture — so without the claim the viewer opens over a drag
+shadow the reader never asked for.
 
 ### What the other two gestures must not do
 

--- a/docs/adr/0022-pinch-on-the-page.md
+++ b/docs/adr/0022-pinch-on-the-page.md
@@ -342,7 +342,15 @@ is and the arithmetic stays sane: width times height inside
 `MAX_DECODE_PIXELS`, which is eight million, about 32MB as ARGB_8888.
 Above that, or where the dimensions are unknown, it falls back to the
 screen-sized decode, because a blurry plate is a worse outcome than a
-crash only until the crash happens. `ResourceAddress` gains a
+crash only until the crash happens.
+
+Those dimensions come from the *file*, not from the document. The
+document's `naturalWidth` is corrected for a `srcset` descriptor and an
+SVG's fallback is only the box the picture is drawn in, so a book can
+name a plate far smaller than it decodes to and walk a huge raster past
+the budget. The header is read on its own, with `inJustDecodeBounds`,
+which allocates nothing — the same move `LocalLibraryRepository` makes
+before decoding a cover, and for the same reason. `ResourceAddress` gains a
 public `href()` extracted from its existing private `path()`, so the one
 spelling of "turn a `readium_package` URL into a publication href" is
 shared rather than copied.

--- a/docs/adr/0022-pinch-on-the-page.md
+++ b/docs/adr/0022-pinch-on-the-page.md
@@ -347,8 +347,7 @@ public `href()` extracted from its existing private `path()`, so the one
 spelling of "turn a `readium_package` URL into a publication href" is
 shared rather than copied.
 
-**Paper under the ink.** A great many book illustrations are black line
-art on a transparent background — Standard Ebooks marks them
+**Paper under the ink.** A great many book illustrations are black lineart on a transparent background — Standard Ebooks marks them
 `se:image.color-depth.black-on-transparent` — and on a black scrim those
 are not dimmed, they are gone. So a white rectangle is drawn behind the
 picture's own fitted rectangle. Behind the fitted rectangle rather than
@@ -356,6 +355,15 @@ behind the screen, so a photograph covers it completely and never shows
 a white border; white rather than the reading theme's paper, because the
 overlay is not the page and because a transparent image in an EPUB is
 ink, not chalk.
+
+**Dragging it away is counted, not measured.** A picture at fit has
+nowhere to pan to, so its offset is clamped back to centre after every
+frame — which means the offset can never accumulate the 96dp that means
+"put this away", and reading the dismissal off it measures a single
+frame of a drag instead of the drag. The travel is therefore kept
+separately, added up across the gesture and reset when every finger
+leaves, so distance covered by two unrelated drags is not a drag. Travel
+back up cancels travel down, and the count never goes negative.
 
 **Modal to a screen reader as well as to a finger.** Drawn as the last
 child of the reading box rather than in a window of its own, so that it
@@ -403,6 +411,13 @@ opened the viewer. A long press on an image is also a long press as far
 as the web view is concerned, and the web view answers one by starting a
 drag of the picture — so without the claim the viewer opens over a drag
 shadow the reader never asked for.
+
+"One pointer, no travel" is not on its own enough to tell a long press
+from the tail of a pinch. A first finger that stays still while a second
+one resizes and then lifts leaves exactly one pointer, unmoved — so the
+long press has to ask the same question the late answer does, whether a
+resize has taken this touch, or a quick pinch commits a size and then
+opens a picture on top of it.
 
 ### What the other two gestures must not do
 

--- a/docs/adr/0022-pinch-on-the-page.md
+++ b/docs/adr/0022-pinch-on-the-page.md
@@ -230,6 +230,15 @@ Fingers that take their time arriving at a picture are not late for
 anything; a document that took half a second to answer, while those
 fingers were already resizing, is.
 
+"Has got hold of" is remembered on the touch, not read off the live
+pinch. A pinch is forgotten the instant it drops to one finger, but the
+touch runs on until the last finger leaves — so reading the live pinch
+would make a resize that ran long count as unclaimed again the moment a
+finger lifted, and a replacement finger landing then would open the
+picture the *first* finger had been over, minutes of travel ago. The
+flag is set when a resize takes the gesture and cleared only when a
+genuinely new touch begins.
+
 ### Which images count
 
 Two filters, because either alone gets it wrong.
@@ -329,6 +338,17 @@ on screen, which is worse than useless: it is a control the reader can
 operate and cannot see. So the page and the chrome are hidden from
 accessibility while the viewer is up, the way `Endpaper` already hides
 what it has not revealed, and the overlay carries a pane title.
+
+The cost of drawing it as a sibling rather than in its own window is
+that being hidden has to be *applied*, once per sibling, and a window
+gets it for free. The bookmark ribbon, the footer, the note card, the
+selection bar and the size HUD all carry it for that reason. Anything
+new added to the reading box has to carry it too; a sibling that forgets
+is a control a reader cannot see and can still reach. The trade is
+deliberate — a separate window would mean re-deriving the immersive bar
+handling this screen is careful about — but it is the fragile half of
+this decision, and the place to look first if a control ever turns up
+where it should not.
 
 ### Long-press, and why not the web view's own
 

--- a/docs/adr/0022-pinch-on-the-page.md
+++ b/docs/adr/0022-pinch-on-the-page.md
@@ -311,12 +311,13 @@ leaves the reader pinching their way back to exactly 1.0 before the page
 turns properly again. The overlay is also the only place `BackHandler`
 means anything.
 
-The bytes come from `publication.get(href)?.read(0 until limit + 1)` on
-`Dispatchers.IO`, inside the suspending function that blocks, and Coil
-does the downsampling. `ResourceAddress` gains a public `href()`
-extracted from its existing private `path()`, so the one spelling of
-"turn a `readium_package` URL into a publication href" is shared rather
-than copied.
+The bytes come from `publication.get(href)` on `Dispatchers.IO`, inside
+the suspending function that blocks, read as the range described above —
+the entry's declared length where the container knows it, and `limit + 1`
+where it does not. Coil does the downsampling. `ResourceAddress` gains a
+public `href()` extracted from its existing private `path()`, so the one
+spelling of "turn a `readium_package` URL into a publication href" is
+shared rather than copied.
 
 **Paper under the ink.** A great many book illustrations are black line
 art on a transparent background — Standard Ebooks marks them

--- a/docs/adr/0022-pinch-on-the-page.md
+++ b/docs/adr/0022-pinch-on-the-page.md
@@ -139,15 +139,23 @@ book underneath does not move.
 
 ### It snaps to the slider's own positions
 
-The eighteen positions are derived once from `ReaderPrefs.MIN_FONT_SIZE`,
-`ReaderPrefs.MAX_FONT_SIZE` and the slider's step count, in one place
-that the sheet and the gesture both read, so the two cannot drift into
-offering different sizes for the same book. Snapping also bounds how far
-a single gesture can travel and gives the pill something discrete to
-show, instead of a continuously sliding sample that never settles.
+The count lives in `ReaderPrefs` and *both* controls read it: the
+gesture derives its positions from it and the slider derives its `steps`
+from it. Not one from the other and not each from a literal, because a
+`Slider` counts the notches *between* its ends and a set of positions
+counts the ends too, so writing the same intention twice gets it wrong
+by one — and the whole point of snapping is that a book resized by the
+gesture and then nudged by the slider does not jump. Snapping also
+bounds how far a single gesture can travel and gives the pill something
+discrete to show, instead of a continuously sliding sample that never
+settles.
 
 A dead zone at the start keeps a two-finger rest — a thumb and a
-finger holding the phone — from being a resize.
+finger holding the phone — from being a resize. Fingers that spread and
+then come home again have therefore asked for nothing, and the target is
+*assigned* on every move rather than merged: a target kept from earlier
+in the gesture, because the dead zone answered with nothing this time,
+is a size the reader backed out of and would be committed on lift.
 
 ### The pill is the text, not a number
 
@@ -170,9 +178,22 @@ nothing about a fixed layout stops an image being too small.
 
 ### Asking the page what is under the fingers, without stalling them
 
-`document.elementFromPoint` where the first finger landed, walking up for
-an `<img>` or an SVG `<image>`, answered as JSON — the shape
-`WideContentFit` established.
+`document.elementsFromPoint` where the first finger landed — the whole
+stack under the point, so a picture beneath a link, a caption's wrapper
+or a transparent overlay is found without guessing which of them the
+browser will report on top. Answered as JSON, the shape `WideContentFit`
+established.
+
+Where the stack holds no picture the script falls back to walking up a
+few levels from `elementFromPoint` and looking *inside* each ancestor,
+for the book that wraps its plate in something the hit stack reports
+without reporting the plate. Anything found that way has to have the
+point inside its own bounding box. That check is not a nicety: an
+ancestor two levels up is usually the `<section>`, a `<section>`
+contains the chapter's illustration wherever in the chapter that
+illustration happens to be, and without it a pinch on a paragraph — or
+on a plate's own caption — opens a picture from three pages away instead
+of resizing the text.
 
 The point crosses as a **fraction of the web view**, not as a pixel
 count. A reflowable page is drawn at the display density and a fixed-layout
@@ -192,6 +213,22 @@ hand when the second finger arrives. Only if it is not does the gesture
 hold undecided — consumed, committing nothing — for a short budget, and
 if the budget runs out it falls into resize with the span measured from
 that moment, so the size does not jump.
+
+The probe is optimistic while it is in flight: between a page turn and
+its answer the resource is assumed to have images, because a wrong yes
+costs one script evaluation on one touch and a wrong no is the feature
+quietly not working on exactly the plate the reader has just turned to.
+It is keyed by the resource as well as by the web view, since the pager
+recycles a view from one chapter into the next.
+
+The budget is asked in one place and consulted from two — the coroutine
+that receives the answer, and the pointer loop on the next event after
+it was written down. Checked in only one of them it is no budget at all:
+the answer is stored either way, and whichever side does not check acts
+on it. And it applies only to a touch a resize has already got hold of.
+Fingers that take their time arriving at a picture are not late for
+anything; a document that took half a second to answer, while those
+fingers were already resizing, is.
 
 ### Which images count
 
@@ -233,6 +270,30 @@ the exact opposite of what zooming is for. The script reads
 
 `alt` is a caption the book has already written, so the viewer shows it.
 
+### Everything the book says is a size the book chose
+
+This reader opens whatever file it is pointed at, so the document on the
+other side of `evaluateJavascript` is not friendly by construction, and
+three things are bounded because of it. The answer's address and caption
+have ceilings, since a book can inline a plate as a `data:` URL and
+would otherwise hand back megabytes across the bridge on every touch.
+The picture itself is read as a **range** rather than whole: an archive
+entry's declared size is the archive's word for it, and a two-finger
+touch is not much to ask of a reader before it exhausts its heap. That
+range is the entry's own declared length wherever the container knows
+it, because Readium answers a range that runs off the end of a
+*compressed* entry with a decoding failure rather than clamping it — the
+useful bound and the safe one are the same number here only because the
+declaration is checked against the limit first and what comes back is
+measured again afterwards. The declaration bounds the request; it is
+never trusted for what it says arrived. And the evaluation itself
+has a timeout, because a renderer that hangs or a process that goes away
+never calls the callback at all, and the touch that asked would wait for
+it forever with its job still in flight when the next one starts.
+
+None of this is about injection. The script interpolates only numbers
+this app computed. It is about what comes back.
+
 ### The viewer is the app's page, not the book's
 
 A full-screen overlay, not an in-place zoom of the web view. An in-place
@@ -241,7 +302,7 @@ leaves the reader pinching their way back to exactly 1.0 before the page
 turns properly again. The overlay is also the only place `BackHandler`
 means anything.
 
-The bytes come from `publication.get(href)?.read()` on
+The bytes come from `publication.get(href)?.read(0 until limit + 1)` on
 `Dispatchers.IO`, inside the suspending function that blocks, and Coil
 does the downsampling. `ResourceAddress` gains a public `href()`
 extracted from its existing private `path()`, so the one spelling of
@@ -257,6 +318,17 @@ behind the screen, so a photograph covers it completely and never shows
 a white border; white rather than the reading theme's paper, because the
 overlay is not the page and because a transparent image in an EPUB is
 ink, not chalk.
+
+**Modal to a screen reader as well as to a finger.** Drawn as the last
+child of the reading box rather than in a window of its own, so that it
+inherits the reader's immersive bars instead of fighting them — and so
+nothing under it is reachable by touch, because the pointer loop stops
+there. A screen reader is not steered by the pointer loop. Left alone it
+walks past the picture into a chapter and a row of controls that are not
+on screen, which is worse than useless: it is a control the reader can
+operate and cannot see. So the page and the chrome are hidden from
+accessibility while the viewer is up, the way `Endpaper` already hides
+what it has not revealed, and the overlay carries a pane title.
 
 ### Long-press, and why not the web view's own
 
@@ -311,7 +383,7 @@ the gesture is an addition, not a replacement.
 with scroll mode, and is not the gesture readers reach for.
 
 **Double-tap cycling through preset sizes.** Double-tap is wanted
-elsewhere, and cycling suits a three-way choice, not eighteen steps.
+elsewhere, and cycling suits a three-way choice, not nineteen steps.
 
 **A per-book pinch preference.** The gesture is about the hand, not the
 book. Per-book typography stays where it is.
@@ -333,7 +405,15 @@ picture-heavy page where the hit test has not answered yet.
 
 The minimum size will be wrong for somebody's book in one direction or
 the other, and the decorative vocabulary only knows the roles it has
-been told about.
+been told about. The ceiling on how large a picture may be will be
+wrong for somebody's book too — a genuine 20MB plate is refused in
+silence, which is the price of not being able to tell one from a hostile
+archive entry before reading it.
+
+Requiring the point to fall inside the picture's own box costs the case
+where a book draws a plate under something opaque that the hit stack
+does not report. Nobody has one; a pinch on a paragraph opening an
+illustration from elsewhere in the chapter is not hypothetical at all.
 
 Readium's swallowing of multi-touch is behaviour, not contract. A
 toolkit upgrade is a thing to re-test.
@@ -342,5 +422,6 @@ toolkit upgrade is a thing to re-test.
 `reader/chrome/FontSizeHud.kt`, `reader/chrome/ImageViewer.kt`,
 `reader/ImageAtPoint.kt`, `reader/ResourceAddress.kt`,
 `reader/chrome/ReaderTapZones.kt`, `reader/chrome/ScrollEdgeTurner.kt`,
-`reader/ReaderViewModel.kt`, `data/settings/AppSettings.kt`,
+`reader/ReaderViewModel.kt`, `data/settings/ReaderPrefs.kt`,
+`data/settings/AppSettings.kt`, `ui/reading/ReadingAppearanceControls.kt`,
 `ui/settings/ReadingNavigationScreen.kt`.

--- a/docs/adr/0022-pinch-on-the-page.md
+++ b/docs/adr/0022-pinch-on-the-page.md
@@ -176,6 +176,15 @@ carrying the same line the typography sheet already shows, and nothing
 is committed. A pinch on an image in that book still zooms, because
 nothing about a fixed layout stops an image being too small.
 
+The refusal waits for the same dead zone the resize does. A fixed-layout
+book is the one place where a thumb and a finger resting on the page
+would otherwise put something on screen: the resize has nothing to
+commit, so a rest costs it nothing, but a refusal that fires the instant
+two fingers land pops a pill at every one-handed hold. Both halves ask
+the same question — have these fingers actually moved? — so both ask it
+through `PinchResize.moved()`, rather than one of them inferring it from
+having a target and the other not asking at all.
+
 ### Asking the page what is under the fingers, without stalling them
 
 `document.elementsFromPoint` where the first finger landed — the whole
@@ -277,7 +286,14 @@ the exact opposite of what zooming is for. The script reads
 `currentSrc` — the URL the page actually resolved — and falls back to
 `src` only when there is none.
 
-`alt` is a caption the book has already written, so the viewer shows it.
+`alt` and a caption are not the same thing, and the script reads both.
+`alt` is what an illustration *is*, written for someone who cannot see
+it; a `<figcaption>` is the line the book prints under the plate for
+everyone. Where a picture sits in a `<figure>` the viewer shows that
+figcaption, because it is what the reader would have seen on the page
+anyway, and falls back to `alt` where there is none. The two never
+merge: `contentDescription` is always `alt`, so a screen reader hears
+the description even when the printed caption is what is drawn.
 
 ### Everything the book says is a size the book chose
 
@@ -314,7 +330,19 @@ means anything.
 The bytes come from `publication.get(href)` on `Dispatchers.IO`, inside
 the suspending function that blocks, read as the range described above —
 the entry's declared length where the container knows it, and `limit + 1`
-where it does not. Coil does the downsampling. `ResourceAddress` gains a
+where it does not.
+
+**Decoded at the size the file was written, within reason.** Coil sizes
+a decode to the layout constraints it is given, which for a picture
+drawn to fit the screen means the bitmap is the screen. Zoom that to six
+times and the reader is looking at six-times-magnified screen pixels,
+not at the plate — which is the whole of what #110 asked for, missed. So
+the request asks for the original size where the page told us what that
+is and the arithmetic stays sane: width times height inside
+`MAX_DECODE_PIXELS`, which is eight million, about 32MB as ARGB_8888.
+Above that, or where the dimensions are unknown, it falls back to the
+screen-sized decode, because a blurry plate is a worse outcome than a
+crash only until the crash happens. `ResourceAddress` gains a
 public `href()` extracted from its existing private `path()`, so the one
 spelling of "turn a `readium_package` URL into a publication href" is
 shared rather than copied.
@@ -342,9 +370,10 @@ what it has not revealed, and the overlay carries a pane title.
 
 The cost of drawing it as a sibling rather than in its own window is
 that being hidden has to be *applied*, once per sibling, and a window
-gets it for free. The bookmark ribbon, the footer, the note card and the
-size HUD all carry it for that reason. Anything new added to the reading
-box has to carry it too; a sibling that forgets is a control a reader
+gets it for free. The bookmark ribbon, the footer, the note card, the
+size HUD and the endpaper all carry it for that reason. Anything new
+added to the reading box has to carry it too; a sibling that forgets is
+a control a reader
 cannot see and can still reach. The trade is deliberate — a separate
 window would mean re-deriving the immersive bar handling this screen is
 careful about — but it is the fragile half of this decision, and the


### PR DESCRIPTION
## Summary

Two fingers on the page now do something. Spread or squeeze them on text and
the reading size changes; do it on a picture, or hold a finger on one, and the
picture opens full screen where it can be zoomed and panned.

Changing the size used to mean opening the typography sheet, dragging a slider
that sits over the very text it is resizing, closing it again, and finding your
place. Pictures could not be enlarged at all.

Both requests want the same two fingers on the same surface, so what is under
them when the gesture starts decides which one it is. That, and everything else
these two share, is settled in a new ADR rather than twice in code.

Fixes #139
Fixes #110

## Changes

- Pinching the page changes the reading size. It lands on the same sizes the
  slider offers, shows an "Aa" at the size it is heading for while the fingers
  move, and commits once when they lift, keeping your place on the page.
- On a book that carries its own layout the pinch says so instead of quietly
  doing nothing.
- Pinching a picture, or holding a finger on one, opens it full screen with the
  book's own caption underneath. Ornaments, logos and drop caps are left alone.
- Line art drawn in black on a transparent background gets white paper behind
  it, so it is not black on black.
- Pinch to resize can be turned off in Settings, Reading and navigation. Opening
  a picture cannot; a stray one is a single visible thing dismissed with a tap,
  while a stray resize silently changes every page from then on.
- New ADR 22 records why the gesture is split this way and what was ruled out.
- A `dev` build type landed separately so this could be tried on a phone
  alongside the real app.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

Tested on an API 36 emulator against a book built for it: text and a picture in
the same section, a picture with a caption, and line art on a transparent
background. Checked that holding a finger on the words still selects them
rather than opening the picture beside them, that the size holds your place,
and that the viewer zooms, pans and dismisses.

The implementation was also reviewed by a second model over five rounds; ten
issues it raised are fixed in the last four commits.

## Screenshots or recordings

The size the pinch is heading for, shown while the fingers are still moving:

![The reading page with an "Aa" shown at the size the pinch is heading for](https://github.com/user-attachments/assets/f2fcc925-eff5-42e8-a8ed-cb6b59bb6a09)

A picture opened full screen, with the book's own caption under it:

![A picture from the book shown full screen with its caption underneath](https://github.com/user-attachments/assets/d2a44d0a-3b44-4f36-abd3-788b2506be93)

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
