### PR TITLE
Make a refused liseur-sync push recoverable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,16 +204,23 @@ emulator.
 - A server refusal of a batch is about one item and stores nothing.
   Never mark a whole batch as sent because of it. Sessions: the named
   sitting goes into `session_refusal` for that peer and the rest go
-  again; a body too big is halved; a refusal that names nothing is
-  bisected; a code this app does not know is left pending and
-  reported. Ops: `unknown_work` re-resolves, `locator_too_large`
-  resends the op bare under the same id. `awaitingUploadTo` joins the
-  alias and the refusals *before* it limits, or unnamed books block
-  the queue.
+  again, but only for a reason the server calls permanent; a body too
+  big is halved; a refusal that names nothing is bisected; a code this
+  app does not know is left pending and reported, named item or not.
+  Ops: `unknown_work` re-resolves, `locator_too_large` resends the op
+  bare under the same id, and a batch refused for its size is cut to
+  the limit the server named — a lone op still refused goes bare, since
+  its locator is the only part with any size to it.
+  `awaitingUploadTo` joins the alias and the refusals *before* it
+  limits, or unnamed books block the queue.
 - The account key is `liseursync|<url>|<account_id>`, and it changed
   spelling once (from the device id). `carryPeerState` moves every
   peer-keyed table to the new spelling in the connect transaction; add
-  any new peer-keyed table there and to `forgetSyncPeer`.
+  any new peer-keyed table there and to `forgetSyncPeer`. A password
+  sign-in names the account by itself, so a device id that came back
+  changed — the server forgot it, or is too old to be offered it — is
+  not an account switch. Only a pasted token, which names nobody, is
+  told apart by its device id.
 - A book's name on liseur-sync is a `work_alias`. A book from its
   own catalog resolves through `POST /v1/books/{id}/resolve`. The
   server reads the identifiers off its record, so no download is needed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,25 @@ emulator.
   (`UUIDv3(deviceKey|…)`) and every payload field comes from stored
   state rather than the clock, so a retry is byte-identical and the
   server answers `duplicate`. Do not introduce a random id or a
-  `pending_ops` table.
+  `pending_ops` table. The server compares its own `device_id` too, so
+  a reconnect offers the stored one back (`ServerSetup.reconnect`) and
+  the phone stays one device; a pasted token cannot, and its replays
+  may come back `conflict`, which is answered by moving the book's
+  revision on (`renameRevision`, conditional on the sent revision) so
+  the same reading goes out under a fresh id.
+- A server refusal of a batch is about one item and stores nothing.
+  Never mark a whole batch as sent because of it. Sessions: the named
+  sitting goes into `session_refusal` for that peer and the rest go
+  again; a body too big is halved; a refusal that names nothing is
+  bisected; a code this app does not know is left pending and
+  reported. Ops: `unknown_work` re-resolves, `locator_too_large`
+  resends the op bare under the same id. `awaitingUploadTo` joins the
+  alias and the refusals *before* it limits, or unnamed books block
+  the queue.
+- The account key is `liseursync|<url>|<account_id>`, and it changed
+  spelling once (from the device id). `carryPeerState` moves every
+  peer-keyed table to the new spelling in the connect transaction; add
+  any new peer-keyed table there and to `forgetSyncPeer`.
 - A book's name on liseur-sync is a `work_alias`. A book from its
   own catalog resolves through `POST /v1/books/{id}/resolve`. The
   server reads the identifiers off its record, so no download is needed

