### PR TITLE
Misc fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,22 +18,41 @@ jobs:
           bash -n hack/release hack/verify-fdroid-tags hack/test-fdroid-tags
           hack/test-fdroid-tags
 
+      - name: Check for Android/Gradle changes
+        id: changes
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          filters: |
+            android:
+              - 'app/**'
+              - 'gradle/**'
+              - 'gradlew'
+              - 'gradlew.bat'
+              - '*.gradle.kts'
+              - 'gradle.properties'
+              - '.github/workflows/build.yml'
+
       - name: Set up JDK 17
+        if: steps.changes.outputs.android == 'true'
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v5
         with:
           distribution: temurin
           java-version: "17"
 
       - name: Set up Gradle
+        if: steps.changes.outputs.android == 'true'
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
 
       - name: Unit tests
+        if: steps.changes.outputs.android == 'true'
         run: ./gradlew testDebugUnitTest --console=plain
 
       - name: Lint
+        if: steps.changes.outputs.android == 'true'
         run: ./gradlew lintDebug --console=plain
 
       - name: Assemble debug APK
+        if: steps.changes.outputs.android == 'true'
         run: ./gradlew assembleDebug --console=plain
 
       # The release build is the one people install, and it is the only
@@ -42,16 +61,18 @@ jobs:
       # evening a tag is cut. Unsigned without a keystore, which is fine:
       # the point is that it builds and shrinks.
       - name: Assemble release APK
+        if: steps.changes.outputs.android == 'true'
         run: ./gradlew assembleRelease --console=plain
 
       - name: Upload debug APK
+        if: steps.changes.outputs.android == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: liseur-debug-apk
           path: app/build/outputs/apk/debug/*.apk
 
       - name: Upload test/lint reports
-        if: always()
+        if: always() && steps.changes.outputs.android == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: reports

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,14 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-push]
+        files: '^(app/|gradle/|gradlew$|gradlew\.bat$|.*\.gradle\.kts$|gradle\.properties$)'
       - id: lint
         name: Android Lint (lintDebug)
         entry: ./gradlew lintDebug --console=plain --daemon
         language: system
         pass_filenames: false
         stages: [pre-push]
+        files: '^(app/|gradle/|gradlew$|gradlew\.bat$|.*\.gradle\.kts$|gradle\.properties$)'
       # - id: assemble-release
       #   name: Release build (assembleRelease)
       #   entry: ./gradlew assembleRelease --console=plain --daemon

--- a/Makefile
+++ b/Makefile
@@ -125,23 +125,23 @@ dev:
 	$(GRADLE) assembleDev
 
 dev-install: dev
-	$(ADB) $(ADB_TARGET) install -r '$(DEV_APK)'
+	$(ADB) install -r '$(DEV_APK)'
 
 dev-run: dev-install
-	$(ADB) $(ADB_TARGET) shell am start -n '$(DEV_ACTIVITY)'
+	$(ADB)  shell am start -n '$(DEV_ACTIVITY)'
 
 dev-uninstall:
-	$(ADB) $(ADB_TARGET) uninstall '$(DEV_PACKAGE)'
+	$(ADB)  uninstall '$(DEV_PACKAGE)'
 
 # Filtered by pid rather than by tag: the app logs under a dozen of them,
 # and the pid is the one thing that says "this build and not the other".
 dev-logcat:
-	@pid=$$($(ADB) $(ADB_TARGET) shell pidof '$(DEV_PACKAGE)' 2>/dev/null | tr -d '\r' | awk '{print $$1}'); \
+	@pid=$$($(ADB)  shell pidof '$(DEV_PACKAGE)' 2>/dev/null | tr -d '\r' | awk '{print $$1}'); \
 	if [ -z "$$pid" ]; then \
 		printf 'error: %s is not running; start it with make dev-run\n' '$(DEV_PACKAGE)' >&2; \
 		exit 1; \
 	fi; \
-	$(ADB) $(ADB_TARGET) logcat --pid="$$pid"
+	$(ADB)  logcat --pid="$$pid"
 
 screenshots:
 	./hack/screenshots


### PR DESCRIPTION
This pull request introduces several improvements to the CI workflow and development tooling, focusing on optimizing Android-related checks and builds. The main changes ensure that Android build steps and pre-commit hooks are only triggered when relevant files are modified, and also simplify ADB command usage in the `Makefile`.

**CI/CD workflow optimizations:**

* The GitHub Actions workflow in `.github/workflows/build.yml` now uses the `dorny/paths-filter` action to detect changes in Android/Gradle-related files. Android build, test, and artifact upload steps are now conditionally executed only when such files are changed, reducing unnecessary runs. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R21-R55) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R64-R75)

**Pre-commit hook improvements:**

* The `pre-commit` configuration in `.pre-commit-config.yaml` now restricts Android Gradle-related hooks (`testDebugUnitTest` and `lintDebug`) to only run when relevant files are changed, improving pre-push efficiency.

**Development tooling simplification:**

* The `Makefile` has been updated to remove the `$(ADB_TARGET)` variable from ADB commands, simplifying device interaction commands for install, run, uninstall, and logcat.## Summary

<!-- What does this change do, and why? Link related issues with "Fixes #123". -->

## Changes

-

## Testing

- [ ] `./gradlew testDebugUnitTest`
- [ ] `./gradlew lintDebug`
- [ ] `./gradlew assembleDebug`
- [ ] Manually tested on a device or emulator, if applicable

## Screenshots or recordings

<!-- Include before/after visuals for UI changes. Remove personal information. -->

## Checklist

- [ ] I have kept this change focused and documented any user-facing behaviour.
- [ ] I have added or updated tests where needed.
- [ ] I have checked that dependencies remain FOSS and available from allowed repositories.
- [ ] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
