### PR TITLE
fix: keep footnotes out of the page until they are asked for

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
@@ -407,7 +407,7 @@ class ReaderActivity : FragmentActivity() {
                                         ReaderProgressActions(
                                             cycleFooterMode = viewModel::cycleFooterMode,
                                             setFooterMode = viewModel::setFooterMode,
-                                            onJump = viewModel::onJump,
+                                            jumpFrom = viewModel::onJump,
                                             dismissJumpBack = viewModel::dismissJumpBack,
                                             acceptCatchUp = viewModel::acceptCatchUp,
                                             dismissCatchUp = viewModel::dismissCatchUp,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -2390,20 +2390,42 @@ fun ReaderScreen(
                     anchorY = lastTouchY,
                     onGoToNote = {
                         onDismissFootnote()
-                        onProgressAction.onJump()
                         navigator?.let { nav ->
                             // Where the reader is now, read before the reveal
                             // below moves anything: that is the place a jump
                             // back is meant to return them to.
-                            val from = nav.currentLocator.value.restorePoint()
+                            val here = nav.currentLocator.value
+                            val from = here.restorePoint()
                             val fragment = note.link.href.toString().substringAfter('#', "")
                             effectScope.launch {
-                                // The note is hidden in the page it belongs to,
-                                // so going to it without this is going nowhere.
-                                // Revealed before the jump rather than after,
-                                // because after, the reader is already looking
-                                // at the empty place it should have been.
-                                if (fragment.isNotEmpty()) FootnoteLayout.reveal(nav, fragment)
+                                // The note is hidden in the page it belongs
+                                // to, so going to it without this is going
+                                // nowhere. Revealed before the jump rather
+                                // than after, because after, the reader is
+                                // already looking at the empty place it
+                                // should have been.
+                                //
+                                // Putting a block back into the page moves
+                                // every block after it, so the reveal is held
+                                // in the reflow scope and settled inside it.
+                                // Outside, that movement is the navigator
+                                // announcing pages nobody turned.
+                                if (fragment.isNotEmpty()) {
+                                    reflow.within {
+                                        val before = ExactLocatorAnchor.layoutSignature(nav)
+                                        if (FootnoteLayout.reveal(nav, fragment)) {
+                                            awaitReflowSettled(nav, before)
+                                        }
+                                    }
+                                }
+                                // Armed only now, and from the place read
+                                // above. The marker is single use, so a
+                                // reveal that announced anything would have
+                                // spent it on the text moving and left the
+                                // jump itself to be recorded as reading: a
+                                // distance nobody read, taught to the pace
+                                // estimator and published as progress.
+                                onProgressAction.jumpFrom(here)
                                 val noteToken = moves.issue(
                                     from = from,
                                     to = publication.locatorFromLink(note.link)?.destination(),
@@ -2779,10 +2801,15 @@ class ReaderAnnotationActions(
  * A refusal or a failure is not a change. The book's own
  * Content-Security-Policy can turn either of these down, and a page that
  * was never touched is a page that never moved.
+ *
+ * A note the navigator's own position names is kept: that fragment is
+ * where the reader is being put, and hiding it would take the ground out
+ * from under them.
  */
 private suspend fun repairPage(nav: EpubNavigatorFragment): Boolean {
     val fitted = WideContentFit.apply(nav) == WideContentFit.Result.CHANGED
-    val noted = FootnoteLayout.apply(nav) == FootnoteLayout.Result.CHANGED
+    val here = nav.currentLocator.value.locations.fragments
+    val noted = FootnoteLayout.apply(nav, here) == FootnoteLayout.Result.CHANGED
     return fitted || noted
 }
 
@@ -2869,7 +2896,7 @@ class ReaderPrefsActions(
 class ReaderProgressActions(
     val cycleFooterMode: () -> Unit,
     val setFooterMode: (FooterMode) -> Unit,
-    val onJump: () -> Unit,
+    val jumpFrom: (Locator?) -> Unit,
     val dismissJumpBack: () -> Unit,
     val acceptCatchUp: () -> Unit,
     val dismissCatchUp: () -> Unit,
@@ -2884,7 +2911,10 @@ class ReaderProgressActions(
     val locatorAtOrBeforeProgression: (Double) -> Locator?,
     val prepareLocator: (Locator) -> Locator,
     val onApproximateResume: () -> Unit,
-)
+) {
+    /** The reader is jumping away from wherever they are now. */
+    fun onJump() = jumpFrom(null)
+}
 
 /**
  * Syncing this one book on purpose, from the Navigate screen.

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -1042,11 +1042,17 @@ fun ReaderScreen(
         val nav = navigator ?: return@LaunchedEffect
         if (!reflowableText) return@LaunchedEffect
         val root = nav.publicationView
-        var fitted: WebView? = null
+        var fitted: Pair<WebView, String>? = null
         merge(nav.currentLocator.map { }, layoutPasses(root)).collect {
             val web = visibleWebView(root) ?: return@collect
-            if (web === fitted) return@collect
-            fitted = web
+            // Keyed by the resource as well as by the view, for the same
+            // reason the image probe below is: the pager recycles a web
+            // view from one chapter into another, and the same instance
+            // is then a different document with its own notes to hide
+            // and its own pictures to fit.
+            val key = web to nav.currentLocator.value.href.toString()
+            if (key == fitted) return@collect
+            fitted = key
             // Which position to come back to, decided before the reflow
             // scope opens: the wait below is not a reflow, and holding
             // the scope through it would read a page the reader turned

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -111,6 +111,7 @@ import com.chmouel.liseur.reader.annotations.shareText
 import com.chmouel.liseur.reader.annotations.toDecorations
 import com.chmouel.liseur.reader.dictionary.DefinitionSheet
 import com.chmouel.liseur.reader.dictionary.WiktionaryClient
+import com.chmouel.liseur.reader.footnotes.FootnoteLayout
 import com.chmouel.liseur.data.settings.FooterMode
 import com.chmouel.liseur.data.settings.ColumnMode
 import com.chmouel.liseur.data.settings.ReadingFont
@@ -1001,10 +1002,9 @@ fun ReaderScreen(
                     // A table can be comfortable at 100% and too wide at 175%,
                     // so what fits has to be asked again once the new size has
                     // landed — and before the anchor is restored, since fitting
-                    // it moves the text once more.
-                    if (reflowableText &&
-                        WideContentFit.apply(nav) == WideContentFit.Result.CHANGED
-                    ) {
+                    // it moves the text once more. A note marker is sized in
+                    // `em` and so moves with the text for the same reason.
+                    if (reflowableText && repairPage(nav)) {
                         awaitReflowSettled(nav, before)
                     }
                     // A reader who tapped a contents entry while the
@@ -1028,7 +1028,10 @@ fun ReaderScreen(
     // Content wider than the page paints over the page after it rather than
     // being clipped, because in paginated mode the columns Readium sets
     // `overflow: visible` on are the pages themselves. Measure and constrain
-    // what actually overflows, once per resource that gets laid out.
+    // what actually overflows, once per resource that gets laid out — and in
+    // the same pass, put the book's notes back where a reading system is
+    // supposed to keep them, which is out of the page until they are asked
+    // for. See `repairPage`.
     //
     // Positions and layout passes are both only prompts to go and look, for
     // the same reasons the e-ink block above gives: a position alone misses
@@ -1100,7 +1103,7 @@ fun ReaderScreen(
             reflow.within {
                 val anchor = here?.takeIf { stillFitting() }?.let { capture(nav, it) }
                 val before = ExactLocatorAnchor.layoutSignature(nav)
-                if (WideContentFit.apply(nav) == WideContentFit.Result.CHANGED) {
+                if (repairPage(nav)) {
                     // Settled before the scope closes whether or not
                     // there is an anchor: the text the fit moved
                     // reports where it came to rest either way, and
@@ -2383,12 +2386,25 @@ fun ReaderScreen(
                         onDismissFootnote()
                         onProgressAction.onJump()
                         navigator?.let { nav ->
-                            val noteToken = moves.issue(
-                                from = nav.currentLocator.value.restorePoint(),
-                                to = publication.locatorFromLink(note.link)?.destination(),
-                                nowMs = SystemClock.elapsedRealtime(),
-                            )
-                            if (!nav.go(note.link, animated = false)) moves.cancel(noteToken)
+                            // Where the reader is now, read before the reveal
+                            // below moves anything: that is the place a jump
+                            // back is meant to return them to.
+                            val from = nav.currentLocator.value.restorePoint()
+                            val fragment = note.link.href.toString().substringAfter('#', "")
+                            effectScope.launch {
+                                // The note is hidden in the page it belongs to,
+                                // so going to it without this is going nowhere.
+                                // Revealed before the jump rather than after,
+                                // because after, the reader is already looking
+                                // at the empty place it should have been.
+                                if (fragment.isNotEmpty()) FootnoteLayout.reveal(nav, fragment)
+                                val noteToken = moves.issue(
+                                    from = from,
+                                    to = publication.locatorFromLink(note.link)?.destination(),
+                                    nowMs = SystemClock.elapsedRealtime(),
+                                )
+                                if (!nav.go(note.link, animated = false)) moves.cancel(noteToken)
+                            }
                         }
                     },
                     onDismiss = onDismissFootnote,
@@ -2744,6 +2760,25 @@ class ReaderAnnotationActions(
     val remove: (BookAnnotation) -> Unit,
     val notebookMarkdown: () -> String,
 )
+
+/**
+ * Puts right what a stylesheet alone cannot, in the document on screen.
+ *
+ * Two unrelated faults are repaired the same way — by measuring the live
+ * DOM and writing an attribute back into it — so they are asked together
+ * and answer as one: whether the page moved. Each is independent of the
+ * other and neither is allowed to hide the other's answer, because the
+ * caller uses it to decide whether the reader's place has to be put back.
+ *
+ * A refusal or a failure is not a change. The book's own
+ * Content-Security-Policy can turn either of these down, and a page that
+ * was never touched is a page that never moved.
+ */
+private suspend fun repairPage(nav: EpubNavigatorFragment): Boolean {
+    val fitted = WideContentFit.apply(nav) == WideContentFit.Result.CHANGED
+    val noted = FootnoteLayout.apply(nav) == FootnoteLayout.Result.CHANGED
+    return fitted || noted
+}
 
 /**
  * Opens the next chapter and waits for it to arrive, or says it could

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -1172,15 +1172,30 @@ class ReaderViewModel(
         _catchUp.value = null
     }
 
-    /** Called before jumping, so the reader can come back in one tap. */
-    fun onJump() {
-        val from = lastLocator ?: return
+    /**
+     * Called before jumping, so the reader can come back in one tap.
+     *
+     * [from] is the place to offer them back, for a caller that has to do
+     * something to the page before it can navigate: by the time it does,
+     * the layout has moved and the last position on hand is no longer the
+     * one the reader was looking at. Everyone else passes nothing and gets
+     * exactly that last position.
+     */
+    fun onJump(from: Locator? = null) {
+        val given = from?.let(::prepareLocator)
+        val place = given ?: lastLocator ?: return
         val progress = _progress.value
         // The jump itself is not reading, and neither is finding your
         // way back, so it must not affect the speed estimate.
         speed.forgetLastPosition()
         pendingPositionEvent = NavigatorPositionEvent.LOCAL_JUMP
-        _jumpBack.value = JumpBack(locator = from, position = progress?.position)
+        _jumpBack.value = JumpBack(
+            locator = place,
+            // Resolved from the given place rather than read off the
+            // progress on hand, which counted the page as it is now.
+            position = given?.let { bookPositions?.resolve(it)?.position }
+                ?: progress?.position,
+        )
         jumpBackTimer?.cancel()
         jumpBackTimer = viewModelScope.launch {
             delay(JUMP_BACK_TIMEOUT_MS)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteLayout.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteLayout.kt
@@ -2,6 +2,7 @@ package com.chmouel.liseur.reader.footnotes
 
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.shared.ExperimentalReadiumApi
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Keeping a book's notes out of the page they were written for.
@@ -49,11 +50,12 @@ import org.readium.r2.shared.ExperimentalReadiumApi
  *
  * ### Ownership
  *
- * The attribute carries a token minted per document rather than a fixed
- * class or id. A publisher is free to ship `data-liseur-note` on their own
- * markup, and stripping it from their page — or letting it suppress our own
- * work — would be our bug, not theirs. Only attributes carrying this
- * document's token are ever read or removed.
+ * The attribute's *name* carries a token minted per document, rather than a
+ * fixed name marked in its value. A publisher is free to ship
+ * `data-liseur-note` on their own markup: taking the name and writing our
+ * token into it would overwrite theirs on any element we also wanted to
+ * hide, and lose it for good when the reader revealed the note. A name they
+ * cannot have guessed is never read, never written over and never stripped.
  */
 internal object FootnoteLayout {
 
@@ -99,8 +101,6 @@ internal object FootnoteLayout {
      */
     const val SCRIPT: String = """
         (function () {
-          var NOTE_ATTR = "data-liseur-note";
-          var MARK_ATTR = "data-liseur-mark";
           var NOTE_TYPES = ["footnote", "endnote", "rearnote", "note"];
           var NOTE_ROLES = ["doc-footnote", "doc-endnote"];
           var NOTE_TAG = "aside";
@@ -112,7 +112,18 @@ internal object FootnoteLayout {
           var state = window.__liseurNotes || (window.__liseurNotes = {});
           var tok = state.token ||
                     (state.token = "n" + Math.random().toString(36).slice(2, 10));
-          var revealed = state.revealed || (state.revealed = {});
+          // The token is part of the attribute's *name*, not its value. A
+          // publisher who ships `data-liseur-note` of their own is then
+          // never read from, never written over and never stripped, which
+          // taking the name and marking ourselves in the value could not
+          // promise: the element we wanted to hide might be theirs.
+          var NOTE_ATTR = state.noteAttr ||
+                          (state.noteAttr = "data-liseur-note-" + tok);
+          var MARK_ATTR = state.markAttr ||
+                          (state.markAttr = "data-liseur-mark-" + tok);
+          // A bare object answers for `constructor` and `toString`, which
+          // are legal ids, and would report a note revealed that never was.
+          var revealed = state.revealed || (state.revealed = Object.create(null));
           var installed = false;
 
           // Served as XHTML the attribute is namespaced and `getAttribute`
@@ -156,12 +167,34 @@ internal object FootnoteLayout {
             return String(el.textContent || "").replace(/\s+/g, "").length;
           }
 
+          // A book writes a reference to a note in its own chapter either as
+          // "#n1" or as "ch1.xhtml#n1", and both name the same element.
+          // Reading only the first spelling left the second kind of book
+          // exactly as broken as before, so the href is resolved against the
+          // document's own address and counted as local when everything but
+          // the fragment agrees.
+          function localFragment(anchor) {
+            var href = anchor.getAttribute("href") || "";
+            if (!href) return "";
+            if (href.charAt(0) === "#") return href.slice(1);
+            try {
+              var there = new URL(href, document.baseURI);
+              var here = new URL(document.baseURI);
+              if (there.origin !== here.origin) return "";
+              if (there.pathname !== here.pathname) return "";
+              if (there.search !== here.search) return "";
+              return there.hash.slice(1);
+            } catch (e) {
+              return "";
+            }
+          }
+
           // The attribute is set from a list rather than toggled in place, so
           // a note that stops qualifying — because the reader asked to see
           // it, because the document was rewritten under us — is released
           // rather than left hidden forever.
           function sync(attr, wanted) {
-            var previous = document.querySelectorAll('[' + attr + '="' + tok + '"]');
+            var previous = document.querySelectorAll('[' + attr + ']');
             var dirty = false, i;
             for (i = 0; i < previous.length; i++) {
               if (wanted.indexOf(previous[i]) < 0) {
@@ -170,8 +203,8 @@ internal object FootnoteLayout {
               }
             }
             for (i = 0; i < wanted.length; i++) {
-              if (wanted[i].getAttribute(attr) !== tok) {
-                wanted[i].setAttribute(attr, tok);
+              if (!wanted[i].hasAttribute(attr)) {
+                wanted[i].setAttribute(attr, "");
                 dirty = true;
               }
             }
@@ -181,8 +214,8 @@ internal object FootnoteLayout {
           if (!state.styleEl || !state.styleEl.isConnected) {
             var css = document.createElement("style");
             css.textContent =
-              '[' + NOTE_ATTR + '="' + tok + '"]{display:none!important}' +
-              '[' + MARK_ATTR + '="' + tok + '"]{' +
+              '[' + NOTE_ATTR + ']{display:none!important}' +
+              '[' + MARK_ATTR + ']{' +
                 'height:1em!important;width:auto!important;' +
                 'max-height:1.2em!important;max-width:4em!important;' +
                 'min-height:0!important;min-width:0!important;' +
@@ -198,10 +231,9 @@ internal object FootnoteLayout {
           var notes = [], marks = [], i, j;
           for (i = 0; i < anchors.length; i++) {
             var anchor = anchors[i];
-            var href = anchor.getAttribute("href") || "";
+            var id = localFragment(anchor);
             var note = null;
-            if (href.charAt(0) === "#" && href.length > 1) {
-              var id = href.slice(1);
+            if (id) {
               try { id = decodeURIComponent(id); } catch (e) { /* keep it raw */ }
               var target = document.getElementById(id);
               // An anchor inside a note is a backlink, or one note citing
@@ -254,7 +286,7 @@ internal object FootnoteLayout {
         (function () {
           var id = ${jsString(fragment)};
           var state = window.__liseurNotes || (window.__liseurNotes = {});
-          var revealed = state.revealed || (state.revealed = {});
+          var revealed = state.revealed || (state.revealed = Object.create(null));
           revealed[id] = true;
           var el = document.getElementById(id);
           if (!el) {
@@ -264,7 +296,10 @@ internal object FootnoteLayout {
           // Keyed on the element's own id as well as on the spelling the
           // link used, because that is what the pass above reads back.
           revealed[el.getAttribute("id")] = true;
-          el.removeAttribute("data-liseur-note");
+          // The attribute's name carries this document's token, so it is
+          // read back from the same place the pass above wrote it. Nothing
+          // has been hidden yet if that pass has not run.
+          if (state.noteAttr) el.removeAttribute(state.noteAttr);
           return "revealed";
         })();
         """.trimIndent()
@@ -305,14 +340,29 @@ internal object FootnoteLayout {
 
     @OptIn(ExperimentalReadiumApi::class)
     internal suspend fun apply(navigator: EpubNavigatorFragment): Result =
-        parse(runCatching { navigator.evaluateJavascript(SCRIPT) }.getOrNull())
+        parse(evaluate(navigator, SCRIPT))
 
     /** Reveals [fragment], returning whether the page may have moved. */
     @OptIn(ExperimentalReadiumApi::class)
     internal suspend fun reveal(navigator: EpubNavigatorFragment, fragment: String): Boolean {
-        val answer = runCatching {
-            navigator.evaluateJavascript(revealScript(fragment))
-        }.getOrNull()
+        val answer = evaluate(navigator, revealScript(fragment))
         return answer?.trim()?.removeSurrounding("\"")?.trim() == "revealed"
     }
+
+    /**
+     * [script] in the book's page, or null if the page would not run it.
+     *
+     * A cancellation is not a failed evaluation, and swallowing it here
+     * would be the worst kind of quiet: the caller carries on to navigate a
+     * navigator whose screen has already gone.
+     */
+    @OptIn(ExperimentalReadiumApi::class)
+    private suspend fun evaluate(navigator: EpubNavigatorFragment, script: String): String? =
+        try {
+            navigator.evaluateJavascript(script)
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (refused: Exception) {
+            null
+        }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteLayout.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteLayout.kt
@@ -1,0 +1,318 @@
+package com.chmouel.liseur.reader.footnotes
+
+import org.readium.r2.navigator.epub.EpubNavigatorFragment
+import org.readium.r2.shared.ExperimentalReadiumApi
+
+/**
+ * Keeping a book's notes out of the page they were written for.
+ *
+ * EPUB 3 says a note should be marked up where it belongs and *hidden* by
+ * the reading system until the reader asks for it. Readium does not hide it:
+ * there is no footnote rule anywhere in Readium CSS — not in the default
+ * sheet, not in the CJK or RTL variants, not before the publisher's styles
+ * and not after. So a book that puts its notes in an `<aside>` at the top of
+ * the chapter, as many translated editions do, shows the translator's gloss
+ * before the sentence being glossed. The reader meets the answer first and
+ * the question second.
+ *
+ * The marker fares no better. A book that draws its reference as a small
+ * image — a circled 注, a printer's dagger — has that image painted at its
+ * natural size, because `ReadiumCSS-before.css` sets `width:auto;height:auto`
+ * on every `img`, which beats the `width` and `height` attributes the
+ * publisher put on the element (a presentation attribute loses to any author
+ * rule). What is left holding it back is `max-height: 95vh`, which is not a
+ * limit so much as a permission: a 200-pixel glyph in the middle of a
+ * paragraph, and the sentence torn in half around it.
+ *
+ * Both are fixed here, in the book's own document, by the same means
+ * [com.chmouel.liseur.reader.WideContentFit] uses and for the same reason:
+ * Readium decides whether to link its default stylesheet by looking for
+ * `<style` in the resource, so shipping one ahead of it would make an
+ * unstyled book look styled and cost it Readium's typography entirely.
+ *
+ * ### What is hidden, and what is carefully not
+ *
+ * A note body is hidden only when it is both a note by [NoteVocabulary] *and*
+ * pointed at by an anchor in the same document. That second condition is the
+ * whole safety of this file. A chapter of endnotes is referenced from the
+ * chapters it serves, not from itself, so nothing in it is touched and it
+ * stays as readable as its author meant it to be. An `<aside>` holding a pull
+ * quote is a note by the generous tag rule but nothing links to it, so it
+ * stays too.
+ *
+ * Two narrower guards sit behind that. An anchor that is itself inside a note
+ * is a backlink or one note citing another, and neither says the note it
+ * points at was ever referenced from the text. And a document that is *mostly*
+ * notes is a notes document however its links run — a numbered list with a
+ * contents entry per note would otherwise vanish entirely — so past
+ * [MOSTLY_NOTES] of the document's own words nothing is hidden at all.
+ *
+ * ### Ownership
+ *
+ * The attribute carries a token minted per document rather than a fixed
+ * class or id. A publisher is free to ship `data-liseur-note` on their own
+ * markup, and stripping it from their page — or letting it suppress our own
+ * work — would be our bug, not theirs. Only attributes carrying this
+ * document's token are ever read or removed.
+ */
+internal object FootnoteLayout {
+
+    /**
+     * How much of a document may be notes before it is treated as a document
+     * *of* notes and left alone.
+     *
+     * Duplicated as a literal inside [SCRIPT] for the reason given there;
+     * `FootnoteLayoutTest` keeps the two the same number.
+     */
+    internal const val MOSTLY_NOTES = 0.6
+
+    internal enum class Result {
+        /** Something was hidden, sized or released: the page may have moved. */
+        CHANGED,
+
+        /** Nothing to do; the layout is untouched. */
+        STABLE,
+
+        /** The book's Content-Security-Policy refused the stylesheet. */
+        BLOCKED,
+
+        /** No reflowable page to talk to, or the script did not answer. */
+        FAILED,
+    }
+
+    /**
+     * Runs in the book's own document, repeatedly, so it must end where it
+     * started when there is nothing to do.
+     *
+     * The vocabulary is spelled out here as JavaScript literals rather than
+     * interpolated from [NoteVocabulary], so that the harness in
+     * `hack/verify-footnotes` can lift the script out of this file as plain
+     * text and run the very lines the app ships. `FootnoteLayoutTest` is what
+     * keeps the two lists honest: it fails the build if a word is added to
+     * one and not the other.
+     *
+     * Notes are found through the anchors that reference them rather than by
+     * sweeping the document for asides. That is not an optimisation — it is
+     * the rule itself. An anchor pointing at a note in this document is the
+     * evidence that the note was referenced here, and the evidence is what
+     * distinguishes a gloss from a chapter.
+     */
+    const val SCRIPT: String = """
+        (function () {
+          var NOTE_ATTR = "data-liseur-note";
+          var MARK_ATTR = "data-liseur-mark";
+          var NOTE_TYPES = ["footnote", "endnote", "rearnote", "note"];
+          var NOTE_ROLES = ["doc-footnote", "doc-endnote"];
+          var NOTE_TAG = "aside";
+          var REF_TYPES = ["noteref"];
+          var REF_ROLES = ["doc-noteref"];
+          var MOSTLY_NOTES = 0.6;
+          var EPUB_NS = "http://www.idpf.org/2007/ops";
+
+          var state = window.__liseurNotes || (window.__liseurNotes = {});
+          var tok = state.token ||
+                    (state.token = "n" + Math.random().toString(36).slice(2, 10));
+          var revealed = state.revealed || (state.revealed = {});
+          var installed = false;
+
+          // Served as XHTML the attribute is namespaced and `getAttribute`
+          // may not see it; served as HTML there is no namespace and
+          // `getAttributeNS` will not. Books arrive both ways.
+          function typeOf(el) {
+            return el.getAttributeNS(EPUB_NS, "type") ||
+                   el.getAttribute("epub:type") ||
+                   el.getAttribute("type") || "";
+          }
+
+          function names(value, vocabulary) {
+            var parts = String(value).split(/\s+/);
+            for (var i = 0; i < parts.length; i++) {
+              var word = parts[i], colon = word.lastIndexOf(":");
+              if (colon >= 0) word = word.slice(colon + 1);
+              if (vocabulary.indexOf(word) >= 0) return true;
+            }
+            return false;
+          }
+
+          function isNote(el) {
+            if (names(typeOf(el), NOTE_TYPES)) return true;
+            if (names(el.getAttribute("role") || "", NOTE_ROLES)) return true;
+            return String(el.localName || "").toLowerCase() === NOTE_TAG;
+          }
+
+          function isRef(el) {
+            return names(typeOf(el), REF_TYPES) ||
+                   names(el.getAttribute("role") || "", REF_ROLES);
+          }
+
+          function insideNote(el) {
+            for (var p = el.parentElement; p; p = p.parentElement) {
+              if (isNote(p)) return true;
+            }
+            return false;
+          }
+
+          function weight(el) {
+            return String(el.textContent || "").replace(/\s+/g, "").length;
+          }
+
+          // The attribute is set from a list rather than toggled in place, so
+          // a note that stops qualifying — because the reader asked to see
+          // it, because the document was rewritten under us — is released
+          // rather than left hidden forever.
+          function sync(attr, wanted) {
+            var previous = document.querySelectorAll('[' + attr + '="' + tok + '"]');
+            var dirty = false, i;
+            for (i = 0; i < previous.length; i++) {
+              if (wanted.indexOf(previous[i]) < 0) {
+                previous[i].removeAttribute(attr);
+                dirty = true;
+              }
+            }
+            for (i = 0; i < wanted.length; i++) {
+              if (wanted[i].getAttribute(attr) !== tok) {
+                wanted[i].setAttribute(attr, tok);
+                dirty = true;
+              }
+            }
+            return dirty;
+          }
+
+          if (!state.styleEl || !state.styleEl.isConnected) {
+            var css = document.createElement("style");
+            css.textContent =
+              '[' + NOTE_ATTR + '="' + tok + '"]{display:none!important}' +
+              '[' + MARK_ATTR + '="' + tok + '"]{' +
+                'height:1em!important;width:auto!important;' +
+                'max-height:1.2em!important;max-width:4em!important;' +
+                'min-height:0!important;min-width:0!important;' +
+                'vertical-align:super!important;margin:0 .1em!important;' +
+                'object-fit:contain;display:inline-block}';
+            document.head.appendChild(css);
+            state.styleEl = css;
+            installed = true;
+            if (!css.sheet) return "blocked";
+          }
+
+          var anchors = document.getElementsByTagName("a");
+          var notes = [], marks = [], i, j;
+          for (i = 0; i < anchors.length; i++) {
+            var anchor = anchors[i];
+            var href = anchor.getAttribute("href") || "";
+            var note = null;
+            if (href.charAt(0) === "#" && href.length > 1) {
+              var id = href.slice(1);
+              try { id = decodeURIComponent(id); } catch (e) { /* keep it raw */ }
+              var target = document.getElementById(id);
+              // An anchor inside a note is a backlink, or one note citing
+              // another. Neither is the text referring to a note.
+              if (target && isNote(target) && !insideNote(anchor)) note = target;
+            }
+            if (note && notes.indexOf(note) < 0) notes.push(note);
+            if (note || isRef(anchor)) {
+              var media = anchor.querySelectorAll("img, svg, image");
+              for (j = 0; j < media.length; j++) {
+                if (marks.indexOf(media[j]) < 0) marks.push(media[j]);
+              }
+            }
+          }
+
+          var page = document.body ? weight(document.body) : 0;
+          var held = 0;
+          for (i = 0; i < notes.length; i++) held += weight(notes[i]);
+          if (page > 0 && held / page > MOSTLY_NOTES) notes = [];
+
+          var wanted = [];
+          for (i = 0; i < notes.length; i++) {
+            if (!revealed[notes[i].getAttribute("id")]) wanted.push(notes[i]);
+          }
+
+          var changed = installed;
+          if (sync(NOTE_ATTR, wanted)) changed = true;
+          if (sync(MARK_ATTR, marks)) changed = true;
+          return changed ? "changed" : "stable";
+        })();
+    """
+
+    /**
+     * Puts the note called [fragment] back on the page, for good.
+     *
+     * The card's "go to note" carries the reader to the note itself, and a
+     * note that is hidden is a note they arrive at and cannot see. Revealing
+     * is therefore permanent for as long as the document lives: they asked
+     * for it, and having it disappear again on the next layout pass would be
+     * the same bug wearing a different hat.
+     *
+     * It runs before the jump rather than after, which is the only order that
+     * works: after, the reader is already looking at the place the note ought
+     * to be. A note in *another* resource is never hidden in the first place
+     * — nothing in that document references it — so there is nothing there
+     * for this to miss.
+     */
+    fun revealScript(fragment: String): String =
+        """
+        (function () {
+          var id = ${jsString(fragment)};
+          var state = window.__liseurNotes || (window.__liseurNotes = {});
+          var revealed = state.revealed || (state.revealed = {});
+          revealed[id] = true;
+          var el = document.getElementById(id);
+          if (!el) {
+            try { el = document.getElementById(decodeURIComponent(id)); } catch (e) { }
+          }
+          if (!el) return "absent";
+          // Keyed on the element's own id as well as on the spelling the
+          // link used, because that is what the pass above reads back.
+          revealed[el.getAttribute("id")] = true;
+          el.removeAttribute("data-liseur-note");
+          return "revealed";
+        })();
+        """.trimIndent()
+
+    /**
+     * [value] as a JavaScript string literal.
+     *
+     * A fragment identifier is whatever the book's author typed, so it is
+     * quoted rather than trusted. Anything outside plain printable ASCII goes
+     * out as an escape, and so do the three characters that make markup —
+     * `<`, `>` and `&` — which is what stops a `</script` in an id from
+     * ending whatever the script is one day embedded in.
+     */
+    internal fun jsString(value: String): String =
+        value.map { char ->
+            when {
+                char == '"' -> "\\\""
+                char == '\\' -> "\\\\"
+                char in "<>&" -> "\\u" + char.code.toString(16).padStart(4, '0')
+                char.code in 0x20..0x7E -> char.toString()
+                else -> "\\u" + char.code.toString(16).padStart(4, '0')
+            }
+        }.joinToString(separator = "", prefix = "\"", postfix = "\"")
+
+    /**
+     * `evaluateJavascript` hands back the JSON encoding of the value, so a
+     * plain string arrives wearing quotes.
+     */
+    internal fun parse(result: String?): Result {
+        val value = result?.trim()?.removeSurrounding("\"")?.trim()
+        return when (value) {
+            "changed" -> Result.CHANGED
+            "stable" -> Result.STABLE
+            "blocked" -> Result.BLOCKED
+            else -> Result.FAILED
+        }
+    }
+
+    @OptIn(ExperimentalReadiumApi::class)
+    internal suspend fun apply(navigator: EpubNavigatorFragment): Result =
+        parse(runCatching { navigator.evaluateJavascript(SCRIPT) }.getOrNull())
+
+    /** Reveals [fragment], returning whether the page may have moved. */
+    @OptIn(ExperimentalReadiumApi::class)
+    internal suspend fun reveal(navigator: EpubNavigatorFragment, fragment: String): Boolean {
+        val answer = runCatching {
+            navigator.evaluateJavascript(revealScript(fragment))
+        }.getOrNull()
+        return answer?.trim()?.removeSurrounding("\"")?.trim() == "revealed"
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteLayout.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteLayout.kt
@@ -224,8 +224,13 @@ internal object FootnoteLayout {
             document.head.appendChild(css);
             state.styleEl = css;
             installed = true;
-            if (!css.sheet) return "blocked";
           }
+          // A stylesheet the book's Content-Security-Policy turned down is
+          // still an element and still connected, so asking only on the
+          // pass that installed it means every later pass sails through and
+          // starts marking notes that nothing can hide — reporting the page
+          // moved when it cannot have. The question belongs on every pass.
+          if (!state.styleEl.sheet) return "blocked";
 
           var anchors = document.getElementsByTagName("a");
           var notes = [], marks = [], i, j;
@@ -338,9 +343,28 @@ internal object FootnoteLayout {
         }
     }
 
+    /**
+     * Hides this document's notes, sizes its markers, and answers whether
+     * the page may have moved.
+     *
+     * [keep] names notes the reader is being sent to, or has already been
+     * sent to, and which must therefore survive this pass. The exemption
+     * the card's "go to note" writes lives on the document's `window` and
+     * dies with the document, so a reader who reopens the book at a
+     * position inside a revealed note, or who arrives at one from search or
+     * the table of contents, would otherwise watch it be hidden out from
+     * under the place they were being restored to.
+     */
     @OptIn(ExperimentalReadiumApi::class)
-    internal suspend fun apply(navigator: EpubNavigatorFragment): Result =
-        parse(evaluate(navigator, SCRIPT))
+    internal suspend fun apply(
+        navigator: EpubNavigatorFragment,
+        keep: List<String> = emptyList(),
+    ): Result {
+        for (fragment in keep) {
+            if (fragment.isNotEmpty()) evaluate(navigator, revealScript(fragment))
+        }
+        return parse(evaluate(navigator, SCRIPT))
+    }
 
     /** Reveals [fragment], returning whether the page may have moved. */
     @OptIn(ExperimentalReadiumApi::class)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteResolver.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteResolver.kt
@@ -29,12 +29,6 @@ import org.jsoup.safety.Safelist
  */
 object FootnoteResolver {
 
-    /** `epub:type` words that name a note. */
-    private val NOTE_TYPES = setOf("footnote", "endnote", "rearnote", "note")
-
-    /** ARIA roles that name a note. */
-    private val NOTE_ROLES = setOf("doc-footnote", "doc-endnote")
-
     /**
      * The note identified by [fragment] in [html], or null if there is none.
      *
@@ -58,17 +52,19 @@ object FootnoteResolver {
     /**
      * Whether [element] is a note rather than somewhere the reader asked to go.
      *
-     * The element's children are not consulted: a chapter that happens to
-     * contain a note is not a note, and a note nested in a section is found
-     * by its id, never by looking down.
+     * The vocabulary itself lives in [NoteVocabulary], because the stylesheet
+     * injected into the page has to reach the same verdict about the same
+     * element; see there for why.
      */
     private fun isNote(element: Element): Boolean {
         // Jsoup lowercases attribute names but keeps the namespace prefix, so
         // the EPUB attribute survives as `epub:type`. `type` alone is the
         // shape it takes once a sanitiser has flattened the namespace.
         val epubType = element.attr("epub:type").ifEmpty { element.attr("type") }
-        if (epubType.split(' ').any { it.substringAfterLast(':') in NOTE_TYPES }) return true
-        if (element.attr("role").split(' ').any { it in NOTE_ROLES }) return true
-        return element.normalName() == "aside"
+        return NoteVocabulary.isNote(
+            epubType = epubType,
+            role = element.attr("role"),
+            tagName = element.normalName(),
+        )
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/footnotes/NoteVocabulary.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/footnotes/NoteVocabulary.kt
@@ -51,10 +51,14 @@ internal object NoteVocabulary {
     /**
      * Whether [attribute] names any of [vocabulary].
      *
-     * The value is a space-separated list, and each word may carry a
-     * namespace prefix the sanitiser never flattened, so only what follows
-     * the last colon is compared.
+     * The value is a whitespace-separated list — a book is free to write it
+     * across a tab or a newline, and the injected script's `/\s+/` reads it
+     * that way — and each word may carry a namespace prefix the sanitiser
+     * never flattened, so only what follows the last colon is compared.
      */
     private fun names(attribute: String, vocabulary: Set<String>): Boolean =
-        attribute.split(' ').any { it.substringAfterLast(':') in vocabulary }
+        attribute.split(WHITESPACE).any { it.substringAfterLast(':') in vocabulary }
+
+    /** What the script's `/\s+/` splits on, spelled the same way here. */
+    private val WHITESPACE = Regex("\\s+")
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/footnotes/NoteVocabulary.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/footnotes/NoteVocabulary.kt
@@ -1,0 +1,60 @@
+package com.chmouel.liseur.reader.footnotes
+
+/**
+ * What counts as a note, in one place.
+ *
+ * Two things need this answer and they must not disagree. [FootnoteResolver]
+ * asks it of a Jsoup document, off the main thread, to decide whether a tap
+ * pops a card up or throws the reader into another chapter. [FootnoteLayout]
+ * asks it of the live DOM, inside the book's own web view, to decide what to
+ * hide. A book where one says yes and the other says no is a book that shows
+ * the note twice or not at all, so the vocabulary lives here and both read it
+ * from the same set.
+ *
+ * The words are the three ways a book says "this is a note", which between
+ * them cover everything worth opening: the EPUB vocabulary, the ARIA one, and
+ * the bare `<aside>` that the EPUB specification itself suggests notes be
+ * written as.
+ */
+internal object NoteVocabulary {
+
+    /** `epub:type` words that name a note. */
+    val NOTE_TYPES: Set<String> = setOf("footnote", "endnote", "rearnote", "note")
+
+    /** ARIA roles that name a note. */
+    val NOTE_ROLES: Set<String> = setOf("doc-footnote", "doc-endnote")
+
+    /** The element a note is written as when it is not labelled at all. */
+    const val NOTE_TAG: String = "aside"
+
+    /** `epub:type` words that name a reference *to* a note. */
+    val REF_TYPES: Set<String> = setOf("noteref")
+
+    /** ARIA roles that name a reference to a note. */
+    val REF_ROLES: Set<String> = setOf("doc-noteref")
+
+    /**
+     * Whether an element carrying [epubType], [role] and [tagName] is a note.
+     *
+     * Children are never consulted: a chapter that happens to contain a note
+     * is not a note, and a note nested in a section is found by its id.
+     */
+    fun isNote(epubType: String, role: String, tagName: String): Boolean =
+        names(epubType, NOTE_TYPES) ||
+            names(role, NOTE_ROLES) ||
+            tagName.lowercase() == NOTE_TAG
+
+    /** Whether an anchor carrying [epubType] and [role] points at a note. */
+    fun isNoteRef(epubType: String, role: String): Boolean =
+        names(epubType, REF_TYPES) || names(role, REF_ROLES)
+
+    /**
+     * Whether [attribute] names any of [vocabulary].
+     *
+     * The value is a space-separated list, and each word may carry a
+     * namespace prefix the sanitiser never flattened, so only what follows
+     * the last colon is compared.
+     */
+    private fun names(attribute: String, vocabulary: Set<String>): Boolean =
+        attribute.split(' ').any { it.substringAfterLast(':') in vocabulary }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteLayoutTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteLayoutTest.kt
@@ -100,7 +100,12 @@ class FootnoteLayoutTest {
 
     @Test
     fun `a stylesheet the book's policy refused is reported rather than assumed`() {
-        assertTrue(FootnoteLayout.SCRIPT.contains("if (!css.sheet) return \"blocked\""))
+        assertTrue(FootnoteLayout.SCRIPT.contains("if (!state.styleEl.sheet) return \"blocked\""))
+        // Asked of the stored element rather than the one just made, and so
+        // asked on every pass: a refused stylesheet stays connected, and a
+        // later pass that only checked at installation would mark notes
+        // that nothing can hide and report the page moved.
+        assertFalse(FootnoteLayout.SCRIPT.contains("if (!css.sheet)"))
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteLayoutTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteLayoutTest.kt
@@ -1,0 +1,161 @@
+package com.chmouel.liseur.reader.footnotes
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FootnoteLayoutTest {
+
+    @Test
+    fun `the javascript answer is read through its json quoting`() {
+        assertEquals(FootnoteLayout.Result.CHANGED, FootnoteLayout.parse("\"changed\""))
+        assertEquals(FootnoteLayout.Result.STABLE, FootnoteLayout.parse("\"stable\""))
+        assertEquals(FootnoteLayout.Result.BLOCKED, FootnoteLayout.parse("\"blocked\""))
+    }
+
+    @Test
+    fun `no answer is a failure, never a silent success`() {
+        assertEquals(FootnoteLayout.Result.FAILED, FootnoteLayout.parse(null))
+        assertEquals(FootnoteLayout.Result.FAILED, FootnoteLayout.parse(""))
+        assertEquals(FootnoteLayout.Result.FAILED, FootnoteLayout.parse("null"))
+        assertEquals(FootnoteLayout.Result.FAILED, FootnoteLayout.parse("undefined"))
+    }
+
+    @Test
+    fun `the script is one expression, so evaluateJavascript returns its value`() {
+        val script = FootnoteLayout.SCRIPT.trim()
+        assertTrue(script.startsWith("(function"))
+        assertTrue(script.endsWith("})();"))
+    }
+
+    // The page and the card have to agree about what a note is, or the same
+    // note is hidden without being poppable, or popped without being hidden.
+    // The script spells the vocabulary out as literals so the headless
+    // harness can run it as plain text; this is what stops the two drifting.
+
+    @Test
+    fun `the script knows the same note types as the resolver`() {
+        assertEquals(NoteVocabulary.NOTE_TYPES, scriptWords("NOTE_TYPES"))
+    }
+
+    @Test
+    fun `the script knows the same note roles as the resolver`() {
+        assertEquals(NoteVocabulary.NOTE_ROLES, scriptWords("NOTE_ROLES"))
+    }
+
+    @Test
+    fun `the script knows the same reference vocabulary`() {
+        assertEquals(NoteVocabulary.REF_TYPES, scriptWords("REF_TYPES"))
+        assertEquals(NoteVocabulary.REF_ROLES, scriptWords("REF_ROLES"))
+    }
+
+    @Test
+    fun `the script falls back to the same bare element`() {
+        assertTrue(FootnoteLayout.SCRIPT.contains("var NOTE_TAG = \"${NoteVocabulary.NOTE_TAG}\";"))
+    }
+
+    @Test
+    fun `the script uses the same majority threshold`() {
+        assertTrue(
+            FootnoteLayout.SCRIPT.contains("var MOSTLY_NOTES = ${FootnoteLayout.MOSTLY_NOTES};"),
+        )
+    }
+
+    @Test
+    fun `a note is hidden only because something in the page points at it`() {
+        // Notes are reached through the anchors that reference them. Sweeping
+        // the document for asides instead would empty a chapter of endnotes,
+        // which is a chapter somebody meant to be read.
+        assertTrue(FootnoteLayout.SCRIPT.contains("getElementsByTagName(\"a\")"))
+        assertFalse(FootnoteLayout.SCRIPT.contains("querySelectorAll(\"aside"))
+    }
+
+    @Test
+    fun `a link from inside a note is not evidence the note was referenced`() {
+        assertTrue(FootnoteLayout.SCRIPT.contains("insideNote(anchor)"))
+    }
+
+    @Test
+    fun `a document that is mostly notes is left alone entirely`() {
+        assertTrue(FootnoteLayout.SCRIPT.contains("held / page > MOSTLY_NOTES"))
+    }
+
+    @Test
+    fun `the marker is owned by a per-document token, not a guessable name`() {
+        assertTrue(FootnoteLayout.SCRIPT.contains("state.token"))
+    }
+
+    @Test
+    fun `the author's own markup is never rewritten`() {
+        assertFalse(FootnoteLayout.SCRIPT.contains("className"))
+        assertFalse(FootnoteLayout.SCRIPT.contains("classList"))
+        assertFalse(FootnoteLayout.SCRIPT.contains("innerHTML"))
+        // The one thing given any content is the stylesheet we made
+        // ourselves; nothing the publisher shipped is ever written to.
+        FootnoteLayout.SCRIPT.lineSequence()
+            .filter { it.contains("textContent =") }
+            .forEach { assertTrue(it, it.trim().startsWith("css.textContent =")) }
+    }
+
+    @Test
+    fun `a stylesheet the book's policy refused is reported rather than assumed`() {
+        assertTrue(FootnoteLayout.SCRIPT.contains("if (!css.sheet) return \"blocked\""))
+    }
+
+    @Test
+    fun `a marker is sized against the text rather than the screen`() {
+        // ReadiumCSS caps images at 95vh, which is most of a phone. An `em`
+        // is the only unit that keeps a marker the size of the words it sits
+        // between when the reader changes the type size.
+        assertTrue(FootnoteLayout.SCRIPT.contains("max-height:1.2em!important"))
+        assertFalse(FootnoteLayout.SCRIPT.contains("vh!important"))
+    }
+
+    @Test
+    fun `both epub attribute spellings are looked for`() {
+        // Served as XHTML the attribute is namespaced; served as HTML it is
+        // not, and books arrive both ways.
+        assertTrue(FootnoteLayout.SCRIPT.contains("getAttributeNS(EPUB_NS, \"type\")"))
+        assertTrue(FootnoteLayout.SCRIPT.contains("getAttribute(\"epub:type\")"))
+    }
+
+    @Test
+    fun `a fragment is quoted into the reveal script, never pasted into it`() {
+        val script = FootnoteLayout.revealScript("n\"1")
+        assertTrue(script.contains("""var id = "n\"1";"""))
+    }
+
+    @Test
+    fun `a fragment cannot close the script it is carried in`() {
+        val script = FootnoteLayout.revealScript("</script><img onerror=alert(1)>")
+        assertFalse(script.contains("</script>"))
+    }
+
+    @Test
+    fun `a fragment outside plain ascii survives as an escape`() {
+        assertEquals("\"\\u6ce8\"", FootnoteLayout.jsString("注"))
+        assertEquals("\"\\u000a\"", FootnoteLayout.jsString("\n"))
+        assertEquals("\"note-1\"", FootnoteLayout.jsString("note-1"))
+    }
+
+    @Test
+    fun `revealing is remembered, or the next layout pass hides it again`() {
+        val script = FootnoteLayout.revealScript("note-1")
+        assertTrue(script.contains("revealed[id] = true"))
+        assertTrue(script.contains("removeAttribute(\"data-liseur-note\")"))
+    }
+
+    /** The words of a `var NAME = [...]` list in the script. */
+    private fun scriptWords(name: String): Set<String> {
+        val list = Regex("var $name = \\[([^\\]]*)]")
+            .find(FootnoteLayout.SCRIPT)
+            ?.groupValues
+            ?.get(1)
+        requireNotNull(list) { "$name is not declared in the script" }
+        return list.split(',')
+            .map { it.trim().removeSurrounding("\"") }
+            .filter { it.isNotEmpty() }
+            .toSet()
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteLayoutTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteLayoutTest.kt
@@ -143,7 +143,30 @@ class FootnoteLayoutTest {
     fun `revealing is remembered, or the next layout pass hides it again`() {
         val script = FootnoteLayout.revealScript("note-1")
         assertTrue(script.contains("revealed[id] = true"))
-        assertTrue(script.contains("removeAttribute(\"data-liseur-note\")"))
+        assertTrue(script.contains("removeAttribute(state.noteAttr)"))
+    }
+
+    @Test
+    fun `an id that names something on Object's prototype is not read as revealed`() {
+        // `constructor` and `toString` are legal EPUB ids, and a bare object
+        // answers for both, so the map both scripts share carries no
+        // prototype at all.
+        assertTrue(FootnoteLayout.SCRIPT.contains("Object.create(null)"))
+        assertTrue(FootnoteLayout.revealScript("n1").contains("Object.create(null)"))
+    }
+
+    @Test
+    fun `the token names the attribute rather than filling it`() {
+        // A publisher shipping `data-liseur-note` of their own must not have
+        // it overwritten, which taking the bare name would do.
+        assertTrue(FootnoteLayout.SCRIPT.contains("\"data-liseur-note-\" + tok"))
+        assertTrue(FootnoteLayout.SCRIPT.contains("\"data-liseur-mark-\" + tok"))
+    }
+
+    @Test
+    fun `a reference carrying its own chapter's path is still a local one`() {
+        assertTrue(FootnoteLayout.SCRIPT.contains("document.baseURI"))
+        assertTrue(FootnoteLayout.SCRIPT.contains("localFragment"))
     }
 
     /** The words of a `var NAME = [...]` list in the script. */

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/footnotes/NoteVocabularyTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/footnotes/NoteVocabularyTest.kt
@@ -1,0 +1,60 @@
+package com.chmouel.liseur.reader.footnotes
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NoteVocabularyTest {
+
+    @Test
+    fun `the epub vocabulary names a note`() {
+        assertTrue(NoteVocabulary.isNote("footnote", "", "div"))
+        assertTrue(NoteVocabulary.isNote("endnote", "", "li"))
+        assertTrue(NoteVocabulary.isNote("rearnote", "", "div"))
+        assertTrue(NoteVocabulary.isNote("note", "", "section"))
+    }
+
+    @Test
+    fun `a prefixed epub type is read past its prefix`() {
+        assertTrue(NoteVocabulary.isNote("epub:footnote", "", "div"))
+    }
+
+    @Test
+    fun `one word among several is enough`() {
+        assertTrue(NoteVocabulary.isNote("backlink footnote", "", "div"))
+    }
+
+    @Test
+    fun `the aria vocabulary names a note too`() {
+        assertTrue(NoteVocabulary.isNote("", "doc-footnote", "div"))
+        assertTrue(NoteVocabulary.isNote("", "doc-endnote", "div"))
+    }
+
+    @Test
+    fun `an unlabelled aside is taken at its word`() {
+        assertTrue(NoteVocabulary.isNote("", "", "aside"))
+        assertTrue(NoteVocabulary.isNote("", "", "ASIDE"))
+    }
+
+    @Test
+    fun `a chapter is not a note however it is spelled`() {
+        assertFalse(NoteVocabulary.isNote("chapter", "", "section"))
+        assertFalse(NoteVocabulary.isNote("", "doc-chapter", "div"))
+        assertFalse(NoteVocabulary.isNote("", "", "div"))
+    }
+
+    @Test
+    fun `a word that merely contains a note word is not one`() {
+        assertFalse(NoteVocabulary.isNote("footnotes", "", "div"))
+        assertFalse(NoteVocabulary.isNote("noteref", "", "div"))
+    }
+
+    @Test
+    fun `a reference is recognised by either vocabulary`() {
+        assertTrue(NoteVocabulary.isNoteRef("noteref", ""))
+        assertTrue(NoteVocabulary.isNoteRef("epub:noteref", ""))
+        assertTrue(NoteVocabulary.isNoteRef("", "doc-noteref"))
+        assertFalse(NoteVocabulary.isNoteRef("footnote", ""))
+        assertFalse(NoteVocabulary.isNoteRef("", ""))
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/footnotes/NoteVocabularyTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/footnotes/NoteVocabularyTest.kt
@@ -57,4 +57,15 @@ class NoteVocabularyTest {
         assertFalse(NoteVocabulary.isNoteRef("footnote", ""))
         assertFalse(NoteVocabulary.isNoteRef("", ""))
     }
+
+    @Test
+    fun `a token list may be written across any whitespace`() {
+        // The injected script splits on `/\s+/`, and a book is free to wrap
+        // a long `epub:type` across a line. Reading only spaces here made
+        // the two disagree about the same element.
+        assertTrue(NoteVocabulary.isNote("backmatter\tfootnote", "", "div"))
+        assertTrue(NoteVocabulary.isNote("backmatter\nfootnote", "", "div"))
+        assertTrue(NoteVocabulary.isNote("", "doc-chapter\tdoc-footnote", "div"))
+        assertTrue(NoteVocabulary.isNoteRef("backmatter\nnoteref", ""))
+    }
 }

--- a/hack/README.md
+++ b/hack/README.md
@@ -108,6 +108,18 @@ target wrapping them. Run `make help` for the short list. See
   `./gradlew assembleDebug` (Readium's CSS is unpacked from the AAR by the
   build), so it is a check to run by hand when that script
   changes, not part of `make check`. `PORT=` picks another port.
+- `verify-footnotes`: The same kind of check for the notes in issue #152:
+  that a book's notes stay out of the page until they are asked for, and
+  that a marker drawn as an image is the size of the words around it. The
+  script comes out of `FootnoteLayout.kt`, and the cases run against
+  Readium's CJK stylesheets, which are what it picks for the book in the
+  issue and which nothing else here exercises. Same requirements and same
+  reasons for staying out of `make check`. `PORT=` picks another port.
+- `make-notes-book`: Builds the fixture book those notes are reproduced
+  with — deliberately badly behaved in the two ways the reporter's edition
+  is, and well behaved everywhere else, so a fix can be seen to leave the
+  second alone. Seeded onto the shelf by `reset-books` and `screenshots`,
+  and buildable on its own for opening by hand.
 - `icon`: Renders the adaptive launcher icon (two vector drawables)
   to a flat PNG for the F-Droid listing and the README.
 - `feature-graphic`: Renders the 1024x500 store feature graphic

--- a/hack/lib/demo-books.sh
+++ b/hack/lib/demo-books.sh
@@ -198,7 +198,19 @@ fetch_books() {
     fi
     mv "$file.part" "$file"
   done
+
+  # And one book nobody published: a reproducer for the notes in issue #152,
+  # which the shelf above cannot provide because Standard Ebooks mark their
+  # notes up correctly. Rebuilt every time, so a change to the fixture is on
+  # the device the next time the shelf is seeded.
+  note "building the notes fixture"
+  "$REPO_ROOT/hack/make-notes-book" "$CACHE_DIR/liseur_notes-fixture.epub" >/dev/null ||
+    die "could not build the notes fixture book"
 }
+
+# What the shelf should hold once it has been scanned: the downloaded books
+# and the fixture built alongside them.
+expected_books() { echo $((${#DEMO_BOOKS[@]} + 1)); }
 
 push_books() {
   adb shell mkdir -p "$DEVICE_BOOKS"
@@ -206,7 +218,7 @@ push_books() {
   for file in "$CACHE_DIR"/*.epub; do
     adb push "$file" "$DEVICE_BOOKS/" >/dev/null
   done
-  note "${#DEMO_BOOKS[@]} books in $DEVICE_BOOKS"
+  note "$(expected_books) books in $DEVICE_BOOKS"
 }
 
 # Grant the folder through the real picker, because there is no other way
@@ -246,11 +258,12 @@ grant_folder() {
   # which does nothing and loses the folder.
   tap_on "ALLOW" exact
   note "waiting for the shelf to fill"
-  local waited=0 count=0
+  local waited=0 count=0 wanted
+  wanted=$(expected_books)
   while ((waited < 90)); do
     count=$(adb shell "run-as $APP_ID sqlite3 /data/data/$APP_ID/databases/liseur.db \
             'select count(*) from books;'" 2>/dev/null | tr -d '\r')
-    ((count >= ${#DEMO_BOOKS[@]})) && break
+    ((count >= wanted)) && break
     sleep 5
     waited=$((waited + 5))
   done

--- a/hack/make-notes-book
+++ b/hack/make-notes-book
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Builds the notes fixture book (issue #152).
+
+A reproducer, not a demo. The shelf of Standard Ebooks that `make reset`
+seeds is beautifully made, which is exactly why none of it reproduces this:
+those books mark their notes up the way a reading system expects, and the
+bug is about the ones that do not.
+
+So this book is written to be badly behaved in the two specific ways the
+reporter's edition is, and well behaved everywhere else, so that a fix can
+be seen to work on the first without touching the second:
+
+  * chapter one puts a translator's note in an `<aside epub:type="footnote">`
+    at the top of the document, before the paragraph that refers to it, and
+    marks the reference with a 200-pixel image;
+  * chapter two does the same in the ARIA vocabulary, and adds an aside that
+    is a pull quote rather than a note, which nothing links to;
+  * the endnotes chapter is a chapter somebody meant to be read, with a
+    contents list at the top pointing at every note in it, which is the
+    shape that a careless rule blanks entirely.
+
+Chinese, because that is the book in the issue and because it sends Readium
+down its CJK stylesheets, which nothing else here exercises.
+
+    hack/make-notes-book [PATH]
+
+Writes to tmp/books/liseur_notes-fixture.epub by default.
+"""
+
+import os
+import subprocess
+import sys
+import zipfile
+
+TITLE = "注释与脚注（Notes fixture）"
+AUTHOR = "Liseur"
+# Fixed, so that rebuilding the book does not make the library treat it as a
+# different one and lose whatever position was on it.
+BOOK_ID = "urn:uuid:9f2a1c34-5f7e-4a51-9a2e-liseur-notes-152"
+
+MARKER_SVG = """<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <circle cx="100" cy="100" r="94" fill="#6d5a4a"/>
+  <text x="100" y="136" font-size="120" text-anchor="middle" fill="#f4ece2"
+        font-family="serif">注</text>
+</svg>
+"""
+
+# Deliberately says nothing about the marker's size. A publisher who sized it
+# would have hidden the bug, and the point of this book is not to.
+CSS = """@charset "utf-8";
+body { margin: 0 5%; line-height: 1.6; }
+h1 { text-align: center; margin: 2em 0 1em; }
+p { text-indent: 2em; margin: 0.6em 0; }
+aside p { text-indent: 0; }
+ol { padding-left: 2em; }
+"""
+
+CONTAINER = """<?xml version="1.0" encoding="utf-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>
+"""
+
+PACKAGE = f"""<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="zh"
+         unique-identifier="pub-id">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="pub-id">{BOOK_ID}</dc:identifier>
+    <dc:title>{TITLE}</dc:title>
+    <dc:creator>{AUTHOR}</dc:creator>
+    <dc:language>zh</dc:language>
+    <dc:description>A reproducer for issue #152: notes in the page and a marker drawn at its natural size.</dc:description>
+    <meta property="dcterms:modified">2026-01-01T00:00:00Z</meta>
+  </metadata>
+  <manifest>
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+    <item id="css" href="style.css" media-type="text/css"/>
+    <item id="marker" href="zhu.svg" media-type="image/svg+xml"/>
+    <item id="ch1" href="ch1.xhtml" media-type="application/xhtml+xml"/>
+    <item id="ch2" href="ch2.xhtml" media-type="application/xhtml+xml"/>
+    <item id="notes" href="notes.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="ch1"/>
+    <itemref idref="ch2"/>
+    <itemref idref="notes"/>
+  </spine>
+</package>
+"""
+
+NAV = """<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops"
+      lang="zh" xml:lang="zh">
+<head><meta charset="utf-8"/><title>目录</title></head>
+<body>
+<nav epub:type="toc" id="toc">
+  <h1>目录</h1>
+  <ol>
+    <li><a href="ch1.xhtml">引言</a></li>
+    <li><a href="ch2.xhtml">第二章</a></li>
+    <li><a href="notes.xhtml">注释</a></li>
+  </ol>
+</nav>
+</body>
+</html>
+"""
+
+# The reporter's chapter. The note is above the text it belongs to, and the
+# marker is an image with no size on it.
+CH1 = """<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops"
+      lang="zh" xml:lang="zh">
+<head><meta charset="utf-8"/><title>引言</title>
+<link rel="stylesheet" type="text/css" href="style.css"/></head>
+<body>
+<h1>引言</h1>
+<aside epub:type="footnote" id="n1">
+  <p>宾夕法尼亚州东北部城市，宾州的主要城市之一。——译者</p>
+</aside>
+<aside epub:type="footnote" id="n2">
+  <p>一种以慢火炖煮的家常菜，在当地餐馆几乎家家都有。——译者</p>
+</aside>
+<p>宾夕法尼亚州的老福格镇有8000人口，位于斯克兰顿市<a epub:type="noteref"
+   href="#n1" id="ref1"><img src="zhu.svg" alt="注"/></a>以南几十公里的地方，
+   人们大多在附近的仓库和医院上班。</p>
+<p>三十四岁的库苏马诺身体健壮，他从上小学的时候开始学着做饭。妻子尼娜比他小两岁，
+   十六岁就开始在餐厅干活了。店里最受欢迎的一道菜<a epub:type="noteref"
+   href="#n2" id="ref2"><img src="zhu.svg" alt="注"/></a>从开张那天卖到现在。</p>
+<p>到2020年1月，即使是周三周四，也有不少人前来消费，这种好日子一直持续到2月。
+   那年的情人节恰好是星期五，那天晚上可能是这家餐厅开业七年多来生意最好的周五之夜。</p>
+</body>
+</html>
+"""
+
+# The same fault in the ARIA vocabulary, plus an aside that is not a note at
+# all and must come through the fix untouched.
+CH2 = """<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops"
+      lang="zh" xml:lang="zh">
+<head><meta charset="utf-8"/><title>第二章</title>
+<link rel="stylesheet" type="text/css" href="style.css"/></head>
+<body>
+<h1>第二章</h1>
+<div role="doc-footnote" id="a1">
+  <p>指1929年开始的经济大萧条。——译者</p>
+</div>
+<p>那家店开在镇上唯一一条主街的尽头，招牌是父辈留下来的。他们经历过那段最难的日子
+   <a role="doc-noteref" href="#a1"><img src="zhu.svg" alt="注"/></a>，
+   也熬过了后来的每一次。</p>
+<aside id="pull-quote">
+  <p>“我们不是在做生意，我们是在喂饱邻居。”</p>
+</aside>
+<p>这句话被印在菜单的背面，客人一边等菜一边把它读上好几遍。多年以后，镇上的人还记得
+   这家店在停业那天贴出的告示，和告示下面摆着的一小束花。</p>
+<p>后面还有一段文字，好让这一章不只是注释和引文，读起来像真正的一章。这一段没有任何
+   注释，也没有任何链接，它就是正文本身。</p>
+</body>
+</html>
+"""
+
+# A chapter of endnotes that somebody meant to be read, with a contents list
+# pointing at every note in it. A rule that hides whatever is linked to would
+# leave this page blank.
+NOTES = """<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops"
+      lang="zh" xml:lang="zh">
+<head><meta charset="utf-8"/><title>注释</title>
+<link rel="stylesheet" type="text/css" href="style.css"/></head>
+<body>
+<h1>注释</h1>
+<ol>
+  <li><a href="#e1">关于镇名的由来</a></li>
+  <li><a href="#e2">关于那条主街</a></li>
+  <li><a href="#e3">关于那束花</a></li>
+</ol>
+<aside epub:type="endnote" id="e1">
+  <p>镇名来自十九世纪末在此定居的一户人家，他们的姓氏后来成了整片山谷的名字，
+     至今仍写在镇公所门口的铜牌上。</p>
+</aside>
+<aside epub:type="endnote" id="e2">
+  <p>主街原本是一条运煤的土路，铺上石板是1911年的事，镇志里保留着当年的账目，
+     连每一车石头的价钱都记得清清楚楚。</p>
+</aside>
+<aside epub:type="endnote" id="e3">
+  <p>花是隔壁花店送的，店主在告示贴出来的第二天早上放在门口，没有留下名字，
+     后来是别人认出了包花的纸。</p>
+</aside>
+</body>
+</html>
+"""
+
+FILES = {
+    "META-INF/container.xml": CONTAINER,
+    "EPUB/package.opf": PACKAGE,
+    "EPUB/nav.xhtml": NAV,
+    "EPUB/style.css": CSS,
+    "EPUB/zhu.svg": MARKER_SVG,
+    "EPUB/ch1.xhtml": CH1,
+    "EPUB/ch2.xhtml": CH2,
+    "EPUB/notes.xhtml": NOTES,
+}
+
+
+def default_path() -> str:
+    root = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    return os.path.join(root, "tmp", "books", "liseur_notes-fixture.epub")
+
+
+def build(path: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".part"
+    # The mimetype entry has to be first and stored uncompressed, or the file
+    # is not an EPUB however well-formed everything after it is.
+    with zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as book:
+        book.writestr(
+            zipfile.ZipInfo("mimetype"), "application/epub+zip",
+            compress_type=zipfile.ZIP_STORED,
+        )
+        for name, text in FILES.items():
+            book.writestr(name, text)
+    os.replace(tmp, path)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 2:
+        sys.exit(__doc__)
+    target = sys.argv[1] if len(sys.argv) == 2 else default_path()
+    build(target)
+    print(target)

--- a/hack/make-notes-book
+++ b/hack/make-notes-book
@@ -213,7 +213,9 @@ def default_path() -> str:
 
 
 def build(path: str) -> None:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    # A bare filename has no directory part, and `makedirs("")` raises rather
+    # than doing nothing, so the path is made absolute before it is asked.
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
     tmp = path + ".part"
     # The mimetype entry has to be first and stored uncompressed, or the file
     # is not an EPUB however well-formed everything after it is.

--- a/hack/reset-books
+++ b/hack/reset-books
@@ -76,4 +76,4 @@ push_books
 step "Granting the folder"
 grant_folder
 
-printf '\nDone. %s books on the shelf.\n' "${#DEMO_BOOKS[@]}"
+printf '\nDone. %s books on the shelf.\n' "$(expected_books)"

--- a/hack/verify-footnotes
+++ b/hack/verify-footnotes
@@ -1,0 +1,461 @@
+#!/usr/bin/env bash
+#
+# Checks that a book's notes stay out of the page until they are asked for,
+# and that a note marker drawn as an image is the size of the words around it
+# (issue #152).
+#
+# Like hack/verify-wide-content, none of what the fix has to get right can be
+# seen from the JVM: whether an aside is actually hidden once Readium's own
+# stylesheets are in front of it, whether a 200-pixel glyph comes down to one
+# line, whether a chapter of endnotes survives untouched. So the script is
+# lifted out of FootnoteLayout.kt — the same text the app ships, never a copy
+# — and run against Readium's real stylesheets in headless Chrome, in a frame
+# the size of a phone.
+#
+# The CJK sheets are the default here because that is what Readium picks for
+# the book in the issue, and because they are the variant nothing else
+# exercises.
+#
+# One limit worth knowing: the harness loads each case through `srcdoc`, so
+# the documents are parsed as HTML. A book served as XHTML puts `epub:type`
+# in a namespace instead, which is why the script asks for it both ways and
+# why FootnoteLayoutTest checks that it still does.
+#
+# There is no Chrome on the CI runners, so this is a check to run by hand
+# when the script changes, not part of `make check`.
+
+set -euo pipefail
+
+readonly SOURCE="app/src/main/kotlin/com/chmouel/liseur/reader/footnotes/FootnoteLayout.kt"
+readonly ASSETS="app/build/intermediates/assets/debug/mergeDebugAssets/readium/readium-css"
+readonly PORT="${PORT:-8792}"
+
+die() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+cd "$(git rev-parse --show-toplevel)"
+
+browser=""
+for candidate in google-chrome-stable google-chrome chromium chromium-browser; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+        browser=$candidate
+        break
+    fi
+done
+[[ -n $browser ]] || die "no chrome or chromium on PATH"
+
+command -v python3 >/dev/null 2>&1 || die "python3 is needed to serve the harness"
+
+# Readium's stylesheets arrive from the navigator AAR and are only unpacked
+# once something has been built.
+[[ -d $ASSETS ]] || die "$ASSETS is missing — run ./gradlew assembleDebug first"
+
+work=$(mktemp -d)
+server=""
+cleanup() {
+    # Under `set -e` a kill that loses the race would abort the trap and
+    # leave the temporary tree behind.
+    if [[ -n $server ]]; then
+        kill "$server" 2>/dev/null || true
+        wait "$server" 2>/dev/null || true
+    fi
+    rm -rf "$work"
+}
+trap cleanup EXIT
+
+cp -r "$ASSETS" "$work/readium-css"
+mkdir -p "$work/cases"
+
+# Both scripts come out of the Kotlin, so the harness can never pass against
+# a copy that has drifted from what the app runs. The reveal script is a
+# template with the fragment interpolated into it; the interpolation is
+# replaced by a placeholder the harness fills in per case.
+python3 - "$SOURCE" "$work/notes.js" "$work/reveal.js" <<'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+
+match = re.search(r'const val SCRIPT: String = """(.*?)"""', src, re.S)
+if not match:
+    sys.exit("could not find SCRIPT in " + sys.argv[1])
+open(sys.argv[2], "w").write(match.group(1))
+
+match = re.search(
+    r'fun revealScript\(fragment: String\): String =\s*"""(.*?)"""', src, re.S
+)
+if not match:
+    sys.exit("could not find revealScript in " + sys.argv[1])
+template = match.group(1)
+if "${jsString(fragment)}" not in template:
+    sys.exit("revealScript no longer quotes its fragment")
+open(sys.argv[3], "w").write(template.replace("${jsString(fragment)}", "__ID__"))
+PY
+
+# A 200px glyph, which is roughly what the book in the issue ships and about
+# twelve times the height of the line it sits in.
+marker=$(python3 -c '
+import base64
+svg = ("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"200\" height=\"200\">"
+       "<circle cx=\"100\" cy=\"100\" r=\"95\" fill=\"#654321\"/></svg>")
+print("data:image/svg+xml;base64," + base64.b64encode(svg.encode()).decode())
+')
+
+emit() { sed "s|__MARKER__|$marker|g" >"$work/cases/$1"; }
+
+# The reporter's chapter: the note is an aside at the top of the document,
+# read before the sentence it glosses, and the marker is an image.
+emit inline-note.xhtml <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="zh" xml:lang="zh">
+<head><title>t</title></head><body>
+<h1>引言</h1>
+<aside epub:type="footnote" id="n1"><p id="note-body">宾夕法尼亚州东北部城市，宾州的主要城市之一。——译者</p></aside>
+<p id="probe">宾夕法尼亚州的老福格镇有8000人口，位于斯克兰顿市<a epub:type="noteref" href="#n1" id="ref"><img id="marker" src="__MARKER__" alt="注"/></a>以南几十公里的地方。</p>
+<p>到2020年1月，即使是周三周四，也有不少人前来消费。</p>
+</body></html>
+EOF
+
+# The same thing said in the ARIA vocabulary, which plenty of converted books
+# use instead of the EPUB one.
+emit aria-note.xhtml <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="zh" xml:lang="zh">
+<head><title>t</title></head><body>
+<div role="doc-footnote" id="n1"><p>The note, written where nobody wants to read it.</p></div>
+<p id="probe">A sentence that needs a gloss<a role="doc-noteref" href="#n1"><img id="marker" src="__MARKER__" alt="note"/></a> and then carries on.</p>
+</body></html>
+EOF
+
+# A chapter of endnotes: referenced from the chapters it serves, never from
+# itself, apart from the backlinks. Nothing here may be hidden.
+emit endnotes.xhtml <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><title>t</title></head><body>
+<h1>Notes</h1>
+<aside epub:type="endnote" id="n1"><p>The first note, which somebody meant to be read. <a href="#ref1">↩</a></p></aside>
+<aside epub:type="endnote" id="n2"><p>The second note, likewise. <a href="#ref2">↩</a></p></aside>
+<aside epub:type="endnote" id="n3"><p>And a third, for good measure. <a href="#ref3">↩</a></p></aside>
+</body></html>
+EOF
+
+# The same chapter with a contents list at the top, so every note *is*
+# referenced from its own document. The majority guard is the only thing
+# standing between this page and being blank.
+emit endnotes-listed.xhtml <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><title>t</title></head><body>
+<h1>Notes</h1>
+<ol><li><a href="#n1">1</a></li><li><a href="#n2">2</a></li><li><a href="#n3">3</a></li></ol>
+<aside epub:type="endnote" id="n1"><p>The first note, which somebody meant to be read, at some length so that it weighs more than the list pointing at it.</p></aside>
+<aside epub:type="endnote" id="n2"><p>The second note, likewise long enough to matter to the weighing, because a note nobody can see is a note nobody can read.</p></aside>
+<aside epub:type="endnote" id="n3"><p>And a third, for good measure, also of a length that a reader would recognise as the substance of the page.</p></aside>
+</body></html>
+EOF
+
+# An aside that is not a note at all. Nothing links to it, so nothing happens
+# to it — which is the entire reason the rule is written the way it is.
+emit pull-quote.xhtml <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><title>t</title></head><body>
+<p>Some prose before the pull quote, long enough to be the bulk of the page by any measure at all.</p>
+<aside id="quote"><p>"A sentence the designer wanted in the margin."</p></aside>
+<p>And some prose after it, also long enough to count, so the page is mostly its own text.</p>
+</body></html>
+EOF
+
+# A marker pointing at a note in another file, which is how most EPUB 3 books
+# do it. There is nothing to hide here; the image still has to come down.
+emit cross-document.xhtml <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><title>t</title></head><body>
+<p id="probe">A sentence<a epub:type="noteref" href="endnotes.xhtml#n1"><img id="marker" src="__MARKER__" alt="1"/></a> and its continuation.</p>
+</body></html>
+EOF
+
+# A plain cross-reference. Not a note by any spelling, so the image inside it
+# is the author's illustration and must be left at the size they chose.
+emit cross-reference.xhtml <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><title>t</title></head><body>
+<section id="n1"><h2>Chapter Two</h2><p>An ordinary chapter, linked to from an ordinary link.</p></section>
+<p id="probe">See <a href="#n1"><img id="marker" src="__MARKER__" alt="chapter two"/></a> for more.</p>
+</body></html>
+EOF
+
+# A publisher who happens to have picked our names for their own markup. Their
+# aside is nobody's note — nothing links to it — so it must come through
+# untouched, and their attribute value must not be what hides it.
+emit publisher-markers.xhtml <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head><title>t</title><style id="liseur-note-css">.liseur-note{color:#333}</style></head><body>
+<aside id="theirs" class="liseur-note" data-liseur-note="theirs"><p>Their aside, with their attribute on it.</p></aside>
+<aside epub:type="footnote" id="n1"><p>A real note.</p></aside>
+<p id="probe">Prose that is the bulk of the page, and rather more of it besides, so that the weighing of notes against text comes out the way a reader would expect it to and nothing is spared on a technicality. <a epub:type="noteref" href="#n1">1</a></p>
+<p>A second paragraph, for the same reason: the page has to be mostly its own words before any of this means anything at all.</p>
+</body></html>
+EOF
+
+cat >"$work/index.html" <<'EOF'
+<!DOCTYPE html><html><head><meta charset="utf-8"><title>running</title>
+<style>body{margin:0;font:12px monospace}#f{border:0;width:412px;height:820px}</style>
+</head><body>
+<iframe id="f"></iframe><pre id="out"></pre>
+<script>
+var NOTES = null, REVEAL = null;
+var results = [];
+function log(ok, name, detail) {
+  results.push((ok ? "PASS " : "FAIL ") + name + (detail ? "  [" + detail + "]" : ""));
+}
+function frame(caseName, fontSize, variant) {
+  return fetch("cases/" + caseName).then(function (r) { return r.text(); }).then(function (src) {
+    var base = "../readium-css/" + (variant || "cjk-horizontal") + "/";
+    var vars = "--USER__fontSize:" + fontSize + "%;--USER__view:readium-paged-on;";
+    var head =
+      '<link rel="stylesheet" href="' + base + 'ReadiumCSS-before.css"/>' +
+      '<style>:root,:root > body{overflow:visible !important}html,body{height:100%}</style>';
+    var tail = '<link rel="stylesheet" href="' + base + 'ReadiumCSS-after.css"/>';
+    src = src.replace("</head>", head + tail + "</head>")
+             .replace("<body>", '<body style="' + vars + '">');
+    src = src.replace(/<html([^>]*)>/, '<html$1 style="' + vars + '">');
+    var f = document.getElementById("f");
+    return new Promise(function (res) {
+      f.onload = function () { setTimeout(function () { res(f.contentWindow); }, 60); };
+      f.srcdoc = src;
+    });
+  });
+}
+function run(win) { return win.eval(NOTES); }
+function reveal(win, id) { return win.eval(REVEAL.replace("__ID__", JSON.stringify(id))); }
+function shown(win, sel) {
+  var el = win.document.querySelector(sel);
+  if (!el) return null;
+  return win.getComputedStyle(el).display !== "none";
+}
+function marker(win) {
+  var el = win.document.getElementById("marker");
+  if (!el) return null;
+  var line = parseFloat(win.getComputedStyle(el.parentElement).fontSize);
+  return { h: Math.round(el.getBoundingClientRect().height),
+           w: Math.round(el.getBoundingClientRect().width),
+           em: Math.round(line) };
+}
+function dom(win) { return win.document.body.innerHTML; }
+
+var TESTS = [];
+
+TESTS.push(function () {
+  return frame("inline-note.xhtml", 100).then(function (w) {
+    var before = marker(w), wasShown = shown(w, "#n1");
+    var r = run(w);
+    var after = marker(w);
+    log(wasShown, "the note really is in the page to begin with");
+    log(before.h > 100, "the marker really is oversized to begin with", before.h + "px");
+    log(r === "changed", "the pass reports the page moved", "got " + r);
+    log(!shown(w, "#n1"), "the referenced note is out of the page");
+    log(after.h <= after.em * 1.3, "the marker comes down to the line",
+        before.h + "px -> " + after.h + "px, line " + after.em + "px");
+    log(after.w > 0 && Math.abs(after.w - after.h) <= 2,
+        "the marker keeps its shape", after.w + "x" + after.h);
+  });
+});
+
+[100, 175].forEach(function (fs) {
+  TESTS.push(function () {
+    return frame("inline-note.xhtml", fs).then(function (w) {
+      run(w);
+      var m = marker(w);
+      log(m.h <= m.em * 1.3 && m.h > 0, "the marker follows the type size at " + fs + "%",
+          m.h + "px against a " + m.em + "px line");
+    });
+  });
+});
+
+TESTS.push(function () {
+  return frame("aria-note.xhtml", 100).then(function (w) {
+    run(w);
+    var m = marker(w);
+    log(!shown(w, "#n1"), "an aria note is hidden too");
+    log(m.h <= m.em * 1.3, "an aria marker comes down too", m.h + "px");
+  });
+});
+
+TESTS.push(function () {
+  return frame("endnotes.xhtml", 100).then(function (w) {
+    var r = run(w);
+    log(shown(w, "#n1") && shown(w, "#n2") && shown(w, "#n3"),
+        "a chapter of endnotes is left alone", "result " + r);
+  });
+});
+
+TESTS.push(function () {
+  return frame("endnotes-listed.xhtml", 100).then(function (w) {
+    run(w);
+    log(shown(w, "#n1") && shown(w, "#n2") && shown(w, "#n3"),
+        "a chapter that is mostly notes is left alone even when it links to them");
+  });
+});
+
+TESTS.push(function () {
+  return frame("pull-quote.xhtml", 100).then(function (w) {
+    run(w);
+    log(shown(w, "#quote"), "an aside nobody links to is not a note");
+  });
+});
+
+TESTS.push(function () {
+  return frame("cross-document.xhtml", 100).then(function (w) {
+    var before = marker(w);
+    run(w);
+    var after = marker(w);
+    log(after.h <= after.em * 1.3, "a marker for a note in another file comes down",
+        before.h + "px -> " + after.h + "px");
+  });
+});
+
+TESTS.push(function () {
+  return frame("cross-reference.xhtml", 100).then(function (w) {
+    var before = marker(w);
+    run(w);
+    var after = marker(w);
+    log(shown(w, "#n1"), "a chapter linked to is not a note");
+    log(after.h === before.h, "an illustration in a cross-reference keeps its size",
+        before.h + "px -> " + after.h + "px");
+  });
+});
+
+TESTS.push(function () {
+  return frame("inline-note.xhtml", 100).then(function (w) {
+    var r1 = run(w);
+    var afterRun1 = dom(w);
+    var installed = !!w.__liseurNotes && !!w.__liseurNotes.styleEl;
+    var r2 = run(w);
+    log(r1 === "changed", "run 1 reports changed", "got " + r1);
+    log(installed, "run 1 installs the stylesheet");
+    log(r2 === "stable", "run 2 reports stable", "got " + r2);
+    log(dom(w) === afterRun1, "run 2 leaves the dom as run 1 left it");
+  });
+});
+
+TESTS.push(function () {
+  return frame("endnotes.xhtml", 100).then(function (w) {
+    run(w);
+    log(run(w) === "stable", "an untouched page settles to stable");
+  });
+});
+
+TESTS.push(function () {
+  return frame("inline-note.xhtml", 100).then(function (w) {
+    run(w);
+    var hidden = !shown(w, "#n1");
+    var answer = reveal(w, "n1");
+    var back = shown(w, "#n1");
+    var r = run(w);
+    log(hidden, "hidden before the reader asked for it");
+    log(answer === "revealed", "the reveal says it found the note", "got " + answer);
+    log(back, "the note is on the page once it has been asked for");
+    log(shown(w, "#n1"), "and a later pass does not take it away again", "result " + r);
+  });
+});
+
+TESTS.push(function () {
+  return frame("inline-note.xhtml", 100).then(function (w) {
+    run(w);
+    log(reveal(w, "nothing-of-the-sort") === "absent",
+        "a fragment that is not there is reported, not assumed");
+  });
+});
+
+TESTS.push(function () {
+  return frame("publisher-markers.xhtml", 100).then(function (w) {
+    var r = run(w);
+    var theirs = w.document.getElementById("theirs");
+    log(!!w.__liseurNotes.styleEl, "installs despite an author id=liseur-note-css");
+    log(theirs.className === "liseur-note", "author classes untouched", theirs.className);
+    log(theirs.getAttribute("data-liseur-note") === "theirs",
+        "the author's own data-liseur-note value is left alone",
+        "attr " + theirs.getAttribute("data-liseur-note"));
+    log(w.getComputedStyle(theirs).display !== "none",
+        "and their aside is not hidden by their own attribute");
+    log(!shown(w, "#n1"), "while the note that really is one still goes",
+        "result " + r);
+  });
+});
+
+TESTS.push(function () {
+  return frame("inline-note.xhtml", 100, "").then(function (w) {
+    run(w);
+    log(!shown(w, "#n1"), "the default stylesheets behave the same way");
+  });
+});
+
+Promise.all([
+  fetch("notes.js").then(function (r) { return r.text(); }),
+  fetch("reveal.js").then(function (r) { return r.text(); })
+]).then(function (sources) {
+  NOTES = sources[0];
+  REVEAL = sources[1];
+  return TESTS.reduce(function (p, t) { return p.then(t); }, Promise.resolve());
+}).then(function () {
+  var failed = results.filter(function (r) { return r.indexOf("FAIL") === 0; }).length;
+  document.getElementById("out").textContent = results.join("\n");
+  document.title = failed === 0 ? "ALL PASS" : failed + " FAILED";
+}).catch(function (e) {
+  document.getElementById("out").textContent = "harness error: " + (e && e.stack || e);
+  document.title = "HARNESS ERROR";
+});
+</script></body></html>
+EOF
+
+(cd "$work" && exec python3 -m http.server "$PORT" >/dev/null 2>&1) &
+server=$!
+
+# Wait for the server rather than guessing at it, and make it prove the tree
+# it is serving is this one: a stale server left on the port would answer
+# every request with someone else's script, and every assertion below would
+# then be about the wrong thing.
+ready=false
+for _ in $(seq 1 50); do
+    status=0
+    python3 - "$PORT" "$work/notes.js" <<'PY' || status=$?
+import sys, urllib.request
+port, path = sys.argv[1], sys.argv[2]
+try:
+    served = urllib.request.urlopen("http://127.0.0.1:%s/notes.js" % port, timeout=1).read()
+except Exception:
+    sys.exit(1)
+sys.exit(0 if served == open(path, "rb").read() else 2)
+PY
+    case $status in
+        0)
+            ready=true
+            break
+            ;;
+        2)
+            die "port $PORT is serving another tree; try PORT=… "
+            ;;
+    esac
+    kill -0 "$server" 2>/dev/null ||
+        die "could not serve the harness on port $PORT; something else is using it (try PORT=…)"
+    sleep 0.2
+done
+$ready || die "the harness server never came up on port $PORT"
+
+"$browser" --headless=new --disable-gpu --no-sandbox \
+    --virtual-time-budget=20000 \
+    --user-data-dir="$work/chrome" \
+    --dump-dom "http://127.0.0.1:$PORT/index.html" \
+    >"$work/dump.html" 2>/dev/null
+
+python3 - "$work/dump.html" <<'PY'
+import html, re, sys
+page = open(sys.argv[1]).read()
+title = re.search(r"<title>(.*?)</title>", page, re.S)
+out = re.search(r'<pre id="out">(.*?)</pre>', page, re.S)
+title = title.group(1) if title else "?"
+print(html.unescape(out.group(1)) if out else "(the harness produced no output)")
+print()
+print(title)
+sys.exit(0 if title == "ALL PASS" else 1)
+PY

--- a/hack/verify-footnotes
+++ b/hack/verify-footnotes
@@ -360,6 +360,23 @@ TESTS.push(function () {
 });
 
 TESTS.push(function () {
+  return frame("inline-note.xhtml", 100).then(function (w) {
+    var r1 = run(w);
+    // A stylesheet the page refuses is still an element and still in the
+    // head; what it never gets is a `sheet`. That is what the pass has to
+    // keep asking about, or the second one marks notes nothing can hide.
+    Object.defineProperty(w.__liseurNotes.styleEl, "sheet", { get: function () { return null; } });
+    var marked = w.document.querySelectorAll("[" + w.__liseurNotes.noteAttr + "]").length;
+    var r2 = run(w);
+    var stillMarked = w.document.querySelectorAll("[" + w.__liseurNotes.noteAttr + "]").length;
+    log(r1 === "changed", "run 1 reports changed", "got " + r1);
+    log(r2 === "blocked", "a refused stylesheet is still a refusal on a later run", "got " + r2);
+    log(stillMarked === marked, "and a refused run writes nothing new",
+        marked + " -> " + stillMarked);
+  });
+});
+
+TESTS.push(function () {
   return frame("endnotes.xhtml", 100).then(function (w) {
     run(w);
     log(run(w) === "stable", "an untouched page settles to stable");

--- a/hack/verify-footnotes
+++ b/hack/verify-footnotes
@@ -183,17 +183,34 @@ emit cross-reference.xhtml <<'EOF'
 </body></html>
 EOF
 
-# A publisher who happens to have picked our names for their own markup. Their
-# aside is nobody's note — nothing links to it — so it must come through
-# untouched, and their attribute value must not be what hides it.
+# A publisher who happens to have picked our names for their own markup. One
+# of their asides is nobody's note — nothing links to it — so it must come
+# through untouched. The other is a real note, referenced from the text and
+# hidden: their attribute on it must survive being hidden and revealed, which
+# marking ourselves in that attribute's value could not manage.
 emit publisher-markers.xhtml <<'EOF'
 <?xml version="1.0" encoding="utf-8"?>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head><title>t</title><style id="liseur-note-css">.liseur-note{color:#333}</style></head><body>
 <aside id="theirs" class="liseur-note" data-liseur-note="theirs"><p>Their aside, with their attribute on it.</p></aside>
-<aside epub:type="footnote" id="n1"><p>A real note.</p></aside>
+<aside epub:type="footnote" id="n1" data-liseur-note="also-theirs"><p>A real note.</p></aside>
 <p id="probe">Prose that is the bulk of the page, and rather more of it besides, so that the weighing of notes against text comes out the way a reader would expect it to and nothing is spared on a technicality. <a epub:type="noteref" href="#n1">1</a></p>
 <p>A second paragraph, for the same reason: the page has to be mostly its own words before any of this means anything at all.</p>
+</body></html>
+EOF
+
+# A book that writes its own chapter's name into the reference, which is just
+# as legal as a bare fragment and much more common. The base makes the frame's
+# address a real one, so the script has something to resolve against; it names
+# the case's own directory, so the stylesheet links above it still resolve.
+emit path-note.xhtml <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head><title>t</title><base href="cases/ch1.xhtml"/></head><body>
+<aside epub:type="footnote" id="n1"><p>A note referred to by the chapter's own name.</p></aside>
+<aside epub:type="footnote" id="n2"><p>A note in another chapter's spelling, which is not ours to hide.</p></aside>
+<p id="probe">Prose enough to outweigh the notes, and then some more of it, so the page is its own words before any of this counts for anything at all. <a epub:type="noteref" href="ch1.xhtml#n1">1</a> and <a epub:type="noteref" href="ch2.xhtml#n2">2</a>.</p>
+<p>A second paragraph, for the same reason, carrying no references of any kind.</p>
 </body></html>
 EOF
 
@@ -210,7 +227,11 @@ function log(ok, name, detail) {
 }
 function frame(caseName, fontSize, variant) {
   return fetch("cases/" + caseName).then(function (r) { return r.text(); }).then(function (src) {
-    var base = "../readium-css/" + (variant || "cjk-horizontal") + "/";
+    // Readium keeps its default sheets at the root of the bundle and each
+    // variant in a directory of its own, so "" names the defaults and is a
+    // real answer here rather than a missing one.
+    var dir = variant === undefined ? "cjk-horizontal" : variant;
+    var base = "../readium-css/" + (dir ? dir + "/" : "");
     var vars = "--USER__fontSize:" + fontSize + "%;--USER__view:readium-paged-on;";
     var head =
       '<link rel="stylesheet" href="' + base + 'ReadiumCSS-before.css"/>' +
@@ -371,6 +392,7 @@ TESTS.push(function () {
   return frame("publisher-markers.xhtml", 100).then(function (w) {
     var r = run(w);
     var theirs = w.document.getElementById("theirs");
+    var note = w.document.getElementById("n1");
     log(!!w.__liseurNotes.styleEl, "installs despite an author id=liseur-note-css");
     log(theirs.className === "liseur-note", "author classes untouched", theirs.className);
     log(theirs.getAttribute("data-liseur-note") === "theirs",
@@ -380,6 +402,23 @@ TESTS.push(function () {
         "and their aside is not hidden by their own attribute");
     log(!shown(w, "#n1"), "while the note that really is one still goes",
         "result " + r);
+    log(note.getAttribute("data-liseur-note") === "also-theirs",
+        "their attribute survives on a note we did hide",
+        "attr " + note.getAttribute("data-liseur-note"));
+    reveal(w, "n1");
+    log(shown(w, "#n1"), "the note comes back when it is asked for");
+    log(note.getAttribute("data-liseur-note") === "also-theirs",
+        "and their attribute is still theirs afterwards",
+        "attr " + note.getAttribute("data-liseur-note"));
+  });
+});
+
+TESTS.push(function () {
+  return frame("path-note.xhtml", 100).then(function (w) {
+    var r = run(w);
+    log(!shown(w, "#n1"), "a note named through its own chapter's path is hidden",
+        "result " + r);
+    log(shown(w, "#n2"), "a note named through another chapter's path is not");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #152.

A book that marks each footnote with a small image drew that image at its
full size, so a marker meant to be the height of one letter covered a third
of the screen and split the sentence around it. The note text sat at the top
of the chapter, so the reader met the gloss before the sentence it glossed.

The book is not at fault. It marks its notes the way EPUB 3 says to, and the
spec expects the reading system to keep the note out of the flow until it is
asked for. Readium has no rule for it: grepping every ReadiumCSS variant in
3.3.0 (default, rtl, cjk-horizontal, cjk-vertical, before and after) returns
zero matches for `footnote` and zero for `noteref`. And `ReadiumCSS-before.css`
sets `img{width:auto;height:auto;max-height:95vh!important}`, which beats the
publisher's `width`/`height` presentation attributes. That is where the giant
glyph comes from.

## Changes

Same shape as `WideContentFit`: a `<style>` element injected at runtime by a
script run through `evaluateJavascript`, never written into the resource.
Readium decides whether to link its own stylesheet by looking for `<style` in
the resource, so putting the CSS in the file would cost an unstyled book
Readium's typography entirely.

- `NoteVocabulary.kt`: one definition of what counts as a note and a note
  reference, shared by `FootnoteResolver` and the injected script so the two
  cannot drift apart.
- `FootnoteLayout.kt`: the script. Sizes a marker image to the line, and hides
  a note body only when the vocabulary calls it a note *and* an anchor in the
  same document points at its id. Notes are found through the anchors that
  reference them, never by sweeping for asides.
- `ReaderScreen.kt`: runs it wherever `WideContentFit` already ran, and reveals
  a note before **Go to note** navigates, since jumping to something hidden
  would land the reader on an empty page.

Two guards keep it conservative. An anchor inside a note is a backlink and does
not count as a reference. And if the notes to be hidden come to more than 60% of
the document's text, nothing is hidden at all, which is what keeps an endnotes
chapter with its own contents list readable.

Ownership rides on `data-liseur-note` with a per-document random token, as in
`WideContentFit`, so a publisher shipping an attribute of that name is neither
hidden by it nor stripped of it.

- `hack/verify-footnotes`: headless-Chrome harness, modelled on
  `hack/verify-wide-content`. It extracts the script from the Kotlin source, so
  it cannot test a stale copy, and runs it against Readium's real stylesheets.
  32 assertions.
- `hack/make-notes-book`: builds a small `zh` EPUB carrying the markup from the
  report, seeded through `hack/reset-books`. The harness proves the CSS; only a
  device proves Readium wires it up and the card still opens.

The reporter's own file has not been shared yet, so the markup was read off the
screenshots. If it turns out to differ, the fixture is where to encode that.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] `./hack/verify-footnotes` (32/32)
- [x] Manually tested on an emulator

On device, against the fixture: markers sit inline, no note text in the flow,
tapping a marker still opens the card, **Go to note** reveals the note and lands
on it, chapter 2's pull-quote aside is untouched, and the endnotes chapter is
fully readable.

Re-checked after merging `main`, since the pinch and image-viewer work landed in
the same file and moved the note card into the viewer's box. The card still
opens on a tap rather than the image viewer, and three consecutive cold opens
all came up repaired.

## Screenshots or recordings

Chapter 1 of the fixture book, same build settings, before and after.

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/d0bd419f-b34e-417a-acd0-7896db1082c3" width="320"> | <img src="https://github.com/user-attachments/assets/da692108-4b16-4f22-a85a-53d579b12b6b" width="320"> |

Both translator's notes are stacked above the first paragraph on the left, and
the two 注 markers each take a third of the screen. On the right the markers are
inline at line height and the notes are gone until they are tapped.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
