### PR TITLE
fix: tune the pinch gestures for electronic paper

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -457,12 +457,14 @@ fun ReaderScreen(
     // Consumed, so nothing else acts on the touch, but committing
     // nothing, because what the gesture means is not settled (ADR 22).
     var pinchHeld by remember { mutableStateOf(false) }
-    // Off on electronic paper, whatever the setting says. Every step of
-    // a pinch resize reflows the book and repaints the page, and a panel
-    // that takes a tenth of a second to do that turns one requested size
-    // into a strobe of six on the way to it. Read from [LocalEInk] and
+    // Off on electronic paper, whatever the setting says. The size
+    // itself commits once on lift, but the way a reader lands on one is
+    // by watching the preview pill grow as the fingers move, and a small
+    // region redrawn many times a second is what such a panel is worst
+    // at. A pinch without a usable preview is aiming blind, and every
+    // attempt costs a full-page reflow to see. Read from [LocalEInk] and
     // not from `isEInkDevice()`, so that the reader who is on a panel we
-    // failed to recognise — or not on one we wrongly did — gets the
+    // failed to recognise, or not on one we wrongly did, gets the
     // gesture back by setting E-ink mode themselves. That is the only
     // reason the mode keeps a manual override (ADR 22).
     val pinchToResizeNow by rememberUpdatedState(pinchToResize && !LocalEInk.current)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -457,7 +457,15 @@ fun ReaderScreen(
     // Consumed, so nothing else acts on the touch, but committing
     // nothing, because what the gesture means is not settled (ADR 22).
     var pinchHeld by remember { mutableStateOf(false) }
-    val pinchToResizeNow by rememberUpdatedState(pinchToResize)
+    // Off on electronic paper, whatever the setting says. Every step of
+    // a pinch resize reflows the book and repaints the page, and a panel
+    // that takes a tenth of a second to do that turns one requested size
+    // into a strobe of six on the way to it. Read from [LocalEInk] and
+    // not from `isEInkDevice()`, so that the reader who is on a panel we
+    // failed to recognise — or not on one we wrongly did — gets the
+    // gesture back by setting E-ink mode themselves. That is the only
+    // reason the mode keeps a manual override (ADR 22).
+    val pinchToResizeNow by rememberUpdatedState(pinchToResize && !LocalEInk.current)
     val fontSizeNow by rememberUpdatedState(prefs.fontSize)
     val setFontSizeNow by rememberUpdatedState(onPrefsAction.setFontSize)
     val touch = remember { TouchProbe() }
@@ -2399,7 +2407,9 @@ fun ReaderScreen(
         // Last of all: a picture asked for full screen is the thing the
         // reader is looking at, and everything else in the box is what
         // they asked to be shown it over.
-        viewedImage?.let { ImageViewer(image = it, onDismiss = { viewedImage = null }) }
+        viewedImage?.let {
+            ImageViewer(image = it, theme = readingTheme, onDismiss = { viewedImage = null })
+        }
     }
 
     // Letting a selection go from our own bar rather than from the page.

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageViewer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageViewer.kt
@@ -334,21 +334,21 @@ fun ImageViewer(image: ViewedImage, theme: ReaderTheme, onDismiss: () -> Unit) {
                     .safeDrawingPadding()
                     .padding(horizontal = 24.dp, vertical = 16.dp)
                     // The caption sits over whatever the picture leaves
-                    // there, which after the paper behind a line drawing
-                    // can be white. That backing goes with the white
-                    // rectangle it was there for: on an e-paper panel the
-                    // caption is the theme's own ink on the theme's own
-                    // paper, and a pill around it is one more edge for
-                    // the panel to ghost.
+                    // there, and a photograph tall enough to reach the
+                    // bottom leaves the photograph, so it needs something
+                    // opaque behind it on any backdrop. On paper that is
+                    // the theme's own paper, square and shadowless: a
+                    // translucent pill would have to be composited against
+                    // the picture, and a rounded edge is one more thing
+                    // for the panel to ghost.
                     .then(
                         if (onPaper) {
-                            Modifier
+                            Modifier.background(backdrop)
                         } else {
-                            Modifier
-                                .background(CAPTION_BACKING, RoundedCornerShape(8.dp))
-                                .padding(horizontal = 12.dp, vertical = 6.dp)
+                            Modifier.background(CAPTION_BACKING, RoundedCornerShape(8.dp))
                         },
-                    ),
+                    )
+                    .padding(horizontal = 12.dp, vertical = 6.dp),
             )
         }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageViewer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageViewer.kt
