### PR TITLE
Sync reading changes live

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,6 +316,17 @@ emulator.
   position, annotation and session hangs off, and only `remote_uuid` and
   `download_href` are written (`BookDao.linkToRemote`). Never rewrite
   `books.url` to the server's spelling: the reader's place goes with it.
+- Live notifications are topic-only hints routed through `data/remote/`.
+  Keep their foreground connection separate from the full-sync debounce,
+  with a short background grace period. Connection identity includes the
+  account and credentials, never feed cursors or sync timestamps.
+  Topic refresh shares `PositionSyncCoordinator`'s turn lock; an event
+  arriving during a refresh remains owed. Never call `syncAll()` for an
+  invalidation or bypass the existing cursor and annotation reconciliation
+  rules. Signal local annotation edits after commit, not by observing
+  every Room mutation. An incoming position must not turn an open book's
+  page or show a new catch-up offer until resume; acceptance uses the
+  original preview's account, peer, fingerprint and local revision.
 - Blocking network calls move to `Dispatchers.IO` inside the client that
   blocks, not in the caller. A `suspend` signature reads as a promise
   that the thread is safe, and a repository reached from a

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ and a sync server that know nothing about each other still add up to a
 library that follows you. What each server can and cannot do is in
 [`docs/SERVER_CAPABILITIES.md`](docs/SERVER_CAPABILITIES.md).
 
