### PR TITLE
Use a scrollable tab row for large fonts

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ContentsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ContentsScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
@@ -56,6 +57,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontStyle
@@ -180,11 +182,7 @@ fun ContentsScreen(
                         actionIconContentColor = theme.foreground,
                     ),
                 )
-                TabRow(
-                    selectedTabIndex = tab.ordinal,
-                    containerColor = theme.background,
-                    contentColor = theme.foreground,
-                ) {
+                val tabs: @Composable () -> Unit = {
                     ContentsTab.entries.forEach { entry ->
                         Tab(
                             selected = tab == entry,
@@ -194,11 +192,34 @@ fun ContentsScreen(
                             text = {
                                 Text(
                                     text = stringResource(entry.labelRes),
-                                    style = MaterialTheme.typography.labelLarge,
+                                    style = MaterialTheme.typography.labelSmall,
                                     maxLines = 1,
                                 )
                             },
                         )
+                    }
+                }
+                // Four equal tabs fit side by side at the normal font size,
+                // with the labels kept small so "Bookmarks" is not clipped.
+                // Once the reader enlarges the system font there is no
+                // compact style that keeps them all, so the row scrolls
+                // instead of truncating words.
+                if (LocalDensity.current.fontScale <= 1f) {
+                    TabRow(
+                        selectedTabIndex = tab.ordinal,
+                        containerColor = theme.background,
+                        contentColor = theme.foreground,
+                    ) {
+                        tabs()
+                    }
+                } else {
+                    ScrollableTabRow(
+                        selectedTabIndex = tab.ordinal,
+                        containerColor = theme.background,
+                        contentColor = theme.foreground,
+                        edgePadding = 0.dp,
+                    ) {
+                        tabs()
                     }
                 }
             }


### PR DESCRIPTION
<!-- What does this change do, and why? Link related issues with "Fixes #123". -->

## Summary

Keep the contents tabs readable when the system uses a larger font by switching to a scrollable tab row.

## Changes

- Use the fixed tab row at the normal font size.
- Use a scrollable tab row for larger font sizes.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on an emulator

## Screenshots or recordings

The contents screen with a large system font is attached.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

![Contents tabs with large font](https://github.com/user-attachments/assets/b7f93a1a-526e-4406-9245-522ea72defc3)