@@ -49,9 +49,23 @@ import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.size.Size as CoilSize
 import com.chmouel.liseur.R
+import com.chmouel.liseur.data.settings.ReaderTheme
+import com.chmouel.liseur.ui.LocalEInk
 
 /** Enough of the scrim to keep a caption legible over a pale picture. */
 private val CAPTION_BACKING = Color.Black.copy(alpha = 0.66f)
+
+/**
+ * Somewhere to keep a gesture that is being counted and not drawn.
+ *
+ * A plain box rather than a `MutableState`, on purpose: reading a state
+ * object from the gesture callback and writing it back would recompose
+ * on every pointer change, which is the repaint the whole arrangement
+ * exists to avoid.
+ */
+private class PendingGesture {
+    var value: PendingTransform? = null
+}
 
 /**
  * The largest picture decoded at its own size rather than the screen's.
@@ -106,9 +120,16 @@ data class ViewedImage(
  * Drawn over everything on a black scrim, in Material colours rather than
  * in the reading theme: this is not the page any more, and a picture is
  * judged against black in every other viewer the reader owns.
+ *
+ * Except on electronic paper, where it is drawn on [theme]'s own paper.
+ * Driving every pixel to black and back again is the slowest and
+ * ghostiest thing such a panel does, and it would happen twice for every
+ * picture; on paper the picture is a page-sized change rather than a
+ * full inversion. The gesture is held back for the same reason and
+ * applied once on the lift.
  */
 @Composable