+With a recent liseur-sync server, positions and annotations refresh while
+Liseur is open; statistics refresh when their screen is visible. A remote
+position never turns the page under you. Returning to the reader offers
+the further place, and accepting takes the exact position you were shown.
+Older servers keep the existing scheduled and on-open sync.
+
 No trackers, no analytics, no ads, no subscriptions. Liseur only talks to the
 servers and dictionary sources you configure. See the
 [privacy policy](https://chmouel.github.io/liseur/PRIVACY).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -212,6 +212,7 @@ dependencies {
     ksp(libs.room.compiler)
 
     implementation(libs.okhttp)
+    implementation(libs.okhttp.sse)
     implementation(libs.androidx.work.runtime.ktx)
 
     implementation(libs.coil.compose)

--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -36,6 +36,7 @@ import com.chmouel.liseur.data.liseursync.LiseurSyncCatalogClient
 import com.chmouel.liseur.data.liseursync.LiseurSyncDeleteClient
 import com.chmouel.liseur.data.liseursync.LiseurSyncFileSource
 import com.chmouel.liseur.data.liseursync.LiseurSyncInsights
+import com.chmouel.liseur.data.liseursync.LiseurSyncLive
 import com.chmouel.liseur.data.liseursync.LiseurSyncPositionSync
 import com.chmouel.liseur.data.liseursync.LiseurSyncServerSetup
 import com.chmouel.liseur.data.liseursync.LiseurSyncSeriesClient
@@ -44,6 +45,9 @@ import com.chmouel.liseur.data.liseursync.WorkResolver
 import com.chmouel.liseur.data.kosync.KosyncAccountRepository
 import com.chmouel.liseur.data.kosync.KosyncPositionSync
 import com.chmouel.liseur.data.remote.RemoteAccountRepository
+import com.chmouel.liseur.data.remote.LiveIdentity
+import com.chmouel.liseur.data.remote.LiveRefresh
+import com.chmouel.liseur.data.remote.LiveTopic
 import com.chmouel.liseur.data.remote.RemoteCatalogRepository
 import com.chmouel.liseur.data.remote.SeriesExtrasRepository
 import com.chmouel.liseur.data.remote.RemoteRouter
@@ -53,6 +57,7 @@ import com.chmouel.liseur.data.remote.SyncReporting
 import com.chmouel.liseur.data.settings.SessionStateRepository
 import com.chmouel.liseur.sync.PositionSyncCoordinator
 import com.chmouel.liseur.sync.LatestPositionSync
+import com.chmouel.liseur.sync.LiveSyncConnector
 import com.chmouel.liseur.sync.PositionSyncWorker
 import com.chmouel.liseur.sync.ReadingPositionPublisher
 import com.chmouel.liseur.ui.eink.EInkDisplay
@@ -66,6 +71,8 @@ import org.readium.r2.streamer.parser.DefaultPublicationParser
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * Manual composition root: shared Readium services and app-wide
@@ -143,6 +150,7 @@ class AppContainer(context: Context) {
         context = context.applicationContext,
         annotationDao = database.annotationDao(),
         bookDao = database.bookDao(),
+        requestBookSync = ::requestBookSync,
     )
 
     /** The one answer to whether a book is read, shared by everything that asks. */
@@ -362,6 +370,24 @@ class AppContainer(context: Context) {
         uploaders = mapOf(
             ServerKind.LISEUR_SYNC to LiseurSyncUploadClient(),
         ),
+        live = mapOf(
+            ServerKind.LISEUR_SYNC to LiseurSyncLive(
+                refreshTopics = { identity, topics ->
+                    val readingTopics = topics - LiveTopic.INSIGHTS
+                    val result = if (readingTopics.isEmpty()) {
+                        LiveRefresh()
+                    } else {
+                        liseurSync.refresh(identity, readingTopics)
+                    }
+                    if (LiveTopic.INSIGHTS in topics &&
+                        database.remoteServerDao().get()?.let(LiveIdentity::from) == identity
+                    ) {
+                        _insightInvalidations.value += 1
+                        result.copy(completed = result.completed + LiveTopic.INSIGHTS)
+                    } else result
+                },
+            ),
+        ),
     )
 
     /**
@@ -383,6 +409,24 @@ class AppContainer(context: Context) {
         request = { positionSync.request(SyncScope.Book(it)) },
         scheduleRetry = { PositionSyncWorker.retryBook(context.applicationContext, it) },
         onError = { message, error -> Log.e("position-sync", message, error) },
+    )
+
+    fun requestBookSync(bookId: String) = latestPositionSync.signal(bookId)
+
+    private val _insightInvalidations = MutableStateFlow(0L)
+    val insightInvalidations = _insightInvalidations.asStateFlow()
+
+    val liveSync = LiveSyncConnector(
+        scope = applicationScope,
+        accounts = database.remoteServerDao().observe(),
+        sourceFor = { remoteRouter.liveFor(it.kind) },
+        coordinator = positionSync,
+        requestBook = ::requestBookSync,
+        reportFailure = { identity, reason ->
+            if (database.remoteServerDao().get()?.let(LiveIdentity::from) == identity) {
+                syncReporting.report(com.chmouel.liseur.data.remote.PositionSyncStatus.Failed(reason))
+            }
+        },
     )
 
     val readingPositions = ReadingPositionPublisher(

--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -419,7 +419,9 @@ class AppContainer(context: Context) {
     val liveSync = LiveSyncConnector(
         scope = applicationScope,
         accounts = database.remoteServerDao().observe(),
-        sourceFor = { remoteRouter.liveFor(it.kind) },
+        sourceFor = { server ->
+            remoteRouter.liveFor(server.kind).takeIf { server.credentials != null }
+        },
         coordinator = positionSync,
         requestBook = ::requestBookSync,
         reportFailure = { identity, reason ->

--- a/app/src/main/kotlin/com/chmouel/liseur/LiseurApplication.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/LiseurApplication.kt
@@ -60,6 +60,7 @@ class LiseurApplication : Application(), SingletonImageLoader.Factory {
         ProcessLifecycleOwner.get().lifecycle.addObserver(
             object : DefaultLifecycleObserver {
                 override fun onStart(owner: LifecycleOwner) {
+                    container.liveSync.foreground()
                     val now = System.currentTimeMillis()
                     if (now - lastForegroundSyncAt < FOREGROUND_SYNC_DEBOUNCE_MS) return
                     lastForegroundSyncAt = now
@@ -76,6 +77,10 @@ class LiseurApplication : Application(), SingletonImageLoader.Factory {
                         if (!due) return@launch
                         runCatching { container.positionSync.request(SyncScope.Full, now) }
                     }
+                }
+
+                override fun onStop(owner: LifecycleOwner) {
+                    container.liveSync.background()
                 }
             },
         )

--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.platform.LocalLocale
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -222,7 +223,7 @@ private fun LiseurApp(settings: AppSettings) {
             // from here, where the locale is observable state.
             val weekStart = localeWeekStart(LocalLocale.current.platformLocale)
             LaunchedEffect(model, weekStart) { model.setWeekStart(weekStart) }
-            LaunchedEffect(model) { model.refreshServerInsights() }
+            LiveStatsEffect(model)
             val statsState by model.state.collectAsStateWithLifecycle()
             ReadingStatsScreen(
                 state = statsState,
@@ -257,7 +258,7 @@ private fun LiseurApp(settings: AppSettings) {
                 )
                 val weekStart = localeWeekStart(LocalLocale.current.platformLocale)
                 LaunchedEffect(model, weekStart) { model.setWeekStart(weekStart) }
-                LaunchedEffect(model, target.bookUrl) { model.refreshServerInsights() }
+                LiveStatsEffect(model)
                 val bookStatsState by remember(model, target.bookUrl) { model.forBook(target.bookUrl) }
                     .collectAsStateWithLifecycle()
                 val serverInsights by remember(model, target.bookUrl) {
@@ -500,6 +501,16 @@ private fun rememberAnnotationBackup(): AnnotationBackupUi {
 /** Opening a link must never take the app down with it. */
 private fun android.content.Context.openLink(uri: Uri) {
     runCatching { startActivity(Intent(Intent.ACTION_VIEW, uri)) }
+}
+
+@Composable
+private fun LiveStatsEffect(model: ReadingStatsViewModel) {
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    LaunchedEffect(model, lifecycle) {
+        lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            model.observeLiveInsights()
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/com/chmouel/liseur/data/calibre/KoboSyncRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/calibre/KoboSyncRepository.kt
@@ -187,6 +187,7 @@ class KoboSyncRepository(
         bookUrl: String,
         atRevision: Long,
         peerId: String?,
+        expectedAccountKey: String?,
     ): ResolveOutcome {
         val server = serverDao.get() ?: return ResolveOutcome.Done
         val stored = progressDao.get(bookUrl) ?: return ResolveOutcome.Done

--- a/app/src/main/kotlin/com/chmouel/liseur/data/calibre/KoboSyncRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/calibre/KoboSyncRepository.kt
@@ -189,18 +189,35 @@ class KoboSyncRepository(
         peerId: String?,
         expectedAccountKey: String?,
     ): ResolveOutcome {
-        val server = serverDao.get() ?: return ResolveOutcome.Done
-        val stored = progressDao.get(bookUrl) ?: return ResolveOutcome.Done
-        val progression = stored.pendingProgression ?: return ResolveOutcome.Done
-        val applied = progressDao.applyPull(
-            bookUrl = bookUrl,
-            expectedRevision = atRevision,
-            progression = progression,
-            status = ReadingStatus.fromWire(stored.pendingStatus).wireName,
-            account = server.accountKey,
-            remoteUpdatedAt = stored.pendingUpdatedAt,
-            now = System.currentTimeMillis(),
-        )
+        val server = serverDao.get() ?: return if (expectedAccountKey != null) {
+            ResolveOutcome.Superseded
+        } else {
+            ResolveOutcome.Done
+        }
+        if (expectedAccountKey != null && server.accountKey != expectedAccountKey) {
+            return ResolveOutcome.Superseded
+        }
+        var applied = false
+        var accountMatches = false
+        inTransaction {
+            val current = serverDao.get()
+            if (current?.accountKey != server.accountKey || current.koboToken != server.koboToken) {
+                return@inTransaction
+            }
+            val stored = progressDao.get(bookUrl) ?: return@inTransaction
+            val progression = stored.pendingProgression ?: return@inTransaction
+            accountMatches = true
+            applied = progressDao.applyPull(
+                bookUrl = bookUrl,
+                expectedRevision = atRevision,
+                progression = progression,
+                status = ReadingStatus.fromWire(stored.pendingStatus).wireName,
+                account = server.accountKey,
+                remoteUpdatedAt = stored.pendingUpdatedAt,
+                now = System.currentTimeMillis(),
+            )
+        }
+        if (!accountMatches) return ResolveOutcome.Superseded
         if (!applied) return ResolveOutcome.Superseded
         finishedState.refreshFromProgress(bookUrl)
         return ResolveOutcome.Done

--- a/app/src/main/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepository.kt
@@ -208,6 +208,7 @@ class KomgaSyncRepository(
         bookUrl: String,
         atRevision: Long,
         peerId: String?,
+        expectedAccountKey: String?,
     ): ResolveOutcome {
         val server = serverDao.get() ?: return ResolveOutcome.Done
         val stored = progressDao.get(bookUrl) ?: return ResolveOutcome.Done

--- a/app/src/main/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepository.kt
@@ -210,19 +210,36 @@ class KomgaSyncRepository(
         peerId: String?,
         expectedAccountKey: String?,
     ): ResolveOutcome {
-        val server = serverDao.get() ?: return ResolveOutcome.Done
-        val stored = progressDao.get(bookUrl) ?: return ResolveOutcome.Done
-        val progression = stored.pendingProgression ?: return ResolveOutcome.Done
-        val applied = progressDao.applyPull(
-            bookUrl = bookUrl,
-            expectedRevision = atRevision,
-            progression = progression,
-            status = ReadingStatus.fromWire(stored.pendingStatus).wireName,
-            account = server.accountKey,
-            remoteUpdatedAt = stored.pendingUpdatedAt,
-            now = System.currentTimeMillis(),
-            locatorJson = stored.pendingLocatorJson.takeIf(ExactLocatorAnchor::isExactJson),
-        )
+        val server = serverDao.get() ?: return if (expectedAccountKey != null) {
+            ResolveOutcome.Superseded
+        } else {
+            ResolveOutcome.Done
+        }
+        if (expectedAccountKey != null && server.accountKey != expectedAccountKey) {
+            return ResolveOutcome.Superseded
+        }
+        var applied = false
+        var accountMatches = false
+        inTransaction {
+            val current = serverDao.get()
+            if (current?.accountKey != server.accountKey || current.baseUrl != server.baseUrl) {
+                return@inTransaction
+            }
+            val stored = progressDao.get(bookUrl) ?: return@inTransaction
+            val progression = stored.pendingProgression ?: return@inTransaction
+            accountMatches = true
+            applied = progressDao.applyPull(
+                bookUrl = bookUrl,
+                expectedRevision = atRevision,
+                progression = progression,
+                status = ReadingStatus.fromWire(stored.pendingStatus).wireName,
+                account = server.accountKey,
+                remoteUpdatedAt = stored.pendingUpdatedAt,
+                now = System.currentTimeMillis(),
+                locatorJson = stored.pendingLocatorJson.takeIf(ExactLocatorAnchor::isExactJson),
+            )
+        }
+        if (!accountMatches) return ResolveOutcome.Superseded
         if (!applied) return ResolveOutcome.Superseded
         finishedState.refreshFromProgress(bookUrl)
         return ResolveOutcome.Done

--- a/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSync.kt
@@ -178,12 +178,30 @@ class KosyncPositionSync(
         peerId: String?,
         expectedAccountKey: String?,
     ): ResolveOutcome {
-        val account = account() ?: return ResolveOutcome.Done
-        val state = peerStateDao.get(bookUrl, account.peerId) ?: return ResolveOutcome.Done
-        val progression = state.pendingProgression ?: return ResolveOutcome.Done
+        val account = account() ?: return if (expectedAccountKey != null) {
+            ResolveOutcome.Superseded
+        } else {
+            ResolveOutcome.Done
+        }
+        if (expectedAccountKey != null && account.peerId != expectedAccountKey) {
+            return ResolveOutcome.Superseded
+        }
+        val state = peerStateDao.get(bookUrl, account.peerId) ?: return if (expectedAccountKey != null) {
+            ResolveOutcome.Superseded
+        } else {
+            ResolveOutcome.Done
+        }
+        val progression = state.pendingProgression ?: return if (expectedAccountKey != null) {
+            ResolveOutcome.Superseded
+        } else {
+            ResolveOutcome.Done
+        }
         val status = ReadingStatus.fromWire(state.pendingStatus)
         var applied = false
+        var accountMatches = false
         inTransaction {
+            if (kosyncDao.get()?.accountKey != account.peerId) return@inTransaction
+            accountMatches = true
             applied = progressDao.applyPeerPull(
                 bookUrl = bookUrl,
                 expectedRevision = atRevision,
@@ -203,6 +221,7 @@ class KosyncPositionSync(
                 )
             }
         }
+        if (!accountMatches) return ResolveOutcome.Superseded
         if (!applied) return ResolveOutcome.Superseded
         finishedState.refreshFromProgress(bookUrl)
         return ResolveOutcome.Done

--- a/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSync.kt
@@ -176,6 +176,7 @@ class KosyncPositionSync(
         bookUrl: String,
         atRevision: Long,
         peerId: String?,
+        expectedAccountKey: String?,
     ): ResolveOutcome {
         val account = account() ?: return ResolveOutcome.Done
         val state = peerStateDao.get(bookUrl, account.peerId) ?: return ResolveOutcome.Done

--- a/app/src/main/kotlin/com/chmouel/liseur/data/library/AnnotationBackupRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/library/AnnotationBackupRepository.kt
@@ -73,6 +73,7 @@ class AnnotationBackupRepository(
     private val context: Context,
     private val annotationDao: BookAnnotationDao,
     private val bookDao: BookDao,
+    private val requestBookSync: (String) -> Unit = {},
 ) {
     /** What an export would carry, for saying so before asking where. */
     suspend fun exportPreview(): BackupSummary = withContext(Dispatchers.IO) {
@@ -162,7 +163,13 @@ class AnnotationBackupRepository(
         }
         if (incoming.isEmpty()) return@withContext BackupResult.Imported(added = 0, alreadyHere = 0)
 
-        val added = annotationDao.insertMissing(incoming).count { it != -1L }
+        val inserted = annotationDao.insertMissing(incoming)
+        val added = inserted.count { it != -1L }
+        incoming.zip(inserted)
+            .filter { (_, rowId) -> rowId != -1L }
+            .map { (mark, _) -> mark.bookId }
+            .distinct()
+            .forEach(requestBookSync)
         BackupResult.Imported(added = added, alreadyHere = incoming.size - added)
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncAnnotations.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncAnnotations.kt
@@ -173,7 +173,7 @@ class LiseurSyncAnnotations(
         }
 
         for (row in pending.filter { it.pendingKind == AnnotationSync.PENDING_DELETE }) {
-            if (progress.unreachable != null) return
+            if (progress.stopped) return
             // Re-read: the pending set was taken at the top of the pass,
             // and settling the writes above took network time in which
             // this row may have been answered, dropped or replaced.
@@ -570,7 +570,7 @@ class LiseurSyncAnnotations(
         if (items.isEmpty()) return
 
         for (batch in items.chunked(AnnotationWire.MAX_BATCH)) {
-            if (progress.unreachable != null) return
+            if (progress.stopped) return
             val marked = batch.map { (row, item) ->
                 row.copy(
                     bookId = row.bookId,
@@ -900,7 +900,7 @@ class LiseurSyncAnnotations(
             .filter { annotationDao.byId(it.id) == null }
 
         for (row in rows) {
-            if (progress.unreachable != null) return
+            if (progress.stopped) return
             if (row.rev < 1) {
                 // Possibly created and never acknowledged; `rev=0` is a
                 // 400, so there is nothing to send. Reconciling the work

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncAnnotations.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncAnnotations.kt
@@ -95,8 +95,13 @@ class LiseurSyncAnnotations(
         var unreachable: SyncFailure? = null
         val reresolve = mutableMapOf<String, String>()
         var hasMore = false
+        // A 429 is answered, so it never sets [unreachable], but letting
+        // the pass run on regardless would still send its remaining
+        // feed pages and reconcile requests into a server that just
+        // asked it to slow down.
+        private var rateLimited = false
         val stopped: Boolean
-            get() = unreachable != null || failure == SyncFailure.Unauthorised ||
+            get() = unreachable != null || rateLimited || failure == SyncFailure.Unauthorised ||
                 failure == SyncFailure.Forbidden || failure == SyncFailure.InsecureTransport
 
         fun failed(cause: IOException, reason: SyncFailure) {
@@ -105,6 +110,7 @@ class LiseurSyncAnnotations(
                     (reason == SyncFailure.Forbidden || reason == SyncFailure.InsecureTransport))
             ) failure = reason
             if (!cause.serverAnswered()) unreachable = unreachable ?: reason
+            if (reason is SyncFailure.ServerError && reason.code == 429) rateLimited = true
         }
 
         fun outcome() = Outcome(pulled, pushed, failure, unreachable, reresolve, hasMore)

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncAnnotations.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncAnnotations.kt
@@ -85,6 +85,7 @@ class LiseurSyncAnnotations(
         val failure: SyncFailure? = null,
         val unreachable: SyncFailure? = null,
         val reresolve: Map<String, String> = emptyMap(),
+        val hasMore: Boolean = false,
     )
 
     private class Progress {
@@ -93,13 +94,20 @@ class LiseurSyncAnnotations(
         var failure: SyncFailure? = null
         var unreachable: SyncFailure? = null
         val reresolve = mutableMapOf<String, String>()
+        var hasMore = false
+        val stopped: Boolean
+            get() = unreachable != null || failure == SyncFailure.Unauthorised ||
+                failure == SyncFailure.Forbidden || failure == SyncFailure.InsecureTransport
 
         fun failed(cause: IOException, reason: SyncFailure) {
-            failure = failure ?: reason
+            if (failure == null || reason == SyncFailure.Unauthorised ||
+                (failure != SyncFailure.Unauthorised &&
+                    (reason == SyncFailure.Forbidden || reason == SyncFailure.InsecureTransport))
+            ) failure = reason
             if (!cause.serverAnswered()) unreachable = unreachable ?: reason
         }
 
-        fun outcome() = Outcome(pulled, pushed, failure, unreachable, reresolve)
+        fun outcome() = Outcome(pulled, pushed, failure, unreachable, reresolve, hasMore)
     }
 
     /**
@@ -121,17 +129,17 @@ class LiseurSyncAnnotations(
         }
 
         settle(peer, aliases, progress)
-        if (progress.unreachable != null) return progress.outcome()
+        if (progress.stopped) return progress.outcome()
 
         pull(peer, aliases, progress)
-        if (progress.unreachable != null) return progress.outcome()
+        if (progress.stopped) return progress.outcome()
 
         val scope = if (book == null) aliases else aliases.filter { it.bookUrl == book }
         val agreed = reconcile(peer, scope, aliases, progress)
-        if (progress.unreachable != null) return progress.outcome()
+        if (progress.stopped) return progress.outcome()
 
         push(peer, scope, aliases, agreed, progress)
-        if (progress.unreachable != null) return progress.outcome()
+        if (progress.stopped) return progress.outcome()
 
         deletes(peer, scope, aliases, progress)
         return progress.outcome()
@@ -212,6 +220,7 @@ class LiseurSyncAnnotations(
             if (!page.optBoolean("has_more", false)) return
         }
         Log.i(TAG, "Stopped reading annotation changes after $MAX_PAGES pages")
+        progress.hasMore = true
     }
 
     /** Writes a page and moves the cursor, together or not at all. */
@@ -223,7 +232,7 @@ class LiseurSyncAnnotations(
         progress: Progress,
     ) {
         inTransaction {
-            if (serverDao.get()?.accountKey != peer.accountKey) return@inTransaction
+            if (!stillOurs(peer)) return@inTransaction
             // The feed is state, not history, so a record edited twice
             // mid-page arrives twice; the newest is the one that counts
             // and the rest are noise. Newest by seq, like everywhere
@@ -373,7 +382,7 @@ class LiseurSyncAnnotations(
                 continue
             }
             if (budget-- <= 0) continue
-            if (progress.unreachable != null) break
+            if (progress.stopped) break
             if (!stillOurs(peer)) break
 
             val asked = syncDao.forWork(peer.peerId, alias.workId)
@@ -486,7 +495,7 @@ class LiseurSyncAnnotations(
         progress: Progress,
     ) {
         inTransaction {
-            if (serverDao.get()?.accountKey != peer.accountKey) return@inTransaction
+            if (!stillOurs(peer)) return@inTransaction
             for (record in live) {
                 if (land(peer, record, aliases)) progress.pulled++
             }
@@ -575,7 +584,7 @@ class LiseurSyncAnnotations(
             // Written before the call, so that a process killed between
             // the two wakes up owing a replay rather than owing nothing.
             inTransaction {
-                if (serverDao.get()?.accountKey != peer.accountKey) return@inTransaction
+                if (!stillOurs(peer)) return@inTransaction
                 syncDao.upsertAll(marked)
             }
 
@@ -650,7 +659,7 @@ class LiseurSyncAnnotations(
             Answer.BatchRefused -> {
                 if (batch.size == 1) {
                     inTransaction {
-                        if (serverDao.get()?.accountKey != peer.accountKey) return@inTransaction
+                        if (!stillOurs(peer)) return@inTransaction
                         val row = stillAsking(peer, batch[0]) ?: return@inTransaction
                         syncDao.upsert(row.clearPending(rejected = row.pendingFingerprint))
                     }
@@ -682,7 +691,7 @@ class LiseurSyncAnnotations(
         val byId = rows.associateBy { it.id }
         var settled = 0
         inTransaction {
-            if (serverDao.get()?.accountKey != peer.accountKey) return@inTransaction
+            if (!stillOurs(peer)) return@inTransaction
             for (i in 0 until results.length()) {
                 val result = results.optJSONObject(i) ?: continue
                 val sent = byId[result.optString("id")] ?: continue
@@ -919,7 +928,7 @@ class LiseurSyncAnnotations(
                 pendingFingerprint = null,
             )
             inTransaction {
-                if (serverDao.get()?.accountKey != peer.accountKey) return@inTransaction
+                if (!stillOurs(peer)) return@inTransaction
                 syncDao.upsert(marked)
             }
             sendDelete(peer, marked, row.rev, aliases, progress)
@@ -952,7 +961,7 @@ class LiseurSyncAnnotations(
         val tombstone = answer.optLong("rev", rev)
         val seq = answer.optLong("seq", row.seq)
         inTransaction {
-            if (serverDao.get()?.accountKey != peer.accountKey) return@inTransaction
+            if (!stillOurs(peer)) return@inTransaction
             val current = stillAsking(peer, row) ?: return@inTransaction
             if (annotationDao.byId(row.id) == null) {
                 syncDao.deleteById(peer.peerId, row.id)
@@ -984,7 +993,7 @@ class LiseurSyncAnnotations(
         aliases: List<WorkAlias>,
     ) {
         inTransaction {
-            if (serverDao.get()?.accountKey != peer.accountKey) return@inTransaction
+            if (!stillOurs(peer)) return@inTransaction
             val row = stillAsking(peer, row) ?: return@inTransaction
             when (refused.code) {
                 // Never stored, or its tombstone has been swept. Either
@@ -1051,7 +1060,9 @@ class LiseurSyncAnnotations(
      * answer is too late; the request is the side effect.
      */
     private suspend fun stillOurs(peer: Peer): Boolean =
-        serverDao.get()?.accountKey == peer.accountKey
+        serverDao.get()?.let {
+            it.accountKey == peer.accountKey && it.credentials == peer.credentials
+        } == true
 
     private suspend fun stillAsking(peer: Peer, sent: AnnotationSync): AnnotationSync? =
         syncDao.get(peer.peerId, sent.id)?.takeIf { it.sameRequestAs(sent) }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncInsights.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncInsights.kt
@@ -5,6 +5,7 @@ import com.chmouel.liseur.data.db.RemoteServer
 import com.chmouel.liseur.data.db.RemoteServerDao
 import com.chmouel.liseur.data.db.WorkIdentityDao
 import com.chmouel.liseur.data.remote.RemoteCredentials
+import com.chmouel.liseur.data.remote.LiveIdentity
 import com.chmouel.liseur.data.remote.RemoteHttpFailure
 import com.chmouel.liseur.data.remote.ServerKind
 import com.chmouel.liseur.data.remote.SyncFailure
@@ -347,7 +348,13 @@ class LiseurSyncInsights(
         url: String,
     ): JSONObject {
         try {
+            if (serverDao.get()?.let(LiveIdentity::from) != LiveIdentity.from(account)) {
+                throw IOException("Statistics account changed")
+            }
             val answer = http.get(url, credentials)
+            if (serverDao.get()?.let(LiveIdentity::from) != LiveIdentity.from(account)) {
+                throw IOException("Statistics account changed")
+            }
             if (!account.canReadInsights) record(account, allowed = true)
             return answer
         } catch (e: RemoteHttpFailure) {

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncLive.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncLive.kt
@@ -10,6 +10,7 @@ import com.chmouel.liseur.data.remote.RemoteCredentials
 import com.chmouel.liseur.data.remote.RemoteHttp
 import java.io.IOException
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -65,6 +66,7 @@ internal class BoundedEventSource(source: Source, private val limit: Long = 64 *
                 afterCr = false
                 continue
             }
+
             afterCr = false
             if (++frameBytes > limit) throw IOException("Live frame exceeds $limit bytes")
             if (byte == 10 || byte == 13) {
@@ -73,6 +75,34 @@ internal class BoundedEventSource(source: Source, private val limit: Long = 64 *
                 afterCr = byte == 13
             } else {
                 lineBytes++
+            }
+        }
+
+        sink.write(chunk, read)
+        return read
+    }
+}
+
+internal class RetryAdviceSource(
+    source: Source,
+    private val retryMillis: AtomicLong,
+) : ForwardingSource(source) {
+    private val line = StringBuilder()
+
+    override fun read(sink: Buffer, byteCount: Long): Long {
+        val chunk = Buffer()
+        val read = super.read(chunk, byteCount)
+        if (read <= 0) return read
+        for (index in 0 until read) {
+            val byte = chunk[index].toInt()
+            if (byte == '\n'.code || byte == '\r'.code) {
+                val value = line.toString().removePrefix("retry:").trim().toLongOrNull()
+                if (line.startsWith("retry:") && value != null && value >= 0) {
+                    retryMillis.set(value)
+                }
+                line.setLength(0)
+            } else if (line.length < 32) {
+                line.append(byte.toChar())
             }
         }
         sink.write(chunk, read)
@@ -93,7 +123,8 @@ class LiseurSyncLive(
             // Application interceptors see the decompressed body. Bounding
             // a network interceptor's gzip bytes leaves inflated frames unbounded.
             val body = response.body
-            val bounded = BoundedEventSource(body.source()).buffer()
+            val retryMillis = chain.request().tag(AtomicLong::class.java) ?: AtomicLong(-1)
+            val bounded = RetryAdviceSource(BoundedEventSource(body.source()), retryMillis).buffer()
             response.newBuilder().body(object : ResponseBody() {
                 override fun contentType() = body.contentType()
                 override fun contentLength() = body.contentLength()
@@ -112,10 +143,12 @@ class LiseurSyncLive(
         if (credentials == null) return@flow
         val wake = Channel<Unit>(Channel.CONFLATED)
         val pending = mutableSetOf<LiveTopic>()
+        val retryMillis = AtomicLong(-1)
         val request = Request.Builder()
             .url(LiseurSyncApi.url(baseUrl, "/v1/events"))
             .header("Accept", "text/event-stream")
             .also { credentials.signInto(it) }
+            .tag(AtomicLong::class.java, retryMillis)
             .build()
         val source = EventSources.createFactory(client).newEventSource(request, object : EventSourceListener() {
             override fun onEvent(eventSource: EventSource, id: String?, type: String?, data: String) {
@@ -126,11 +159,17 @@ class LiseurSyncLive(
             }
 
             override fun onClosed(eventSource: EventSource) {
-                wake.close(LiveStreamFailure())
+                wake.close(LiveStreamFailure(retryMillis = retryMillis.get().takeIf { it >= 0 }))
             }
 
             override fun onFailure(eventSource: EventSource, t: Throwable?, response: Response?) {
-                wake.close(LiveStreamFailure(response?.code, response?.header("Retry-After")))
+                wake.close(
+                    LiveStreamFailure(
+                        response?.code,
+                        response?.header("Retry-After"),
+                        retryMillis.get().takeIf { it >= 0 },
+                    ),
+                )
             }
         })
         try {

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncLive.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncLive.kt
@@ -1,0 +1,146 @@
+package com.chmouel.liseur.data.liseursync
+
+import com.chmouel.liseur.data.db.RemoteServer
+import com.chmouel.liseur.data.remote.LiveChanges
+import com.chmouel.liseur.data.remote.LiveIdentity
+import com.chmouel.liseur.data.remote.LiveRefresh
+import com.chmouel.liseur.data.remote.LiveStreamFailure
+import com.chmouel.liseur.data.remote.LiveTopic
+import com.chmouel.liseur.data.remote.RemoteCredentials
+import com.chmouel.liseur.data.remote.RemoteHttp
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody
+import okhttp3.sse.EventSource
+import okhttp3.sse.EventSourceListener
+import okhttp3.sse.EventSources
+import okio.Buffer
+import okio.BufferedSource
+import okio.ForwardingSource
+import okio.Source
+import okio.buffer
+import org.json.JSONObject
+
+internal fun liveTopics(type: String?, data: String): Set<LiveTopic> {
+    if (type != "invalidate") return emptySet()
+    return try {
+        val array = JSONObject(data).optJSONArray("topics") ?: return emptySet()
+        buildSet {
+            for (i in 0 until array.length()) {
+                when (array.optString(i)) {
+                    "positions" -> add(LiveTopic.POSITIONS)
+                    "annotations" -> add(LiveTopic.ANNOTATIONS)
+                    "insights" -> add(LiveTopic.INSIGHTS)
+                }
+            }
+        }
+    } catch (_: org.json.JSONException) {
+        emptySet()
+    }
+}
+
+/**
+ * okhttp-sse searches for a newline without a limit and accumulates all data
+ * lines. Bound the raw frame before either allocation, not in onEvent.
+ */
+internal class BoundedEventSource(source: Source, private val limit: Long = 64 * 1024) :
+    ForwardingSource(source) {
+    private var frameBytes = 0L
+    private var lineBytes = 0L
+    private var afterCr = false
+
+    override fun read(sink: Buffer, byteCount: Long): Long {
+        val chunk = Buffer()
+        val read = super.read(chunk, minOf(byteCount, 8192))
+        if (read <= 0) return read
+        for (index in 0 until read) {
+            val byte = chunk[index].toInt()
+            if (afterCr && byte == 10) {
+                afterCr = false
+                continue
+            }
+            afterCr = false
+            if (++frameBytes > limit) throw IOException("Live frame exceeds $limit bytes")
+            if (byte == 10 || byte == 13) {
+                if (lineBytes == 0L) frameBytes = 0
+                lineBytes = 0
+                afterCr = byte == 13
+            } else {
+                lineBytes++
+            }
+        }
+        sink.write(chunk, read)
+        return read
+    }
+}
+
+class LiseurSyncLive(
+    private val refreshTopics: suspend (LiveIdentity, Set<LiveTopic>) -> LiveRefresh,
+    client: OkHttpClient = RemoteHttp.default(),
+    idleMillis: Long = 60_000,
+) : LiveChanges {
+    private val client = client.newBuilder()
+        .readTimeout(idleMillis, TimeUnit.MILLISECONDS)
+        .callTimeout(0, TimeUnit.MILLISECONDS)
+        .addInterceptor { chain ->
+            val response = chain.proceed(chain.request())
+            // Application interceptors see the decompressed body. Bounding
+            // a network interceptor's gzip bytes leaves inflated frames unbounded.
+            val body = response.body
+            val bounded = BoundedEventSource(body.source()).buffer()
+            response.newBuilder().body(object : ResponseBody() {
+                override fun contentType() = body.contentType()
+                override fun contentLength() = body.contentLength()
+                override fun source(): BufferedSource = bounded
+            }).build()
+        }
+        .build()
+
+    override suspend fun refresh(identity: LiveIdentity, topics: Set<LiveTopic>): LiveRefresh =
+        refreshTopics(identity, topics)
+
+    override fun events(server: RemoteServer): Flow<Set<LiveTopic>> =
+        stream(server.baseUrl, server.credentials)
+
+    internal fun stream(baseUrl: String, credentials: RemoteCredentials?): Flow<Set<LiveTopic>> = flow {
+        if (credentials == null) return@flow
+        val wake = Channel<Unit>(Channel.CONFLATED)
+        val pending = mutableSetOf<LiveTopic>()
+        val request = Request.Builder()
+            .url(LiseurSyncApi.url(baseUrl, "/v1/events"))
+            .header("Accept", "text/event-stream")
+            .also { credentials.signInto(it) }
+            .build()
+        val source = EventSources.createFactory(client).newEventSource(request, object : EventSourceListener() {
+            override fun onEvent(eventSource: EventSource, id: String?, type: String?, data: String) {
+                val topics = liveTopics(type, data)
+                if (topics.isEmpty()) return
+                synchronized(pending) { pending.addAll(topics) }
+                wake.trySend(Unit)
+            }
+
+            override fun onClosed(eventSource: EventSource) {
+                wake.close(LiveStreamFailure())
+            }
+
+            override fun onFailure(eventSource: EventSource, t: Throwable?, response: Response?) {
+                wake.close(LiveStreamFailure(response?.code, response?.header("Retry-After")))
+            }
+        })
+        try {
+            for (ignored in wake) {
+                val topics = synchronized(pending) { pending.toSet().also { pending.clear() } }
+                if (topics.isNotEmpty()) emit(topics)
+            }
+        } finally {
+            source.cancel()
+            wake.cancel()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
@@ -18,6 +18,9 @@ import com.chmouel.liseur.data.db.WorkIdentityDao
 import com.chmouel.liseur.data.library.FinishedState
 import com.chmouel.liseur.data.remote.failureForCode
 import com.chmouel.liseur.data.remote.PositionSync
+import com.chmouel.liseur.data.remote.LiveIdentity
+import com.chmouel.liseur.data.remote.LiveRefresh
+import com.chmouel.liseur.data.remote.LiveTopic
 import com.chmouel.liseur.data.remote.PositionSyncStatus
 import com.chmouel.liseur.data.remote.PreviewOutcome
 import com.chmouel.liseur.data.remote.RemoteCredentials
@@ -95,6 +98,57 @@ class LiseurSyncPositionSync(
     override suspend fun syncAll(snapshot: SyncSnapshot?): SyncOutcome = run(book = null)
 
     override suspend fun syncBook(bookUrl: String): SyncOutcome = run(book = bookUrl)
+
+    /** Topic reads never name files, upload sessions, or claim a full sync. */
+    suspend fun refresh(identity: LiveIdentity, topics: Set<LiveTopic>): LiveRefresh {
+        val server = server()?.takeIf { LiveIdentity.from(it) == identity } ?: return LiveRefresh()
+        val account = account() ?: return LiveRefresh()
+        if (serverDao.get()?.let(LiveIdentity::from) != identity ||
+            account.accountKey != identity.account || account.credentials != server.credentials
+        ) return LiveRefresh()
+        val completed = mutableSetOf<LiveTopic>()
+        val owed = mutableSetOf<String>()
+        val failures = mutableMapOf<LiveTopic, SyncFailure>()
+        if (LiveTopic.POSITIONS in topics) {
+            val trouble = Trouble()
+            val caughtUp = pull(account, trouble)
+            trouble.first?.let { failures[LiveTopic.POSITIONS] = it }
+            if (trouble.first == SyncFailure.Unauthorised) {
+                return LiveRefresh(completed, owed, failures)
+            }
+            val aliases = if (trouble.first?.worthRetrying == false) {
+                emptyList()
+            } else {
+                identityDao.aliasesFor(account.peerId).filter { it.usable }
+            }
+            for (alias in aliases) {
+                val book = bookDao.getByUrl(alias.bookUrl) ?: continue
+                // An alias can be confirmed after an earlier page skipped it.
+                // Leave that seed to a book run instead of hashing or naming here.
+                if (!alias.seeded) owed += book.url
+                if (reconcile(account, book to alias) is Reconciled.Owed) owed += book.url
+            }
+            if (caughtUp && trouble.first == null) completed += LiveTopic.POSITIONS
+        }
+        if (LiveTopic.ANNOTATIONS in topics && serverDao.get()?.let(LiveIdentity::from) == identity) {
+            val outcome = annotations?.sync(
+                LiseurSyncAnnotations.Peer(
+                    account.baseUrl, account.credentials, account.peerId,
+                    account.accountKey, server.annotationCursorSeq,
+                ),
+                book = null,
+            )
+            outcome?.reresolve?.forEach { (book, stale) ->
+                forAccount(account) { identityDao.deleteAliasIfStale(book, account.peerId, stale) }
+                owed += book
+            }
+            outcome?.failure?.let { failures[LiveTopic.ANNOTATIONS] = it }
+            if (outcome == null || (outcome.failure == null && !outcome.hasMore)) {
+                completed += LiveTopic.ANNOTATIONS
+            }
+        }
+        return LiveRefresh(completed, owed, failures)
+    }
 
     override suspend fun canSync(bookUrl: String): Boolean {
         val account = account() ?: return false
@@ -673,10 +727,11 @@ class LiseurSyncPositionSync(
      * reading nobody will ever see again, and unlike everything else
      * here it cannot be asked for a second time.
      */
-    private suspend fun pull(account: Account, trouble: Trouble) {
+    private suspend fun pull(account: Account, trouble: Trouble): Boolean {
         var cursor = account.cursorSeq
         var guard = MAX_PAGES
         while (guard-- > 0) {
+            if (!sameAccount(account)) return false
             val page = try {
                 http.get(
                     LiseurSyncApi.changes(account.baseUrl, since = cursor, limit = PAGE),
@@ -688,7 +743,7 @@ class LiseurSyncPositionSync(
             } catch (e: IOException) {
                 Log.i(TAG, "Could not read what changed", e)
                 trouble.failed(e, reasonFor(e))
-                return
+                return false
             }
 
             val items = feed(page.optJSONArray("ops"))
@@ -698,12 +753,13 @@ class LiseurSyncPositionSync(
             apply(account, items.mapNotNull(SyncFeedItem::op), next)
             cursor = next
 
-            if (!page.optBoolean("has_more", false)) return
+            if (!page.optBoolean("has_more", false)) return true
         }
         // A server that always says there is more would otherwise keep
         // this run going forever. Stopping is safe: the cursor is
         // durable and the next run carries on from it.
         Log.i(TAG, "Stopped reading changes after $MAX_PAGES pages")
+        return false
     }
 
     /**
@@ -715,33 +771,35 @@ class LiseurSyncPositionSync(
      * partial history. The snapshot is the newest position per book and
      * per device, which is exactly the baseline to start again from.
      */
-    private suspend fun resync(account: Account, trouble: Trouble) {
+    private suspend fun resync(account: Account, trouble: Trouble): Boolean {
         Log.i(TAG, "The cursor fell behind the server's horizon; starting from a snapshot")
         val snapshot = try {
             http.get(LiseurSyncApi.url(account.baseUrl, LiseurSyncApi.HEADS), account.credentials)
         } catch (e: IOException) {
             trouble.failed(e, reasonFor(e))
-            return
+            return false
         }
         apply(
             account,
             feed(snapshot.optJSONArray("ops")).mapNotNull(SyncFeedItem::op),
             snapshot.optLong("snapshot_seq"),
         )
+        return true
     }
 
     /** Lands a page and moves the cursor, together or not at all. */
     private suspend fun apply(account: Account, ops: List<SyncOp>, cursor: Long) {
-        val byWork = identityDao.aliasesFor(account.peerId).associateBy { it.workId }
         inTransaction {
-            if (serverDao.get()?.accountKey != account.accountKey) return@inTransaction
+            if (!sameAccount(account)) return@inTransaction
+            val byWork = identityDao.aliasesFor(account.peerId).filter { it.usable }.groupBy { it.workId }
             val newestByWork = ops
                 .filterNot { it.deviceId != null && it.deviceId == account.deviceId }
                 .groupBy(SyncOp::workId)
                 .mapNotNull { (_, candidates) -> candidates.maxByOrNull(SyncOp::seq) }
             for (op in newestByWork) {
-                val bookUrl = byWork[op.workId]?.takeIf { it.usable }?.bookUrl ?: continue
-                land(account, bookUrl, op)
+                for (alias in byWork[op.workId].orEmpty()) {
+                    land(account, alias.bookUrl, op)
+                }
             }
             serverDao.setSyncCursor(cursor)
         }
@@ -1546,9 +1604,13 @@ class LiseurSyncPositionSync(
      */
     private suspend fun forAccount(account: Account, work: suspend () -> Unit) {
         inTransaction {
-            if (serverDao.get()?.accountKey == account.accountKey) work()
+            if (sameAccount(account)) work()
         }
     }
+
+    private suspend fun sameAccount(account: Account): Boolean = serverDao.get()?.let {
+        it.accountKey == account.accountKey && it.credentials == account.credentials
+    } == true
 
     /**
      * What to call a failure that stopped one request.

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
@@ -262,8 +262,12 @@ class LiseurSyncPositionSync(
         bookUrl: String,
         atRevision: Long,
         peerId: String?,
+        expectedAccountKey: String?,
     ): ResolveOutcome {
         val account = account() ?: return ResolveOutcome.Done
+        if (expectedAccountKey != null && account.accountKey != expectedAccountKey) {
+            return ResolveOutcome.Superseded
+        }
         val state = peerStateDao.get(bookUrl, account.peerId) ?: return ResolveOutcome.Done
         val progression = state.pendingProgression ?: return ResolveOutcome.Done
 
@@ -272,8 +276,11 @@ class LiseurSyncPositionSync(
         val locator = state.exactLocatorFor(alias)
 
         var applied = false
+        var accountMatches = false
         val status = ReadingStatus.fromWire(state.pendingStatus)
         inTransaction {
+            if (!sameAccount(account)) return@inTransaction
+            accountMatches = true
             applied = progressDao.applyPeerPull(
                 bookUrl = bookUrl,
                 expectedRevision = atRevision,
@@ -294,6 +301,7 @@ class LiseurSyncPositionSync(
                 )
             }
         }
+        if (!accountMatches) return ResolveOutcome.Superseded
         if (!applied) return ResolveOutcome.Superseded
         finishedState.refreshFromProgress(bookUrl)
         return ResolveOutcome.Done

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
@@ -264,12 +264,24 @@ class LiseurSyncPositionSync(
         peerId: String?,
         expectedAccountKey: String?,
     ): ResolveOutcome {
-        val account = account() ?: return ResolveOutcome.Done
+        val account = account() ?: return if (expectedAccountKey != null) {
+            ResolveOutcome.Superseded
+        } else {
+            ResolveOutcome.Done
+        }
         if (expectedAccountKey != null && account.accountKey != expectedAccountKey) {
             return ResolveOutcome.Superseded
         }
-        val state = peerStateDao.get(bookUrl, account.peerId) ?: return ResolveOutcome.Done
-        val progression = state.pendingProgression ?: return ResolveOutcome.Done
+        val state = peerStateDao.get(bookUrl, account.peerId) ?: return if (expectedAccountKey != null) {
+            ResolveOutcome.Superseded
+        } else {
+            ResolveOutcome.Done
+        }
+        val progression = state.pendingProgression ?: return if (expectedAccountKey != null) {
+            ResolveOutcome.Superseded
+        } else {
+            ResolveOutcome.Done
+        }
 
         val alias = bookDao.getByUrl(bookUrl)
             ?.let { works.cached(it, account.peerId) }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/LiveChanges.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/LiveChanges.kt
@@ -1,0 +1,35 @@
+package com.chmouel.liseur.data.remote
+
+import com.chmouel.liseur.data.db.RemoteServer
+import kotlinx.coroutines.flow.Flow
+
+enum class LiveTopic { POSITIONS, ANNOTATIONS, INSIGHTS }
+
+/** Credentials are compared in their stored form, never logged or sent as an identity. */
+data class LiveIdentity(
+    val account: String,
+    val endpoint: String,
+    val kind: ServerKind,
+    val credential: String?,
+    val device: String?,
+) {
+    override fun toString(): String = "LiveIdentity($kind)"
+
+    companion object {
+        fun from(server: RemoteServer): LiveIdentity = LiveIdentity(
+            server.accountKey, server.baseUrl, server.kind,
+            server.liseurTokenCipher, server.accountId,
+        )
+    }
+}
+
+data class LiveRefresh(
+    val completed: Set<LiveTopic> = emptySet(),
+    val owedBooks: Set<String> = emptySet(),
+    val failures: Map<LiveTopic, SyncFailure> = emptyMap(),
+)
+
+interface LiveChanges {
+    fun events(server: RemoteServer): Flow<Set<LiveTopic>>
+    suspend fun refresh(identity: LiveIdentity, topics: Set<LiveTopic>): LiveRefresh
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/LiveRetry.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/LiveRetry.kt
@@ -1,0 +1,28 @@
+package com.chmouel.liseur.data.remote
+
+import java.io.IOException
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.random.Random
+
+class LiveStreamFailure(val code: Int? = null, val retryAfter: String? = null) :
+    IOException("Live stream ended${code?.let { " ($it)" }.orEmpty()}")
+
+/** No reset on HTTP 200: a server that opens then drops is still failing. */
+internal class LiveRetry(private val jitter: () -> Double = { Random.nextDouble() }) {
+    private var failures = 0
+
+    fun delayMillis(failure: LiveStreamFailure, now: Long = System.currentTimeMillis()): Long? {
+        if (failure.code in setOf(401, 403, 404, 501)) return null
+        val backoff = (15_000L shl failures).coerceAtMost(300_000L)
+        failures = (failures + 1).coerceAtMost(5)
+        val retryAfter = if (failure.code == 429) {
+            failure.retryAfter?.toLongOrNull()?.coerceIn(0, Long.MAX_VALUE / 1000)?.times(1000)
+                ?: runCatching {
+                    ZonedDateTime.parse(failure.retryAfter, DateTimeFormatter.RFC_1123_DATE_TIME)
+                        .toInstant().toEpochMilli().minus(now).coerceAtLeast(0)
+                }.getOrNull()
+        } else null
+        return maxOf(retryAfter ?: 0, (backoff * (1 + jitter().coerceIn(0.0, 1.0))).toLong())
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/LiveRetry.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/LiveRetry.kt
@@ -5,7 +5,11 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import kotlin.random.Random
 
-class LiveStreamFailure(val code: Int? = null, val retryAfter: String? = null) :
+class LiveStreamFailure(
+    val code: Int? = null,
+    val retryAfter: String? = null,
+    val retryMillis: Long? = null,
+) :
     IOException("Live stream ended${code?.let { " ($it)" }.orEmpty()}")
 
 /** No reset on HTTP 200: a server that opens then drops is still failing. */
@@ -23,6 +27,10 @@ internal class LiveRetry(private val jitter: () -> Double = { Random.nextDouble(
                         .toInstant().toEpochMilli().minus(now).coerceAtLeast(0)
                 }.getOrNull()
         } else null
-        return maxOf(retryAfter ?: 0, (backoff * (1 + jitter().coerceIn(0.0, 1.0))).toLong())
+        return maxOf(
+            retryAfter ?: 0,
+            failure.retryMillis ?: 0,
+            (backoff * (1 + jitter().coerceIn(0.0, 1.0))).toLong(),
+        )
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/PeerPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/PeerPositionSync.kt
@@ -100,7 +100,7 @@ class CompositePositionSync(private val peers: List<PeerPositionSync>) : Positio
         peerId: String?,
         expectedAccountKey: String?,
     ): ResolveOutcome =
-        resolve(bookUrl, peerId) {
+        resolve(bookUrl, peerId, expectedAccountKey) {
             it.takeRemotePosition(bookUrl, atRevision, expectedAccountKey = expectedAccountKey)
         }
 
@@ -142,10 +142,13 @@ class CompositePositionSync(private val peers: List<PeerPositionSync>) : Positio
     private suspend fun resolve(
         bookUrl: String,
         peerId: String?,
+        expectedAccountKey: String? = null,
         act: suspend (PeerPositionSync) -> ResolveOutcome,
     ): ResolveOutcome {
         val holders = holders(peerId).filter { it.preservedConflict(bookUrl) != null }
-        if (holders.isEmpty()) return ResolveOutcome.Done
+        if (holders.isEmpty()) {
+            return if (expectedAccountKey != null) ResolveOutcome.Superseded else ResolveOutcome.Done
+        }
         return holders
             .map { act(it) }
             .fold(ResolveOutcome.Done as ResolveOutcome) { worst, outcome ->

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/PeerPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/PeerPositionSync.kt
@@ -98,8 +98,11 @@ class CompositePositionSync(private val peers: List<PeerPositionSync>) : Positio
         bookUrl: String,
         atRevision: Long,
         peerId: String?,
+        expectedAccountKey: String?,
     ): ResolveOutcome =
-        resolve(bookUrl, peerId) { it.takeRemotePosition(bookUrl, atRevision) }
+        resolve(bookUrl, peerId) {
+            it.takeRemotePosition(bookUrl, atRevision, expectedAccountKey = expectedAccountKey)
+        }
 
     override suspend fun keepLocalPosition(bookUrl: String, peerId: String?): ResolveOutcome =
         resolve(bookUrl, peerId) { it.keepLocalPosition(bookUrl) }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/PositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/PositionSync.kt
@@ -267,6 +267,7 @@ interface PositionSync {
         bookUrl: String,
         atRevision: Long,
         peerId: String? = null,
+        expectedAccountKey: String? = null,
     ): ResolveOutcome
 
     /** Keeps what is on this device, for the partner named by [peerId]. */

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteRouter.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteRouter.kt
@@ -101,8 +101,14 @@ class RoutedPositionSync(private val router: RemoteRouter) : PeerPositionSync {
         bookUrl: String,
         atRevision: Long,
         peerId: String?,
+        expectedAccountKey: String?,
     ): ResolveOutcome =
-        router.positionSync()?.takeRemotePosition(bookUrl, atRevision) ?: ResolveOutcome.Done
+        router.positionSync()?.takeRemotePosition(
+            bookUrl,
+            atRevision,
+            peerId,
+            expectedAccountKey,
+        ) ?: ResolveOutcome.Done
 
     override suspend fun keepLocalPosition(bookUrl: String, peerId: String?): ResolveOutcome =
         router.positionSync()?.keepLocalPosition(bookUrl) ?: ResolveOutcome.Done

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteRouter.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteRouter.kt
@@ -108,7 +108,7 @@ class RoutedPositionSync(private val router: RemoteRouter) : PeerPositionSync {
             atRevision,
             peerId,
             expectedAccountKey,
-        ) ?: ResolveOutcome.Done
+        ) ?: if (expectedAccountKey != null) ResolveOutcome.Superseded else ResolveOutcome.Done
 
     override suspend fun keepLocalPosition(bookUrl: String, peerId: String?): ResolveOutcome =
         router.positionSync()?.keepLocalPosition(bookUrl) ?: ResolveOutcome.Done

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteRouter.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteRouter.kt
@@ -27,6 +27,7 @@ class RemoteRouter(
      * never offered for that kind, the same rule [deleters] follows.
      */
     private val uploaders: Map<ServerKind, BookUploader> = emptyMap(),
+    private val live: Map<ServerKind, LiveChanges> = emptyMap(),
 ) {
     private suspend fun kind(): ServerKind? = serverDao.get()?.kind
 
@@ -47,6 +48,10 @@ class RemoteRouter(
     fun filesFor(kind: ServerKind): FileSource? = files[kind]
 
     suspend fun positionSync(): PositionSync? = kind()?.let(positions::get)
+
+    suspend fun live(): LiveChanges? = kind()?.let(live::get)
+
+    fun liveFor(kind: ServerKind): LiveChanges? = live[kind]
 
     /** The deleter for a server already in hand, when the kind has one. */
     fun deleterFor(kind: ServerKind): BookDeleter? = deleters[kind]

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -623,6 +623,19 @@ fun ReaderScreen(
         return captured
     }
 
+    onProgressAction.prepareCatchUp = {
+        if (effectiveScrolling) {
+            navigatorNow?.let { nav ->
+                val since = heldPlace.mark()
+                scrolledPlace(nav)?.let {
+                    if (heldPlace.hold(it, since)) {
+                        onLocatorChanged(it, NavigatorPositionEvent.LOCAL_JUMP)
+                    }
+                }
+            }
+        }
+    }
+
     suspend fun settleLayout() {
         withFrameNanos { }
         withFrameNanos { }
@@ -2215,7 +2228,12 @@ fun ReaderScreen(
                             remoteAt = offer.remoteAt,
                             confidence = offer.confidence,
                             theme = readingTheme,
-                            onCatchUp = onProgressAction.acceptCatchUp,
+                            onCatchUp = {
+                                effectScope.launch {
+                                    onProgressAction.prepareCatchUp()
+                                    onProgressAction.acceptCatchUp()
+                                }
+                            },
                             onDismiss = onProgressAction.dismissCatchUp,
                         )
                     }
@@ -2899,6 +2917,7 @@ class ReaderProgressActions(
     val jumpFrom: (Locator?) -> Unit,
     val dismissJumpBack: () -> Unit,
     val acceptCatchUp: () -> Unit,
+    var prepareCatchUp: suspend () -> Unit = {},
     val dismissCatchUp: () -> Unit,
     val chapterTicks: () -> List<Float>,
     val chapterTitleAtPosition: (Int) -> String?,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -2231,7 +2231,7 @@ fun ReaderScreen(
                             onCatchUp = {
                                 effectScope.launch {
                                     onProgressAction.prepareCatchUp()
-                                    onProgressAction.acceptCatchUp()
+                                    onProgressAction.acceptCatchUp(offer)
                                 }
                             },
                             onDismiss = onProgressAction.dismissCatchUp,
@@ -2916,7 +2916,7 @@ class ReaderProgressActions(
     val setFooterMode: (FooterMode) -> Unit,
     val jumpFrom: (Locator?) -> Unit,
     val dismissJumpBack: () -> Unit,
-    val acceptCatchUp: () -> Unit,
+    val acceptCatchUp: (ReaderViewModel.CatchUp?) -> Unit,
     var prepareCatchUp: suspend () -> Unit = {},
     val dismissCatchUp: () -> Unit,
     val chapterTicks: () -> List<Float>,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -625,7 +625,7 @@ fun ReaderScreen(
 
     onProgressAction.prepareCatchUp = {
         if (!effectiveScrolling) {
-            false
+            true
         } else {
             navigatorNow?.let { nav ->
                 val since = heldPlace.mark()

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -624,15 +624,17 @@ fun ReaderScreen(
     }
 
     onProgressAction.prepareCatchUp = {
-        if (effectiveScrolling) {
+        if (!effectiveScrolling) {
+            false
+        } else {
             navigatorNow?.let { nav ->
                 val since = heldPlace.mark()
                 scrolledPlace(nav)?.let {
-                    if (heldPlace.hold(it, since)) {
-                        onLocatorChanged(it, NavigatorPositionEvent.LOCAL_JUMP)
-                    }
-                }
-            }
+                    if (!heldPlace.hold(it, since)) return@let false
+                    onLocatorChanged(it, NavigatorPositionEvent.LOCAL_JUMP)
+                    true
+                } ?: false
+            } ?: false
         }
     }
 
@@ -2230,8 +2232,9 @@ fun ReaderScreen(
                             theme = readingTheme,
                             onCatchUp = {
                                 effectScope.launch {
-                                    onProgressAction.prepareCatchUp()
-                                    onProgressAction.acceptCatchUp(offer)
+                                    if (onProgressAction.prepareCatchUp()) {
+                                        onProgressAction.acceptCatchUp(offer)
+                                    }
                                 }
                             },
                             onDismiss = onProgressAction.dismissCatchUp,
@@ -2917,7 +2920,7 @@ class ReaderProgressActions(
     val jumpFrom: (Locator?) -> Unit,
     val dismissJumpBack: () -> Unit,
     val acceptCatchUp: (ReaderViewModel.CatchUp?) -> Unit,
-    var prepareCatchUp: suspend () -> Unit = {},
+    var prepareCatchUp: suspend () -> Boolean = { true },
     val dismissCatchUp: () -> Unit,
     val chapterTicks: () -> List<Float>,
     val chapterTitleAtPosition: (Int) -> String?,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -1169,8 +1169,8 @@ class ReaderViewModel(
     }
 
     /** Takes the offer: the further position wins, and the page turns. */
-    fun acceptCatchUp() {
-        val offer = _catchUp.value ?: return
+    fun acceptCatchUp(offered: CatchUp? = _catchUp.value) {
+        val offer = offered ?: return
         val acceptedFrom = lastLocator
         _catchUp.value = null
         viewModelScope.launch {

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -828,6 +828,15 @@ class ReaderViewModel(
     var lastLocator: Locator? = null
         private set
 
+    /**
+     * Advances only on persisted local reading movement — never on a
+     * non-persisting reflow or lifecycle callback, which can replace
+     * [lastLocator] with a structurally different locator for the same
+     * page. Catch-up guards compare this instead of [lastLocator] so
+     * such a callback cannot masquerade as the reader having moved.
+     */
+    private var readingGeneration = 0L
+
     init {
         viewModelScope.launch {
             positionPublisher.failures.collect { failedBook ->
@@ -1028,6 +1037,7 @@ class ReaderViewModel(
         // even when its stable resource position has not moved. Keep the
         // display current, but do not turn that layout detail into reading.
         if (samePosition || !effectiveEvent.persists) return
+        readingGeneration++
         _catchUp.value = null
         val totalProgression = stable?.progression ?: return
         if (effectiveEvent.teachesPace) {
@@ -1133,12 +1143,12 @@ class ReaderViewModel(
         if (catchUpChecking || publication == null) return
         catchUpChecking = true
         _catchUp.value = null
-        val offeredFrom = lastLocator
+        val offeredGeneration = readingGeneration
         viewModelScope.launch {
             try {
                 if (!positionPublisher.flush(bookId)) return@launch
                 val outcome = positionSync.preview(bookId)
-                if (!readerActive || lastLocator != offeredFrom) return@launch
+                if (!readerActive || readingGeneration != offeredGeneration) return@launch
                 val preview = (outcome as? PreviewOutcome.Ready)?.preview ?: return@launch
                 val there = preview.remote ?: return@launch
                 val here = preview.local
@@ -1171,14 +1181,14 @@ class ReaderViewModel(
     /** Takes the offer: the further position wins, and the page turns. */
     fun acceptCatchUp(offered: CatchUp? = _catchUp.value) {
         val offer = offered ?: return
-        val acceptedFrom = lastLocator
+        val acceptedGeneration = readingGeneration
         _catchUp.value = null
         viewModelScope.launch {
-            if (!positionPublisher.flush(bookId) || lastLocator != acceptedFrom) return@launch
+            if (!positionPublisher.flush(bookId) || readingGeneration != acceptedGeneration) return@launch
             val outcome = offer.resolve(bookId, positionSync)
             // Anything but a clean adoption leaves the book where it is;
             // the offer will simply be made again if it still stands.
-            if (outcome != ResolveOutcome.Done || lastLocator != acceptedFrom) return@launch
+            if (outcome != ResolveOutcome.Done || readingGeneration != acceptedGeneration) return@launch
             goToRemotePosition(offer.preview)
         }
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -142,6 +142,7 @@ class ReaderViewModel(
     private val remoteAccount: RemoteAccountRepository,
     private val userFonts: UserFontRepository,
     sessionManager: ReadingSessionManager,
+    private val requestBookSync: (String) -> Unit = {},
 ) : ViewModel() {
 
     /**
@@ -354,7 +355,17 @@ class ReaderViewModel(
         val excerpt: String?,
         val remoteAt: Long?,
         val confidence: ResumeConfidence,
-    )
+        val preview: SyncPreview,
+    ) {
+        internal suspend fun resolve(bookId: String, coordinator: PositionSyncCoordinator): ResolveOutcome =
+            coordinator.resolve(
+                bookUrl = bookId,
+                takeRemote = true,
+                atRevision = preview.localRevision ?: 0,
+                expecting = preview.fingerprint(),
+                peerId = preview.peerId,
+            )
+    }
 
     private val _catchUp = MutableStateFlow<CatchUp?>(null)
 
@@ -720,15 +731,14 @@ class ReaderViewModel(
         }
     }
 
-    /** Navigates to the exact adopted locator, or conservatively before its percentage. */
+    /** Navigates to the position that was offered, not a later database snapshot. */
     private suspend fun goToRemotePosition(preview: SyncPreview) {
         val positions = positionsFor(publication ?: return)
-        val stored = progressDao.get(bookId) ?: return
-        val exact = runCatching { Locator.fromJSON(JSONObject(stored.locatorJson)) }
-            .getOrNull()
+        val exact = preview.remoteLocatorJson
+            ?.let { runCatching { Locator.fromJSON(JSONObject(it)) }.getOrNull() }
             ?.takeIf(ExactLocatorAnchor::isExact)
         val target = exact
-            ?: stored.totalProgression?.let(positions::locatorAtOrBeforeProgression)
+            ?: preview.remote?.let(positions::locatorAtOrBeforeProgression)
             ?: return
         onJump()
         _jumpBack.value = _jumpBack.value?.copy(
@@ -1018,6 +1028,7 @@ class ReaderViewModel(
         // even when its stable resource position has not moved. Keep the
         // display current, but do not turn that layout detail into reading.
         if (samePosition || !effectiveEvent.persists) return
+        _catchUp.value = null
         val totalProgression = stable?.progression ?: return
         if (effectiveEvent.teachesPace) {
             val sample = speed.record(
@@ -1121,9 +1132,13 @@ class ReaderViewModel(
     private fun maybeOfferCatchUp() {
         if (catchUpChecking || publication == null) return
         catchUpChecking = true
+        _catchUp.value = null
+        val offeredFrom = lastLocator
         viewModelScope.launch {
             try {
+                if (!positionPublisher.flush(bookId)) return@launch
                 val outcome = positionSync.preview(bookId)
+                if (!readerActive || lastLocator != offeredFrom) return@launch
                 val preview = (outcome as? PreviewOutcome.Ready)?.preview ?: return@launch
                 val there = preview.remote ?: return@launch
                 val here = preview.local
@@ -1145,6 +1160,7 @@ class ReaderViewModel(
                     excerpt = preview.excerpt,
                     remoteAt = preview.remoteAt,
                     confidence = preview.confidence,
+                    preview = preview,
                 )
             } finally {
                 catchUpChecking = false
@@ -1155,25 +1171,15 @@ class ReaderViewModel(
     /** Takes the offer: the further position wins, and the page turns. */
     fun acceptCatchUp() {
         val offer = _catchUp.value ?: return
+        val acceptedFrom = lastLocator
         _catchUp.value = null
         viewModelScope.launch {
-            val outcome = positionSync.resolve(
-                bookId,
-                takeRemote = true,
-                atRevision = progressDao.currentRevision(bookId) ?: 0,
-            )
+            if (!positionPublisher.flush(bookId) || lastLocator != acceptedFrom) return@launch
+            val outcome = offer.resolve(bookId, positionSync)
             // Anything but a clean adoption leaves the book where it is;
             // the offer will simply be made again if it still stands.
-            if (outcome != ResolveOutcome.Done) return@launch
-            goToRemotePosition(
-                SyncPreview(
-                    local = null,
-                    remote = offer.progression,
-                    remoteAt = offer.remoteAt,
-                    excerpt = offer.excerpt,
-                    confidence = offer.confidence,
-                ),
-            )
+            if (outcome != ResolveOutcome.Done || lastLocator != acceptedFrom) return@launch
+            goToRemotePosition(offer.preview)
         }
     }
 
@@ -1450,7 +1456,7 @@ class ReaderViewModel(
         val locator = lastLocator ?: return
         val existing = bookmarkForCurrentPage()
         if (existing != null) {
-            viewModelScope.launch { annotationDao.delete(existing) }
+            remove(existing)
         } else {
             save(annotation(locator, AnnotationKind.BOOKMARK))
         }
@@ -1479,7 +1485,10 @@ class ReaderViewModel(
     }
 
     fun remove(annotation: BookAnnotation) {
-        viewModelScope.launch { annotationDao.delete(annotation) }
+        viewModelScope.launch {
+            annotationDao.delete(annotation)
+            requestBookSync(annotation.bookId)
+        }
     }
 
     /** The notebook as Markdown, ready to be shared. */
@@ -1502,7 +1511,10 @@ class ReaderViewModel(
      */
     private fun save(annotation: BookAnnotation) {
         val stamped = annotation.copy(updatedAt = System.currentTimeMillis() * 1000)
-        viewModelScope.launch { annotationDao.upsert(stamped) }
+        viewModelScope.launch {
+            annotationDao.upsert(stamped)
+            requestBookSync(stamped.bookId)
+        }
     }
 
     private fun annotation(locator: Locator, kind: AnnotationKind): BookAnnotation {
@@ -1717,6 +1729,7 @@ class ReaderViewModel(
                     remoteAccount = container.remoteAccount,
                     userFonts = container.userFonts,
                     sessionManager = container.readingSessions,
+                    requestBookSync = container::requestBookSync,
                 )
             }
         }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/progress/BookPositions.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/progress/BookPositions.kt
@@ -92,15 +92,25 @@ class BookPositions(
     }
 
     /**
-     * A conservative synthetic locator which never starts after [progression].
-     * Used when an exact text quote is unavailable or belongs to another edition.
+     * An approximate resource locator at [progression], using the inverse of
+     * [resolve]. Flooring the synthetic position alone can send most of a
+     * two-position chapter back to its first paragraph.
      */
     fun locatorAtOrBeforeProgression(progression: Double): Locator? {
         if (!isUsable) return null
-        if (totalPositions == 1) return locators.first()
-        val coordinate = 1.0 + progression.coerceIn(0.0, 1.0) * (totalPositions - 1)
+        val bounded = progression.takeIf { it.isFinite() }?.coerceIn(0.0, 1.0) ?: 0.0
+        val coordinate = 1.0 + bounded * (totalPositions - 1)
         val position = floor(coordinate).toInt().coerceIn(1, totalPositions)
-        return locatorAt(position)
+        val resource = resources.lastOrNull { it.firstPosition <= coordinate }
+            ?: return locatorAt(position)
+        return resource.positions.first().copy(
+            locations = Locator.Locations(
+                progression = if (totalPositions == 1) bounded else resource.progressionAt(coordinate),
+                position = position,
+                totalProgression = bounded,
+            ),
+            text = Locator.Text(),
+        )
     }
 
     private fun progressAtCoordinate(coordinate: Double): StableBookProgress {
@@ -173,6 +183,17 @@ class BookPositions(
             if (width <= 0.0) return upper.second
             val fraction = (progression - lower.first) / width
             return lower.second + (upper.second - lower.second) * fraction
+        }
+
+        fun progressionAt(coordinate: Double): Double {
+            val upperIndex = anchors.indexOfFirst { it.second >= coordinate }
+            if (upperIndex < 0) return anchors.last().first
+            if (upperIndex == 0) return anchors.first().first
+            val lower = anchors[upperIndex - 1]
+            val upper = anchors[upperIndex]
+            val width = upper.second - lower.second
+            if (width <= 0.0) return lower.first
+            return lower.first + (upper.first - lower.first) * (coordinate - lower.second) / width
         }
     }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/sync/LiveSyncConnector.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/sync/LiveSyncConnector.kt
@@ -1,0 +1,135 @@
+package com.chmouel.liseur.sync
+
+import com.chmouel.liseur.data.db.RemoteServer
+import com.chmouel.liseur.data.remote.LiveRetry
+import com.chmouel.liseur.data.remote.LiveStreamFailure
+import com.chmouel.liseur.data.remote.LiveChanges
+import com.chmouel.liseur.data.remote.LiveIdentity
+import com.chmouel.liseur.data.remote.LiveTopic
+import com.chmouel.liseur.data.remote.SyncFailure
+import java.io.IOException
+import kotlin.random.Random
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.launch
+
+/** One foreground connection; a short trip away does not replay the opening hint. */
+class LiveSyncConnector(
+    private val scope: CoroutineScope,
+    accounts: Flow<RemoteServer?>,
+    private val sourceFor: (RemoteServer) -> LiveChanges?,
+    private val coordinator: PositionSyncCoordinator,
+    private val requestBook: (String) -> Unit,
+    private val graceMillis: Long = 15_000,
+    private val retryJitter: () -> Double = { Random.nextDouble() },
+    private val reportFailure: suspend (LiveIdentity, SyncFailure) -> Unit = { _, _ -> },
+) {
+    private val active = MutableStateFlow(false)
+    private var stopping: Job? = null
+
+    init {
+        scope.launch {
+            combine(active, accounts) { foreground, server -> server.takeIf { foreground } }
+                .distinctUntilChangedBy { it?.let(LiveIdentity::from) }
+                .collectLatest { server ->
+                    val identity = server?.let(LiveIdentity::from)
+                    coordinator.liveAccount(identity)
+                    if (server != null && identity != null) {
+                        sourceFor(server)?.let { connected(server, identity, it) }
+                    }
+                }
+        }
+    }
+
+    fun foreground() {
+        stopping?.cancel()
+        active.value = true
+    }
+
+    fun background() {
+        stopping?.cancel()
+        stopping = scope.launch {
+            delay(graceMillis)
+            active.value = false
+        }
+    }
+
+    private suspend fun connected(server: RemoteServer, identity: LiveIdentity, source: LiveChanges) =
+        coroutineScope {
+            val wake = Channel<Unit>(Channel.CONFLATED)
+            val stopped = CompletableDeferred<Unit>()
+            val refreshing = launch {
+                val paused = mutableSetOf<LiveTopic>()
+                var retry = LiveRetry(retryJitter)
+                for (ignored in wake) {
+                    while (coordinator.hasLiveWork(identity, excluding = paused)) {
+                        val failed = try {
+                            val result = coordinator.refreshLive(identity, excluding = paused, refresh = source::refresh)
+                            result.failures.values.firstOrNull {
+                                it == SyncFailure.Unauthorised || it == SyncFailure.Forbidden ||
+                                    it == SyncFailure.InsecureTransport
+                            }?.let { reportFailure(identity, it) }
+                            if (SyncFailure.Unauthorised in result.failures.values) {
+                                stopped.complete(Unit)
+                                return@launch
+                            }
+                            paused += result.failures.filterValues { !it.worthRetryingLive() }.keys
+                            // Never request sync under the coordinator's turn.
+                            result.owedBooks.forEach(requestBook)
+                            result.failures.values.any { it.worthRetryingLive() }
+                        } catch (cancelled: CancellationException) {
+                            throw cancelled
+                        } catch (_: Exception) {
+                            // The topic remains owed even if the stream has nothing more to say.
+                            true
+                        }
+                        if (!failed) retry = LiveRetry(retryJitter)
+                        if (coordinator.hasLiveWork(identity, excluding = paused)) {
+                            delay(if (failed) retry.delayMillis(LiveStreamFailure())!! else 15_000)
+                        }
+                    }
+                }
+            }
+            val streaming = launch {
+                val retry = LiveRetry(retryJitter)
+                while (true) {
+                    val failure = try {
+                        source.events(server).collect { topics ->
+                            coordinator.invalidate(identity, topics)
+                            wake.trySend(Unit)
+                        }
+                        LiveStreamFailure()
+                    } catch (cancelled: CancellationException) {
+                        throw cancelled
+                    } catch (failure: LiveStreamFailure) {
+                        failure
+                    } catch (_: IOException) {
+                        LiveStreamFailure()
+                    }
+                    val wait = retry.delayMillis(failure) ?: run {
+                        if (failure.code == 401) reportFailure(identity, SyncFailure.Unauthorised)
+                        stopped.complete(Unit)
+                        return@launch
+                    }
+                    delay(wait)
+                }
+            }
+            stopped.await()
+            streaming.cancelAndJoin()
+            refreshing.cancelAndJoin()
+        }
+
+    private fun SyncFailure.worthRetryingLive(): Boolean =
+        worthRetrying || (this is SyncFailure.ServerError && code == 429)
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/sync/LiveSyncConnector.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/sync/LiveSyncConnector.kt
@@ -8,6 +8,7 @@ import com.chmouel.liseur.data.remote.LiveIdentity
 import com.chmouel.liseur.data.remote.LiveTopic
 import com.chmouel.liseur.data.remote.SyncFailure
 import java.io.IOException
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.random.Random
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -36,6 +37,7 @@ class LiveSyncConnector(
     private val reportFailure: suspend (LiveIdentity, SyncFailure) -> Unit = { _, _ -> },
 ) {
     private val active = MutableStateFlow(false)
+    private val lifecycleGeneration = AtomicLong(0)
     private var stopping: Job? = null
 
     init {
@@ -53,15 +55,17 @@ class LiveSyncConnector(
     }
 
     fun foreground() {
+        lifecycleGeneration.incrementAndGet()
         stopping?.cancel()
         active.value = true
     }
 
     fun background() {
+        val generation = lifecycleGeneration.incrementAndGet()
         stopping?.cancel()
         stopping = scope.launch {
             delay(graceMillis)
-            active.value = false
+            if (lifecycleGeneration.get() == generation) active.value = false
         }
     }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/sync/LiveSyncConnector.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/sync/LiveSyncConnector.kt
@@ -38,6 +38,7 @@ class LiveSyncConnector(
 ) {
     private val active = MutableStateFlow(false)
     private val lifecycleGeneration = AtomicLong(0)
+    private val lifecycleLock = Any()
     private var stopping: Job? = null
 
     init {
@@ -55,17 +56,27 @@ class LiveSyncConnector(
     }
 
     fun foreground() {
-        lifecycleGeneration.incrementAndGet()
-        stopping?.cancel()
-        active.value = true
+        synchronized(lifecycleLock) {
+            lifecycleGeneration.incrementAndGet()
+            stopping?.cancel()
+            stopping = null
+            active.value = true
+        }
     }
 
     fun background() {
-        val generation = lifecycleGeneration.incrementAndGet()
-        stopping?.cancel()
-        stopping = scope.launch {
-            delay(graceMillis)
-            if (lifecycleGeneration.get() == generation) active.value = false
+        synchronized(lifecycleLock) {
+            val generation = lifecycleGeneration.incrementAndGet()
+            stopping?.cancel()
+            stopping = scope.launch {
+                delay(graceMillis)
+                synchronized(lifecycleLock) {
+                    if (lifecycleGeneration.get() == generation) {
+                        active.value = false
+                        stopping = null
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/sync/PositionSyncCoordinator.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/sync/PositionSyncCoordinator.kt
@@ -1,6 +1,9 @@
 package com.chmouel.liseur.sync
 
 import com.chmouel.liseur.data.remote.PositionSync
+import com.chmouel.liseur.data.remote.LiveIdentity
+import com.chmouel.liseur.data.remote.LiveRefresh
+import com.chmouel.liseur.data.remote.LiveTopic
 import com.chmouel.liseur.data.remote.PreviewOutcome
 import com.chmouel.liseur.data.remote.ResolveOutcome
 import com.chmouel.liseur.data.remote.SyncFingerprint
@@ -62,6 +65,56 @@ class PositionSyncCoordinator(private val sync: PositionSync) {
 
     private var inFlight: Running? = null
     private val queued = mutableMapOf<SyncScope, CompletableDeferred<SyncOutcome>>()
+    private var liveIdentity: LiveIdentity? = null
+    private var liveAccountGeneration = 0L
+    private var liveGeneration = 0L
+    private val pendingTopics = mutableMapOf<LiveTopic, Long>()
+
+    suspend fun liveAccount(identity: LiveIdentity?) = state.withLock {
+        if (liveIdentity != identity) {
+            liveIdentity = identity
+            liveAccountGeneration++
+            liveGeneration++
+            pendingTopics.clear()
+        }
+    }
+
+    suspend fun invalidate(identity: LiveIdentity, topics: Set<LiveTopic>) = state.withLock {
+        if (liveIdentity == identity) {
+            val generation = ++liveGeneration
+            topics.forEach { pendingTopics[it] = generation }
+        }
+    }
+
+    suspend fun hasLiveWork(identity: LiveIdentity, excluding: Set<LiveTopic> = emptySet()): Boolean = state.withLock {
+        liveIdentity == identity && pendingTopics.keys.any { it !in excluding }
+    }
+
+    /** A completion only pays the notifications captured before this turn. */
+    suspend fun refreshLive(
+        identity: LiveIdentity,
+        excluding: Set<LiveTopic> = emptySet(),
+        refresh: suspend (LiveIdentity, Set<LiveTopic>) -> LiveRefresh,
+    ): LiveRefresh = turn.withLock {
+        val (generation, captured) = state.withLock {
+            liveAccountGeneration to if (liveIdentity != identity) {
+                emptyMap()
+            } else {
+                pendingTopics.filterKeys { it !in excluding }
+            }
+        }
+        if (captured.isEmpty()) return@withLock LiveRefresh()
+        val result = refresh(identity, captured.keys)
+        state.withLock {
+            if (liveIdentity != identity || liveAccountGeneration != generation) {
+                return@withLock LiveRefresh()
+            }
+            result.completed.forEach { topic ->
+                if (pendingTopics[topic] == captured[topic]) pendingTopics.remove(topic)
+            }
+            result
+        }
+    }
 
     private class Running(
         val scope: SyncScope,

--- a/app/src/main/kotlin/com/chmouel/liseur/sync/PositionSyncCoordinator.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/sync/PositionSyncCoordinator.kt
@@ -254,7 +254,12 @@ class PositionSyncCoordinator(private val sync: PositionSync) {
             if (now == null || !expecting.matches(now)) return@withLock ResolveOutcome.Superseded
         }
         if (takeRemote) {
-            sync.takeRemotePosition(bookUrl, atRevision, peerId)
+            sync.takeRemotePosition(
+                bookUrl,
+                atRevision,
+                peerId,
+                expectedAccountKey = expecting?.accountKey,
+            )
         } else {
             sync.keepLocalPosition(bookUrl, peerId)
         }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
@@ -10,6 +10,7 @@ import com.chmouel.liseur.container
 import com.chmouel.liseur.data.db.BookDao
 import com.chmouel.liseur.data.db.ReadingProgressDao
 import com.chmouel.liseur.data.db.ReadingSessionDao
+import com.chmouel.liseur.data.remote.LiveIdentity
 import com.chmouel.liseur.data.liseursync.InsightDay
 import com.chmouel.liseur.data.liseursync.InsightsSummary
 import com.chmouel.liseur.data.liseursync.LiseurSyncInsights
@@ -41,6 +42,9 @@ import java.util.Locale
 import kotlin.math.roundToLong
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -128,7 +132,30 @@ class ReadingStatsViewModel(
     private val zone: () -> ZoneId = ZoneId::systemDefault,
     private val now: (ZoneId) -> ZonedDateTime = ZonedDateTime::now,
     initialWeekStart: DayOfWeek = localeWeekStart(Locale.getDefault()),
+    private val liveInvalidations: Flow<Long> = flowOf(0L),
+    private val liveAccounts: Flow<LiveIdentity?> = flowOf(null),
+    private val currentAccount: suspend () -> LiveIdentity? = { null },
 ) : ViewModel() {
+
+    /** Collected only by the visible route, and refreshed again on entry. */
+    suspend fun observeLiveInsights() {
+        try {
+            combine(liveInvalidations, liveAccounts.distinctUntilChanged()) { tick, account ->
+                tick to account
+            }.collect { (_, account) ->
+                if (account != shownAccount) {
+                    shownAccount = account
+                    forgetServerAnswers()
+                }
+                refreshServerInsights()
+            }
+        } finally {
+            generation++
+            refresh?.cancel()
+        }
+    }
+
+    private var shownAccount: LiveIdentity? = null
 
     /**
      * Everything that decides which question the screen is asking.
@@ -309,11 +336,14 @@ class ReadingStatsViewModel(
         val token = ++generation
         refresh?.cancel()
         refresh = viewModelScope.launch {
+            val account = currentAccount()
             val end = window.today
             val week = window.weekStart
             launch {
                 val summary = source.summary(window.range, end, week)
-                if (token == generation) _acrossDevices.value = Answered(window, summary)
+                if (token == generation && currentAccount() == account) {
+                    _acrossDevices.value = Answered(window, summary)
+                }
             }
             launch {
                 val calendar = source.calendar(
@@ -323,11 +353,15 @@ class ReadingStatsViewModel(
                     ),
                     to = end,
                 )
-                if (token == generation) _recentAcrossDevices.value = Answered(window, calendar)
+                if (token == generation && currentAccount() == account) {
+                    _recentAcrossDevices.value = Answered(window, calendar)
+                }
             }
             launch {
                 val books = source.allBooks(window.range, end, week)
-                if (token == generation) _booksAcrossDevices.value = Answered(window, books)
+                if (token == generation && currentAccount() == account) {
+                    _booksAcrossDevices.value = Answered(window, books)
+                }
             }
         }
     }
@@ -842,6 +876,11 @@ class ReadingStatsViewModel(
                     bookDao = container.database.bookDao(),
                     progressDao = container.database.readingProgressDao(),
                     insights = container.syncInsights,
+                    liveInvalidations = container.insightInvalidations,
+                    liveAccounts = container.remoteAccount.server.map { it?.let(LiveIdentity::from) },
+                    currentAccount = {
+                        container.database.remoteServerDao().get()?.let(LiveIdentity::from)
+                    },
                     settings = container.appSettings,
                 )
             }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/library/AnnotationBackupRepositoryTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/library/AnnotationBackupRepositoryTest.kt
@@ -1,0 +1,137 @@
+package com.chmouel.liseur.data.library
+
+import android.content.Context
+import android.net.Uri
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.chmouel.liseur.data.db.AnnotationKind
+import com.chmouel.liseur.data.db.Book
+import com.chmouel.liseur.data.db.BookAnnotation
+import com.chmouel.liseur.data.db.BookAnnotationDao
+import com.chmouel.liseur.data.db.LiseurDatabase
+import com.chmouel.liseur.domain.BackedUpBook
+import com.chmouel.liseur.domain.encodeAnnotationBackup
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.io.ByteArrayInputStream
+
+@Config(sdk = [35], application = android.app.Application::class)
+@RunWith(RobolectricTestRunner::class)
+class AnnotationBackupRepositoryTest {
+    private lateinit var context: Context
+    private lateinit var db: LiseurDatabase
+    private val requested = mutableListOf<String>()
+    private val committedCounts = mutableListOf<Int>()
+
+    @Before
+    fun open() {
+        context = ApplicationProvider.getApplicationContext()
+        db = Room.inMemoryDatabaseBuilder(context, LiseurDatabase::class.java).build()
+    }
+
+    @After
+    fun close() {
+        db.close()
+    }
+
+    private fun repository(dao: BookAnnotationDao = db.annotationDao()) =
+        AnnotationBackupRepository(context, dao, db.bookDao()) { bookId ->
+            requested += bookId
+            committedCounts += runBlocking { db.annotationDao().count(bookId) }
+        }
+
+    private fun mark(id: String, bookId: String = "book-one") = BookAnnotation(
+        id = id,
+        bookId = bookId,
+        kind = AnnotationKind.BOOK_NOTE.name,
+        locatorJson = "",
+        note = "A restored note",
+        createdAt = 123,
+    )
+
+    private fun source(vararg marks: BookAnnotation): Uri {
+        val text = encodeAnnotationBackup(
+            marks.groupBy { it.bookId }.map { (id, annotations) ->
+                BackedUpBook(id, "A book", "An author", annotations)
+            },
+        )
+        val uri = Uri.parse("content://test/backup")
+        shadowOf(context.contentResolver).registerInputStreamSupplier(uri) {
+            ByteArrayInputStream(text.toByteArray())
+        }
+        return uri
+    }
+
+    @Test
+    fun `imports request each changed book once after all inserts commit`() = runTest {
+        val result = repository().importFrom(
+            source(mark("one"), mark("two"), mark("three", "book-two")),
+        )
+
+        assertEquals(BackupResult.Imported(3, 0), result)
+        assertEquals(listOf("book-one", "book-two"), requested)
+        assertEquals(listOf(2, 1), committedCounts)
+    }
+
+    @Test
+    fun `duplicates do not request sync even beside a new book`() = runTest {
+        db.annotationDao().upsert(mark("existing"))
+        val repo = repository()
+        val source = source(mark("existing"), mark("new", "book-two"))
+
+        assertEquals(BackupResult.Imported(1, 1), repo.importFrom(source))
+        assertEquals(listOf("book-two"), requested)
+        requested.clear()
+        assertEquals(BackupResult.Imported(0, 2), repo.importFrom(source))
+        assertTrue(requested.isEmpty())
+    }
+
+    @Test
+    fun `the matched local book is requested rather than the backup path`() = runTest {
+        db.bookDao().upsert(
+            Book(
+                url = "local-book",
+                title = "A book",
+                author = "An author",
+                coverPath = null,
+                source = null,
+                addedAt = 0,
+                lastOpenedAt = null,
+            ),
+        )
+
+        assertEquals(BackupResult.Imported(2, 0), repository().importFrom(source(mark("one"), mark("two"))))
+        assertEquals(listOf("local-book"), requested)
+        assertEquals(listOf(2), committedCounts)
+    }
+
+    @Test
+    fun `a failed insert emits no local change signal`() = runTest {
+        val failure = IllegalStateException("write failed")
+        val dao = object : BookAnnotationDao by db.annotationDao() {
+            override suspend fun insertMissing(annotations: List<BookAnnotation>): List<Long> =
+                throw failure
+        }
+
+        val result = runCatching { repository(dao).importFrom(source(mark("one"))) }
+        assertTrue(result.exceptionOrNull() is IllegalStateException)
+        assertEquals(failure.message, result.exceptionOrNull()?.message)
+        assertTrue(requested.isEmpty())
+        assertTrue(db.annotationDao().all().isEmpty())
+    }
+
+    @Test
+    fun `an empty import requests nothing`() = runTest {
+        assertEquals(BackupResult.Imported(0, 0), repository().importFrom(source()))
+        assertTrue(requested.isEmpty())
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncAnnotationsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncAnnotationsTest.kt
@@ -1261,6 +1261,24 @@ class LiseurSyncAnnotationsTest {
     }
 
     @Test
+    fun `a rate-limited feed stops the pass instead of reconciling on`() = runTest {
+        // 429 is answered, so it is not "unreachable" — but running on
+        // regardless would still spend the reconcile budget against a
+        // server that just asked this device to slow down.
+        connect()
+        alias()
+        reconciled()
+        db.annotationDao().upsert(mark(note = "edited offline", updatedAt = MICROS + 5))
+        db.annotationSyncDao().upsert(syncRow(rev = 3, acked = "stale"))
+        server.enqueue(MockResponse(code = 429))
+
+        sync()
+
+        assertTrue(requests().none { it.target == "/v1/works/$WORK/annotations" })
+        assertEquals(0, pushes())
+    }
+
+    @Test
     fun `a pass that outlives its account stops talking to the server`() = runTest {
         // Refusing to store the answer is too late: the request is the
         // side effect. A device that has been unpaired must not go on

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncLiveTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncLiveTest.kt
@@ -150,29 +150,29 @@ class LiseurSyncLiveTest {
                 }.exceptionOrNull() is LiveStreamFailure,
             )
         }
+    }
 
-        @Test
-        fun `gzip expansion is bounded before parsing the event`() = runBlocking {
-            MockWebServer().use { server ->
-                server.start(InetAddress.getLoopbackAddress(), 0)
-                val compressed = Buffer()
-                GzipSink(compressed).buffer().use {
-                    it.writeUtf8("event: invalidate\ndata: {\"topics\":[\"positions\"],\"padding\":\"")
-                    it.writeUtf8("x".repeat(100_000))
-                    it.writeUtf8("\"}\n\n")
-                }
-                assertTrue(compressed.size < 1_000)
-                server.enqueue(
-                    MockResponse.Builder().addHeader("Content-Type", "text/event-stream")
-                        .addHeader("Content-Encoding", "gzip").body(compressed).build(),
-                )
-                val live = LiseurSyncLive({ _, _ -> LiveRefresh() })
-                assertTrue(
-                    runCatching {
-                        withTimeout(3_000) { live.stream(server.url("/").toString(), TOKEN).first() }
-                    }.exceptionOrNull() is LiveStreamFailure,
-                )
+    @Test
+    fun `gzip expansion is bounded before parsing the event`() = runBlocking {
+        MockWebServer().use { server ->
+            server.start(InetAddress.getLoopbackAddress(), 0)
+            val compressed = Buffer()
+            GzipSink(compressed).buffer().use {
+                it.writeUtf8("event: invalidate\ndata: {\"topics\":[\"positions\"],\"padding\":\"")
+                it.writeUtf8("x".repeat(100_000))
+                it.writeUtf8("\"}\n\n")
             }
+            assertTrue(compressed.size < 1_000)
+            server.enqueue(
+                MockResponse.Builder().addHeader("Content-Type", "text/event-stream")
+                    .addHeader("Content-Encoding", "gzip").body(compressed).build(),
+            )
+            val live = LiseurSyncLive({ _, _ -> LiveRefresh() })
+            assertTrue(
+                runCatching {
+                    withTimeout(3_000) { live.stream(server.url("/").toString(), TOKEN).first() }
+                }.exceptionOrNull() is LiveStreamFailure,
+            )
         }
     }
 

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncLiveTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncLiveTest.kt
@@ -1,0 +1,182 @@
+package com.chmouel.liseur.data.liseursync
+
+import com.chmouel.liseur.data.remote.LiveRefresh
+import com.chmouel.liseur.data.remote.LiveRetry
+import com.chmouel.liseur.data.remote.LiveStreamFailure
+import com.chmouel.liseur.data.remote.LiveTopic
+import com.chmouel.liseur.data.remote.RemoteCredentials
+import com.chmouel.liseur.data.remote.RemoteHttp
+import java.io.IOException
+import java.net.InetAddress
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.Call
+import okhttp3.EventListener
+import okio.Buffer
+import okio.GzipSink
+import okio.buffer
+import org.junit.Assert.*
+import org.junit.Test
+
+class LiseurSyncLiveTest {
+    @Test
+    fun `only known invalidation topics are read`() {
+        assertEquals(
+            setOf(LiveTopic.POSITIONS, LiveTopic.ANNOTATIONS),
+            liveTopics("invalidate", """{"topics":["positions","future","annotations","positions"]}"""),
+        )
+        assertTrue(liveTopics("other", """{"topics":["positions"]}""").isEmpty())
+        assertTrue(liveTopics("invalidate", "{").isEmpty())
+        assertTrue(liveTopics("invalidate", "{}").isEmpty())
+    }
+
+    @Test
+    fun `retry policy stops refusals and does not reset on short connections`() {
+        val retry = LiveRetry { 0.0 }
+        assertEquals(15_000L, retry.delayMillis(LiveStreamFailure()))
+        assertEquals(30_000L, retry.delayMillis(LiveStreamFailure(200)))
+        assertEquals(600_000L, retry.delayMillis(LiveStreamFailure(429, "600")))
+        assertEquals(120_000L, retry.delayMillis(LiveStreamFailure(429, "bad")))
+        for (code in listOf(401, 403, 404, 501)) {
+            assertNull(retry.delayMillis(LiveStreamFailure(code)))
+        }
+        repeat(50) { assertTrue(retry.delayMillis(LiveStreamFailure())!! <= 300_000) }
+        assertEquals(
+            120_000L,
+            LiveRetry { 0.0 }.delayMillis(
+                LiveStreamFailure(429, "Thu, 1 Jan 1970 00:02:00 GMT"), now = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `raw bound rejects unterminated lines and accumulated data before parser`() {
+        for (frame in listOf("data: " + "a".repeat(100), "data: x\n".repeat(20), ":" + "a".repeat(100))) {
+            val source = BoundedEventSource(Buffer().writeUtf8(frame), 64).buffer()
+            assertThrows(IOException::class.java) { source.readUtf8() }
+        }
+        for (newline in listOf("\n", "\r\n", "\r")) {
+            val frames = (": heartbeat$newline$newline").repeat(100)
+            assertEquals(frames, BoundedEventSource(Buffer().writeUtf8(frames), 32).buffer().readUtf8())
+        }
+    }
+
+    @Test
+    fun `opening frame is parsed and cancellation releases call`() = runBlocking {
+        MockWebServer().use { server ->
+            server.start(InetAddress.getLoopbackAddress(), 0)
+            server.enqueue(
+                MockResponse.Builder().addHeader("Content-Type", "text/event-stream")
+                    .body(": comment\r\nevent: invalidate\r\ndata: {\"topics\":[\"insights\"]}\r\n\r\n")
+                    .build(),
+            )
+            val live = LiseurSyncLive({ _, _ -> LiveRefresh() })
+            assertEquals(
+                setOf(LiveTopic.INSIGHTS),
+                withTimeout(5_000) { live.stream(server.url("/").toString(), TOKEN).first() },
+            )
+            assertEquals("/v1/events", server.takeRequest().target)
+        }
+    }
+
+    @Test
+    fun `silent response times out but comment heartbeats keep socket alive`() = runBlocking {
+        MockWebServer().use { server ->
+            server.start(InetAddress.getLoopbackAddress(), 0)
+            val live = LiseurSyncLive({ _, _ -> LiveRefresh() }, idleMillis = 400)
+            server.enqueue(
+                MockResponse.Builder().addHeader("Content-Type", "text/event-stream")
+                    .body("event: invalidate\ndata: {\"topics\":[\"positions\"]}\n\n")
+                    .bodyDelay(1, TimeUnit.SECONDS).build(),
+            )
+            val silent = runCatching {
+                withTimeout(3_000) { live.stream(server.url("/").toString(), TOKEN).first() }
+            }.exceptionOrNull()
+            assertTrue(silent is LiveStreamFailure)
+
+            val heartbeat = ": ping\n\n"
+            server.enqueue(
+                MockResponse.Builder().addHeader("Content-Type", "text/event-stream")
+                    .body(heartbeat.repeat(16) + "event: invalidate\ndata: {\"topics\":[\"positions\"]}\n\n")
+                    .throttleBody(heartbeat.length.toLong(), 40, TimeUnit.MILLISECONDS).build(),
+            )
+            assertEquals(
+                setOf(LiveTopic.POSITIONS),
+                withTimeout(5_000) { live.stream(server.url("/").toString(), TOKEN).first() },
+            )
+        }
+    }
+
+    @Test
+    fun `cancelling a silent stream cancels its network call immediately`() = runBlocking {
+        MockWebServer().use { server ->
+            server.start(InetAddress.getLoopbackAddress(), 0)
+            server.enqueue(
+                MockResponse.Builder().addHeader("Content-Type", "text/event-stream")
+                    .body("data: waiting\n\n").bodyDelay(3, TimeUnit.SECONDS).build(),
+            )
+            val cancelled = CountDownLatch(1)
+            val client = RemoteHttp.default().newBuilder().eventListener(object : EventListener() {
+                override fun canceled(call: Call) { cancelled.countDown() }
+            }).build()
+            val live = LiseurSyncLive({ _, _ -> LiveRefresh() }, client)
+            val job = launch(Dispatchers.IO) { live.stream(server.url("/").toString(), TOKEN).collect {} }
+            assertNotNull(server.takeRequest(3, TimeUnit.SECONDS))
+            withTimeout(1_000) { job.cancelAndJoin() }
+            assertTrue(cancelled.await(1, TimeUnit.SECONDS))
+        }
+    }
+
+    @Test
+    fun `transport rejects an oversized unterminated frame`() = runBlocking {
+        MockWebServer().use { server ->
+            server.start(InetAddress.getLoopbackAddress(), 0)
+            server.enqueue(
+                MockResponse.Builder().addHeader("Content-Type", "text/event-stream")
+                    .body("data: " + "x".repeat(100_000)).build(),
+            )
+            val live = LiseurSyncLive({ _, _ -> LiveRefresh() })
+            assertTrue(
+                runCatching {
+                    withTimeout(3_000) { live.stream(server.url("/").toString(), TOKEN).first() }
+                }.exceptionOrNull() is LiveStreamFailure,
+            )
+        }
+
+        @Test
+        fun `gzip expansion is bounded before parsing the event`() = runBlocking {
+            MockWebServer().use { server ->
+                server.start(InetAddress.getLoopbackAddress(), 0)
+                val compressed = Buffer()
+                GzipSink(compressed).buffer().use {
+                    it.writeUtf8("event: invalidate\ndata: {\"topics\":[\"positions\"],\"padding\":\"")
+                    it.writeUtf8("x".repeat(100_000))
+                    it.writeUtf8("\"}\n\n")
+                }
+                assertTrue(compressed.size < 1_000)
+                server.enqueue(
+                    MockResponse.Builder().addHeader("Content-Type", "text/event-stream")
+                        .addHeader("Content-Encoding", "gzip").body(compressed).build(),
+                )
+                val live = LiseurSyncLive({ _, _ -> LiveRefresh() })
+                assertTrue(
+                    runCatching {
+                        withTimeout(3_000) { live.stream(server.url("/").toString(), TOKEN).first() }
+                    }.exceptionOrNull() is LiveStreamFailure,
+                )
+            }
+        }
+    }
+
+    private companion object {
+        val TOKEN = RemoteCredentials.Bearer("test-only")
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
@@ -14,6 +14,8 @@ import com.chmouel.liseur.data.remote.ResumeConfidence
 import com.chmouel.liseur.data.remote.ResolveOutcome
 import com.chmouel.liseur.data.remote.SyncFailure
 import com.chmouel.liseur.data.remote.SyncOutcome
+import com.chmouel.liseur.data.remote.LiveIdentity
+import com.chmouel.liseur.data.remote.LiveTopic
 import java.io.File
 import java.net.InetAddress
 import javax.crypto.KeyGenerator
@@ -1401,7 +1403,158 @@ class LiseurSyncPositionSyncTest {
     }
 
     // -- Scaffolding ------------------------------------------------------
-    private fun sync(online: Boolean = true): LiseurSyncPositionSync {
+    @Test
+    fun `live positions only read deltas and do not claim a full sync`() = runTest {
+        connect(cursor = 4)
+        db.bookDao().upsert(local())
+        alias()
+        server.enqueue(json("""{"ops":[${op(5, 0.7)}],"has_more":false}"""))
+        val result = sync().refresh(
+            LiveIdentity.from(db.remoteServerDao().get()!!), setOf(LiveTopic.POSITIONS),
+        )
+        assertEquals(setOf(LiveTopic.POSITIONS), result.completed)
+        assertEquals(0.7, db.readingProgressDao().get(LOCAL)!!.totalProgression!!, 0.0)
+        assertEquals(5L, db.remoteServerDao().get()!!.syncCursorSeq)
+        assertNull(db.remoteServerDao().get()!!.positionSyncedAt)
+        assertEquals(listOf("/v1/changes?since=4&limit=500"), requests().map { it.target })
+    }
+
+    @Test
+    fun `live positions preserve the open page and its exact pending offer`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        alias(editionSha = "edition")
+        db.readingProgressDao().recordLocal(LOCAL, LOCATOR, 0.2, null, "reading", NOW)
+        val revision = db.readingProgressDao().get(LOCAL)!!.localRevision
+        db.readingProgressDao().openBooks.enter(LOCAL)
+        try {
+            server.enqueue(json("""{"ops":[${op(1, 0.8, locatorJson = exactLocator("new"), editionSha = "edition")}]}"""))
+            sync().refresh(LiveIdentity.from(db.remoteServerDao().get()!!), setOf(LiveTopic.POSITIONS))
+            assertEquals(revision, db.readingProgressDao().get(LOCAL)!!.localRevision)
+            assertEquals(0.2, db.readingProgressDao().get(LOCAL)!!.totalProgression!!, 0.0)
+            assertEquals(0.8, db.syncPeerStateDao().get(LOCAL, peer())!!.pendingProgression!!, 0.0)
+            assertTrue(sync().preservedConflict(LOCAL, null)!!.remoteLocatorJson!!.contains("new"))
+            assertEquals(1, server.requestCount)
+        } finally {
+            db.readingProgressDao().openBooks.leave(LOCAL)
+        }
+    }
+
+    @Test
+    fun `live positions leave outgoing reading and unseeded aliases to a book run`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        alias(seeded = false)
+        db.readingProgressDao().recordLocal(LOCAL, LOCATOR, 0.4, null, "reading", NOW)
+        server.enqueue(json("""{"ops":[]}"""))
+        val result = sync().refresh(
+            LiveIdentity.from(db.remoteServerDao().get()!!), setOf(LiveTopic.POSITIONS),
+        )
+        assertEquals(setOf(LOCAL), result.owedBooks)
+        assertFalse(db.workIdentityDao().alias(LOCAL, peer())!!.seeded)
+        assertEquals(1, server.requestCount)
+        assertTrue(requests().single().target.startsWith("/v1/changes"))
+    }
+
+    @Test
+    fun `live position cursor compaction recovers through heads only`() = runTest {
+        connect(cursor = 1)
+        db.bookDao().upsert(local())
+        alias()
+        server.enqueue(MockResponse(code = 410, body = "{}"))
+        server.enqueue(json("""{"ops":[${op(8, 0.8)}],"snapshot_seq":8}"""))
+        val result = sync().refresh(
+            LiveIdentity.from(db.remoteServerDao().get()!!), setOf(LiveTopic.POSITIONS),
+        )
+        assertEquals(setOf(LiveTopic.POSITIONS), result.completed)
+        assertEquals(8L, db.remoteServerDao().get()!!.syncCursorSeq)
+        assertEquals(listOf("/v1/changes?since=1&limit=500", "/v1/heads"), requests().map { it.target })
+    }
+
+    @Test
+    fun `live topic does not complete when page budget is exhausted`() = runTest {
+        connect()
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest) =
+                json("""{"ops":[],"high_water":${server.requestCount},"has_more":true}""")
+        }
+        val result = sync().refresh(
+            LiveIdentity.from(db.remoteServerDao().get()!!), setOf(LiveTopic.POSITIONS),
+        )
+        assertTrue(result.completed.isEmpty())
+        assertTrue(db.remoteServerDao().get()!!.syncCursorSeq > 0)
+        assertNull(db.remoteServerDao().get()!!.positionSyncedAt)
+    }
+
+    @Test
+    fun `insights and annotations topics do not run the position publisher`() = runTest {
+        connect()
+        sync().refresh(
+            LiveIdentity.from(db.remoteServerDao().get()!!),
+            setOf(LiveTopic.INSIGHTS, LiveTopic.ANNOTATIONS),
+        )
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `annotation invalidation uses the annotation feed and reconcile without positions`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        server.enqueue(json("""{"annotations":[],"high_water":7}"""))
+        server.enqueue(json("""{"annotations":[]}"""))
+        val result = sync(withAnnotations = true).refresh(
+            LiveIdentity.from(db.remoteServerDao().get()!!), setOf(LiveTopic.ANNOTATIONS),
+        )
+        assertEquals(setOf(LiveTopic.ANNOTATIONS), result.completed)
+        assertEquals(7L, db.remoteServerDao().get()!!.annotationCursorSeq)
+        assertEquals(0L, db.remoteServerDao().get()!!.syncCursorSeq)
+        assertNull(db.remoteServerDao().get()!!.positionSyncedAt)
+        val paths = requests().map { it.target }
+        assertEquals(2, paths.size)
+        assertTrue(paths[0].startsWith("/v1/annotations/changes?"))
+        assertEquals("/v1/works/w-1/annotations", paths[1])
+    }
+
+    @Test
+    fun `rotated credential refuses an old refresh before any network call`() = runTest {
+        connect()
+        val account = db.remoteServerDao().get()!!
+        db.remoteServerDao().upsert(account.copy(liseurTokenCipher = CredentialCipher.encrypt("new-token")))
+        assertTrue(sync().refresh(LiveIdentity.from(account), setOf(LiveTopic.POSITIONS)).completed.isEmpty())
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `live refresh preserves auth refusal and skips later topic requests`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        server.enqueue(MockResponse(code = 401, body = "{}"))
+        val result = sync(withAnnotations = true).refresh(
+            LiveIdentity.from(db.remoteServerDao().get()!!),
+            setOf(LiveTopic.POSITIONS, LiveTopic.ANNOTATIONS),
+        )
+        assertEquals(mapOf(LiveTopic.POSITIONS to SyncFailure.Unauthorised), result.failures)
+        assertTrue(result.completed.isEmpty())
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `live annotations preserve capability refusal without retrying later phases`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        server.enqueue(MockResponse(code = 403, body = "{}"))
+        val result = sync(withAnnotations = true).refresh(
+            LiveIdentity.from(db.remoteServerDao().get()!!), setOf(LiveTopic.ANNOTATIONS),
+        )
+        assertEquals(mapOf(LiveTopic.ANNOTATIONS to SyncFailure.Forbidden), result.failures)
+        assertTrue(result.completed.isEmpty())
+        assertEquals(1, server.requestCount)
+    }
+
+    private fun sync(online: Boolean = true, withAnnotations: Boolean = false): LiseurSyncPositionSync {
         val context = ApplicationProvider.getApplicationContext<android.app.Application>()
         return LiseurSyncPositionSync(
             serverDao = db.remoteServerDao(),
@@ -1419,6 +1572,13 @@ class LiseurSyncPositionSyncTest {
             deviceKey = { "device-a" },
             finishedState = FinishedState(db.bookDao(), db.readingProgressDao()),
             networkAvailability = { online },
+            annotations = if (withAnnotations) LiseurSyncAnnotations(
+                serverDao = db.remoteServerDao(),
+                annotationDao = db.annotationDao(),
+                syncDao = db.annotationSyncDao(),
+                identityDao = db.workIdentityDao(),
+                now = { NOW },
+            ) else null,
             now = { NOW },
         )
     }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/CompositePositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/CompositePositionSyncTest.kt
@@ -53,6 +53,7 @@ class CompositePositionSyncTest {
             bookUrl: String,
             atRevision: Long,
             peerId: String?,
+            expectedAccountKey: String?,
         ): ResolveOutcome {
             resolved++
             return resolveOutcome

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/ReaderCatchUpTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/ReaderCatchUpTest.kt
@@ -1,0 +1,130 @@
+package com.chmouel.liseur.reader
+
+import com.chmouel.liseur.data.remote.CompositePositionSync
+import com.chmouel.liseur.data.remote.PeerPositionSync
+import com.chmouel.liseur.data.remote.PreviewOutcome
+import com.chmouel.liseur.data.remote.ResolveOutcome
+import com.chmouel.liseur.data.remote.ResumeConfidence
+import com.chmouel.liseur.data.remote.SyncPreview
+import com.chmouel.liseur.data.remote.SyncOutcome
+import com.chmouel.liseur.data.remote.SyncSnapshot
+import com.chmouel.liseur.sync.PositionSyncCoordinator
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReaderCatchUpTest {
+    private val original = SyncPreview(
+        local = 0.2,
+        remote = 0.6,
+        remoteAt = 123,
+        excerpt = "The exact passage",
+        confidence = ResumeConfidence.EXACT,
+        accountKey = "account-one",
+        remoteStatus = "reading",
+        remoteLocatorJson = """{"href":"/chapter.xhtml","text":{"highlight":"The exact passage"}}""",
+        localRevision = 7,
+    )
+
+    private class Peer(override val peerId: String, val answer: SyncPreview) : PeerPositionSync {
+        var pending: SyncPreview? = null
+        var revision = answer.localRevision ?: 0
+        val adoptions = mutableListOf<Long>()
+
+        override suspend fun previewBook(bookUrl: String): PreviewOutcome {
+            pending = answer
+            return PreviewOutcome.Ready(answer)
+        }
+
+        override suspend fun preservedConflict(bookUrl: String, peerId: String?) = pending
+
+        override suspend fun takeRemotePosition(
+            bookUrl: String,
+            atRevision: Long,
+            peerId: String?,
+        ): ResolveOutcome {
+            adoptions += atRevision
+            return if (revision == atRevision) ResolveOutcome.Done else ResolveOutcome.Superseded
+        }
+
+        override suspend fun keepLocalPosition(bookUrl: String, peerId: String?) =
+            error("Catch-up must adopt, not keep")
+
+        override suspend fun canSync(bookUrl: String) = true
+        override suspend fun syncAll(snapshot: SyncSnapshot?) = SyncOutcome.Success
+        override suspend fun syncBook(bookUrl: String) = SyncOutcome.Success
+        override suspend fun refreshUnresolved() = Unit
+        override suspend fun identity() = null
+    }
+
+    private suspend fun offer(coordinator: PositionSyncCoordinator): ReaderViewModel.CatchUp {
+        val preview = (coordinator.preview("book") as PreviewOutcome.Ready).preview
+        return ReaderViewModel.CatchUp(
+            progression = preview.remote!!,
+            position = 60,
+            excerpt = preview.excerpt,
+            remoteAt = preview.remoteAt,
+            confidence = preview.confidence,
+            preview = preview,
+        )
+    }
+
+    @Test
+    fun `acceptance uses the original revision and only the offered peer`() = runTest {
+        val offered = Peer("liseur-sync", original)
+        val other = Peer("kosync", original.copy(remote = 0.9)).apply { pending = answer }
+        val coordinator = PositionSyncCoordinator(CompositePositionSync(listOf(offered, other)))
+        val catchUp = offer(coordinator)
+
+        assertEquals(ResolveOutcome.Done, catchUp.resolve("book", coordinator))
+        assertEquals(listOf(7L), offered.adoptions)
+        assertTrue(other.adoptions.isEmpty())
+        assertEquals(original.copy(peerId = offered.peerId), catchUp.preview)
+        assertSame(original.remoteLocatorJson, catchUp.preview.remoteLocatorJson)
+    }
+
+    @Test
+    fun `a page committed after the offer supersedes it`() = runTest {
+        val peer = Peer("liseur-sync", original)
+        val coordinator = PositionSyncCoordinator(CompositePositionSync(listOf(peer)))
+        val catchUp = offer(coordinator)
+        peer.revision++
+
+        assertEquals(ResolveOutcome.Superseded, catchUp.resolve("book", coordinator))
+        assertEquals(listOf(7L), peer.adoptions)
+    }
+
+    @Test
+    fun `changed remote identity is refused before adoption`() = runTest {
+        val changes = listOf(
+            original.copy(accountKey = "another-account"),
+            original.copy(remote = 0.8),
+            original.copy(remoteAt = 124),
+            original.copy(remoteStatus = "finished"),
+            original.copy(remoteLocatorJson = """{"href":"/other.xhtml"}"""),
+            null,
+        )
+        for (changed in changes) {
+            val peer = Peer("liseur-sync", original)
+            val coordinator = PositionSyncCoordinator(CompositePositionSync(listOf(peer)))
+            val catchUp = offer(coordinator)
+            peer.pending = changed
+
+            assertEquals(ResolveOutcome.Superseded, catchUp.resolve("book", coordinator))
+            assertTrue(peer.adoptions.isEmpty())
+        }
+    }
+
+    @Test
+    fun `an offer without a local row keeps its original zero revision`() = runTest {
+        val peer = Peer("liseur-sync", original.copy(local = null, localRevision = null))
+        val coordinator = PositionSyncCoordinator(CompositePositionSync(listOf(peer)))
+        val catchUp = offer(coordinator)
+        peer.revision = 1
+
+        assertEquals(ResolveOutcome.Superseded, catchUp.resolve("book", coordinator))
+        assertEquals(listOf(0L), peer.adoptions)
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/ReaderCatchUpTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/ReaderCatchUpTest.kt
@@ -44,6 +44,7 @@ class ReaderCatchUpTest {
             bookUrl: String,
             atRevision: Long,
             peerId: String?,
+            expectedAccountKey: String?,
         ): ResolveOutcome {
             adoptions += atRevision
             return if (revision == atRevision) ResolveOutcome.Done else ResolveOutcome.Superseded

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/progress/BookPositionsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/progress/BookPositionsTest.kt
@@ -160,6 +160,66 @@ class BookPositionsTest {
         assertEquals(5, book.locatorAtOrBeforeProgression(1.0)?.locations?.position)
     }
 
+    @Test
+    fun `approximate resume within two synthetic positions does not return chapter start`() {
+        val book = positions(
+            listOf(
+                listOf(
+                    locator("chapter.xhtml", 0.0, 1),
+                    locator("chapter.xhtml", 0.5, 2),
+                ),
+            ),
+        )
+        val target = book.locatorAtOrBeforeProgression(0.85)!!
+        assertEquals(0.425, target.locations.progression!!, 0.0001)
+        assertEquals(0.85, book.resolve(target)!!.progression, 0.0001)
+        assertEquals(0.85, target.locations.totalProgression!!, 0.0001)
+    }
+
+    @Test
+    fun `approximate resume interpolates within the chosen resource and crosses boundaries`() {
+        val book = positions(
+            listOf(
+                listOf(
+                    locator("one.xhtml", 0.0, 1),
+                    locator("one.xhtml", 0.5, 2),
+                ),
+                listOf(
+                    locator("two.xhtml", 0.0, 3),
+                    locator("two.xhtml", 0.6, 4),
+                ),
+            ),
+        )
+        for (progression in listOf(0.0, 0.2, 0.5, 2.0 / 3, 0.85, 1.0)) {
+            val target = book.locatorAtOrBeforeProgression(progression)!!
+            assertEquals(progression, book.resolve(target)!!.progression, 0.0001)
+        }
+        assertEquals(
+            "https://example.com/two.xhtml",
+            book.locatorAtOrBeforeProgression(2.0 / 3)!!.href.toString(),
+        )
+        assertEquals(0.0, book.locatorAtOrBeforeProgression(2.0 / 3)!!.locations.progression!!, 0.0)
+    }
+
+    @Test
+    fun `approximate resume retains duplicate resource disambiguation`() {
+        val book = positions(
+            listOf(
+                listOf(locator("same.xhtml", 0.0, 1), locator("same.xhtml", 0.5, 2)),
+                listOf(locator("same.xhtml", 0.0, 3), locator("same.xhtml", 0.5, 4)),
+            ),
+        )
+        val target = book.locatorAtOrBeforeProgression(0.85)!!
+        assertEquals(3, target.locations.position)
+        assertEquals(0.85, book.resolve(target)!!.progression, 0.0001)
+    }
+
+    @Test
+    fun `a single position still carries a usable resource progression for resume`() {
+        val book = positions(listOf(listOf(locator("short.xhtml", 0.0, 1))))
+        assertEquals(0.85, book.locatorAtOrBeforeProgression(0.85)!!.locations.progression!!, 0.0)
+    }
+
     /**
      * The reason a scrolled book has to measure its own distance before
      * saving a place. Readium's `findFirstVisibleLocator` names a place

--- a/app/src/test/kotlin/com/chmouel/liseur/sync/LiveSyncConnectorTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/sync/LiveSyncConnectorTest.kt
@@ -262,7 +262,12 @@ class LiveSyncConnectorTest {
         override suspend fun canSync(bookUrl: String) = false
         override suspend fun previewBook(bookUrl: String) = PreviewOutcome.NotSynced
         override suspend fun preservedConflict(bookUrl: String, peerId: String?) = null
-        override suspend fun takeRemotePosition(bookUrl: String, atRevision: Long, peerId: String?) =
+        override suspend fun takeRemotePosition(
+            bookUrl: String,
+            atRevision: Long,
+            peerId: String?,
+            expectedAccountKey: String?,
+        ) =
             ResolveOutcome.Done
         override suspend fun keepLocalPosition(bookUrl: String, peerId: String?) = ResolveOutcome.Done
         override suspend fun refreshUnresolved() = Unit

--- a/app/src/test/kotlin/com/chmouel/liseur/sync/LiveSyncConnectorTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/sync/LiveSyncConnectorTest.kt
@@ -1,0 +1,280 @@
+package com.chmouel.liseur.sync
+
+import com.chmouel.liseur.data.db.RemoteServer
+import com.chmouel.liseur.data.remote.LiveChanges
+import com.chmouel.liseur.data.remote.LiveIdentity
+import com.chmouel.liseur.data.remote.LiveRefresh
+import com.chmouel.liseur.data.remote.LiveStreamFailure
+import com.chmouel.liseur.data.remote.LiveTopic
+import com.chmouel.liseur.data.remote.PositionSync
+import com.chmouel.liseur.data.remote.PreviewOutcome
+import com.chmouel.liseur.data.remote.ResolveOutcome
+import com.chmouel.liseur.data.remote.ServerKind
+import com.chmouel.liseur.data.remote.SyncIdentity
+import com.chmouel.liseur.data.remote.SyncFailure
+import com.chmouel.liseur.data.remote.SyncOutcome
+import com.chmouel.liseur.data.remote.SyncSnapshot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.transform
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LiveSyncConnectorTest {
+    @Test
+    fun `unauthorised refresh reports auth and stops a still healthy event stream`() = runTest {
+        val accounts = MutableStateFlow<RemoteServer?>(account())
+        val source = Source().apply { failures = mapOf(LiveTopic.POSITIONS to SyncFailure.Unauthorised) }
+        val reported = mutableListOf<SyncFailure>()
+        val coordinator = PositionSyncCoordinator(NoSync)
+        val connector = LiveSyncConnector(
+            backgroundScope, accounts, { source }, coordinator, {},
+            reportFailure = { _, failure -> reported += failure },
+        )
+        connector.foreground()
+        runCurrent()
+        source.events.emit(setOf(LiveTopic.POSITIONS))
+        runCurrent()
+        advanceTimeBy(60_000)
+        runCurrent()
+        assertEquals(listOf(SyncFailure.Unauthorised), reported)
+        assertEquals(1, source.closes)
+        assertEquals(1, source.refreshes.size)
+        assertTrue(coordinator.hasLiveWork(LiveIdentity.from(accounts.value!!)))
+        source.failures = emptyMap()
+        accounts.value = accounts.value!!.copy(liseurTokenCipher = "replacement")
+        runCurrent()
+        source.events.emit(setOf(LiveTopic.POSITIONS))
+        runCurrent()
+        assertEquals(2, source.refreshes.size)
+    }
+
+    @Test
+    fun `forbidden topic stays paused on more events but other topics still refresh`() = runTest {
+        val accounts = MutableStateFlow<RemoteServer?>(account())
+        val source = Source().apply { failures = mapOf(LiveTopic.POSITIONS to SyncFailure.Forbidden) }
+        val connector = LiveSyncConnector(
+            backgroundScope, accounts, { source }, PositionSyncCoordinator(NoSync), {},
+        )
+        connector.foreground()
+        runCurrent()
+        source.events.emit(setOf(LiveTopic.POSITIONS))
+        runCurrent()
+        source.failures = emptyMap()
+        source.events.emit(setOf(LiveTopic.POSITIONS, LiveTopic.INSIGHTS))
+        runCurrent()
+        advanceTimeBy(60_000)
+        runCurrent()
+        assertEquals(listOf(setOf(LiveTopic.POSITIONS), setOf(LiveTopic.INSIGHTS)), source.refreshes)
+        connector.background()
+        advanceTimeBy(15_000)
+        runCurrent()
+        connector.foreground()
+        runCurrent()
+        source.events.emit(setOf(LiveTopic.POSITIONS))
+        runCurrent()
+        assertEquals(setOf(LiveTopic.POSITIONS), source.refreshes.last())
+        assertEquals(3, source.refreshes.size)
+    }
+
+    @Test
+    fun `transient refresh failures back off instead of polling every fifteen seconds`() = runTest {
+        val accounts = MutableStateFlow<RemoteServer?>(account())
+        val source = Source().apply { failures = mapOf(LiveTopic.POSITIONS to SyncFailure.Offline) }
+        val connector = LiveSyncConnector(
+            backgroundScope, accounts, { source }, PositionSyncCoordinator(NoSync), {},
+            retryJitter = { 0.0 },
+        )
+        connector.foreground()
+        runCurrent()
+        source.events.emit(setOf(LiveTopic.POSITIONS))
+        runCurrent()
+        advanceTimeBy(15_000)
+        runCurrent()
+        assertEquals(2, source.refreshes.size)
+        advanceTimeBy(29_999)
+        runCurrent()
+        assertEquals(2, source.refreshes.size)
+        advanceTimeBy(1)
+        runCurrent()
+        assertEquals(3, source.refreshes.size)
+    }
+
+    @Test
+    fun `terminal stream refusal stops failed refresh retries without paying the topic`() = runTest {
+        val accounts = MutableStateFlow<RemoteServer?>(account())
+        val source = Source().apply { succeeds = false }
+        val coordinator = PositionSyncCoordinator(NoSync)
+        val connector = LiveSyncConnector(
+            backgroundScope, accounts, { source }, coordinator, {},
+        )
+        connector.foreground()
+        runCurrent()
+        source.events.emit(setOf(LiveTopic.POSITIONS))
+        runCurrent()
+        assertEquals(1, source.refreshes.size)
+        source.refusal = LiveStreamFailure(401)
+        source.events.emit(emptySet())
+        runCurrent()
+        advanceTimeBy(60_000)
+        runCurrent()
+        assertEquals(1, source.refreshes.size)
+        assertEquals(1, source.opens)
+        assertTrue(coordinator.hasLiveWork(LiveIdentity.from(accounts.value!!)))
+    }
+
+    @Test
+    fun `unsupported streams stop until a new foreground session`() = runTest {
+        val accounts = MutableStateFlow<RemoteServer?>(account())
+        val source = Source().apply { refusal = LiveStreamFailure(404) }
+        val connector = LiveSyncConnector(
+            backgroundScope, accounts, { source }, PositionSyncCoordinator(NoSync), {},
+        )
+        connector.foreground()
+        runCurrent()
+        advanceTimeBy(60_000)
+        runCurrent()
+        assertEquals(1, source.opens)
+        connector.background()
+        advanceTimeBy(15_000)
+        runCurrent()
+        connector.foreground()
+        runCurrent()
+        assertEquals(2, source.opens)
+    }
+
+    @Test
+    fun `foreground connects despite fresh sync and cursor writes never reconnect`() = runTest {
+        val account = account()
+        val accounts = MutableStateFlow<RemoteServer?>(account)
+        val source = Source()
+        val connector = LiveSyncConnector(
+            backgroundScope, accounts, { source }, PositionSyncCoordinator(NoSync), {},
+        )
+        runCurrent()
+        assertEquals(0, source.opens)
+        connector.foreground()
+        runCurrent()
+        assertEquals(1, source.opens)
+        accounts.value = account.copy(syncCursorSeq = 9, annotationCursorSeq = 10, positionSyncedAt = 123)
+        runCurrent()
+        assertEquals(1, source.opens)
+        connector.background()
+        advanceTimeBy(14_999)
+        runCurrent()
+        assertEquals(0, source.closes)
+        connector.foreground()
+        advanceTimeBy(1)
+        runCurrent()
+        assertEquals(1, source.opens)
+        connector.background()
+        advanceTimeBy(15_000)
+        runCurrent()
+        assertEquals(1, source.closes)
+        connector.foreground()
+        runCurrent()
+        assertEquals(2, source.opens)
+    }
+
+    @Test
+    fun `credential replacement cancels old stream and discards failed topics`() = runTest {
+        val accounts = MutableStateFlow<RemoteServer?>(account())
+        val source = Source().apply { succeeds = false }
+        val coordinator = PositionSyncCoordinator(NoSync)
+        val connector = LiveSyncConnector(backgroundScope, accounts, { source }, coordinator, {})
+        connector.foreground()
+        runCurrent()
+        val old = LiveIdentity.from(accounts.value!!)
+        source.events.emit(setOf(LiveTopic.POSITIONS))
+        runCurrent()
+        assertTrue(coordinator.hasLiveWork(old))
+        accounts.value = accounts.value!!.copy(liseurTokenCipher = "replacement")
+        runCurrent()
+        assertEquals(2, source.opens)
+        assertEquals(1, source.closes)
+        assertFalse(coordinator.hasLiveWork(old))
+        advanceTimeBy(15_000)
+        runCurrent()
+        assertEquals(1, source.refreshes.size)
+    }
+
+    @Test
+    fun `failed refresh retries without another event and book debt runs outside turn`() = runTest {
+        val accounts = MutableStateFlow<RemoteServer?>(account())
+        val source = Source().apply { succeeds = false }
+        val books = mutableListOf<String>()
+        val connector = LiveSyncConnector(
+            backgroundScope, accounts, { source }, PositionSyncCoordinator(NoSync), books::add,
+        )
+        connector.foreground()
+        runCurrent()
+        source.events.emit(setOf(LiveTopic.ANNOTATIONS))
+        runCurrent()
+        assertEquals(listOf(setOf(LiveTopic.ANNOTATIONS)), source.refreshes)
+        source.succeeds = true
+        source.owed = setOf("book")
+        advanceTimeBy(15_000)
+        runCurrent()
+        assertEquals(2, source.refreshes.size)
+        assertEquals(listOf("book"), books)
+    }
+
+    private class Source : LiveChanges {
+        var opens = 0
+        var closes = 0
+        var succeeds = true
+        var refusal: LiveStreamFailure? = null
+        var owed = emptySet<String>()
+        var failures = emptyMap<LiveTopic, SyncFailure>()
+        val refreshes = mutableListOf<Set<LiveTopic>>()
+        val events = MutableSharedFlow<Set<LiveTopic>>()
+        override fun events(server: RemoteServer) = flow {
+            opens++
+            try {
+                refusal?.let { throw it }
+                emitAll(events.transform {
+                    refusal?.let { failure -> throw failure }
+                    emit(it)
+                })
+                awaitCancellation()
+            } finally {
+                closes++
+            }
+        }
+
+        override suspend fun refresh(identity: LiveIdentity, topics: Set<LiveTopic>): LiveRefresh {
+            refreshes += topics
+            return LiveRefresh(if (succeeds) topics - failures.keys else emptySet(), owed, failures)
+        }
+    }
+
+    private object NoSync : PositionSync {
+        override suspend fun syncAll(snapshot: SyncSnapshot?): SyncOutcome = error("No full sync from events")
+        override suspend fun syncBook(bookUrl: String): SyncOutcome = error("No inline book sync")
+        override suspend fun canSync(bookUrl: String) = false
+        override suspend fun previewBook(bookUrl: String) = PreviewOutcome.NotSynced
+        override suspend fun preservedConflict(bookUrl: String, peerId: String?) = null
+        override suspend fun takeRemotePosition(bookUrl: String, atRevision: Long, peerId: String?) =
+            ResolveOutcome.Done
+        override suspend fun keepLocalPosition(bookUrl: String, peerId: String?) = ResolveOutcome.Done
+        override suspend fun refreshUnresolved() = Unit
+        override suspend fun identity(): SyncIdentity? = null
+    }
+
+    private fun account() = RemoteServer(
+        kind = ServerKind.LISEUR_SYNC, baseUrl = "http://localhost",
+        username = "reader", passwordCipher = null, apiKeyCipher = null,
+        accountId = "device", userId = null, koboTokenCipher = null,
+        canDownload = true, addedAt = 1, catalogSyncedAt = null,
+        positionSyncedAt = System.currentTimeMillis(), syncToken = null,
+        liseurTokenCipher = "cipher", liseurAccountId = "account",
+    )
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/sync/PositionSyncCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/sync/PositionSyncCoordinatorTest.kt
@@ -31,6 +31,83 @@ import org.junit.Test
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class PositionSyncCoordinatorTest {
+    private val liveIdentity = com.chmouel.liseur.data.remote.LiveIdentity(
+        "account", "http://localhost", com.chmouel.liseur.data.remote.ServerKind.LISEUR_SYNC,
+        "cipher", "device",
+    )
+
+    @Test
+    fun `later events stay owed and failed topics retry without another event`() = runTest {
+        val coordinator = PositionSyncCoordinator(FakeSync())
+        val position = com.chmouel.liseur.data.remote.LiveTopic.POSITIONS
+        val annotations = com.chmouel.liseur.data.remote.LiveTopic.ANNOTATIONS
+        coordinator.liveAccount(liveIdentity)
+        coordinator.invalidate(liveIdentity, setOf(position, annotations))
+        val gate = CompletableDeferred<Unit>()
+        val first = async {
+            coordinator.refreshLive(liveIdentity) { _, topics ->
+                assertEquals(setOf(position, annotations), topics)
+                gate.await()
+                com.chmouel.liseur.data.remote.LiveRefresh(setOf(position))
+            }
+        }
+        runCurrent()
+        coordinator.invalidate(liveIdentity, setOf(position))
+        gate.complete(Unit)
+        first.await()
+        assertTrue(coordinator.hasLiveWork(liveIdentity))
+        coordinator.refreshLive(liveIdentity) { _, topics ->
+            assertEquals(setOf(position, annotations), topics)
+            com.chmouel.liseur.data.remote.LiveRefresh(topics)
+        }
+        assertTrue(!coordinator.hasLiveWork(liveIdentity))
+    }
+
+    @Test
+    fun `refresh waits for ordinary sync and never invokes syncAll itself`() = runTest {
+        val sync = FakeSync().apply { gate = CompletableDeferred() }
+        val coordinator = PositionSyncCoordinator(sync)
+        val ordinary = async { coordinator.request(SyncScope.Book("book")) }
+        runCurrent()
+        coordinator.liveAccount(liveIdentity)
+        coordinator.invalidate(liveIdentity, setOf(com.chmouel.liseur.data.remote.LiveTopic.INSIGHTS))
+        var refreshed = false
+        val live = async {
+            coordinator.refreshLive(liveIdentity) { _, topics ->
+                refreshed = true
+                com.chmouel.liseur.data.remote.LiveRefresh(topics)
+            }
+        }
+        runCurrent()
+        assertTrue(!refreshed)
+        sync.gate!!.complete(Unit)
+        ordinary.await()
+        live.await()
+        assertTrue(refreshed)
+        assertEquals(listOf(SyncScope.Book("book")), sync.started)
+    }
+
+    @Test
+    fun `an old account run cannot pay a new account or return book work`() = runTest {
+        val coordinator = PositionSyncCoordinator(FakeSync())
+        val topic = com.chmouel.liseur.data.remote.LiveTopic.POSITIONS
+        coordinator.liveAccount(liveIdentity)
+        coordinator.invalidate(liveIdentity, setOf(topic))
+        val gate = CompletableDeferred<Unit>()
+        val run = async {
+            coordinator.refreshLive(liveIdentity) { _, topics ->
+                gate.await()
+                com.chmouel.liseur.data.remote.LiveRefresh(topics, setOf("old-book"))
+            }
+        }
+        runCurrent()
+        coordinator.liveAccount(null)
+        coordinator.liveAccount(liveIdentity)
+        coordinator.invalidate(liveIdentity, setOf(topic))
+        gate.complete(Unit)
+        assertTrue(run.await().owedBooks.isEmpty())
+        assertTrue(coordinator.hasLiveWork(liveIdentity))
+    }
 
     /**
      * A sync that does nothing until it is told to, so a test can hold a

--- a/app/src/test/kotlin/com/chmouel/liseur/sync/PositionSyncCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/sync/PositionSyncCoordinatorTest.kt
@@ -159,6 +159,7 @@ class PositionSyncCoordinatorTest {
             bookUrl: String,
             atRevision: Long,
             peerId: String?,
+            expectedAccountKey: String?,
         ): ResolveOutcome {
             resolved += bookUrl to true
             peersResolved += peerId

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModelTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModelTest.kt
@@ -31,6 +31,10 @@ import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -49,6 +53,44 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class ReadingStatsViewModelTest {
+
+    @Test
+    fun `live insight notifications refresh only while collected and catch up on reentry`() = runTest {
+        Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        try {
+            val invalidations = MutableStateFlow(0L)
+            var samples = 0
+            val model = ReadingStatsViewModel(
+                sessionDao = db.readingSessionDao(),
+                bookDao = db.bookDao(),
+                progressDao = db.readingProgressDao(),
+                now = { samples++; today.atStartOfDay(it) },
+                liveInvalidations = invalidations,
+            )
+            models.put("live-insights", model)
+            val initial = samples
+            invalidations.value++
+            runCurrent()
+            assertEquals(initial, samples)
+            var visible = launch { model.observeLiveInsights() }
+            runCurrent()
+            assertEquals(initial + 1, samples)
+            invalidations.value++
+            runCurrent()
+            assertEquals(initial + 2, samples)
+            visible.cancelAndJoin()
+            invalidations.value++
+            runCurrent()
+            assertEquals(initial + 2, samples)
+            visible = launch { model.observeLiveInsights() }
+            runCurrent()
+            assertEquals(initial + 3, samples)
+            visible.cancelAndJoin()
+        } finally {
+            models.clear()
+            Dispatchers.resetMain()
+        }
+    }
 
     private lateinit var db: LiseurDatabase
     private lateinit var models: ViewModelStore

--- a/docs/adr/0011-annotation-sync.md
+++ b/docs/adr/0011-annotation-sync.md
@@ -37,9 +37,16 @@ request currently in flight.
 `annotation_sync(id, peer_id)` holds what the server confirmed:
 `rev`, `seq`, and a content fingerprint, alongside the exact bytes of
 any request in the air. Outbound work is the diff between the live
-`annotations` table and that fingerprint, so no DAO method and no call
-site had to learn about sync: a mark becomes syncable by being in the
-table, and importing a backup is a batch of creates for free.
+`annotations` table and that fingerprint. After a local edit or deletion
+commits, the reader signals the existing coalesced book sync. Backup
+imports signal each book with newly inserted marks once. These explicit
+signals avoid observing Room writes from a pull and feeding them back
+into another sync.
+
+Foreground live annotation invalidations use this same complete pass,
+under the position coordinator's turn, without the position, naming or
+session-upload stages. Settle and pull remain account-wide even when a
+local edit requested a single book.
 
 Freshness is ordered by `seq`, never by `rev`. A rev counts writes to
 one mark and restarts at 1 when the server recreates an id whose

--- a/docs/adr/0023-position-sync-versus-whispersync.md
+++ b/docs/adr/0023-position-sync-versus-whispersync.md
@@ -41,7 +41,7 @@ is what those two carry on their own, which is nothing.
 | Highlights, notes, bookmarks | yes | yes (ADR-0011) | no | no | no | no |
 | Reading statistics across devices | totals only | yes (ADR-0021) | no | no | no | no |
 | Offline, then back | yes | append-only log, derived ids; a retry is byte-identical and answered `duplicate` | idempotent write of the current value; the sync token moves in the transaction that stores what it covers | idempotent write of the current value | idempotent write | — |
-| Learning what moved elsewhere | server push | cursor over `GET /v1/changes` | Kobo sync token | catalog walk, `readProgress` | one `GET` per candidate book; there is no list | — |
+| Learning what moved elsewhere | server push | foreground invalidations trigger reads through the `GET /v1/changes` cursor | Kobo sync token | catalog walk, `readProgress` | one `GET` per candidate book; there is no list | — |
 | How a book is named | ASIN | SHA-256, KOReader partial-MD5, `ta:` title/author with a confirmation on a low match, `409` to merge | calibre uuid | Komga book id | partial-MD5 | — |
 | Which books | bought, or sent to Kindle | every book, including local books; upload and adoption are optional | downloaded from that calibre-web | downloaded from that Komga | downloaded server books, since a hash needs the file | — |
 | Who else sees the place | Kindle devices and apps | liseur-desktop, the web reader, KOReader through `/adapter/kosync` | Kobo devices, the calibre-web reader | Komga's reader and other Komga clients | KOReader | — |
@@ -63,11 +63,42 @@ top of that come highlights, notes, bookmarks and statistics, which
 Whispersync also has, and a book only on this phone reaching the server,
 which it does not.
 
-Two things are not there and are said plainly. There is no server push:
-a change made elsewhere is learnt on the next open, resume, or hourly
-run. Kindle behaves the same way for positions in practice, so no reader
-notices, but it is a difference. And the guarantee is only as good as
-every client: the web reader and liseur-desktop must push on the same
+While the app is foregrounded, liseur-sync's `GET /v1/events` sends
+topic-only invalidations. Position refresh reads the existing durable
+feed, recovers an expired cursor through the snapshot, and reconciles
+known aliases. It leaves naming, seeding and outgoing positions to
+book-scoped sync requests outside the coordinator's turn. Annotation
+refresh runs the complete settle/pull/reconcile/push/delete pass.
+Statistics invalidations refresh only a visible statistics route.
+Neither topic starts a full library sync or imports remote sessions.
+
+The stream stays connected for a 15-second background grace period.
+Its 60-second idle read timeout tolerates the server's 20-second comment
+heartbeats, and a raw-source bound rejects frames above 64 KiB before
+the SSE parser accumulates them. Reconnects back off with jitter;
+HTTP 429 also honours `Retry-After`. HTTP 401 stops for the current
+connection session without trying to mint a token: Android does not
+store the login password. HTTP 403, 404 and 501 also stop the stream
+and its live refresh retries until a later foreground or account boundary.
+Ordinary sync remains
+available against servers without the endpoint.
+
+Feed refreshes retain their failure classifications. Authentication failures
+stop the live session and use the existing sync error reporting. A refused
+topic stays paused until a credential or foreground boundary, even if more
+events name it; other topics can continue. Transient refresh failures use
+exponential backoff with jitter.
+
+Every connection starts with an invalidation. The coordinator retains
+topics received during a run, and retries failed reads without waiting
+for another event. Account, endpoint, provider and credential changes
+cancel the old connection and discard its queued work; cursor and sync
+timestamp writes do not restart it. An open book keeps its page.
+Catch-up appears on resume only, with acceptance bound to the original
+preview, local revision, account and peer.
+
+The cross-client guarantee is only as good as every client:
+the web reader and liseur-desktop must push on the same
 occasions and merge by the same rule, and nothing yet proves end to end
 that two of them converge. That proof, not another feature, is what
 would justify the sentence in the README.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,6 +54,7 @@ coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version
 androidx-documentfile = { module = "androidx.documentfile:documentfile", version.ref = "documentfile" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+okhttp-sse = { module = "com.squareup.okhttp3:okhttp-sse", version.ref = "okhttp" }
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
 desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar" }
 json = { module = "org.json:json", version.ref = "json" }


### PR DESCRIPTION
## Summary

Open Android readers now receive live position, annotation, and statistics invalidations. They refresh the affected durable feed without moving the current page, and offer position catch-up only after the reader resumes.

## Changes

- Added foreground-only live connection with retry and topic coalescing.
- Routed position, annotation, and insight invalidations through targeted refreshes.
- Kept catch-up bound to the exact offer shown to the reader.
- Added tests and contributor documentation.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on the `liseur_phone_api36` emulator, including live updates and resume-only catch-up.

## Screenshots or recordings

The attached screenshot shows the resume-only catch-up state on the disposable emulator.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

![Android resume-only catch-up](https://github.com/user-attachments/assets/d52bdd36-62a8-4910-b3cf-1044b241bd55)