--- a/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/47.json
+++ b/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/47.json
@@ -1,0 +1,1436 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 47,
+    "identityHash": "a4459c58b7d75e68e0e9dae88a82ebeb",
+    "entities": [
+      {
+        "tableName": "reading_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `total_progression` REAL, `reading_speed` REAL, `reading_seconds_per_position` REAL, `reading_pace_samples` INTEGER NOT NULL DEFAULT 0, `reading_pace_elapsed_ms` INTEGER NOT NULL DEFAULT 0, `reading_pace_evidence` REAL NOT NULL DEFAULT 0, `updated_at` INTEGER NOT NULL, `status` TEXT, `synced_at` INTEGER, `local_revision` INTEGER NOT NULL DEFAULT 0, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `agreed_account` TEXT, `pending_progression` REAL, `pending_locator_json` TEXT, `pending_status` TEXT, `pending_updated_at` INTEGER, `pending_account` TEXT, `owner_account` TEXT, `remote_updated_at` INTEGER, `finished_override` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSpeed",
+            "columnName": "reading_speed",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSecondsPerPosition",
+            "columnName": "reading_seconds_per_position",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingPaceSamples",
+            "columnName": "reading_pace_samples",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceElapsedMs",
+            "columnName": "reading_pace_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceEvidence",
+            "columnName": "reading_pace_evidence",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localRevision",
+            "columnName": "local_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "agreedAccount",
+            "columnName": "agreed_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingLocatorJson",
+            "columnName": "pending_locator_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingAccount",
+            "columnName": "pending_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ownerAccount",
+            "columnName": "owner_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "finishedOverride",
+            "columnName": "finished_override",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `cover_path` TEXT, `source` TEXT, `added_at` INTEGER NOT NULL, `last_opened_at` INTEGER, `local_uri` TEXT, `remote_uuid` TEXT, `remote_book_id` INTEGER, `cover_url` TEXT, `download_href` TEXT, `download_state` TEXT NOT NULL, `remote_updated_at` INTEGER, `downloaded_at` INTEGER, `file_modified_at` INTEGER, `work_id` TEXT, `finished_at` INTEGER, `archived_at` INTEGER, `remote_page_count` INTEGER, `size_bytes` INTEGER, `series_name` TEXT, `series_index` REAL, `file_series_name` TEXT, `file_series_index` REAL, `series_id` TEXT, `series_checked` INTEGER NOT NULL, `catalog_series_name` TEXT, `catalog_series_index` REAL, `catalog_folder_id` TEXT, `catalog_series_source` TEXT, `user_series_name` TEXT, `user_series_index` REAL, `series_override` INTEGER NOT NULL, `user_series_updated_at` INTEGER, `series_claim_pending` INTEGER NOT NULL, `series_claim_reset` INTEGER NOT NULL, `personal_series_updated_at` INTEGER, `series_index_override` INTEGER NOT NULL, `catalog_missing_since` INTEGER, `hidden_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "last_opened_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localUri",
+            "columnName": "local_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUuid",
+            "columnName": "remote_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteBookId",
+            "columnName": "remote_book_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadHref",
+            "columnName": "download_href",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadState",
+            "columnName": "download_state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloaded_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finished_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archived_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remotePageCount",
+            "columnName": "remote_page_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "size_bytes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fileSeriesName",
+            "columnName": "file_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileSeriesIndex",
+            "columnName": "file_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesChecked",
+            "columnName": "series_checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSeriesName",
+            "columnName": "catalog_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesIndex",
+            "columnName": "catalog_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "catalogFolderId",
+            "columnName": "catalog_folder_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesSource",
+            "columnName": "catalog_series_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesName",
+            "columnName": "user_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesIndex",
+            "columnName": "user_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesOverridden",
+            "columnName": "series_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userSeriesUpdatedAt",
+            "columnName": "user_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesClaimPending",
+            "columnName": "series_claim_pending",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesClaimReset",
+            "columnName": "series_claim_reset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personalSeriesUpdatedAt",
+            "columnName": "personal_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "indexOverridden",
+            "columnName": "series_index_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogMissingSince",
+            "columnName": "catalog_missing_since",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hiddenAt",
+            "columnName": "hidden_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_books_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_books_url` ON `${TABLE_NAME}` (`url`)"
+          },
+          {
+            "name": "index_books_series_name",
+            "unique": false,
+            "columnNames": [
+              "series_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_series_name` ON `${TABLE_NAME}` (`series_name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "library_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `added_at` INTEGER NOT NULL, PRIMARY KEY(`url`))",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "url"
+          ]
+        }
+      },
+      {
+        "tableName": "remote_server",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `kind` TEXT NOT NULL, `base_url` TEXT NOT NULL, `catalog_url` TEXT, `username` TEXT, `password_cipher` TEXT, `api_key_cipher` TEXT, `account_id` TEXT, `user_id` INTEGER, `kobo_token` TEXT, `can_download` INTEGER NOT NULL, `can_manage_library` INTEGER NOT NULL, `can_upload` INTEGER NOT NULL, `can_delete` INTEGER NOT NULL, `can_read_insights` INTEGER NOT NULL, `can_admin` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `catalog_synced_at` INTEGER, `position_synced_at` INTEGER, `sync_token` TEXT, `liseur_token_cipher` TEXT, `liseur_account_id` TEXT, `sync_cursor_seq` INTEGER NOT NULL DEFAULT 0, `annotation_cursor_seq` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogUrl",
+            "columnName": "catalog_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "passwordCipher",
+            "columnName": "password_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiKeyCipher",
+            "columnName": "api_key_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "koboTokenCipher",
+            "columnName": "kobo_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "canDownload",
+            "columnName": "can_download",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canManageLibrary",
+            "columnName": "can_manage_library",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canUpload",
+            "columnName": "can_upload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canDelete",
+            "columnName": "can_delete",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canReadInsights",
+            "columnName": "can_read_insights",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canAdmin",
+            "columnName": "can_admin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSyncedAt",
+            "columnName": "catalog_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "positionSyncedAt",
+            "columnName": "position_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncToken",
+            "columnName": "sync_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurTokenCipher",
+            "columnName": "liseur_token_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurAccountId",
+            "columnName": "liseur_account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncCursorSeq",
+            "columnName": "sync_cursor_seq",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "annotationCursorSeq",
+            "columnName": "annotation_cursor_seq",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `book_id` TEXT NOT NULL, `kind` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `text` TEXT, `note` TEXT, `tint` TEXT, `chapter` TEXT, `position` INTEGER, `total_progression` REAL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tint",
+            "columnName": "tint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapter",
+            "columnName": "chapter",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_typography",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `font` TEXT NOT NULL, `font_size` REAL NOT NULL, `line_height` REAL, `page_margins` REAL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "font",
+            "columnName": "font",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "font_size",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineHeight",
+            "columnName": "line_height",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pageMargins",
+            "columnName": "page_margins",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_screen",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `keep_screen_on` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keepScreenOn",
+            "columnName": "keep_screen_on",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_reading_mode",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `scroll` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scroll",
+            "columnName": "scroll",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `book_url` TEXT NOT NULL, `started_at` INTEGER NOT NULL, `ended_at` INTEGER, `last_checkpoint_at` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `start_progression` REAL, `end_progression` REAL, `idle_ms` INTEGER, `uploaded_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "ended_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastCheckpointAt",
+            "columnName": "last_checkpoint_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startProgression",
+            "columnName": "start_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "endProgression",
+            "columnName": "end_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "idleMs",
+            "columnName": "idle_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "uploadedAt",
+            "columnName": "uploaded_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_sessions_book_url",
+            "unique": false,
+            "columnNames": [
+              "book_url"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_book_url` ON `${TABLE_NAME}` (`book_url`)"
+          },
+          {
+            "name": "index_reading_sessions_started_at",
+            "unique": false,
+            "columnNames": [
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_started_at` ON `${TABLE_NAME}` (`started_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_peer_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `pending_progression` REAL, `pending_locator_json` TEXT, `pending_edition_sha` TEXT, `pending_status` TEXT, `pending_updated_at` INTEGER, `has_pending` INTEGER NOT NULL DEFAULT 0, `remote_updated_at` INTEGER, `synced_at` INTEGER, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingLocatorJson",
+            "columnName": "pending_locator_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingEditionSha",
+            "columnName": "pending_edition_sha",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasPending",
+            "columnName": "has_pending",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_peer_state_peer_id",
+            "unique": false,
+            "columnNames": [
+              "peer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_peer_state_peer_id` ON `${TABLE_NAME}` (`peer_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_fingerprint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `sha256` TEXT NOT NULL, `partial_md5` TEXT NOT NULL, `file_size` INTEGER NOT NULL, `file_modified_at` INTEGER, `computed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256",
+            "columnName": "sha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partialMd5",
+            "columnName": "partial_md5",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "computedAt",
+            "columnName": "computed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "work_alias",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_id` TEXT NOT NULL, `confidence` TEXT NOT NULL, `confirmed` INTEGER NOT NULL, `seeded` INTEGER NOT NULL DEFAULT 0, `source_sent` INTEGER NOT NULL DEFAULT 0, `edition_sha` TEXT, `annotations_reconciled_at` INTEGER NOT NULL DEFAULT 0, `resolved_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confirmed",
+            "columnName": "confirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seeded",
+            "columnName": "seeded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceSent",
+            "columnName": "source_sent",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "editionSha",
+            "columnName": "edition_sha",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "annotationsReconciledAt",
+            "columnName": "annotations_reconciled_at",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "resolvedAt",
+            "columnName": "resolved_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "work_ambiguity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_ids` TEXT NOT NULL, `noticed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workIds",
+            "columnName": "work_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noticedAt",
+            "columnName": "noticed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_extra",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`series_id` TEXT NOT NULL, `summary` TEXT, `status` TEXT, `total_book_count` INTEGER, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`series_id`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalBookCount",
+            "columnName": "total_book_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "series_id"
+          ]
+        }
+      },
+      {
+        "tableName": "annotation_sync",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `book_id` TEXT NOT NULL, `work_id` TEXT NOT NULL, `rev` INTEGER NOT NULL, `seq` INTEGER NOT NULL, `acked_fingerprint` TEXT, `pending_kind` TEXT, `pending_json` TEXT, `pending_rev` INTEGER NOT NULL, `pending_fingerprint` TEXT, `rejected_fingerprint` TEXT, `retry_not_before` INTEGER NOT NULL, PRIMARY KEY(`id`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rev",
+            "columnName": "rev",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seq",
+            "columnName": "seq",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ackedFingerprint",
+            "columnName": "acked_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingKind",
+            "columnName": "pending_kind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingJson",
+            "columnName": "pending_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingRev",
+            "columnName": "pending_rev",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pendingFingerprint",
+            "columnName": "pending_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "rejectedFingerprint",
+            "columnName": "rejected_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "retryNotBefore",
+            "columnName": "retry_not_before",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotation_sync_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotation_sync_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          },
+          {
+            "name": "index_annotation_sync_work_id",
+            "unique": false,
+            "columnNames": [
+              "work_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotation_sync_work_id` ON `${TABLE_NAME}` (`work_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kosync_peer",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `base_url` TEXT NOT NULL, `username` TEXT NOT NULL, `key_cipher` TEXT NOT NULL, `added_at` INTEGER NOT NULL, `position_synced_at` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keyCipher",
+            "columnName": "key_cipher",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSyncedAt",
+            "columnName": "position_synced_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "upload_refusal",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `account_key` TEXT NOT NULL, `refused_at` INTEGER NOT NULL, `kind` TEXT NOT NULL, `reason` TEXT, `content_sha256` TEXT, `seen_at` INTEGER, PRIMARY KEY(`book_url`, `account_key`), FOREIGN KEY(`book_url`) REFERENCES `books`(`url`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountKey",
+            "columnName": "account_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "refusedAt",
+            "columnName": "refused_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reason",
+            "columnName": "reason",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentSha256",
+            "columnName": "content_sha256",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seenAt",
+            "columnName": "seen_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "account_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_upload_refusal_account_key_seen_at",
+            "unique": false,
+            "columnNames": [
+              "account_key",
+              "seen_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_upload_refusal_account_key_seen_at` ON `${TABLE_NAME}` (`account_key`, `seen_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "book_url"
+            ],
+            "referencedColumns": [
+              "url"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "session_refusal",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`peer_id` TEXT NOT NULL, `session_id` INTEGER NOT NULL, `wire_session_id` TEXT NOT NULL, `code` TEXT, `refused_at` INTEGER NOT NULL, PRIMARY KEY(`peer_id`, `session_id`), FOREIGN KEY(`session_id`) REFERENCES `reading_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wireSessionId",
+            "columnName": "wire_session_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "refusedAt",
+            "columnName": "refused_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "peer_id",
+            "session_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_session_refusal_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_refusal_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "reading_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "session_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a4459c58b7d75e68e0e9dae88a82ebeb')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -177,6 +177,7 @@ class AppContainer(context: Context) {
         sessionDao = database.readingSessionDao(),
         annotationSyncDao = database.annotationSyncDao(),
         uploadRefusalDao = database.uploadRefusalDao(),
+        sessionRefusalDao = database.sessionRefusalDao(),
         // Declared later in this file, so it is reached through the
         // lambda rather than held: the pairing is only ever touched
         // after a connection has landed, never while one is being built.
@@ -293,6 +294,7 @@ class AppContainer(context: Context) {
         peerStateDao = database.syncPeerStateDao(),
         identityDao = database.workIdentityDao(),
         sessionDao = database.readingSessionDao(),
+        sessionRefusalDao = database.sessionRefusalDao(),
         works = workResolver,
         deviceKey = { deviceIdentity.current().id },
         finishedState = finishedState,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/AnnotationSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/AnnotationSync.kt
@@ -134,4 +134,11 @@ interface AnnotationSyncDao {
     /** Forgets everything one server had confirmed. */
     @Query("DELETE FROM annotation_sync WHERE peer_id = :peerId")
     suspend fun forgetPeer(peerId: String)
+
+    @Query("SELECT COUNT(*) FROM annotation_sync WHERE peer_id = :peerId")
+    suspend fun countForPeer(peerId: String): Int
+
+    /** Renames one server's rows, requests in flight included. Only when nothing sits under [to]. */
+    @Query("UPDATE annotation_sync SET peer_id = :to WHERE peer_id = :from")
+    suspend fun rekeyPeer(from: String, to: String)
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
@@ -26,8 +26,9 @@ import androidx.sqlite.execSQL
         AnnotationSync::class,
         KosyncPeer::class,
         UploadRefusal::class,
+        SessionRefusal::class,
     ],
-    version = 46,
+    version = 47,
     exportSchema = true,
 )
 abstract class LiseurDatabase : RoomDatabase() {
@@ -48,6 +49,7 @@ abstract class LiseurDatabase : RoomDatabase() {
     abstract fun bookReadingModeDao(): BookReadingModeDao
     abstract fun seriesExtraDao(): SeriesExtraDao
     abstract fun uploadRefusalDao(): UploadRefusalDao
+    abstract fun sessionRefusalDao(): SessionRefusalDao
 
     companion object {
         /** Adds the measured reading speed used for time-left estimates. */
@@ -1225,6 +1227,34 @@ abstract class LiseurDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Adds the record of sittings one server refused by name, so a
+         * refused batch sets aside the one sitting it was about instead
+         * of marking the whole batch as sent.
+         */
+        val MIGRATION_46_47 = object : Migration(46, 47) {
+            override fun migrate(connection: SQLiteConnection) {
+                connection.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `session_refusal` (
+                        `peer_id` TEXT NOT NULL,
+                        `session_id` INTEGER NOT NULL,
+                        `wire_session_id` TEXT NOT NULL,
+                        `code` TEXT,
+                        `refused_at` INTEGER NOT NULL,
+                        PRIMARY KEY(`peer_id`, `session_id`),
+                        FOREIGN KEY(`session_id`) REFERENCES `reading_sessions`(`id`)
+                            ON UPDATE NO ACTION ON DELETE CASCADE
+                    )
+                    """.trimIndent(),
+                )
+                connection.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_session_refusal_session_id` " +
+                        "ON `session_refusal` (`session_id`)",
+                )
+            }
+        }
+
         val MIGRATIONS: Array<Migration> get() = arrayOf(
             MIGRATION_1_2,
             MIGRATION_2_3,
@@ -1271,6 +1301,7 @@ abstract class LiseurDatabase : RoomDatabase() {
             MIGRATION_43_44,
             MIGRATION_44_45,
             MIGRATION_45_46,
+            MIGRATION_46_47,
         )
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/ReadingProgress.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/ReadingProgress.kt
@@ -562,6 +562,26 @@ abstract class ReadingProgressDao {
     abstract suspend fun currentRevision(bookUrl: String): Long?
 
     /**
+     * Moves a book's revision on without a page having turned, and only
+     * while it is still the revision that was sent.
+     *
+     * For a position the server has refused for good under this
+     * revision's derived id: it holds that id already, carrying
+     * something else. Sending the same id again would only be refused
+     * again, so the reading is given a fresh revision and with it a
+     * fresh id. Conditional, because a page turned since the send has
+     * already done that, and an unconditional bump would invent a
+     * revision nobody read to.
+     */
+    @Query(
+        """
+        UPDATE reading_progress SET local_revision = local_revision + 1
+        WHERE book_url = :bookUrl AND local_revision = :sentRevision
+        """,
+    )
+    abstract suspend fun renameRevision(bookUrl: String, sentRevision: Long): Int
+
+    /**
      * Takes a status the server reported on its own, leaving the position
      * alone — someone marked the book read elsewhere without opening it.
      *

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/ReadingProgress.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/ReadingProgress.kt
@@ -873,6 +873,23 @@ abstract class ReadingProgressDao {
     abstract suspend fun retireAccountState()
 
     /**
+     * Renames an account everywhere a position remembers it, for the
+     * same account whose key changed spelling. Nothing about the
+     * position moves: which account agreed it, reported it or owns it
+     * is unchanged, only how that account is written.
+     */
+    @Query(
+        """
+        UPDATE reading_progress SET
+            agreed_account = CASE WHEN agreed_account = :from THEN :to ELSE agreed_account END,
+            pending_account = CASE WHEN pending_account = :from THEN :to ELSE pending_account END,
+            owner_account = CASE WHEN owner_account = :from THEN :to ELSE owner_account END
+        WHERE agreed_account = :from OR pending_account = :from OR owner_account = :from
+        """,
+    )
+    abstract suspend fun rekeyAccount(from: String, to: String)
+
+    /**
      * Marks the given books as having reading the server should be told
      * about, once the user has agreed to hand them to a new account.
      */

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/ReadingSession.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/ReadingSession.kt
@@ -180,6 +180,33 @@ interface ReadingSessionDao {
     )
     suspend fun awaitingUpload(limit: Int): List<ReadingSession>
 
+    /**
+     * [awaitingUpload], narrowed to what can actually go to one peer:
+     * sittings of a book that peer has a usable name for, and that it
+     * has not refused by name.
+     *
+     * Both conditions are in the query, before the limit, on purpose.
+     * Selecting the oldest thousand and then filtering was how a shelf
+     * of unnamed books blocked every newer sitting from ever shipping:
+     * the window filled with rows that could not be sent, and nothing
+     * behind them was looked at.
+     */
+    @Query(
+        """
+        SELECT s.* FROM reading_sessions s
+        JOIN work_alias a ON a.book_url = s.book_url AND a.peer_id = :peerId
+          AND (a.confirmed = 1 OR a.confidence = 'high')
+        WHERE s.ended_at IS NOT NULL AND s.uploaded_at IS NULL
+          AND s.start_progression IS NOT NULL AND s.end_progression IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM session_refusal r WHERE r.peer_id = :peerId AND r.session_id = s.id
+          )
+        ORDER BY s.started_at
+        LIMIT :limit
+        """,
+    )
+    suspend fun awaitingUploadTo(peerId: String, limit: Int): List<ReadingSession>
+
     @Query("UPDATE reading_sessions SET uploaded_at = :at WHERE id IN (:ids)")
     suspend fun markUploaded(ids: List<Long>, at: Long)
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/RemoteServer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/RemoteServer.kt
@@ -121,6 +121,19 @@ data class RemoteServer(
     val koboToken: String? get() = koboTokenCipher?.let(CredentialCipher::decrypt)
 
     /**
+     * The device id liseur-sync stamped this phone's ops and sessions
+     * with; null for every other kind.
+     *
+     * [accountId] doubles as that for liseur-sync — the column predates
+     * the stable [liseurAccountId] — and it is worth asking for by its
+     * real name, because it is offered back to the server on reconnect
+     * so the phone stays the same device in the op log.
+     */
+    @get:Ignore
+    val liseurDeviceId: String?
+        get() = accountId.takeIf { kind == ServerKind.LISEUR_SYNC }
+
+    /**
      * How to sign a request to this server, or null when the secret
      * cannot be read back — a database restored onto another phone
      * arrives with ciphertext this Keystore cannot open.

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/SessionRefusal.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/SessionRefusal.kt
@@ -1,0 +1,67 @@
+package com.chmouel.liseur.data.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.Query
+import androidx.room.Upsert
+
+/**
+ * A sitting one sync server said it would never take, written down.
+ *
+ * The server appends a batch of sessions all or nothing, and when it
+ * refuses one it names the item. Before this row existed the whole
+ * batch was marked as sent on any such refusal — up to a thousand hours
+ * of reading gone because a neighbour was malformed. Now only the named
+ * sitting is set aside, here, and the rest go again.
+ *
+ * Per peer, because the refusal is one server's verdict: an id it holds
+ * under a different payload is free on the next server, and a rule it
+ * enforces another may not. Keyed by the *local* row rather than the
+ * wire id so the upload query can anti-join it before it limits; the
+ * wire id is kept for reading the log.
+ */
+@Entity(
+    tableName = "session_refusal",
+    primaryKeys = ["peer_id", "session_id"],
+    foreignKeys = [
+        ForeignKey(
+            entity = ReadingSession::class,
+            parentColumns = ["id"],
+            childColumns = ["session_id"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("session_id")],
+)
+data class SessionRefusal(
+    @ColumnInfo(name = "peer_id") val peerId: String,
+    @ColumnInfo(name = "session_id") val sessionId: Long,
+    @ColumnInfo(name = "wire_session_id") val wireSessionId: String,
+    /** The server's machine-readable reason, or null when it gave prose only. */
+    val code: String?,
+    @ColumnInfo(name = "refused_at") val refusedAt: Long,
+)
+
+@Dao
+interface SessionRefusalDao {
+
+    @Upsert
+    suspend fun record(refusal: SessionRefusal)
+
+    @Query("SELECT * FROM session_refusal WHERE peer_id = :peerId ORDER BY refused_at")
+    suspend fun forPeer(peerId: String): List<SessionRefusal>
+
+    @Query("SELECT COUNT(*) FROM session_refusal WHERE peer_id = :peerId")
+    suspend fun countForPeer(peerId: String): Int
+
+    /** Forgets one server's verdicts, when that account is left. */
+    @Query("DELETE FROM session_refusal WHERE peer_id = :peerId")
+    suspend fun clearPeer(peerId: String)
+
+    /** Renames a peer's rows when its key changes spelling. Only when nothing sits under [to]. */
+    @Query("UPDATE session_refusal SET peer_id = :to WHERE peer_id = :from")
+    suspend fun rekeyPeer(from: String, to: String)
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/SyncPeerState.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/SyncPeerState.kt
@@ -272,4 +272,14 @@ abstract class SyncPeerStateDao {
      */
     @Query("DELETE FROM sync_peer_state WHERE peer_id = :peerId")
     abstract suspend fun forgetPeer(peerId: String)
+
+    @Query("SELECT COUNT(*) FROM sync_peer_state WHERE peer_id = :peerId")
+    abstract suspend fun countForPeer(peerId: String): Int
+
+    /**
+     * Moves one partner's agreements under a new name for the same
+     * partner. Only ever called when nothing sits under [to] yet.
+     */
+    @Query("UPDATE sync_peer_state SET peer_id = :to WHERE peer_id = :from")
+    abstract suspend fun rekeyPeer(from: String, to: String)
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/UploadRefusal.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/UploadRefusal.kt
@@ -6,6 +6,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Upsert
 import kotlinx.coroutines.flow.Flow
 
@@ -137,6 +138,28 @@ interface UploadRefusalDao {
 
     @Query("DELETE FROM upload_refusal WHERE account_key = :accountKey")
     suspend fun clearAccount(accountKey: String)
+
+    /**
+     * Renames an account's refusals when the account's key changes
+     * spelling. A refusal already under [to] is the same verdict from
+     * the same server and can stand; the old-key copy goes.
+     */
+    @Query(
+        """
+        DELETE FROM upload_refusal WHERE account_key = :from AND book_url IN
+            (SELECT book_url FROM upload_refusal WHERE account_key = :to)
+        """,
+    )
+    suspend fun dropShadowed(from: String, to: String)
+
+    @Query("UPDATE upload_refusal SET account_key = :to WHERE account_key = :from")
+    suspend fun rename(from: String, to: String)
+
+    @Transaction
+    suspend fun rekeyAccount(from: String, to: String) {
+        dropShadowed(from, to)
+        rename(from, to)
+    }
 }
 
 /** One refusal and the digest the book hashes to now, for comparison. */

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/WorkIdentity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/WorkIdentity.kt
@@ -4,6 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Dao
 import androidx.room.Entity
 import androidx.room.Query
+import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
 import androidx.room.Upsert
 import com.chmouel.liseur.domain.BookFingerprint
@@ -259,4 +260,29 @@ interface WorkIdentityDao {
 
     @Query("DELETE FROM work_ambiguity WHERE peer_id = :peerId")
     suspend fun forgetPeerAmbiguities(peerId: String)
+
+    /** How many names and open questions one peer holds. */
+    @Query(
+        """
+        SELECT (SELECT COUNT(*) FROM work_alias WHERE peer_id = :peerId) +
+               (SELECT COUNT(*) FROM work_ambiguity WHERE peer_id = :peerId)
+        """,
+    )
+    suspend fun countForPeer(peerId: String): Int
+
+    @Query("UPDATE work_alias SET peer_id = :to WHERE peer_id = :from")
+    suspend fun rekeyAliases(from: String, to: String)
+
+    @Query("UPDATE work_ambiguity SET peer_id = :to WHERE peer_id = :from")
+    suspend fun rekeyAmbiguities(from: String, to: String)
+
+    /**
+     * Moves everything one peer had named under a new spelling of the
+     * same peer. Only ever called when nothing sits under [to] yet.
+     */
+    @Transaction
+    suspend fun rekeyPeer(from: String, to: String) {
+        rekeyAliases(from, to)
+        rekeyAmbiguities(from, to)
+    }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncHttp.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncHttp.kt
@@ -47,6 +47,18 @@ class LiseurSyncRejection(
     val sessionId: String? get() = body?.optString("session_id")?.takeIf { it.isNotEmpty() }
 
     /**
+     * Which item of the batch the refusal is about, by position, when
+     * the server said. The id may be missing — a `missing_field` about
+     * the id itself has none to give — and the same id may appear twice
+     * in one batch, so the position is what settles it.
+     */
+    val itemIndex: Int?
+        get() = body?.takeIf { it.has("item_index") }?.optInt("item_index", -1)?.takeIf { it >= 0 }
+
+    /** The byte or item bound a size refusal was measured against, if named. */
+    val limit: Int? get() = body?.takeIf { it.has("limit") }?.optInt("limit", 0)?.takeIf { it > 0 }
+
+    /**
      * The one refusal a client recovers from: the server no longer
      * holds a work this device had a cached name for.
      *
@@ -62,6 +74,12 @@ class LiseurSyncRejection(
 
         /** A mint asked to keep a device id no token of the account carries. */
         const val UNKNOWN_DEVICE = "unknown_device"
+
+        /** More items than one request may carry; the body names the bound. */
+        const val BATCH_TOO_LARGE = "batch_too_large"
+
+        /** An op's locator over the server's byte bound; the body names it. */
+        const val LOCATOR_TOO_LARGE = "locator_too_large"
     }
 }
 
@@ -235,6 +253,9 @@ class LiseurSyncHttp(private val http: RemoteHttp = RemoteHttp()) {
 
         /** A request bigger than the server was configured to take. */
         const val TOO_LARGE = 413
+
+        /** A batch the server parsed and would not have, with no better word for why. */
+        const val UNPROCESSABLE = 422
 
         /** An annotation this server has no record of, swept or never made. */
         const val NOT_FOUND = 404

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncHttp.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncHttp.kt
@@ -59,6 +59,9 @@ class LiseurSyncRejection(
     companion object {
         /** A batch item named a work the server no longer holds. */
         const val UNKNOWN_WORK = "unknown_work"
+
+        /** A mint asked to keep a device id no token of the account carries. */
+        const val UNKNOWN_DEVICE = "unknown_device"
     }
 }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
@@ -1493,15 +1493,15 @@ class LiseurSyncPositionSync(
      * map would hand both of them whichever answer came last — settling
      * a position the server refused, or moving the revision of one it
      * took. The server returns one result per item in the order they
-     * were sent and names each one, so a result naming something else
-     * is not an answer this app can place and counts as none.
+     * were sent and names each one, so a result that does not name the
+     * op at that position — or names nothing at all — is not an answer
+     * this app can place and counts as none.
      */
     private fun statuses(answer: JSONObject, batch: List<PendingPush>): List<String?> {
         val results = answer.optJSONArray("results")
         return batch.mapIndexed { index, push ->
             val item = results?.optJSONObject(index) ?: return@mapIndexed null
-            val id = item.optString("op_id")
-            if (id.isNotEmpty() && id != push.op.opId) return@mapIndexed null
+            if (item.optString("op_id") != push.op.opId) return@mapIndexed null
             item.optString("status").takeIf { it.isNotEmpty() }
         }
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
@@ -969,26 +969,45 @@ class LiseurSyncPositionSync(
                 return pushed
             } ?: continue
 
-            val accepted = accepted(answer)
+            val statuses = statuses(answer)
             for (item in batch) {
-                if (item.op.opId !in accepted) {
-                    // The server refused this one on its own terms — an
-                    // id reused with a different payload. Leaving the
-                    // book dirty is right: the next run asks again with
-                    // whatever it holds then.
-                    Log.i(TAG, "The server would not take a position")
-                    continue
-                }
-                pushed++
-                forAccount(account) {
-                    peerStateDao.settle(
-                        bookUrl = item.bookUrl,
-                        peerId = account.peerId,
-                        ackedRevision = item.revision,
-                        progression = item.op.progression,
-                        status = readingStatusFor(item.op.progression).wireName,
-                        now = now(),
-                    )
+                when (val status = statuses[item.op.opId]) {
+                    in ACCEPTED -> {
+                        pushed++
+                        forAccount(account) {
+                            peerStateDao.settle(
+                                bookUrl = item.bookUrl,
+                                peerId = account.peerId,
+                                ackedRevision = item.revision,
+                                progression = item.op.progression,
+                                status = readingStatusFor(item.op.progression).wireName,
+                                now = now(),
+                            )
+                        }
+                    }
+
+                    CONFLICT -> {
+                        // The server holds this id already, carrying
+                        // something else — most often the same position
+                        // sent from a credential since replaced. It will
+                        // never take this id again, and sending the same
+                        // one next run would only be refused again. So the
+                        // revision moves on, which derives a fresh id for
+                        // the same reading; conditionally, because a page
+                        // turned since the send has done that already.
+                        Log.i(TAG, "The server holds op ${item.op.opId} with a different payload; renaming the position")
+                        forAccount(account) {
+                            progressDao.renameRevision(item.bookUrl, item.revision)
+                        }
+                        trouble.refused(SyncFailure.ServerError(LiseurSyncHttp.CONFLICT))
+                    }
+
+                    else -> {
+                        // Left dirty and said so: the next run asks again
+                        // with whatever it holds then.
+                        Log.i(TAG, "The server would not take a position: ${status ?: "no answer for it"}")
+                        trouble.refused(SyncFailure.Malformed)
+                    }
                 }
             }
         }
@@ -1008,7 +1027,8 @@ class LiseurSyncPositionSync(
     }
 
     /**
-     * Answers a batch the server refused for naming a deleted work.
+     * Answers a batch the server refused for naming a deleted work, or
+     * for one op's locator being bigger than it takes.
      *
      * Only the book the refusal names is refreshed, and only when the
      * refusal's `op_id` and `work_id` match an op this batch actually
@@ -1019,6 +1039,12 @@ class LiseurSyncPositionSync(
      * unnameable, or whose reading now points the other way, is simply
      * dropped from the retry: its position stays dirty and loses
      * nothing.
+     *
+     * A locator too large is the other refusal with a move: the server's
+     * bound is configurable and may be smaller than this app assumed.
+     * The op goes again without its locator and under the same id — the
+     * refused batch was never stored — so the other device reopens the
+     * book at a percentage rather than not at all.
      */
     private suspend fun recoverPush(
         account: Account,
@@ -1027,6 +1053,18 @@ class LiseurSyncPositionSync(
         recovered: MutableSet<String>,
         trouble: Trouble,
     ): PushRecovery {
+        if (rejection.errorCode == LiseurSyncRejection.LOCATOR_TOO_LARGE) {
+            val heavy = batch.firstOrNull { it.op.opId == rejection.opId }
+                ?: rejection.itemIndex?.let(batch::getOrNull)
+                ?: return PushRecovery.Ordinary
+            // Already bare and still refused: not a size problem this
+            // app can do anything about.
+            if (heavy.op.locatorJson == null) return PushRecovery.Ordinary
+            Log.i(TAG, "The server will not take op ${heavy.op.opId}'s locator (limit ${rejection.limit}); sending the position alone")
+            return PushRecovery.Retry(
+                batch.map { if (it === heavy) it.copy(op = it.op.copy(locatorJson = null)) else it },
+            )
+        }
         if (!rejection.isUnknownWork) return PushRecovery.Ordinary
         val opId = rejection.opId ?: return PushRecovery.Ordinary
         val workId = rejection.workId ?: return PushRecovery.Ordinary
@@ -1398,14 +1436,13 @@ class LiseurSyncPositionSync(
         return SessionRecovery.Retry(rest + rebuilt)
     }
 
-    private fun accepted(answer: JSONObject): Set<String> {
-        val results = answer.optJSONArray("results") ?: return emptySet()
+    private fun statuses(answer: JSONObject): Map<String, String> {
+        val results = answer.optJSONArray("results") ?: return emptyMap()
         return (0 until results.length()).mapNotNull { index ->
             val item = results.optJSONObject(index) ?: return@mapNotNull null
-            item.optString("op_id").takeIf {
-                it.isNotEmpty() && item.optString("status") in ACCEPTED
-            }
-        }.toSet()
+            val id = item.optString("op_id").takeIf { it.isNotEmpty() } ?: return@mapNotNull null
+            id to item.optString("status")
+        }.toMap()
     }
 
     // -- Odds and ends ----------------------------------------------------
@@ -1544,5 +1581,6 @@ class LiseurSyncPositionSync(
         const val LATEST_WINDOW = 20
         const val MAX_RESOLVES_PER_RUN = 25
         val ACCEPTED = setOf("applied", "duplicate")
+        const val CONFLICT = "conflict"
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
@@ -7,6 +7,8 @@ import com.chmouel.liseur.data.db.BookDao
 import com.chmouel.liseur.data.db.ReadingProgress
 import com.chmouel.liseur.data.db.ReadingProgressDao
 import com.chmouel.liseur.data.db.ReadingSessionDao
+import com.chmouel.liseur.data.db.SessionRefusal
+import com.chmouel.liseur.data.db.SessionRefusalDao
 import com.chmouel.liseur.data.db.RemoteServer
 import com.chmouel.liseur.data.db.RemoteServerDao
 import com.chmouel.liseur.data.db.SyncPeerState
@@ -71,6 +73,7 @@ class LiseurSyncPositionSync(
     private val peerStateDao: SyncPeerStateDao,
     private val identityDao: WorkIdentityDao,
     private val sessionDao: ReadingSessionDao,
+    private val sessionRefusalDao: SessionRefusalDao,
     private val works: WorkResolver,
     private val deviceKey: suspend () -> String,
     private val finishedState: FinishedState,
@@ -1132,31 +1135,36 @@ class LiseurSyncPositionSync(
      * Only sessions for books this server already has a name for, and
      * only ones that know where in the book they happened; the rest
      * wait, which costs nothing because a session is a fact about the
-     * past and is no less true next run.
+     * past and is no less true next run. Both filters are in the query,
+     * so a shelf of unnamed books cannot fill the window and stand in
+     * front of everything behind it.
      *
-     * A refusal on the server's own terms — an id it already holds
-     * carrying something else, or a payload it will not parse — is
-     * marked done rather than retried. Neither will ever be accepted,
-     * and a batch that can never succeed would sit at the head of the
-     * queue forever and stop every later session behind it.
+     * The server takes a batch all or nothing, so a refusal means it
+     * stored none of it — and only ever concerns one sitting. Nothing is
+     * ever marked as sent on a refusal. Instead the batch is taken apart:
+     * a stale work name has the book resolved afresh and its sittings
+     * rebuilt; a sitting the server names as unacceptable is set aside,
+     * for this server, in `session_refusal`, and the rest go again; a
+     * body too big is halved; a refusal that names nothing is bisected
+     * until it does. Each batch that lands is marked as sent at once, so
+     * a run cut short keeps what it managed.
      *
-     * The one refusal that is recovered instead is a stale work name:
-     * the book is resolved afresh, its sessions rebuilt under the new
-     * name, and the batch retried. Nothing is marked uploaded until the
-     * server has actually taken it.
+     * Only the server's own no is treated this way. A credential
+     * refused, a server error or no answer at all end the stage as they
+     * always did, with everything still pending.
      */
     private suspend fun uploadSessions(
         account: Account,
         recovered: MutableSet<String>,
         trouble: Trouble,
     ) {
-        val sessions = sessionDao.awaitingUpload(SessionUploads.MAX_BATCH)
+        val sessions = sessionDao.awaitingUploadTo(account.peerId, SessionUploads.MAX_BATCH)
         if (sessions.isEmpty()) return
         val byBook = identityDao.aliasesFor(account.peerId)
             .filter { it.usable }
             .associateBy { it.bookUrl }
 
-        var sending = sessions.mapNotNull { session ->
+        val first = sessions.mapNotNull { session ->
             val alias = byBook[session.bookUrl] ?: return@mapNotNull null
             SessionUploads.toJson(
                 session = session,
@@ -1173,14 +1181,23 @@ class LiseurSyncPositionSync(
                 )
             }
         }
-        if (sending.isEmpty()) return
+        if (first.isEmpty()) return
 
-        var answered = false
-        while (!answered) {
+        val queue = ArrayDeque(listOf(first))
+        var requests = 0
+        while (queue.isNotEmpty()) {
             // As with the pushes: a recovery may have found the server
             // gone quiet, and going round again would only wait again.
             if (trouble.unreachable != null) return
-            answered = try {
+            // A bound on how far a batch is taken apart: bisecting a
+            // thousand down to singletons is twenty rounds at most, and
+            // a server that refuses every one is not going to change.
+            if (++requests > MAX_SESSION_REQUESTS) {
+                trouble.refused(SyncFailure.ServerError(LiseurSyncHttp.BAD_REQUEST))
+                return
+            }
+            val sending = queue.removeFirst()
+            try {
                 http.post(
                     LiseurSyncApi.url(account.baseUrl, LiseurSyncApi.SESSIONS),
                     account.credentials,
@@ -1188,18 +1205,22 @@ class LiseurSyncPositionSync(
                         "sessions",
                         JSONArray().apply { sending.forEach { put(it.json) } },
                     ),
-                    expected = setOf(LiseurSyncHttp.BAD_REQUEST),
+                    expected = SESSION_REFUSALS,
                 )
-                true
+                forAccount(account) { sessionDao.markUploaded(sending.map { it.localId }, now()) }
             } catch (rejection: LiseurSyncRejection) {
-                when (
-                    val recovery = recoverSessions(account, sending, rejection, recovered, trouble)
-                ) {
+                when (val next = setAside(account, sending, rejection, recovered, trouble)) {
                     is SessionRecovery.Retry -> {
-                        recovery.failure?.let(trouble::refused)
-                        if (recovery.sending.isEmpty()) return
-                        sending = recovery.sending
-                        false
+                        next.failure?.let(trouble::refused)
+                        // The rebuilt or trimmed batch goes back to the
+                        // front: it is the same sittings, one question
+                        // further on.
+                        if (next.sending.isNotEmpty()) queue.addFirst(next.sending)
+                    }
+
+                    is SessionRecovery.Split -> {
+                        queue.addFirst(next.second)
+                        queue.addFirst(next.first)
                     }
 
                     SessionRecovery.Exhausted -> {
@@ -1208,41 +1229,104 @@ class LiseurSyncPositionSync(
                     }
 
                     SessionRecovery.Ordinary -> {
-                        // A refusal that names no stale work is the same
-                        // dead end as any other malformed batch.
-                        Log.i(TAG, "The server will never take these sessions; not asking again")
-                        true
+                        // Left pending and reported: a refusal this app
+                        // cannot place is not a licence to drop reading.
+                        Log.i(TAG, "The server refused a batch of sessions in a way this app cannot place")
+                        trouble.refused(failureForCode(rejection.code))
+                        return
                     }
                 }
             } catch (rejected: RemoteHttpFailure) {
-                if (!rejected.reason.isFinal()) {
-                    Log.i(TAG, "Could not send reading sessions", rejected)
-                    trouble.refused(rejected.reason)
-                    return
-                }
-                Log.i(TAG, "The server will never take these sessions; not asking again")
-                true
+                Log.i(TAG, "Could not send reading sessions", rejected)
+                trouble.refused(rejected.reason)
+                return
             } catch (e: IOException) {
                 Log.i(TAG, "Could not send reading sessions", e)
                 trouble.failed(e, reasonFor(e))
                 return
             }
         }
+    }
 
-        forAccount(account) { sessionDao.markUploaded(sending.map { it.localId }, now()) }
+    /**
+     * Decides what a refused session batch becomes.
+     *
+     * In order: a stale work name is recovered as before; a body the
+     * server will not take whole is halved; a refusal that names one
+     * sitting, by id or by position, sets that sitting aside for this
+     * server and retries the rest; one that names nothing is bisected,
+     * and a singleton it still will not place is set aside if the server
+     * called it permanent — a code this app knows, or the prose-only
+     * refusal of an older server — and otherwise left pending and
+     * reported, since a code this app has never seen is not proof the
+     * sitting is at fault.
+     */
+    private suspend fun setAside(
+        account: Account,
+        sending: List<PreparedSession>,
+        rejection: LiseurSyncRejection,
+        recovered: MutableSet<String>,
+        trouble: Trouble,
+    ): SessionRecovery {
+        if (rejection.isUnknownWork) return recoverSessions(account, sending, rejection, recovered, trouble)
+        if (rejection.code == LiseurSyncHttp.TOO_LARGE ||
+            rejection.errorCode == LiseurSyncRejection.BATCH_TOO_LARGE
+        ) {
+            return if (sending.size > 1) split(sending) else refuse(account, sending.single(), rejection)
+        }
+        val culprit = sending.firstOrNull { it.wireId == rejection.sessionId }
+            ?: rejection.itemIndex?.let(sending::getOrNull)
+        if (culprit != null) return refuse(account, culprit, rejection, rest = sending - culprit)
+        if (sending.size > 1) return split(sending)
+        val code = rejection.errorCode
+        if (code == null || code in PERMANENT_SESSION_CODES) {
+            return refuse(account, sending.single(), rejection)
+        }
+        return SessionRecovery.Ordinary
+    }
+
+    private fun split(sending: List<PreparedSession>): SessionRecovery.Split {
+        val half = sending.size / 2
+        return SessionRecovery.Split(sending.subList(0, half), sending.subList(half, sending.size))
+    }
+
+    /** Writes down that this server will not take [culprit], and moves on with [rest]. */
+    private suspend fun refuse(
+        account: Account,
+        culprit: PreparedSession,
+        rejection: LiseurSyncRejection,
+        rest: List<PreparedSession> = emptyList(),
+    ): SessionRecovery {
+        Log.i(TAG, "The server will never take session ${culprit.wireId} (${rejection.errorCode ?: rejection.code}); setting it aside")
+        forAccount(account) {
+            sessionRefusalDao.record(
+                SessionRefusal(
+                    peerId = account.peerId,
+                    sessionId = culprit.localId,
+                    wireSessionId = culprit.wireId,
+                    code = rejection.errorCode ?: rejection.code.toString(),
+                    refusedAt = now(),
+                ),
+            )
+        }
+        return SessionRecovery.Retry(rest, failure = failureForCode(rejection.code))
     }
 
     /** What came of trying to recover a rejected session batch. */
     private sealed interface SessionRecovery {
         /**
          * Retry these instead of the rejected batch; [failure] is a
-         * re-resolution that failed along the way, reported but not
-         * allowed to stop the books whose names are still good.
+         * re-resolution that failed along the way, or a sitting set
+         * aside — reported but not allowed to stop the rest.
          */
         data class Retry(val sending: List<PreparedSession>, val failure: SyncFailure? = null) :
             SessionRecovery
 
-        /** Not a refusal recovery answers; the caller fails the old way. */
+        /** Send these two halves instead, in order. */
+        data class Split(val first: List<PreparedSession>, val second: List<PreparedSession>) :
+            SessionRecovery
+
+        /** Not a refusal this app can place; the batch stays pending. */
         data object Ordinary : SessionRecovery
 
         /** This run already refreshed the book once; stop asking. */
@@ -1313,17 +1397,6 @@ class LiseurSyncPositionSync(
         }
         return SessionRecovery.Retry(rest + rebuilt)
     }
-
-    /**
-     * Whether asking again could ever produce a different answer.
-     *
-     * A malformed batch stays malformed, and an id the server already
-     * holds under a different payload will never become free. Both are
-     * settled by giving up on them rather than by trying harder.
-     */
-    private fun SyncFailure.isFinal(): Boolean =
-        this is SyncFailure.Malformed ||
-            (this is SyncFailure.ServerError && code in FINAL_CODES)
 
     private fun accepted(answer: JSONObject): Set<String> {
         val results = answer.optJSONArray("results") ?: return emptySet()
@@ -1428,8 +1501,35 @@ class LiseurSyncPositionSync(
         }
 
     private companion object {
-        /** Refusals no amount of retrying will turn into an acceptance. */
-        val FINAL_CODES = setOf(400, 409, 422)
+        /**
+         * The answers to a session batch that say something about one
+         * sitting rather than about the credential or the server.
+         */
+        val SESSION_REFUSALS = setOf(
+            LiseurSyncHttp.BAD_REQUEST,
+            LiseurSyncHttp.CONFLICT,
+            LiseurSyncHttp.TOO_LARGE,
+            LiseurSyncHttp.UNPROCESSABLE,
+        )
+
+        /**
+         * Refusal codes the server documents as permanent for that
+         * payload: the sitting will never be taken as it stands, so it
+         * is set aside rather than offered again. A code not in this set
+         * is left pending and reported.
+         */
+        val PERMANENT_SESSION_CODES = setOf(
+            "id_reused", "missing_field", "bad_time", "time_in_future",
+            "progression_out_of_range", "idle_out_of_range",
+        )
+
+        /**
+         * The most requests one session stage makes. Taking a full batch
+         * apart one bisection at a time is a few dozen at the outside;
+         * past this the server is refusing everything and the run should
+         * say so rather than keep asking.
+         */
+        const val MAX_SESSION_REQUESTS = 64
 
         const val TAG = "liseur-sync-positions"
         const val PAGE = 500

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
@@ -976,9 +976,9 @@ class LiseurSyncPositionSync(
                 return pushed
             } ?: continue
 
-            val statuses = statuses(answer)
-            for (item in batch) {
-                when (val status = statuses[item.op.opId]) {
+            val statuses = statuses(answer, batch)
+            for ((index, item) in batch.withIndex()) {
+                when (val status = statuses[index]) {
                     in ACCEPTED -> {
                         pushed++
                         forAccount(account) {
@@ -1086,9 +1086,7 @@ class LiseurSyncPositionSync(
             return PushRecovery.Retry(listOf(listOf(lone.copy(op = lone.op.copy(locatorJson = null)))))
         }
         if (rejection.errorCode == LiseurSyncRejection.LOCATOR_TOO_LARGE) {
-            val heavy = batch.firstOrNull { it.op.opId == rejection.opId }
-                ?: rejection.itemIndex?.let(batch::getOrNull)
-                ?: return PushRecovery.Ordinary
+            val heavy = batch.refused(rejection) ?: return PushRecovery.Ordinary
             // Already bare and still refused: not a size problem this
             // app can do anything about.
             if (heavy.op.locatorJson == null) return PushRecovery.Ordinary
@@ -1100,8 +1098,8 @@ class LiseurSyncPositionSync(
         if (!rejection.isUnknownWork) return PushRecovery.Ordinary
         val opId = rejection.opId ?: return PushRecovery.Ordinary
         val workId = rejection.workId ?: return PushRecovery.Ordinary
-        val stale = batch.firstOrNull { it.op.opId == opId }
-            ?.takeIf { it.op.workId == workId && it.alias.workId == workId }
+        val stale = batch.refused(rejection)
+            ?.takeIf { it.op.opId == opId && it.op.workId == workId && it.alias.workId == workId }
             ?: return PushRecovery.Ordinary
 
         if (!recovered.add(stale.bookUrl)) {
@@ -1128,6 +1126,20 @@ class LiseurSyncPositionSync(
         return PushRecovery.Retry(
             listOf(batch.mapNotNull { if (it.bookUrl == stale.bookUrl) replacement else it }),
         )
+    }
+
+    /**
+     * The op of this batch a refusal is about.
+     *
+     * The position the server named settles it, because two copies of
+     * one book derive the same op id and only the position tells them
+     * apart. An id that disagrees with the position is a malformed
+     * answer and names nothing.
+     */
+    private fun List<PendingPush>.refused(rejection: LiseurSyncRejection): PendingPush? {
+        val named = rejection.itemIndex?.let(::getOrNull)
+            ?: return firstOrNull { it.op.opId == rejection.opId }
+        return named.takeIf { rejection.opId == null || it.op.opId == rejection.opId }
     }
 
     /** What came of asking the server for a name to replace a stale one. */
@@ -1473,13 +1485,25 @@ class LiseurSyncPositionSync(
         return SessionRecovery.Retry(rest + rebuilt)
     }
 
-    private fun statuses(answer: JSONObject): Map<String, String> {
-        val results = answer.optJSONArray("results") ?: return emptyMap()
-        return (0 until results.length()).mapNotNull { index ->
-            val item = results.optJSONObject(index) ?: return@mapNotNull null
-            val id = item.optString("op_id").takeIf { it.isNotEmpty() } ?: return@mapNotNull null
-            id to item.optString("status")
-        }.toMap()
+    /**
+     * The server's answer for each op of [batch], by position.
+     *
+     * Positional rather than keyed by id: two copies of one book on
+     * this device are one work, so they derive the same op id, and a
+     * map would hand both of them whichever answer came last — settling
+     * a position the server refused, or moving the revision of one it
+     * took. The server returns one result per item in the order they
+     * were sent and names each one, so a result naming something else
+     * is not an answer this app can place and counts as none.
+     */
+    private fun statuses(answer: JSONObject, batch: List<PendingPush>): List<String?> {
+        val results = answer.optJSONArray("results")
+        return batch.mapIndexed { index, push ->
+            val item = results?.optJSONObject(index) ?: return@mapIndexed null
+            val id = item.optString("op_id")
+            if (id.isNotEmpty() && id != push.op.opId) return@mapIndexed null
+            item.optString("status").takeIf { it.isNotEmpty() }
+        }
     }
 
     // -- Odds and ends ----------------------------------------------------

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
@@ -932,10 +932,7 @@ class LiseurSyncPositionSync(
             // server has gone quiet. Retrying then costs another whole
             // connect timeout and learns nothing.
             if (trouble.unreachable != null) return pushed
-            // The same bound the sessions have, and for the same
-            // reason: taking a batch apart is a few rounds, and a
-            // server refusing every piece of it will not relent.
-            if (++requests > MAX_PUSH_REQUESTS) {
+            if (++requests > MAX_BATCH_REQUESTS) {
                 trouble.refused(SyncFailure.ServerError(LiseurSyncHttp.BAD_REQUEST))
                 return pushed
             }
@@ -956,12 +953,9 @@ class LiseurSyncPositionSync(
             } catch (rejection: LiseurSyncRejection) {
                 when (val recovery = recoverPush(account, batch, rejection, recovered, trouble)) {
                     is PushRecovery.Retry -> {
-                        if (recovery.batch.isNotEmpty()) queue.addFirst(recovery.batch)
-                        null
-                    }
-
-                    is PushRecovery.Requeue -> {
-                        recovery.batches.reversed().forEach(queue::addFirst)
+                        recovery.batches.reversed()
+                            .filter { it.isNotEmpty() }
+                            .forEach(queue::addFirst)
                         null
                     }
 
@@ -1029,11 +1023,8 @@ class LiseurSyncPositionSync(
 
     /** What came of trying to recover a rejected ops batch. */
     private sealed interface PushRecovery {
-        /** Retry these instead of the rejected batch. */
-        data class Retry(val batch: List<PendingPush>) : PushRecovery
-
         /** Send these in place of the rejected batch, in order. */
-        data class Requeue(val batches: List<List<PendingPush>>) : PushRecovery
+        data class Retry(val batches: List<List<PendingPush>>) : PushRecovery
 
         /** Not a refusal recovery answers; the caller fails the old way. */
         data object Ordinary : PushRecovery
@@ -1081,16 +1072,18 @@ class LiseurSyncPositionSync(
             rejection.errorCode == LiseurSyncRejection.BATCH_TOO_LARGE
         ) {
             if (batch.size > 1) {
+                // The named limit is always positive, and half of a
+                // batch of two or more is at least one.
                 val room = rejection.limit?.takeIf { it < batch.size } ?: (batch.size / 2)
-                Log.i(TAG, "The server will not take ${batch.size} positions at once; sending ${room.coerceAtLeast(1)} at a time")
-                return PushRecovery.Requeue(batch.chunked(room.coerceAtLeast(1)))
+                Log.i(TAG, "The server will not take ${batch.size} positions at once; sending $room at a time")
+                return PushRecovery.Retry(batch.chunked(room))
             }
             val lone = batch.single()
             // Nothing else in an op has any size to it, so a lone op
             // still refused bare is a bound this app cannot get under.
             if (lone.op.locatorJson == null) return PushRecovery.Ordinary
             Log.i(TAG, "The server will not take op ${lone.op.opId} whole; sending the position alone")
-            return PushRecovery.Retry(listOf(lone.copy(op = lone.op.copy(locatorJson = null))))
+            return PushRecovery.Retry(listOf(listOf(lone.copy(op = lone.op.copy(locatorJson = null)))))
         }
         if (rejection.errorCode == LiseurSyncRejection.LOCATOR_TOO_LARGE) {
             val heavy = batch.firstOrNull { it.op.opId == rejection.opId }
@@ -1101,7 +1094,7 @@ class LiseurSyncPositionSync(
             if (heavy.op.locatorJson == null) return PushRecovery.Ordinary
             Log.i(TAG, "The server will not take op ${heavy.op.opId}'s locator (limit ${rejection.limit}); sending the position alone")
             return PushRecovery.Retry(
-                batch.map { if (it === heavy) it.copy(op = it.op.copy(locatorJson = null)) else it },
+                listOf(batch.map { if (it === heavy) it.copy(op = it.op.copy(locatorJson = null)) else it }),
             )
         }
         if (!rejection.isUnknownWork) return PushRecovery.Ordinary
@@ -1133,7 +1126,7 @@ class LiseurSyncPositionSync(
             IdentityRefresh.Unnameable -> null
         }
         return PushRecovery.Retry(
-            batch.mapNotNull { if (it.bookUrl == stale.bookUrl) replacement else it },
+            listOf(batch.mapNotNull { if (it.bookUrl == stale.bookUrl) replacement else it }),
         )
     }
 
@@ -1266,10 +1259,7 @@ class LiseurSyncPositionSync(
             // As with the pushes: a recovery may have found the server
             // gone quiet, and going round again would only wait again.
             if (trouble.unreachable != null) return
-            // A bound on how far a batch is taken apart: bisecting a
-            // thousand down to singletons is twenty rounds at most, and
-            // a server that refuses every one is not going to change.
-            if (++requests > MAX_SESSION_REQUESTS) {
+            if (++requests > MAX_BATCH_REQUESTS) {
                 trouble.refused(SyncFailure.ServerError(LiseurSyncHttp.BAD_REQUEST))
                 return
             }
@@ -1608,12 +1598,6 @@ class LiseurSyncPositionSync(
         )
 
         /**
-         * The most requests one positions stage makes, for the same
-         * reason as [MAX_SESSION_REQUESTS].
-         */
-        const val MAX_PUSH_REQUESTS = 64
-
-        /**
          * Refusal codes the server documents as permanent for that
          * payload: the sitting will never be taken as it stands, so it
          * is set aside rather than offered again. A code not in this set
@@ -1625,12 +1609,12 @@ class LiseurSyncPositionSync(
         )
 
         /**
-         * The most requests one session stage makes. Taking a full batch
-         * apart one bisection at a time is a few dozen at the outside;
-         * past this the server is refusing everything and the run should
-         * say so rather than keep asking.
+         * The most requests one positions or sessions stage makes.
+         * Taking a full batch apart one cut at a time is a few dozen at
+         * the outside; past this the server is refusing everything and
+         * the run should say so rather than keep asking.
          */
-        const val MAX_SESSION_REQUESTS = 64
+        const val MAX_BATCH_REQUESTS = 64
 
         const val TAG = "liseur-sync-positions"
         const val PAGE = 500

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
@@ -926,11 +926,19 @@ class LiseurSyncPositionSync(
     ): Int {
         var pushed = 0
         val queue = ArrayDeque(pushes.chunked(SyncOps.MAX_BATCH))
+        var requests = 0
         while (queue.isNotEmpty()) {
             // A recovery in the middle of this may have discovered the
             // server has gone quiet. Retrying then costs another whole
             // connect timeout and learns nothing.
             if (trouble.unreachable != null) return pushed
+            // The same bound the sessions have, and for the same
+            // reason: taking a batch apart is a few rounds, and a
+            // server refusing every piece of it will not relent.
+            if (++requests > MAX_PUSH_REQUESTS) {
+                trouble.refused(SyncFailure.ServerError(LiseurSyncHttp.BAD_REQUEST))
+                return pushed
+            }
             val batch = queue.removeFirst()
             // A null answer means a recovery rebuilt the batch and it
             // goes back on the queue: nothing from the rejected request
@@ -943,12 +951,17 @@ class LiseurSyncPositionSync(
                         "ops",
                         JSONArray().apply { batch.forEach { put(SyncOps.toJson(it.op)) } },
                     ),
-                    expected = setOf(LiseurSyncHttp.BAD_REQUEST),
+                    expected = PUSH_REFUSALS,
                 )
             } catch (rejection: LiseurSyncRejection) {
                 when (val recovery = recoverPush(account, batch, rejection, recovered, trouble)) {
                     is PushRecovery.Retry -> {
                         if (recovery.batch.isNotEmpty()) queue.addFirst(recovery.batch)
+                        null
+                    }
+
+                    is PushRecovery.Requeue -> {
+                        recovery.batches.reversed().forEach(queue::addFirst)
                         null
                     }
 
@@ -1019,6 +1032,9 @@ class LiseurSyncPositionSync(
         /** Retry these instead of the rejected batch. */
         data class Retry(val batch: List<PendingPush>) : PushRecovery
 
+        /** Send these in place of the rejected batch, in order. */
+        data class Requeue(val batches: List<List<PendingPush>>) : PushRecovery
+
         /** Not a refusal recovery answers; the caller fails the old way. */
         data object Ordinary : PushRecovery
 
@@ -1045,6 +1061,14 @@ class LiseurSyncPositionSync(
      * The op goes again without its locator and under the same id — the
      * refused batch was never stored — so the other device reopens the
      * book at a percentage rather than not at all.
+     *
+     * A batch refused for its size is the third. The server's item
+     * limit and its byte bound are both configurable and either may sit
+     * below what this app sends, so the batch is cut — to the limit the
+     * server named, or in half when it named none — and the pieces go
+     * in its place. A lone op the server still will not take whole is
+     * carrying its locator, which is the only part of an op with any
+     * size to it, so it goes bare like a named locator refusal.
      */
     private suspend fun recoverPush(
         account: Account,
@@ -1053,6 +1077,21 @@ class LiseurSyncPositionSync(
         recovered: MutableSet<String>,
         trouble: Trouble,
     ): PushRecovery {
+        if (rejection.code == LiseurSyncHttp.TOO_LARGE ||
+            rejection.errorCode == LiseurSyncRejection.BATCH_TOO_LARGE
+        ) {
+            if (batch.size > 1) {
+                val room = rejection.limit?.takeIf { it < batch.size } ?: (batch.size / 2)
+                Log.i(TAG, "The server will not take ${batch.size} positions at once; sending ${room.coerceAtLeast(1)} at a time")
+                return PushRecovery.Requeue(batch.chunked(room.coerceAtLeast(1)))
+            }
+            val lone = batch.single()
+            // Nothing else in an op has any size to it, so a lone op
+            // still refused bare is a bound this app cannot get under.
+            if (lone.op.locatorJson == null) return PushRecovery.Ordinary
+            Log.i(TAG, "The server will not take op ${lone.op.opId} whole; sending the position alone")
+            return PushRecovery.Retry(listOf(lone.copy(op = lone.op.copy(locatorJson = null))))
+        }
         if (rejection.errorCode == LiseurSyncRejection.LOCATOR_TOO_LARGE) {
             val heavy = batch.firstOrNull { it.op.opId == rejection.opId }
                 ?: rejection.itemIndex?.let(batch::getOrNull)
@@ -1292,8 +1331,9 @@ class LiseurSyncPositionSync(
      * In order: a stale work name is recovered as before; a body the
      * server will not take whole is halved; a refusal that names one
      * sitting, by id or by position, sets that sitting aside for this
-     * server and retries the rest; one that names nothing is bisected,
-     * and a singleton it still will not place is set aside if the server
+     * server and retries the rest, but only for a reason the server
+     * calls permanent; one that names nothing is bisected, and a
+     * singleton it still will not place is set aside if the server
      * called it permanent — a code this app knows, or the prose-only
      * refusal of an older server — and otherwise left pending and
      * reported, since a code this app has never seen is not proof the
@@ -1312,14 +1352,21 @@ class LiseurSyncPositionSync(
         ) {
             return if (sending.size > 1) split(sending) else refuse(account, sending.single(), rejection)
         }
+        val code = rejection.errorCode
+        // A code this app has never seen is not proof the sitting it
+        // names is at fault, so naming one is not enough to set it
+        // aside for ever: the reason has to be one the server documents
+        // as permanent, or the prose-only refusal of a server too old to
+        // give a code.
+        val permanent = code == null || code in PERMANENT_SESSION_CODES
         val culprit = sending.firstOrNull { it.wireId == rejection.sessionId }
             ?: rejection.itemIndex?.let(sending::getOrNull)
-        if (culprit != null) return refuse(account, culprit, rejection, rest = sending - culprit)
-        if (sending.size > 1) return split(sending)
-        val code = rejection.errorCode
-        if (code == null || code in PERMANENT_SESSION_CODES) {
-            return refuse(account, sending.single(), rejection)
+        if (culprit != null) {
+            if (!permanent) return SessionRecovery.Ordinary
+            return refuse(account, culprit, rejection, rest = sending - culprit)
         }
+        if (sending.size > 1) return split(sending)
+        if (permanent) return refuse(account, sending.single(), rejection)
         return SessionRecovery.Ordinary
     }
 
@@ -1548,6 +1595,23 @@ class LiseurSyncPositionSync(
             LiseurSyncHttp.TOO_LARGE,
             LiseurSyncHttp.UNPROCESSABLE,
         )
+
+        /**
+         * The answers to a positions batch that say something about the
+         * batch or one op in it rather than about the credential or the
+         * server. A body over the byte bound is a 413 with no code, so
+         * it has to be expected as well as the named 400s.
+         */
+        val PUSH_REFUSALS = setOf(
+            LiseurSyncHttp.BAD_REQUEST,
+            LiseurSyncHttp.TOO_LARGE,
+        )
+
+        /**
+         * The most requests one positions stage makes, for the same
+         * reason as [MAX_SESSION_REQUESTS].
+         */
+        const val MAX_PUSH_REQUESTS = 64
 
         /**
          * Refusal codes the server documents as permanent for that

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncServerSetup.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncServerSetup.kt
@@ -1,6 +1,7 @@
 package com.chmouel.liseur.data.liseursync
 
 import android.util.Log
+import com.chmouel.liseur.data.remote.PriorConnection
 import com.chmouel.liseur.data.remote.RemoteCredentials
 import com.chmouel.liseur.data.remote.RemoteHttpFailure
 import com.chmouel.liseur.data.remote.RemoteUrl
@@ -35,10 +36,32 @@ class LiseurSyncServerSetup(
         rawUrl: String,
         credentials: RemoteCredentials,
         allowHttp: Boolean,
+    ): SetupResult = connect(rawUrl, credentials, allowHttp, prior = null)
+
+    override suspend fun reconnect(
+        rawUrl: String,
+        credentials: RemoteCredentials,
+        allowHttp: Boolean,
+        prior: PriorConnection,
+    ): SetupResult = connect(rawUrl, credentials, allowHttp, prior)
+
+    private suspend fun connect(
+        rawUrl: String,
+        credentials: RemoteCredentials,
+        allowHttp: Boolean,
+        prior: PriorConnection?,
     ): SetupResult = withContext(Dispatchers.IO) {
         attempt(rawUrl, allowHttp) { baseUrl ->
             when (credentials) {
-                is RemoteCredentials.Basic -> signIn(baseUrl, credentials)
+                is RemoteCredentials.Basic -> signIn(
+                    baseUrl,
+                    credentials,
+                    // Only the server that issued a device id is ever
+                    // offered it back; compared after normalisation and
+                    // any drop to plain http, since that is the address
+                    // the mint goes to.
+                    keepDevice = prior?.deviceId?.takeIf { prior.baseUrl == baseUrl },
+                )
                 is RemoteCredentials.Bearer -> introspect(baseUrl, credentials)
                 // liseur-sync has no other way in; an API key is Komga's.
                 else -> throw RemoteHttpFailure(SyncFailure.Malformed)
@@ -53,8 +76,21 @@ class LiseurSyncServerSetup(
      * all it does. Nothing writes to the catalog — books reach the
      * server by being put in a folder it watches (ADR-0017) — so there
      * is no scope here that a server might refuse.
+     *
+     * [keepDevice] is the device id the previous token carried, when
+     * this is the same phone coming back to the same server. The server
+     * compares device ids when it decides whether a replayed op or
+     * session is a duplicate, so a fresh id would turn every record
+     * sent before the credential lapsed into a conflict. A server that
+     * predates the field ignores it and mints a new id; that is noticed
+     * by comparing what came back, and changes nothing else — the ids
+     * this app derives never depended on it.
      */
-    private suspend fun signIn(baseUrl: String, credentials: RemoteCredentials.Basic): ServerCapabilities {
+    private suspend fun signIn(
+        baseUrl: String,
+        credentials: RemoteCredentials.Basic,
+        keepDevice: String? = null,
+    ): ServerCapabilities {
         val login = http.post(
             LiseurSyncApi.url(baseUrl, LiseurSyncApi.LOGIN),
             credentials = null,
@@ -67,15 +103,18 @@ class LiseurSyncServerSetup(
         val session = RemoteCredentials.Bearer(auth)
         val name = deviceName()
 
-        val minted = mint(baseUrl, session, name, LiseurSyncApi.SCOPES_FULL)
+        val minted = mint(baseUrl, session, name, LiseurSyncApi.SCOPES_FULL, keepDevice)
         val token = minted.optString("secret").takeIf { it.isNotEmpty() }
             ?: throw RemoteHttpFailure(SyncFailure.Malformed)
 
         // The token is asked what it holds rather than trusting the mint
         // answer: one code path reads scopes, device and account id, and
         // what the server recorded is what governs.
-        return introspect(baseUrl, RemoteCredentials.Bearer(token))
-            .copy(displayName = credentials.username)
+        val capabilities = introspect(baseUrl, RemoteCredentials.Bearer(token))
+        if (keepDevice != null && capabilities.accountId != keepDevice) {
+            Log.i(TAG, "The server minted a new device id rather than keeping the old one")
+        }
+        return capabilities.copy(displayName = credentials.username)
     }
 
     /**
@@ -118,18 +157,42 @@ class LiseurSyncServerSetup(
         )
     }
 
+    /**
+     * Mints a token, asking for [keepDevice] when there is one.
+     *
+     * The server honours the request when any token of the account,
+     * live or not, carried that id. The one refusal with a name,
+     * `unknown_device`, means the predecessor was deleted outright: the
+     * id is gone for good, so the mint is asked again without it, and
+     * this phone becomes a new device. Any other 400 is what it always
+     * was, a mint that failed.
+     */
     private suspend fun mint(
         baseUrl: String,
         session: RemoteCredentials,
         name: String,
         scopes: List<String>,
-    ): JSONObject = http.post(
-        LiseurSyncApi.url(baseUrl, LiseurSyncApi.TOKENS),
-        session,
-        JSONObject()
+        keepDevice: String? = null,
+    ): JSONObject {
+        val body = JSONObject()
             .put("name", name)
-            .put("scopes", JSONArray().apply { scopes.forEach(::put) }),
-    )
+            .put("scopes", JSONArray().apply { scopes.forEach(::put) })
+        if (keepDevice == null) {
+            return http.post(LiseurSyncApi.url(baseUrl, LiseurSyncApi.TOKENS), session, body)
+        }
+        return try {
+            http.post(
+                LiseurSyncApi.url(baseUrl, LiseurSyncApi.TOKENS),
+                session,
+                body.put("device_id", keepDevice),
+                expected = setOf(LiseurSyncHttp.BAD_REQUEST),
+            )
+        } catch (rejection: LiseurSyncRejection) {
+            if (rejection.errorCode != LiseurSyncRejection.UNKNOWN_DEVICE) throw rejection
+            Log.i(TAG, "The server no longer knows this device id; minting as a new device")
+            mint(baseUrl, session, name, scopes)
+        }
+    }
 
     private fun scopesOf(array: JSONArray?): Set<String> =
         (0 until (array?.length() ?: 0)).mapNotNull { array?.optString(it) }.toSet()

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepository.kt
@@ -546,6 +546,16 @@ class RemoteAccountRepository(
         // and neither must read as a different account.
         val stableIdentity = stored?.kind == ServerKind.LISEUR_SYNC &&
             stored.liseurAccountId != null && capabilities.liseurAccountId != null
+        // A liseur-sync password names the account itself, so the same
+        // login to the same server is the same account whatever device
+        // id the mint came back with. The device id only stands in for
+        // an account a pasted token cannot name, and it changes for
+        // honest reasons: a server that has forgotten the previous one,
+        // or one too old to be offered it at all. Reading that as a
+        // stranger threw away the cursor and the book names of someone
+        // who did nothing but sign in again.
+        val namedByLogin = kind == ServerKind.LISEUR_SYNC &&
+            credentials is RemoteCredentials.Basic
         val sameAccount = stored != null &&
             stored.kind == kind &&
             stored.baseUrl == capabilities.baseUrl &&
@@ -555,7 +565,11 @@ class RemoteAccountRepository(
                 stored.username == username &&
                     (stored.userId == capabilities.calibreUserId ||
                         capabilities.calibreUserId == null) &&
-                    (stored.accountId == capabilities.accountId || capabilities.accountId == null)
+                    (
+                        namedByLogin ||
+                            stored.accountId == capabilities.accountId ||
+                            capabilities.accountId == null
+                        )
             }
         val existing = stored?.takeIf { sameAccount }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepository.kt
@@ -8,6 +8,7 @@ import com.chmouel.liseur.data.db.AnnotationSyncDao
 import com.chmouel.liseur.data.db.UploadRefusalDao
 import com.chmouel.liseur.data.db.BookDao
 import com.chmouel.liseur.data.db.SeriesExtraDao
+import com.chmouel.liseur.data.db.SessionRefusalDao
 import com.chmouel.liseur.data.db.ReadingProgressDao
 import com.chmouel.liseur.data.db.ReadingSessionDao
 import com.chmouel.liseur.data.db.RemoteServer
@@ -66,6 +67,12 @@ class RemoteAccountRepository(
      * reader who has just switched accounts should be offered it.
      */
     private val uploadRefusalDao: UploadRefusalDao? = null,
+    /**
+     * Sittings a server said it would never take (one server's verdict,
+     * so it goes with the account). Null in tests that do not exercise a
+     * liseur-sync account.
+     */
+    private val sessionRefusalDao: SessionRefusalDao? = null,
     /**
      * The KOReader pairing, which a connection may drop, replace or
      * leave alone.
@@ -629,7 +636,8 @@ class RemoteAccountRepository(
         if (existing.kind != ServerKind.LISEUR_SYNC || from == to) return next
         val occupied = (peerStateDao?.countForPeer(to) ?: 0) +
             (identityDao?.countForPeer(to) ?: 0) +
-            (annotationSyncDao?.countForPeer(to) ?: 0)
+            (annotationSyncDao?.countForPeer(to) ?: 0) +
+            (sessionRefusalDao?.countForPeer(to) ?: 0)
         if (occupied > 0) {
             Log.w(TAG, "Not moving sync state to a key that already has $occupied rows; keeping the old key")
             return next.copy(liseurAccountId = existing.liseurAccountId)
@@ -638,6 +646,7 @@ class RemoteAccountRepository(
         identityDao?.rekeyPeer(from, to)
         annotationSyncDao?.rekeyPeer(from, to)
         uploadRefusalDao?.rekeyAccount(from, to)
+        sessionRefusalDao?.rekeyPeer(from, to)
         progressDao.rekeyAccount(from, to)
         return next
     }
@@ -770,6 +779,7 @@ class RemoteAccountRepository(
         annotationSyncDao?.forgetPeer(server.accountKey)
         dao.setAnnotationCursor(0)
         sessionDao?.forgetUploads()
+        sessionRefusalDao?.clearPeer(server.accountKey)
     }
 
     private companion object {

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepository.kt
@@ -1,5 +1,6 @@
 package com.chmouel.liseur.data.remote
 
+import android.util.Log
 import com.chmouel.liseur.data.calibre.CalibreParsing
 import com.chmouel.liseur.data.calibre.CalibreSetupClient
 import com.chmouel.liseur.data.calibre.CredentialCipher
@@ -461,7 +462,16 @@ class RemoteAccountRepository(
         allowHttp: Boolean,
     ): SetupResult {
         val setup = setups[kind] ?: return SetupResult.Failure(SetupFailure.WrongServer)
-        val result = setup.connect(url, credentials, allowHttp)
+        // What the stored account of the same kind knew about itself.
+        // Whether the address is the same is the setup's call: it is
+        // the one that normalises the typed URL.
+        val prior = dao.get()?.takeIf { it.kind == kind }
+            ?.let { PriorConnection(baseUrl = it.baseUrl, deviceId = it.liseurDeviceId) }
+        val result = if (prior != null) {
+            setup.reconnect(url, credentials, allowHttp, prior)
+        } else {
+            setup.connect(url, credentials, allowHttp)
+        }
         if (result is SetupResult.Success) store(kind, credentials, result.capabilities)
         return result
     }
@@ -591,8 +601,45 @@ class RemoteAccountRepository(
                 annotationCursorSeq = existing?.annotationCursorSeq ?: 0,
                 liseurAccountId = capabilities.liseurAccountId
                     ?: existing?.liseurAccountId,
-            ),
+            ).let { next -> if (existing != null) carryPeerState(existing, next) else next },
         )
+    }
+
+    /**
+     * Moves what the same account had agreed under its previous key to
+     * the key it will have from now on, or keeps the previous key.
+     *
+     * A liseur-sync account's key changes once: the first time a server
+     * that reports the stable account id is reconnected to, when the
+     * spelling stops being the device id. Every per-peer table is keyed
+     * by that string, and leaving the rows under the old one would
+     * strand the baselines, the work names, the cursor's meaning and
+     * every unsent annotation — the same loss as an account switch, for
+     * a reader who did nothing but reconnect.
+     *
+     * The new key has never been written, so nothing should be under it.
+     * If something is, the move is not made: the row is stored so that
+     * it keeps producing the old key, everything stays where it was and
+     * the next connect tries again. Guessing which of two rows to keep
+     * would be guessing about a reader's unsent position.
+     */
+    private suspend fun carryPeerState(existing: RemoteServer, next: RemoteServer): RemoteServer {
+        val from = existing.accountKey
+        val to = next.accountKey
+        if (existing.kind != ServerKind.LISEUR_SYNC || from == to) return next
+        val occupied = (peerStateDao?.countForPeer(to) ?: 0) +
+            (identityDao?.countForPeer(to) ?: 0) +
+            (annotationSyncDao?.countForPeer(to) ?: 0)
+        if (occupied > 0) {
+            Log.w(TAG, "Not moving sync state to a key that already has $occupied rows; keeping the old key")
+            return next.copy(liseurAccountId = existing.liseurAccountId)
+        }
+        peerStateDao?.rekeyPeer(from, to)
+        identityDao?.rekeyPeer(from, to)
+        annotationSyncDao?.rekeyPeer(from, to)
+        uploadRefusalDao?.rekeyAccount(from, to)
+        progressDao.rekeyAccount(from, to)
+        return next
     }
 
     /**
@@ -726,6 +773,8 @@ class RemoteAccountRepository(
     }
 
     private companion object {
+        const val TAG = "remote-account"
+
         /**
          * How many times a cold read will retry when the account changes
          * underneath it. A handful, because a change that keeps landing

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepository.kt
@@ -548,10 +548,7 @@ class RemoteAccountRepository(
             stored.liseurAccountId != null && capabilities.liseurAccountId != null
         // A liseur-sync password names the account itself, so the same
         // login to the same server is the same account whatever device
-        // id the mint came back with. The device id only stands in for
-        // an account a pasted token cannot name, and it changes for
-        // honest reasons: a server that has forgotten the previous one,
-        // or one too old to be offered it at all. Reading that as a
+        // id the mint came back with. Reading a changed one as a
         // stranger threw away the cursor and the book names of someone
         // who did nothing but sign in again.
         val namedByLogin = kind == ServerKind.LISEUR_SYNC &&
@@ -562,14 +559,17 @@ class RemoteAccountRepository(
             if (stableIdentity) {
                 stored.liseurAccountId == capabilities.liseurAccountId
             } else {
+                // The device id is only a stand-in for an account the
+                // credential cannot name, and it changes for honest
+                // reasons: a server that has forgotten the one it
+                // issued, or one too old to be offered it back.
+                val sameDevice = namedByLogin ||
+                    capabilities.accountId == null ||
+                    stored.accountId == capabilities.accountId
                 stored.username == username &&
                     (stored.userId == capabilities.calibreUserId ||
                         capabilities.calibreUserId == null) &&
-                    (
-                        namedByLogin ||
-                            stored.accountId == capabilities.accountId ||
-                            capabilities.accountId == null
-                        )
+                    sameDevice
             }
         val existing = stored?.takeIf { sameAccount }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteSources.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteSources.kt
@@ -222,7 +222,34 @@ interface ServerSetup {
         credentials: RemoteCredentials,
         allowHttp: Boolean = false,
     ): SetupResult
+
+    /**
+     * [connect], told what the last connection to a server of this kind
+     * knew about itself.
+     *
+     * Most kinds have nothing to do with it. liseur-sync uses the device
+     * id: a token minted while reconnecting asks the server to keep it,
+     * so the phone stays one device in the op log and a position or
+     * sitting it sent before its credential lapsed is recognised as a
+     * replay rather than refused as a conflict.
+     */
+    suspend fun reconnect(
+        rawUrl: String,
+        credentials: RemoteCredentials,
+        allowHttp: Boolean,
+        prior: PriorConnection,
+    ): SetupResult = connect(rawUrl, credentials, allowHttp)
 }
+
+/**
+ * What the stored account remembered about the server it is being
+ * reconnected to. [deviceId] is offered back only to [baseUrl]: a device
+ * id is a label in one server's op log and means nothing to another.
+ */
+data class PriorConnection(
+    val baseUrl: String,
+    val deviceId: String?,
+)
 
 /** How deleting a book from the server went. */
 sealed interface ServerDeleteResult {

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
@@ -1013,6 +1013,6 @@ class MigrationTest {
         const val TEST_DB = "migration-test.db"
 
         /** Kept in step with the `version` on [LiseurDatabase]. */
-        const val LATEST = 46
+        const val LATEST = 47
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
@@ -782,6 +782,37 @@ class LiseurSyncPositionSyncTest {
     }
 
     @Test
+    fun `a sitting refused for a reason this app does not know stays pending`() = runTest {
+        // Naming the item is not proof it is at fault. A code this app
+        // has never seen may well be temporary, so the sitting is left
+        // where it is rather than set aside for good.
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        val good = closedSession(from = 0.1, to = 0.4)
+        val named = closedSession(from = 0.4, to = 0.5)
+        val namedWire = SessionUploads.sessionIdFor("device-a", named)
+        server.enqueue(json("""{"ops":[]}"""))
+        server.enqueue(
+            MockResponse(
+                code = 400,
+                body = """{"error":"session $namedWire: the shelf is full for now",
+                    "code":"quota_exhausted","session_id":"$namedWire","item_index":1}
+                """.trimIndent(),
+            ),
+        )
+
+        val outcome = sync().syncAll(null)
+
+        // Nothing sent, nothing set aside, and said so.
+        assertEquals(1, requests().count { it.target.startsWith("/v1/sessions") })
+        assertTrue(db.sessionRefusalDao().forPeer(peer()).isEmpty())
+        assertNull(db.readingSessionDao().get(good)?.uploadedAt)
+        assertNull(db.readingSessionDao().get(named)?.uploadedAt)
+        assertTrue(outcome !is SyncOutcome.Success)
+    }
+
+    @Test
     fun `a refusal that names no item is bisected down to the one it means`() = runTest {
         // An older server refuses in prose. Bisecting finds the sitting
         // without ever marking a good one as sent.
@@ -1002,6 +1033,90 @@ class LiseurSyncPositionSyncTest {
         // Same id: the refused batch was never stored, so it is free.
         assertEquals(opId, retried.getString("op_id"))
         assertEquals(1L, db.syncPeerStateDao().get(LOCAL, peer())?.ackedRevision)
+    }
+
+    @Test
+    fun `a positions batch the server will not take whole is cut up`() = runTest {
+        // The server's item limit is configurable and may sit below the
+        // 500 this app sends. Before, the identical batch went again
+        // every run and neither position ever landed.
+        connect()
+        db.bookDao().upsert(local())
+        db.bookDao().upsert(local().copy(url = LOCAL2, lastOpenedAt = NOW - 1))
+        alias()
+        alias(workId = "w-2", bookUrl = LOCAL2)
+        db.readingProgressDao().recordLocal(LOCAL, LOCATOR, 0.4, null, "reading", NOW)
+        db.readingProgressDao().recordLocal(LOCAL2, LOCATOR, 0.5, null, "reading", NOW)
+        server.enqueue(json("""{"ops":[]}"""))
+        server.enqueue(
+            MockResponse(
+                code = 400,
+                body = """{"error":"batch too large","code":"batch_too_large","limit":1}""",
+            ),
+        )
+        // Named for both works, so the answer fits whichever op the
+        // cut-up batch sends first.
+        val both = json(
+            """{"results":[
+                {"op_id":"${SyncOps.opIdFor("device-a", "w-1", 1)}","status":"applied"},
+                {"op_id":"${SyncOps.opIdFor("device-a", "w-2", 1)}","status":"applied"}]}
+            """.trimIndent(),
+        )
+        server.enqueue(both)
+        server.enqueue(both)
+
+        assertEquals(SyncOutcome.Success, sync().syncAll(null))
+
+        val pushes = requests().filter { it.target.startsWith("/v1/ops") }
+        assertEquals(3, pushes.size)
+        assertEquals(2, JSONObject(pushes[0].body!!.utf8()).getJSONArray("ops").length())
+        assertEquals(1, JSONObject(pushes[1].body!!.utf8()).getJSONArray("ops").length())
+        assertEquals(1, JSONObject(pushes[2].body!!.utf8()).getJSONArray("ops").length())
+        assertEquals(1L, db.syncPeerStateDao().get(LOCAL, peer())?.ackedRevision)
+        assertEquals(1L, db.syncPeerStateDao().get(LOCAL2, peer())?.ackedRevision)
+    }
+
+    @Test
+    fun `a lone position too big for the server goes without its locator`() = runTest {
+        // A body past the byte bound is a 413 with no code to it. The
+        // locator is the only part of an op with any size, so it is
+        // what goes.
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        db.readingProgressDao().recordLocal(LOCAL, LOCATOR, 0.4, null, "reading", NOW)
+        val opId = SyncOps.opIdFor("device-a", "w-1", 1)
+        server.enqueue(json("""{"ops":[]}"""))
+        server.enqueue(MockResponse(code = 413, body = """{"error":"request body too large"}"""))
+        accepted()
+
+        assertEquals(SyncOutcome.Success, sync().syncAll(null))
+
+        val pushes = requests().filter { it.target.startsWith("/v1/ops") }
+        assertEquals(2, pushes.size)
+        val retried = JSONObject(pushes[1].body!!.utf8()).getJSONArray("ops").getJSONObject(0)
+        assertFalse(retried.has("locator"))
+        assertEquals(opId, retried.getString("op_id"))
+        assertEquals(1L, db.syncPeerStateDao().get(LOCAL, peer())?.ackedRevision)
+    }
+
+    @Test
+    fun `a position refused even bare is reported rather than asked for ever`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        db.readingProgressDao().recordLocal(LOCAL, LOCATOR, 0.4, null, "reading", NOW)
+        server.enqueue(json("""{"ops":[]}"""))
+        val tooBig = MockResponse(code = 413, body = """{"error":"request body too large"}""")
+        server.enqueue(tooBig) // with its locator
+        server.enqueue(tooBig) // and without
+
+        assertTrue(sync().syncAll(null) !is SyncOutcome.Success)
+
+        // It stops there rather than going round again: nothing else in
+        // an op can be made smaller.
+        assertEquals(2, requests().count { it.target.startsWith("/v1/ops") })
+        assertNull(db.syncPeerStateDao().get(LOCAL, peer())?.takeIf { it.ackedRevision > 0 })
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
@@ -411,8 +411,13 @@ class LiseurSyncPositionSyncTest {
         sync().syncAll(null)
 
         // Retrying forever would park it at the head of the queue and
-        // stop every later session behind it.
-        assertNotNull(db.readingSessionDao().get(session)?.uploadedAt)
+        // stop every later session behind it. But it was not sent, so it
+        // is not marked as sent: it is set aside for this server.
+        assertNull(db.readingSessionDao().get(session)?.uploadedAt)
+        assertEquals(listOf(session), db.sessionRefusalDao().forPeer(peer()).map { it.sessionId })
+        server.enqueue(json("""{"ops":[]}"""))
+        sync().syncAll(null)
+        assertEquals(1, requests().count { it.target.startsWith("/v1/sessions") })
     }
 
     @Test
@@ -731,6 +736,138 @@ class LiseurSyncPositionSyncTest {
     }
 
     @Test
+    fun `a refused sitting is set aside by name and the rest still go`() = runTest {
+        // The regression: a 409 for one session used to mark the whole
+        // batch as sent, and the other sittings were never heard of again.
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        val good = closedSession(from = 0.1, to = 0.4)
+        val bad = closedSession(from = 0.4, to = 0.5)
+        val other = closedSession(from = 0.5, to = 0.6)
+        val badWire = SessionUploads.sessionIdFor("device-a", bad)
+        server.enqueue(json("""{"ops":[]}"""))
+        server.enqueue(
+            MockResponse(
+                code = 409,
+                body = """{"error":"session $badWire: session_id reused with a different payload",
+                    "code":"id_reused","session_id":"$badWire","item_index":1}
+                """.trimIndent(),
+            ),
+        )
+        server.enqueue(json("""{"accepted":2}"""))
+
+        val outcome = sync().syncAll(null)
+
+        val sent = requests().filter { it.target.startsWith("/v1/sessions") }
+        assertEquals(2, sent.size)
+        val retried = JSONObject(sent[1].body!!.utf8()).getJSONArray("sessions")
+        assertEquals(2, retried.length())
+        assertNotNull(db.readingSessionDao().get(good)?.uploadedAt)
+        assertNotNull(db.readingSessionDao().get(other)?.uploadedAt)
+        // Not sent, not pretended to be: set aside for this server only.
+        assertNull(db.readingSessionDao().get(bad)?.uploadedAt)
+        val refusals = db.sessionRefusalDao().forPeer(peer())
+        assertEquals(listOf(bad), refusals.map { it.sessionId })
+        assertEquals("id_reused", refusals.single().code)
+        // Reported, not swallowed.
+        assertTrue(outcome !is SyncOutcome.Success)
+
+        // The next run does not offer it again.
+        server.enqueue(json("""{"ops":[]}"""))
+        sync().syncAll(null)
+        assertEquals(2, requests().count { it.target.startsWith("/v1/sessions") })
+    }
+
+    @Test
+    fun `a refusal that names no item is bisected down to the one it means`() = runTest {
+        // An older server refuses in prose. Bisecting finds the sitting
+        // without ever marking a good one as sent.
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        val a = closedSession(from = 0.1, to = 0.2)
+        val b = closedSession(from = 0.2, to = 0.3)
+        val c = closedSession(from = 0.3, to = 0.4)
+        server.enqueue(json("""{"ops":[]}"""))
+        val prose = MockResponse(code = 400, body = """{"error":"session b: idle_ms out of range"}""")
+        server.enqueue(prose) // [a, b, c]
+        server.enqueue(json("""{"accepted":1}""")) // [a]
+        server.enqueue(prose) // [b, c]
+        server.enqueue(prose) // [b]
+        server.enqueue(json("""{"accepted":1}""")) // [c]
+
+        sync().syncAll(null)
+
+        assertNotNull(db.readingSessionDao().get(a)?.uploadedAt)
+        assertNull(db.readingSessionDao().get(b)?.uploadedAt)
+        assertNotNull(db.readingSessionDao().get(c)?.uploadedAt)
+        assertEquals(listOf(b), db.sessionRefusalDao().forPeer(peer()).map { it.sessionId })
+    }
+
+    @Test
+    fun `a body too big is halved rather than refused`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        val a = closedSession(from = 0.1, to = 0.2)
+        val b = closedSession(from = 0.2, to = 0.3)
+        server.enqueue(json("""{"ops":[]}"""))
+        server.enqueue(MockResponse(code = 413, body = """{"error":"request body too large"}"""))
+        server.enqueue(json("""{"accepted":1}"""))
+        server.enqueue(json("""{"accepted":1}"""))
+
+        assertEquals(SyncOutcome.Success, sync().syncAll(null))
+
+        assertNotNull(db.readingSessionDao().get(a)?.uploadedAt)
+        assertNotNull(db.readingSessionDao().get(b)?.uploadedAt)
+        assertTrue(db.sessionRefusalDao().forPeer(peer()).isEmpty())
+    }
+
+    @Test
+    fun `a code this app does not know leaves the sitting pending`() = runTest {
+        // Not proof the sitting is at fault; reported, kept, tried again.
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        val a = closedSession(from = 0.1, to = 0.2)
+        server.enqueue(json("""{"ops":[]}"""))
+        server.enqueue(
+            MockResponse(code = 400, body = """{"error":"something new","code":"a_rule_from_the_future"}"""),
+        )
+
+        val outcome = sync().syncAll(null)
+
+        assertNull(db.readingSessionDao().get(a)?.uploadedAt)
+        assertTrue(db.sessionRefusalDao().forPeer(peer()).isEmpty())
+        assertTrue(outcome !is SyncOutcome.Success)
+    }
+
+    @Test
+    fun `unnamed books do not stand in front of sittings that can be sent`() = runTest {
+        // The head-of-line block: a thousand old sittings of a book the
+        // server has no name for used to fill the window and hide newer
+        // ones behind them.
+        connect()
+        db.bookDao().upsert(local())
+        db.bookDao().upsert(local().copy(url = LOCAL2, title = "Unnamed"))
+        alias()
+        repeat(SessionUploads.MAX_BATCH) { closedSession(from = 0.1, to = 0.2, bookUrl = LOCAL2) }
+        val sendable = closedSession(from = 0.3, to = 0.4)
+        // The server can only guess at the other book, so it has no
+        // usable name here and its sittings wait.
+        server.enqueue(json("""{"work_id":"w-2","confidence":"low","created":false}"""))
+        server.enqueue(json("""{"ops":[]}"""))
+        server.enqueue(json("""{"accepted":1}"""))
+
+        assertEquals(SyncOutcome.Success, sync().syncAll(null))
+
+        assertNotNull(db.readingSessionDao().get(sendable)?.uploadedAt)
+        val sent = requests().filter { it.target.startsWith("/v1/sessions") }
+        assertEquals(1, JSONObject(sent.single().body!!.utf8()).getJSONArray("sessions").length())
+    }
+
+    @Test
     fun `two stale books in one batch recover one at a time`() = runTest {
         connect()
         db.bookDao().upsert(local())
@@ -1007,6 +1144,7 @@ class LiseurSyncPositionSyncTest {
             peerStateDao = db.syncPeerStateDao(),
             identityDao = db.workIdentityDao(),
             sessionDao = db.readingSessionDao(),
+            sessionRefusalDao = db.sessionRefusalDao(),
             works = WorkResolver(
                 dao = db.workIdentityDao(),
                 fingerprints = BookFingerprintStore(context, db.workIdentityDao()) { NOW },
@@ -1092,6 +1230,7 @@ class LiseurSyncPositionSyncTest {
         deviceId: String? = null,
         bookUrl: String = LOCAL,
         editionSha: String? = null,
+        confirmed: Boolean = true,
     ) =
         db.workIdentityDao().upsert(
             com.chmouel.liseur.data.db.WorkAlias(
@@ -1099,7 +1238,7 @@ class LiseurSyncPositionSyncTest {
                 peerId = peer(deviceId),
                 workId = workId,
                 confidence = confidence,
-                confirmed = true,
+                confirmed = confirmed,
                 seeded = seeded,
                 editionSha = editionSha,
                 resolvedAt = NOW,
@@ -1153,11 +1292,11 @@ class LiseurSyncPositionSyncTest {
 
     private val seen = mutableListOf<RecordedRequest>()
 
-    private suspend fun closedSession(from: Double, to: Double): Long {
+    private suspend fun closedSession(from: Double, to: Double, bookUrl: String = LOCAL): Long {
         val dao = db.readingSessionDao()
         val id = dao.insert(
             com.chmouel.liseur.data.db.ReadingSession(
-                bookUrl = LOCAL,
+                bookUrl = bookUrl,
                 startedAt = NOW,
                 lastCheckpointAt = NOW,
             ),

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
@@ -1120,6 +1120,23 @@ class LiseurSyncPositionSyncTest {
     }
 
     @Test
+    fun `an answer that names no position settles none`() = runTest {
+        // Every result the server sends names its op. One that does not
+        // cannot be placed, so the position stays pending and goes
+        // again rather than being written off as accepted.
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        db.readingProgressDao().recordLocal(LOCAL, LOCATOR, 0.4, null, "reading", NOW)
+        server.enqueue(json("""{"ops":[]}"""))
+        server.enqueue(json("""{"results":[{"status":"applied"}]}"""))
+
+        sync().syncAll(null)
+
+        assertEquals(null, db.syncPeerStateDao().get(LOCAL, peer())?.ackedRevision)
+    }
+
+    @Test
     fun `a lone position too big for the server goes without its locator`() = runTest {
         // A body past the byte bound is a 413 with no code to it. The
         // locator is the only part of an op with any size, so it is

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
@@ -1047,33 +1047,76 @@ class LiseurSyncPositionSyncTest {
         alias(workId = "w-2", bookUrl = LOCAL2)
         db.readingProgressDao().recordLocal(LOCAL, LOCATOR, 0.4, null, "reading", NOW)
         db.readingProgressDao().recordLocal(LOCAL2, LOCATOR, 0.5, null, "reading", NOW)
-        server.enqueue(json("""{"ops":[]}"""))
-        server.enqueue(
-            MockResponse(
-                code = 400,
-                body = """{"error":"batch too large","code":"batch_too_large","limit":1}""",
-            ),
-        )
-        // Named for both works, so the answer fits whichever op the
-        // cut-up batch sends first.
-        val both = json(
-            """{"results":[
-                {"op_id":"${SyncOps.opIdFor("device-a", "w-1", 1)}","status":"applied"},
-                {"op_id":"${SyncOps.opIdFor("device-a", "w-2", 1)}","status":"applied"}]}
-            """.trimIndent(),
-        )
-        server.enqueue(both)
-        server.enqueue(both)
+        var pushes = 0
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                if (!request.target.startsWith("/v1/ops")) return json("""{"ops":[]}""")
+                if (++pushes == 1) {
+                    return MockResponse(
+                        code = 400,
+                        body = """{"error":"batch too large","code":"batch_too_large","limit":1}""",
+                    )
+                }
+                return applied(request)
+            }
+        }
 
         assertEquals(SyncOutcome.Success, sync().syncAll(null))
 
-        val pushes = requests().filter { it.target.startsWith("/v1/ops") }
-        assertEquals(3, pushes.size)
-        assertEquals(2, JSONObject(pushes[0].body!!.utf8()).getJSONArray("ops").length())
-        assertEquals(1, JSONObject(pushes[1].body!!.utf8()).getJSONArray("ops").length())
-        assertEquals(1, JSONObject(pushes[2].body!!.utf8()).getJSONArray("ops").length())
+        val sent = requests().filter { it.target.startsWith("/v1/ops") }
+        assertEquals(3, sent.size)
+        assertEquals(2, JSONObject(sent[0].body!!.utf8()).getJSONArray("ops").length())
+        assertEquals(1, JSONObject(sent[1].body!!.utf8()).getJSONArray("ops").length())
+        assertEquals(1, JSONObject(sent[2].body!!.utf8()).getJSONArray("ops").length())
         assertEquals(1L, db.syncPeerStateDao().get(LOCAL, peer())?.ackedRevision)
         assertEquals(1L, db.syncPeerStateDao().get(LOCAL2, peer())?.ackedRevision)
+    }
+
+    @Test
+    fun `two copies of one book take their own answers, not each other's`() = runTest {
+        // Both copies are the same work at the same revision, so they
+        // derive the same op id. The server answers by position: the
+        // first is stored and the second, carrying a different place,
+        // is a conflict. Reading the answers by id gave both of them
+        // whichever came last.
+        connect()
+        db.bookDao().upsert(local())
+        db.bookDao().upsert(local().copy(url = LOCAL2, lastOpenedAt = NOW - 1))
+        alias()
+        alias(bookUrl = LOCAL2)
+        db.readingProgressDao().recordLocal(LOCAL, LOCATOR, 0.4, null, "reading", NOW)
+        db.readingProgressDao().recordLocal(LOCAL2, LOCATOR, 0.5, null, "reading", NOW)
+        val opId = SyncOps.opIdFor("device-a", "w-1", 1)
+        server.enqueue(json("""{"ops":[]}"""))
+        server.enqueue(
+            json(
+                """{"results":[
+                    {"op_id":"$opId","status":"applied"},
+                    {"op_id":"$opId","status":"conflict"}]}
+                """.trimIndent(),
+            ),
+        )
+
+        val outcome = sync().syncAll(null)
+
+        val ops = JSONObject(
+            requests().first { it.target.startsWith("/v1/ops") }.body!!.utf8(),
+        ).getJSONArray("ops")
+        assertEquals(2, ops.length())
+        // The premise: one work, one revision, so one op id for both.
+        assertEquals(opId, ops.getJSONObject(0).getString("op_id"))
+        assertEquals(opId, ops.getJSONObject(1).getString("op_id"))
+        // The copy the server took is settled and keeps its revision;
+        // the refused one is renamed so it can go again, and neither
+        // took the other's answer.
+        val settled = listOf(LOCAL, LOCAL2).filter {
+            db.syncPeerStateDao().get(it, peer())?.ackedRevision == 1L
+        }
+        assertEquals(1, settled.size)
+        val refused = listOf(LOCAL, LOCAL2).single { it !in settled }
+        assertEquals(2L, db.readingProgressDao().currentRevision(refused))
+        assertEquals(1L, db.readingProgressDao().currentRevision(settled.single()))
+        assertTrue(outcome !is SyncOutcome.Success)
     }
 
     @Test
@@ -1419,6 +1462,15 @@ class LiseurSyncPositionSyncTest {
 
     /** The one-off "where does this book stand" for a fresh name. */
     private fun seeded() = server.enqueue(json("""{"ops":[]}"""))
+
+    /** The server takes every op of the request, naming each back. */
+    private fun applied(request: RecordedRequest): MockResponse {
+        val ops = JSONObject(request.body!!.utf8()).getJSONArray("ops")
+        val results = (0 until ops.length()).joinToString(",") {
+            """{"op_id":"${ops.getJSONObject(it).getString("op_id")}","status":"applied"}"""
+        }
+        return json("""{"results":[$results]}""")
+    }
 
     /** The server takes the op — naming it back, as it must. */
     private fun accepted(workId: String = "w-1", revision: Long = 1) = server.enqueue(

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
@@ -18,6 +18,8 @@ import java.io.File
 import java.net.InetAddress
 import javax.crypto.KeyGenerator
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.runBlocking
+import mockwebserver3.Dispatcher
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import mockwebserver3.RecordedRequest
@@ -969,6 +971,95 @@ class LiseurSyncPositionSyncTest {
         assertTrue(outcome is SyncOutcome.Failure)
         assertEquals("w-old", db.workIdentityDao().alias(LOCAL, peer())?.workId)
         assertEquals(0, requests().count { it.target.startsWith("/v1/works/resolve") })
+    }
+
+    @Test
+    fun `a locator the server will not take is dropped and the position sent alone`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        db.readingProgressDao().recordLocal(LOCAL, LOCATOR, 0.4, null, "reading", NOW)
+        val opId = SyncOps.opIdFor("device-a", "w-1", 1)
+        server.enqueue(json("""{"ops":[]}"""))
+        server.enqueue(
+            MockResponse(
+                code = 400,
+                body = """{"error":"op $opId: locator too large","code":"locator_too_large",
+                    "op_id":"$opId","item_index":0,"limit":4096}
+                """.trimIndent(),
+            ),
+        )
+        accepted()
+
+        assertEquals(SyncOutcome.Success, sync().syncAll(null))
+
+        val pushes = requests().filter { it.target.startsWith("/v1/ops") }
+        assertEquals(2, pushes.size)
+        val first = JSONObject(pushes[0].body!!.utf8()).getJSONArray("ops").getJSONObject(0)
+        val retried = JSONObject(pushes[1].body!!.utf8()).getJSONArray("ops").getJSONObject(0)
+        assertTrue(first.has("locator"))
+        assertFalse(retried.has("locator"))
+        // Same id: the refused batch was never stored, so it is free.
+        assertEquals(opId, retried.getString("op_id"))
+        assertEquals(1L, db.syncPeerStateDao().get(LOCAL, peer())?.ackedRevision)
+    }
+
+    @Test
+    fun `a conflict renames the position so the next run can get through`() = runTest {
+        // The server holds this id from a credential since replaced. The
+        // same id will be refused for ever; a fresh revision derives a
+        // fresh one for the same reading.
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        db.readingProgressDao().recordLocal(LOCAL, LOCATOR, 0.4, null, "reading", NOW)
+        val opId = SyncOps.opIdFor("device-a", "w-1", 1)
+        server.enqueue(json("""{"ops":[]}"""))
+        server.enqueue(
+            json("""{"results":[{"op_id":"$opId","status":"conflict","reason":"op_id reused with a different payload"}]}"""),
+        )
+
+        val outcome = sync().syncAll(null)
+
+        // Reported, not swallowed; still dirty, under a new revision.
+        assertTrue(outcome !is SyncOutcome.Success)
+        assertEquals(2L, db.readingProgressDao().currentRevision(LOCAL))
+        assertNull(db.syncPeerStateDao().get(LOCAL, peer())?.takeIf { it.ackedRevision > 0 })
+
+        server.enqueue(json("""{"ops":[]}"""))
+        accepted(revision = 2)
+        assertEquals(SyncOutcome.Success, sync().syncAll(null))
+        val retried = requests().filter { it.target.startsWith("/v1/ops") }[1]
+        val op = JSONObject(retried.body!!.utf8()).getJSONArray("ops").getJSONObject(0)
+        assertEquals(SyncOps.opIdFor("device-a", "w-1", 2), op.getString("op_id"))
+        assertEquals(0.4, op.getDouble("progression"), 0.0)
+        assertEquals(2L, db.syncPeerStateDao().get(LOCAL, peer())?.ackedRevision)
+    }
+
+    @Test
+    fun `a conflict does not touch a revision a page turn already moved`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        db.readingProgressDao().recordLocal(LOCAL, LOCATOR, 0.4, null, "reading", NOW)
+        val opId = SyncOps.opIdFor("device-a", "w-1", 1)
+        server.enqueue(json("""{"ops":[]}"""))
+        server.enqueue(json("""{"results":[{"op_id":"$opId","status":"conflict"}]}"""))
+        // The page turns while the request is in the air.
+        val original = server.dispatcher
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                if (request.target == "/v1/ops") {
+                    runBlocking { db.readingProgressDao().recordLocal(LOCAL, LOCATOR, 0.5, null, "reading", NOW + 1) }
+                }
+                return original.dispatch(request)
+            }
+        }
+
+        sync().syncAll(null)
+
+        // Revision 2 is the page turn's; nothing invented a third.
+        assertEquals(2L, db.readingProgressDao().currentRevision(LOCAL))
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncServerSetupTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncServerSetupTest.kt
@@ -1,5 +1,6 @@
 package com.chmouel.liseur.data.liseursync
 
+import com.chmouel.liseur.data.remote.PriorConnection
 import com.chmouel.liseur.data.remote.RemoteCredentials
 import com.chmouel.liseur.data.remote.SetupFailure
 import com.chmouel.liseur.data.remote.SetupResult
@@ -188,9 +189,85 @@ class LiseurSyncServerSetupTest {
         )
     }
 
+    @Test
+    fun `reconnecting asks the server to keep the device id`() = runTest {
+        server.enqueue(json("""{"auth_token":"hour-token"}"""))
+        server.enqueue(json("""{"token_id":"t-2","device_id":"d-1","scopes":["sync"],"secret":"s-2"}"""))
+        server.enqueue(json("""{"id":"t-2","device_id":"d-1","name":"Test phone","scopes":["sync"],"account_id":"acc-9"}"""))
+
+        val result = reconnect(RemoteCredentials.Basic("ada", "correct"), PriorConnection(base(), "d-1"))
+
+        assertEquals("d-1", (result as SetupResult.Success).capabilities.accountId)
+        server.takeRequest()
+        val minted = JSONObject(server.takeRequest().body!!.utf8())
+        assertEquals("d-1", minted.getString("device_id"))
+        assertEquals(3, server.requestCount)
+    }
+
+    @Test
+    fun `a device id the server no longer knows is dropped and the mint asked again`() = runTest {
+        server.enqueue(json("""{"auth_token":"hour-token"}"""))
+        server.enqueue(
+            MockResponse(
+                code = 400,
+                body = """{"error":"device_id names no device of this account","code":"unknown_device","device_id":"d-old"}""",
+            ),
+        )
+        server.enqueue(json("""{"token_id":"t-2","device_id":"d-new","scopes":["sync"],"secret":"s-2"}"""))
+        server.enqueue(json("""{"id":"t-2","device_id":"d-new","name":"Test phone","scopes":["sync"]}"""))
+
+        val result = reconnect(RemoteCredentials.Basic("ada", "correct"), PriorConnection(base(), "d-old"))
+
+        assertEquals("d-new", (result as SetupResult.Success).capabilities.accountId)
+        server.takeRequest()
+        assertTrue(JSONObject(server.takeRequest().body!!.utf8()).has("device_id"))
+        assertFalse(JSONObject(server.takeRequest().body!!.utf8()).has("device_id"))
+        assertEquals(4, server.requestCount)
+    }
+
+    @Test
+    fun `any other refused mint is not retried`() = runTest {
+        server.enqueue(json("""{"auth_token":"hour-token"}"""))
+        server.enqueue(MockResponse(code = 400, body = """{"error":"name required"}"""))
+
+        val result = reconnect(RemoteCredentials.Basic("ada", "correct"), PriorConnection(base(), "d-1"))
+
+        assertEquals(SetupFailure.WrongServer, (result as SetupResult.Failure).reason)
+        assertEquals(2, server.requestCount)
+    }
+
+    @Test
+    fun `a device id is never offered to a different server`() = runTest {
+        server.enqueue(json("""{"auth_token":"hour-token"}"""))
+        server.enqueue(json("""{"token_id":"t-2","device_id":"d-x","scopes":["sync"],"secret":"s-2"}"""))
+        server.enqueue(json("""{"id":"t-2","device_id":"d-x","name":"Test phone","scopes":["sync"]}"""))
+
+        reconnect(RemoteCredentials.Basic("ada", "correct"), PriorConnection("https://elsewhere.example", "d-1"))
+
+        server.takeRequest()
+        assertFalse(JSONObject(server.takeRequest().body!!.utf8()).has("device_id"))
+    }
+
+    @Test
+    fun `an older server that ignores the field is simply a new device`() = runTest {
+        server.enqueue(json("""{"auth_token":"hour-token"}"""))
+        server.enqueue(json("""{"token_id":"t-2","device_id":"d-fresh","scopes":["sync"],"secret":"s-2"}"""))
+        server.enqueue(json("""{"id":"t-2","device_id":"d-fresh","name":"Test phone","scopes":["sync"]}"""))
+
+        val result = reconnect(RemoteCredentials.Basic("ada", "correct"), PriorConnection(base(), "d-1"))
+
+        assertEquals("d-fresh", (result as SetupResult.Success).capabilities.accountId)
+    }
+
+    private fun base() = "http://127.0.0.1:${server.port}"
+
     private suspend fun connect(credentials: RemoteCredentials): SetupResult =
         LiseurSyncServerSetup(deviceName = { "Test phone" })
-            .connect("http://127.0.0.1:${server.port}", credentials, allowHttp = false)
+            .connect(base(), credentials, allowHttp = false)
+
+    private suspend fun reconnect(credentials: RemoteCredentials, prior: PriorConnection): SetupResult =
+        LiseurSyncServerSetup(deviceName = { "Test phone" })
+            .reconnect(base(), credentials, allowHttp = false, prior = prior)
 
     private fun json(body: String) = MockResponse(code = 200, body = body)
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepositoryTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepositoryTest.kt
@@ -453,7 +453,7 @@ class RemoteAccountRepositoryTest {
      * next ones add `account_id`. Reconnecting keeps the device id when
      * the repository offers it back, as a real server does.
      */
-    private class UpgradingLiseurSync : ServerSetup {
+    private class UpgradingLiseurSync(private val keepsDevice: Boolean = true) : ServerSetup {
         var connects = 0
         var offered: String? = null
 
@@ -467,7 +467,7 @@ class RemoteAccountRepositoryTest {
             prior: PriorConnection,
         ): SetupResult {
             offered = prior.deviceId
-            return answer(rawUrl, keep = prior.deviceId)
+            return answer(rawUrl, keep = prior.deviceId.takeIf { keepsDevice })
         }
 
         private fun answer(rawUrl: String, keep: String?): SetupResult {
@@ -541,6 +541,35 @@ class RemoteAccountRepositoryTest {
         // From here on the key is stable across token rotations.
         repository.connectLiseurSync(BASE, "ada", "pw")
         assertEquals(newKey, db.remoteServerDao().get()!!.accountKey)
+    }
+
+    @Test
+    fun `signing in again keeps the account when the device id could not be kept`() = runTest {
+        // The server has forgotten the device id it once issued, or is
+        // too old to be offered one, so the mint comes back with a new
+        // one alongside the first stable account id. The reader signed
+        // in as themselves, which names the account on its own; reading
+        // this as a stranger discarded the cursor and the book names.
+        val setup = UpgradingLiseurSync(keepsDevice = false)
+        val repository = fullRepository(db.remoteServerDao(), setup)
+        repository.connectLiseurSync(BASE, "ada", "pw")
+        val oldKey = db.remoteServerDao().get()!!.accountKey
+        assertEquals("liseursync|$BASE|device-1", oldKey)
+        db.remoteServerDao().setSyncCursor(41)
+        db.workIdentityDao().upsert(
+            WorkAlias(
+                bookUrl = "file:///book.epub", peerId = oldKey, workId = "w-1",
+                confidence = "high", resolvedAt = 1,
+            ),
+        )
+
+        repository.connectLiseurSync(BASE, "ada", "pw")
+
+        val stored = db.remoteServerDao().get()!!
+        assertEquals("device-2", stored.accountId)
+        assertEquals("liseursync|$BASE|acc-1", stored.accountKey)
+        assertEquals(41, stored.syncCursorSeq)
+        assertEquals("w-1", db.workIdentityDao().alias("file:///book.epub", stored.accountKey)!!.workId)
     }
 
     private fun fullRepository(dao: RemoteServerDao, liseurSyncSetup: ServerSetup) = RemoteAccountRepository(

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepositoryTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepositoryTest.kt
@@ -6,8 +6,10 @@ import com.chmouel.liseur.data.calibre.CredentialCipher
 import com.chmouel.liseur.data.db.AnnotationSync
 import com.chmouel.liseur.data.db.KosyncPeer
 import com.chmouel.liseur.data.db.LiseurDatabase
+import com.chmouel.liseur.data.db.ReadingSession
 import com.chmouel.liseur.data.db.RemoteServer
 import com.chmouel.liseur.data.db.RemoteServerDao
+import com.chmouel.liseur.data.db.SessionRefusal
 import com.chmouel.liseur.data.db.WorkAlias
 import com.chmouel.liseur.data.kosync.KosyncAccountRepository
 import com.chmouel.liseur.data.kosync.KosyncCredentials
@@ -524,6 +526,18 @@ class RemoteAccountRepositoryTest {
                 pendingKind = "write", pendingJson = """{"id":"a-1"}""",
             ),
         )
+        val sessionId = db.readingSessionDao().insert(
+            ReadingSession(
+                bookUrl = "file:///book.epub", startedAt = 1, endedAt = 2,
+                lastCheckpointAt = 2, durationMs = 1,
+            ),
+        )
+        db.sessionRefusalDao().record(
+            SessionRefusal(
+                peerId = oldKey, sessionId = sessionId, wireSessionId = "s-7",
+                code = "id_reused", refusedAt = 1,
+            ),
+        )
         db.readingProgressDao().markDirtyFor(listOf("file:///book.epub"), oldKey)
 
         repository.connectLiseurSync(BASE, "ada", "pw")
@@ -537,6 +551,10 @@ class RemoteAccountRepositoryTest {
         assertEquals("w-1", db.workIdentityDao().alias("file:///book.epub", newKey)!!.workId)
         assertEquals("""{"id":"a-1"}""", db.annotationSyncDao().get(newKey, "a-1")!!.pendingJson)
         assertEquals(0, db.annotationSyncDao().countForPeer(oldKey))
+        // The sittings this server refused follow too, or it is offered
+        // every one of them again under the new key.
+        assertEquals(listOf("s-7"), db.sessionRefusalDao().forPeer(newKey).map { it.wireSessionId })
+        assertEquals(0, db.sessionRefusalDao().countForPeer(oldKey))
 
         // From here on the key is stable across token rotations.
         repository.connectLiseurSync(BASE, "ada", "pw")
@@ -591,6 +609,7 @@ class RemoteAccountRepositoryTest {
         sessionDao = db.readingSessionDao(),
         annotationSyncDao = db.annotationSyncDao(),
         uploadRefusalDao = db.uploadRefusalDao(),
+        sessionRefusalDao = db.sessionRefusalDao(),
         setups = mapOf(ServerKind.LISEUR_SYNC to liseurSyncSetup),
     )
 

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepositoryTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteAccountRepositoryTest.kt
@@ -3,10 +3,12 @@ package com.chmouel.liseur.data.remote
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import com.chmouel.liseur.data.calibre.CredentialCipher
+import com.chmouel.liseur.data.db.AnnotationSync
 import com.chmouel.liseur.data.db.KosyncPeer
 import com.chmouel.liseur.data.db.LiseurDatabase
 import com.chmouel.liseur.data.db.RemoteServer
 import com.chmouel.liseur.data.db.RemoteServerDao
+import com.chmouel.liseur.data.db.WorkAlias
 import com.chmouel.liseur.data.kosync.KosyncAccountRepository
 import com.chmouel.liseur.data.kosync.KosyncCredentials
 import com.chmouel.liseur.data.library.BookRemoval
@@ -444,6 +446,124 @@ class RemoteAccountRepositoryTest {
         // own log.
         assertEquals(0, db.remoteServerDao().get()!!.syncCursorSeq)
     }
+
+    /**
+     * A liseur-sync server as it stood before and after it learnt to say
+     * who the account is: the first connect reports only a device id, the
+     * next ones add `account_id`. Reconnecting keeps the device id when
+     * the repository offers it back, as a real server does.
+     */
+    private class UpgradingLiseurSync : ServerSetup {
+        var connects = 0
+        var offered: String? = null
+
+        override suspend fun connect(rawUrl: String, credentials: RemoteCredentials, allowHttp: Boolean) =
+            answer(rawUrl, keep = null)
+
+        override suspend fun reconnect(
+            rawUrl: String,
+            credentials: RemoteCredentials,
+            allowHttp: Boolean,
+            prior: PriorConnection,
+        ): SetupResult {
+            offered = prior.deviceId
+            return answer(rawUrl, keep = prior.deviceId)
+        }
+
+        private fun answer(rawUrl: String, keep: String?): SetupResult {
+            connects++
+            return SetupResult.Success(
+                ServerCapabilities(
+                    baseUrl = rawUrl,
+                    canDownload = true,
+                    accountId = keep ?: "device-$connects",
+                    displayName = "ada",
+                    liseurToken = "token-$connects",
+                    liseurAccountId = if (connects > 1) "acc-1" else null,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `reconnecting offers the stored device id back to the same server`() = runTest {
+        val setup = UpgradingLiseurSync()
+        val repository = repository(db.remoteServerDao(), setup)
+        repository.connectLiseurSync(BASE, "ada", "pw")
+
+        repository.connectLiseurSync(BASE, "ada", "pw")
+
+        assertEquals("device-1", setup.offered)
+        assertEquals("device-1", db.remoteServerDao().get()!!.accountId)
+    }
+
+    @Test
+    fun `the first server that names the account moves sync state to the new key`() = runTest {
+        // Before the server reported account ids the key was spelled with
+        // the device id. The upgrade must not read as an account switch,
+        // and every table keyed by the old spelling has to follow.
+        val setup = UpgradingLiseurSync()
+        val repository = fullRepository(db.remoteServerDao(), setup)
+        repository.connectLiseurSync(BASE, "ada", "pw")
+        val oldKey = db.remoteServerDao().get()!!.accountKey
+        assertEquals("liseursync|$BASE|device-1", oldKey)
+        db.remoteServerDao().setSyncCursor(41)
+        db.syncPeerStateDao().persistPending(
+            bookUrl = "file:///book.epub", peerId = oldKey, progression = 0.8, status = "Reading",
+            remoteUpdatedAt = 1_000, locatorJson = """{"href":"c"}""", editionSha = "sha",
+        )
+        db.workIdentityDao().upsert(
+            WorkAlias(
+                bookUrl = "file:///book.epub", peerId = oldKey, workId = "w-1",
+                confidence = "high", resolvedAt = 1,
+            ),
+        )
+        db.annotationSyncDao().upsert(
+            AnnotationSync(
+                id = "a-1", peerId = oldKey, bookId = "file:///book.epub", workId = "w-1",
+                pendingKind = "write", pendingJson = """{"id":"a-1"}""",
+            ),
+        )
+        db.readingProgressDao().markDirtyFor(listOf("file:///book.epub"), oldKey)
+
+        repository.connectLiseurSync(BASE, "ada", "pw")
+
+        val stored = db.remoteServerDao().get()!!
+        val newKey = stored.accountKey
+        assertEquals("liseursync|$BASE|acc-1", newKey)
+        assertEquals(41, stored.syncCursorSeq)
+        assertEquals(0.8, db.syncPeerStateDao().get("file:///book.epub", newKey)!!.pendingProgression)
+        assertNull(db.syncPeerStateDao().get("file:///book.epub", oldKey))
+        assertEquals("w-1", db.workIdentityDao().alias("file:///book.epub", newKey)!!.workId)
+        assertEquals("""{"id":"a-1"}""", db.annotationSyncDao().get(newKey, "a-1")!!.pendingJson)
+        assertEquals(0, db.annotationSyncDao().countForPeer(oldKey))
+
+        // From here on the key is stable across token rotations.
+        repository.connectLiseurSync(BASE, "ada", "pw")
+        assertEquals(newKey, db.remoteServerDao().get()!!.accountKey)
+    }
+
+    private fun fullRepository(dao: RemoteServerDao, liseurSyncSetup: ServerSetup) = RemoteAccountRepository(
+        dao = dao,
+        bookDao = db.bookDao(),
+        progressDao = db.readingProgressDao(),
+        bookRemoval = BookRemoval(
+            db.bookDao(),
+            db.readingSessionDao(),
+            db.syncPeerStateDao(),
+            db.workIdentityDao(),
+            db.readingProgressDao(),
+            db.annotationDao(),
+            db.annotationSyncDao(),
+        ),
+        seriesExtraDao = db.seriesExtraDao(),
+        peerStateDao = db.syncPeerStateDao(),
+        identityDao = db.workIdentityDao(),
+        sessionDao = db.readingSessionDao(),
+        annotationSyncDao = db.annotationSyncDao(),
+        uploadRefusalDao = db.uploadRefusalDao(),
+        setups = mapOf(ServerKind.LISEUR_SYNC to liseurSyncSetup),
+    )
 
     private fun repository(
         dao: RemoteServerDao,


### PR DESCRIPTION
## Summary

The Android side of the sync work whose server half went out in
chmouel/liseur-sync#30. Three ways a liseur-sync push could lose reading data,
and the documentation that says how they are answered.

All three came from the same shape of mistake: the app could not tell a
permanent refusal from a temporary one, or itself from a stranger, so it either
threw records away or sent the same rejected thing for ever. The server now
names the item a refused batch is about, honours a device id offered back to it,
and says which account a token belongs to. This is what the phone does with
that.

## Changes

- **A refused batch of reading sessions no longer takes the rest with it.** The
  server appends a batch all or nothing and a refusal is only ever about one
  sitting; the app used to mark the whole batch sent, so up to a thousand hours
  of reading could go because one entry was malformed. Now nothing is marked
  sent on a refusal. The named sitting is set aside for that server in a new
  `session_refusal` table and the rest go again, a body too big is halved, and a
  refusal that names nothing is bisected until it does. A reason the app does
  not recognise leaves the sitting pending and is reported instead of being
  treated as final.
- **A refused position is renamed or sent bare, never left stuck.** An op the
  server already held under the same id with a different payload came back a
  conflict, and the next run sent the identical op again — for ever, while
  reporting success. A conflict now moves the book's revision on, but only if no
  page has been turned since the send, so the same reading goes out under a
  fresh id. A locator the server names as too large is dropped and the position
  sent again alone under the same id, since the refused batch was never stored.
- **Reconnecting keeps the device and the account.** Reconnecting minted a token
  with a fresh device id, and the server compares device ids when it decides
  whether a replay is a duplicate, so everything sent before the credential
  lapsed came back a conflict. Worse, the account key was spelled with that
  device id, so a reconnect read as a new account and discarded the sync cursor,
  the baselines and the book names. The stored device id is now offered back to
  the same server, and when a server first reports the stable account id
  everything keyed by the old spelling moves across in the same transaction.
- Room schema 47 adds `session_refusal` and the columns the above need, with a
  46 → 47 migration.
- `AGENTS.md` records the refusal and identity rules, since they are the kind of
  thing a later change would otherwise undo by accident.

Nothing here needs a new server. A server that predates the `device_id` field
ignores it and mints a new one; a server that does not report `account_id`
leaves the device id doing that duty, as before.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [ ] Manually tested on a device or emulator, if applicable

Covered by unit tests against a stubbed server: each refusal shape on both
endpoints, the halving and the bisection, the conflict rename and its guard
against a page turned mid-flight, the device id offered back and refused, and
the move of every peer-keyed table when the account changes spelling.

## Screenshots or recordings

None. This is the liseur-sync data layer and its tests; no screen changes.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