-fun ImageViewer(image: ViewedImage, onDismiss: () -> Unit) {
+fun ImageViewer(image: ViewedImage, theme: ReaderTheme, onDismiss: () -> Unit) {
     var scale by remember(image) { mutableFloatStateOf(ImageZoom.MIN_SCALE) }
     var offsetX by remember(image) { mutableFloatStateOf(0f) }
     var offsetY by remember(image) { mutableFloatStateOf(0f) }
@@ -127,6 +148,13 @@ fun ImageViewer(image: ViewedImage, onDismiss: () -> Unit) {
     val dismissTravel = with(LocalDensity.current) { ImageZoom.DISMISS_TRAVEL_DP.dp.toPx() }
     val context = LocalContext.current
     val viewerTitle = image.alt ?: stringResource(R.string.reader_image_viewer)
+    val onPaper = LocalEInk.current
+    // The scrim, and the one colour everything drawn over it is in.
+    val backdrop = if (onPaper) theme.background else Color.Black
+    val ink = if (onPaper) theme.foreground else Color.White
+    // Deliberately not a state object: the whole point of accumulating a
+    // gesture is that no frame of it recomposes anything.
+    val pending = remember(image) { PendingGesture() }
 
     fun hold() {
         val (w, h) = ImageZoom.fitted(
@@ -144,7 +172,7 @@ fun ImageViewer(image: ViewedImage, onDismiss: () -> Unit) {
     Box(
         Modifier
             .fillMaxSize()
-            .background(Color.Black)
+            .background(backdrop)
             // Modal in the way that matters to somebody who cannot see
             // it: without this the reader's own chrome stays reachable
             // behind the picture, so a swipe lands on a control that is
@@ -179,8 +207,17 @@ fun ImageViewer(image: ViewedImage, onDismiss: () -> Unit) {
                     },
                 )
             }
-            .pointerInput(image) {
+            .pointerInput(image, onPaper) {
                 detectTransformGestures { _, pan, zoom, _ ->
+                    // On paper the frame is counted and nothing is
+                    // written: `scale` and the translations below are
+                    // what the screen is drawn from, and each of them
+                    // costs a full repaint.
+                    if (onPaper) {
+                        val soFar = pending.value ?: PendingTransform(scale, offsetX, offsetY)
+                        pending.value = soFar.fold(zoom, pan.x, pan.y)
+                        return@detectTransformGestures
+                    }
                     val wasAtFit = ImageZoom.atFit(scale)
                     scale = ImageZoom.clampScale(scale * zoom)
                     offsetX += pan.x
@@ -202,16 +239,31 @@ fun ImageViewer(image: ViewedImage, onDismiss: () -> Unit) {
             }
             // `detectTransformGestures` has no gesture-end callback, and
             // the travel above needs one: distance covered by two
-            // separate drags is not a drag. Watched on the initial pass
-            // and never consumed, so the detector above still sees
-            // everything.
-            .pointerInput(image) {
+            // separate drags is not a drag. It is also where a gesture
+            // counted rather than drawn is finally applied, in one step.
+            // Never consumed, so the detector above still sees
+            // everything; the down is watched on the initial pass so
+            // that nothing beats us to it, and the release on the final
+            // one, so that the last frame of the gesture has already
+            // been folded in before it is committed.
+            .pointerInput(image, onPaper) {
                 awaitEachGesture {
                     awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
                     do {
-                        val event = awaitPointerEvent(PointerEventPass.Initial)
+                        val event = awaitPointerEvent(PointerEventPass.Final)
                     } while (event.changes.any { it.pressed })
                     dragDown = 0f
+                    pending.value?.let { gesture ->
+                        pending.value = null
+                        if (gesture.dismisses(dismissTravel)) {
+                            onDismiss()
+                        } else {
+                            scale = gesture.scale
+                            offsetX = gesture.offsetX
+                            offsetY = gesture.offsetY
+                            hold()
+                        }
+                    }
                 }
             },
     ) {
@@ -250,9 +302,12 @@ fun ImageViewer(image: ViewedImage, onDismiss: () -> Unit) {
                 // — and on the scrim those are simply invisible. Drawn to
                 // the picture's own fitted rectangle rather than to the
                 // whole screen, so a photograph covers it completely and
-                // never shows a white border.
+                // never shows a white border. Not needed on an e-paper
+                // panel, where the viewer is already on the reading
+                // theme's paper and the line art lands on it as it does
+                // on the page.
                 .drawBehind {
-                    if (!natural.isSpecified) return@drawBehind
+                    if (onPaper || !natural.isSpecified) return@drawBehind
                     val (w, h) = ImageZoom.fitted(
                         contentW = natural.width,
                         contentH = natural.height,
@@ -271,7 +326,7 @@ fun ImageViewer(image: ViewedImage, onDismiss: () -> Unit) {
         image.subtitle?.let { caption ->
             Text(
                 text = caption,
-                color = Color.White,
+                color = ink,
                 style = MaterialTheme.typography.bodySmall,
                 textAlign = TextAlign.Center,
                 modifier = Modifier
@@ -280,9 +335,20 @@ fun ImageViewer(image: ViewedImage, onDismiss: () -> Unit) {
                     .padding(horizontal = 24.dp, vertical = 16.dp)
                     // The caption sits over whatever the picture leaves
                     // there, which after the paper behind a line drawing
-                    // can be white.
-                    .background(CAPTION_BACKING, RoundedCornerShape(8.dp))
-                    .padding(horizontal = 12.dp, vertical = 6.dp),
+                    // can be white. That backing goes with the white
+                    // rectangle it was there for: on an e-paper panel the
+                    // caption is the theme's own ink on the theme's own
+                    // paper, and a pill around it is one more edge for
+                    // the panel to ghost.
+                    .then(
+                        if (onPaper) {
+                            Modifier
+                        } else {
+                            Modifier
+                                .background(CAPTION_BACKING, RoundedCornerShape(8.dp))
+                                .padding(horizontal = 12.dp, vertical = 6.dp)
+                        },
+                    ),
             )
         }
 
@@ -296,7 +362,7 @@ fun ImageViewer(image: ViewedImage, onDismiss: () -> Unit) {
             Icon(
                 Icons.Filled.Close,
                 contentDescription = stringResource(R.string.close),
-                tint = Color.White,
+                tint = ink,
             )
         }
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageZoom.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ImageZoom.kt
@@ -82,3 +82,55 @@ object ImageZoom {
         return contentW * ratio to contentH * ratio
     }
 }
+
+/**
+ * A pinch or a pan that is being counted rather than drawn.
+ *
+ * On electronic paper the viewer does not follow the fingers: writing
+ * `scale` and the two translations on every pointer change is one
+ * full-screen repaint per frame, and a panel that takes a tenth of a
+ * second to repaint answers a two-second gesture with a smear. So the
+ * gesture is accumulated here and applied once when the last finger
+ * leaves — the same commit-on-lift bargain [PinchResize] already makes
+ * for the page. See `docs/adr/0022-pinch-on-the-page.md`.
+ *
+ * The fields are what the viewer will be set to, not the movement since
+ * the last frame: [fold] starts from where the picture already is, so
+ * the value is always a complete answer and the lift has nothing to
+ * work out.
+ *
+ * Nothing is clamped to the viewport on the way through, only on the
+ * way out, because the bounds depend on a drawn size that moves with
+ * the scale. A gesture that runs past the edge and comes back therefore
+ * banks the overshoot, which on a screen showing none of this is not
+ * something the reader can be pushing against.
+ */
+data class PendingTransform(
+    val scale: Float,
+    val offsetX: Float,
+    val offsetY: Float,
+    val travelDown: Float = 0f,
+) {
+    /**
+     * This gesture with one more frame of [zoom] and pan folded into it.
+     *
+     * The downward travel is counted only while the picture is at fit on
+     * both sides of the frame, exactly as the drawn path counts it: a
+     * drag on a zoomed-in plate is how the reader reads the far corner
+     * of it, not how they put it away.
+     */
+    fun fold(zoom: Float, panX: Float, panY: Float): PendingTransform {
+        val next = ImageZoom.clampScale(scale * zoom)
+        val stayedAtFit = ImageZoom.atFit(scale) && ImageZoom.atFit(next)
+        return PendingTransform(
+            scale = next,
+            offsetX = offsetX + panX,
+            offsetY = offsetY + panY,
+            travelDown = if (stayedAtFit) ImageZoom.dragTravel(travelDown, panY) else 0f,
+        )
+    }
+
+    /** Whether the gesture asked, by dragging [travel] downwards, to be done. */
+    fun dismisses(travel: Float): Boolean = travelDown > travel
+}
+

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingNavigationScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingNavigationScreen.kt
@@ -130,11 +130,25 @@ fun ReadingNavigationScreen(
                         onSelected = onTapZones,
                     )
                     RowDivider()
+                    // The switch stays visible rather than disappearing
+                    // on e-paper: a row that is simply gone reads as a
+                    // setting the app never had, and this one is off for
+                    // a reason worth giving. The way back is the E-ink
+                    // row in the group below, which is on the same
+                    // screen.
+                    val pinchOffForEInk = LocalEInk.current
                     SwitchRow(
                         title = stringResource(R.string.settings_pinch_to_resize),
-                        subtitle = stringResource(R.string.settings_pinch_to_resize_detail),
-                        checked = settings.pinchToResize,
+                        subtitle = stringResource(
+                            if (pinchOffForEInk) {
+                                R.string.settings_pinch_to_resize_eink
+                            } else {
+                                R.string.settings_pinch_to_resize_detail
+                            },
+                        ),
+                        checked = settings.pinchToResize && !pinchOffForEInk,
                         onCheckedChange = onPinchToResize,
+                        enabled = !pinchOffForEInk,
                     )
                     RowDivider()
                     SwitchRow(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -597,7 +597,7 @@
     <string name="tap_zones_swapped">Swapped</string>
     <string name="settings_pinch_to_resize">Pinch to resize text</string>
     <string name="settings_pinch_to_resize_detail">A two-finger pinch on the page makes the text bigger or smaller, without opening the menu. Turn it off if the way you hold the phone sets it off by accident. Pinching an image to enlarge it still works either way.</string>
-    <string name="settings_pinch_to_resize_eink">Off on electronic paper: every step of the pinch reflows the book and repaints the whole page, so one change of size arrives after several. Pinching an image to enlarge it still works. Turn E-ink screen off below if this is not that kind of screen.</string>
+    <string name="settings_pinch_to_resize_eink">Off on electronic paper. The pinch works by showing you the size while your fingers move, and a preview that redraws many times a second is what such a screen handles worst. Without it you would be aiming blind, and every attempt costs a full repaint of the page, so the Size slider does the job better. Pinching an image to enlarge it still works. Turn E-ink screen off below if this is not that kind of screen.</string>
     <string name="settings_resume">Open on the book you were reading</string>
     <string name="settings_resume_detail">Skip the library when you left off mid-book.</string>
     <string name="settings_keep_screen_on">Keep the screen on</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -597,6 +597,7 @@
     <string name="tap_zones_swapped">Swapped</string>
     <string name="settings_pinch_to_resize">Pinch to resize text</string>
     <string name="settings_pinch_to_resize_detail">A two-finger pinch on the page makes the text bigger or smaller, without opening the menu. Turn it off if the way you hold the phone sets it off by accident. Pinching an image to enlarge it still works either way.</string>
+    <string name="settings_pinch_to_resize_eink">Off on electronic paper: every step of the pinch reflows the book and repaints the whole page, so one change of size arrives after several. Pinching an image to enlarge it still works. Turn E-ink screen off below if this is not that kind of screen.</string>
     <string name="settings_resume">Open on the book you were reading</string>
     <string name="settings_resume_detail">Skip the library when you left off mid-book.</string>
     <string name="settings_keep_screen_on">Keep the screen on</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/ImageZoomTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/ImageZoomTest.kt
@@ -90,3 +90,71 @@ class ImageZoomTest {
         assertEquals(30f, travelled, 0.01f)
     }
 }
+
+/**
+ * The gesture that is counted rather than drawn, on electronic paper.
+ *
+ * The arithmetic tested here is the whole of what a pinch does on such a
+ * panel: nothing is written to the screen until the last of it, so a
+ * mistake in the accumulation is a picture that jumps somewhere the
+ * fingers never went.
+ */
+class PendingTransformTest {
+
+    private fun start(scale: Float = ImageZoom.MIN_SCALE) =
+        PendingTransform(scale = scale, offsetX = 0f, offsetY = 0f)
+
+    @Test
+    fun `a pinch out and back again commits nothing`() {
+        val done = start(2f).fold(1.5f, 0f, 0f).fold(1f / 1.5f, 0f, 0f)
+        assertEquals(2f, done.scale, 1e-4f)
+    }
+
+    @Test
+    fun `pan accumulates across the frames of one gesture`() {
+        var gesture = start(3f)
+        repeat(10) { gesture = gesture.fold(1f, 4f, -2f) }
+        assertEquals(40f, gesture.offsetX, 0.01f)
+        assertEquals(-20f, gesture.offsetY, 0.01f)
+    }
+
+    @Test
+    fun `the committed scale is held inside the same bounds as the drawn one`() {
+        var gesture = start()
+        repeat(20) { gesture = gesture.fold(2f, 0f, 0f) }
+        assertEquals(ImageZoom.MAX_SCALE, gesture.scale, 1e-4f)
+        repeat(40) { gesture = gesture.fold(0.5f, 0f, 0f) }
+        assertEquals(ImageZoom.MIN_SCALE, gesture.scale, 1e-4f)
+    }
+
+    @Test
+    fun `a long drag down on a fitted picture asks to be put away`() {
+        var gesture = start()
+        repeat(10) { gesture = gesture.fold(1f, 0f, 20f) }
+        assertTrue(gesture.dismisses(96f))
+    }
+
+    @Test
+    fun `a hand that wanders down and comes back has asked for nothing`() {
+        var gesture = start()
+        repeat(10) { gesture = gesture.fold(1f, 0f, 20f) }
+        repeat(10) { gesture = gesture.fold(1f, 0f, -20f) }
+        assertFalse(gesture.dismisses(96f))
+    }
+
+    @Test
+    fun `dragging a zoomed-in picture reads the corner rather than dismissing`() {
+        var gesture = start(3f)
+        repeat(10) { gesture = gesture.fold(1f, 0f, 20f) }
+        assertEquals(0f, gesture.travelDown, 0.01f)
+        assertFalse(gesture.dismisses(96f))
+    }
+
+    @Test
+    fun `zooming in mid-drag takes the travel off again`() {
+        var gesture = start()
+        repeat(10) { gesture = gesture.fold(1f, 0f, 20f) }
+        gesture = gesture.fold(2f, 0f, 20f)
+        assertEquals(0f, gesture.travelDown, 0.01f)
+    }
+}

--- a/docs/adr/0022-pinch-on-the-page.md
+++ b/docs/adr/0022-pinch-on-the-page.md
@@ -2,7 +2,8 @@
 
 Status: accepted
 GitHub issues: [#139](https://github.com/chmouel/liseur/issues/139),
-[#110](https://github.com/chmouel/liseur/issues/110)
+[#110](https://github.com/chmouel/liseur/issues/110),
+[#153](https://github.com/chmouel/liseur/issues/153)
 
 ## Context
 
@@ -446,6 +447,61 @@ is named for what it does — "Pinch to resize text" — and sits in
 Settings -> Reading & navigation beside the other rows about how the
 book is turned and held, not in Reading appearance: it is not how the
 page looks, it is what the hands do (ADR 1, ADR 9).
+
+### On electronic paper
+
+Deferred to [#153](https://github.com/chmouel/liseur/issues/153) and
+settled there. All three things the gesture does are cheap on a screen
+that repaints in sixteen milliseconds and expensive on one that does not.
+
+**The resize is refused rather than made cheaper.** Every step of a
+pinch resize reflows the book and repaints the whole page. On an LCD
+that is the preview the gesture is made of; on a panel that takes a
+tenth of a second and ghosts, the reader asks for one size and gets six
+repaints on the way to it. There is no cheaper version — the preview is
+the reflow — so on paper the gesture is simply not there, and the Size
+slider, which commits once, is what remains.
+
+It is refused on `LocalEInk` and not on `isEInkDevice()`. That matters:
+the detection is a list of manufacturer names, which is stated plainly
+in `EInk.kt` and is the reason `EInkMode` keeps a manual override rather
+than trusting itself. Reading the resolved value means a reader on a
+panel the list has never heard of, or on a phone it wrongly recognised,
+sets E-ink mode and gets the right answer to both questions at once.
+
+The issue proposed a third control for this — Auto/On/Off on the pinch
+row itself, on the `EInkMode.resolve()` pattern. It was dropped. It asks
+the reader the same question the E-ink row already asks, two rows apart,
+and the copy they would have to find is the second one. The row instead
+stays where it is, greyed out, saying why and pointing at the row that
+undoes it, and the stored preference stays the boolean it always was.
+
+**The picture commits on lift, like the page's size does.** The viewer
+drives `graphicsLayer` — `scale` and both translations — from
+`detectTransformGestures` on every pointer change, so a pinch or a pan
+is one full-screen repaint per frame for as long as the fingers are
+down. On paper the frames are folded into a `PendingTransform` instead
+and applied once when the last finger leaves. The accumulator is a plain
+box rather than a state object on purpose: a `MutableState` read and
+written from the gesture callback would recompose every frame, which is
+the repaint being avoided. Double-tap is already a single step and is
+untouched.
+
+The lift is also where the drag-to-dismiss is decided, which is a real
+loss: the picture no longer follows the finger down and then goes. It is
+the same bargain the size already makes, and the alternative — a
+throttle at some number of frames a second — still ghosts and asks
+somebody to pick a number correctly for two different panels.
+
+**The scrim gives way to the reading theme's paper.** Filling the screen
+with black and taking it away again is the slowest, ghostiest thing such
+a panel does, and it happened twice per picture. On paper the viewer
+opens on `ReaderTheme.background`, so a picture is a page-sized change
+rather than a full inversion and back. Two things go with the black: the
+white rectangle drawn behind the picture, which exists only so that
+black-on-transparent line art is visible against a black scrim, and the
+dark pill behind the caption, which exists only to survive that
+rectangle. Off paper, all of it is exactly as it was.
 
 ## Ruled out
 

--- a/docs/adr/0022-pinch-on-the-page.md
+++ b/docs/adr/0022-pinch-on-the-page.md
@@ -451,16 +451,28 @@ page looks, it is what the hands do (ADR 1, ADR 9).
 ### On electronic paper
 
 Deferred to [#153](https://github.com/chmouel/liseur/issues/153) and
-settled there. All three things the gesture does are cheap on a screen
-that repaints in sixteen milliseconds and expensive on one that does not.
+settled there. Two of the three things the gesture does are cheap on a
+screen that repaints in sixteen milliseconds and expensive on one that
+does not, and the third is refused for a different reason than the issue
+gave.
 
-**The resize is refused rather than made cheaper.** Every step of a
-pinch resize reflows the book and repaints the whole page. On an LCD
-that is the preview the gesture is made of; on a panel that takes a
-tenth of a second and ghosts, the reader asks for one size and gets six
-repaints on the way to it. There is no cheaper version — the preview is
-the reflow — so on paper the gesture is simply not there, and the Size
-slider, which commits once, is what remains.
+**The resize is refused, but not because it strobes.** The issue said
+every step of a pinch resize reflows the book. It does not: the size is
+committed once, when the fingers leave, and #150 built it that way on
+purpose. What redraws on every pointer change is the preview pill, whose
+sample grows and shrinks with the target size.
+
+That is still why the gesture goes. The pinch is a preview gesture: the
+way a reader lands on a size is by watching it change and stopping when
+it looks right. A small region redrawn a dozen times a second is the
+thing an e-paper panel is worst at, so the preview is unusable there,
+and a pinch without a usable preview is aiming blind. Every attempt then
+costs a full-page reflow to see, and a wrong one costs a second to
+undo. The Size slider asks for a size in one deliberate step and is what
+remains. Suppressing only the preview and keeping the gesture was the
+other way out; it leaves a blind gesture that a large panel held in two
+hands sets off by accident, and an accidental resize on paper is two
+full reflows before the reader is back where they were.
 
 It is refused on `LocalEInk` and not on `isEInkDevice()`. That matters:
 the detection is a list of manufacturer names, which is stated plainly
@@ -469,39 +481,44 @@ than trusting itself. Reading the resolved value means a reader on a
 panel the list has never heard of, or on a phone it wrongly recognised,
 sets E-ink mode and gets the right answer to both questions at once.
 
-The issue proposed a third control for this — Auto/On/Off on the pinch
+The issue proposed a third control for this: Auto/On/Off on the pinch
 row itself, on the `EInkMode.resolve()` pattern. It was dropped. It asks
 the reader the same question the E-ink row already asks, two rows apart,
 and the copy they would have to find is the second one. The row instead
 stays where it is, greyed out, saying why and pointing at the row that
 undoes it, and the stored preference stays the boolean it always was.
 
-**The picture commits on lift, like the page's size does.** The viewer
-drives `graphicsLayer` — `scale` and both translations — from
+**The picture commits on lift, like the page's size already does.** The
+viewer drives `graphicsLayer`, `scale` and both translations, from
 `detectTransformGestures` on every pointer change, so a pinch or a pan
 is one full-screen repaint per frame for as long as the fingers are
-down. On paper the frames are folded into a `PendingTransform` instead
-and applied once when the last finger leaves. The accumulator is a plain
-box rather than a state object on purpose: a `MutableState` read and
-written from the gesture callback would recompose every frame, which is
-the repaint being avoided. Double-tap is already a single step and is
-untouched.
+down. This is the per-frame cost the issue was really describing, and
+here it is real. On paper the frames are folded into a
+`PendingTransform` instead and applied once when the last finger leaves.
+The accumulator is a plain box rather than a state object on purpose: a
+`MutableState` read and written from the gesture callback would
+recompose every frame, which is the repaint being avoided. Double-tap is
+already a single step and is untouched.
 
 The lift is also where the drag-to-dismiss is decided, which is a real
 loss: the picture no longer follows the finger down and then goes. It is
-the same bargain the size already makes, and the alternative — a
-throttle at some number of frames a second — still ghosts and asks
-somebody to pick a number correctly for two different panels.
+the same bargain the size already makes, and the alternative, a throttle
+at some number of frames a second, still ghosts and asks somebody to
+pick a number correctly for two different panels.
 
 **The scrim gives way to the reading theme's paper.** Filling the screen
 with black and taking it away again is the slowest, ghostiest thing such
 a panel does, and it happened twice per picture. On paper the viewer
 opens on `ReaderTheme.background`, so a picture is a page-sized change
-rather than a full inversion and back. Two things go with the black: the
-white rectangle drawn behind the picture, which exists only so that
-black-on-transparent line art is visible against a black scrim, and the
-dark pill behind the caption, which exists only to survive that
-rectangle. Off paper, all of it is exactly as it was.
+rather than a full inversion and back. The white rectangle drawn behind
+the picture goes with the black: it exists only so that
+black-on-transparent line art is visible against a black scrim, and on
+paper such art lands on paper as it does on the page. The caption keeps
+a backing, because a photograph tall enough to reach the bottom of the
+screen is what the caption sits on; on paper that backing is the
+theme's own paper, square and shadowless, rather than a translucent
+pill that would have to be composited against the picture. Off paper,
+all of it is exactly as it was.
 
 ## Ruled out
 


### PR DESCRIPTION
## Summary

The pinch gestures added in #150 were written for a screen that redraws
in a sixteenth of a second. On electronic paper they cost more than they
are worth, so on such a screen they now behave differently.

The issue proposed an Auto/On/Off preference for this. That was dropped:
`LocalEInk` is already the resolved answer to "is this electronic
paper", and the E-ink screen setting is already how a reader overrules
the guess, so a second three-way control would ask the same question
twice. The stored preference is unchanged, so there is nothing to
migrate.

Closes #153

## Changes

**Pinch to resize the text is off on electronic paper.** The reason is
not the one the issue gave. The book does not reflow on every step of
the pinch; it reflows once, when the fingers leave, and #150 built it
that way on purpose. What redraws continuously is the small preview that
shows the size you are heading for, and a preview is the whole point of
the gesture. On a screen that cannot show one, you are pinching blind,
and every attempt costs a full repaint of the page to see and another to
undo. The Size slider asks for a size in one step and is what remains.
Pinching a picture to enlarge it still works.

**The settings row greys out and says why**, pointing at the E-ink
screen setting for anyone whose screen was guessed wrong.

**A picture redraws once, when the fingers leave.** This is where the
per-frame cost was real: the viewer wrote scale and both translations on
every pointer change, so a pinch or a pan repainted the whole screen for
as long as the fingers were down. The gesture is now counted in a plain
box rather than in Compose state, so nothing recomposes mid-gesture. The
cost to accept is that the picture no longer follows the finger, and a
drag down to put it away happens on release.

**The picture opens on the reading theme's paper** rather than on a
black scrim, which was two full-screen inversions per picture. The white
plate behind the image goes with the black, since it exists only so that
line art shows up against a dark backdrop. The caption keeps an opaque
backing on both backdrops, because a photograph tall enough to reach the
bottom of the screen is what the caption sits on.

`docs/adr/0022-pinch-on-the-page.md` records all of this, including the
correction and the departure from the issue text.

Off electronic paper, every one of these paths is what it was.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

Seven new unit tests cover the accumulator: a pinch out and back commits
nothing, pan accumulates, the commit clamps to the scale limits, a long
drag down dismisses while a wander down and back does not, and zooming
mid-drag clears the travel.

On an emulator, with E-ink screen forced On and then Off, the settings
row and the viewer both change in place without a restart, and the drag
down to dismiss fires on release under e-paper and mid-gesture off it.

## Screenshots or recordings

**E-ink screen On.** The row is greyed and explains itself; the picture
opens on paper. The screenshot predates the wording correction, so the
row now gives the reason described above.

| Settings | Viewer |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/7fc4e6f3-883b-43d9-80f8-fa956254a502" width="320"> | <img src="https://github.com/user-attachments/assets/403bcd15-d846-43fa-b806-1a05517e6190" width="320"> |

**E-ink screen Off.** Unchanged.

| Settings | Viewer |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/e09cd8d1-d176-4b6b-8214-5af7f65ff3da" width="320"> | <img src="https://github.com/user-attachments/assets/e8915c74-f543-4140-908e-608eafd88ba9" width="320"> |

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
