### PR TITLE
fix: Count every device in reading stats after an upgrade

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -467,6 +467,7 @@ class AppContainer(context: Context) {
     val syncSnapshots = LiseurSyncSnapshots(
         database.remoteServerDao(), database.readingSessionDao(),
         database.sessionTransmissionDao(), database.workIdentityDao(),
+        deviceKey = { deviceIdentity.current().id },
     )
 
     /**

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSnapshots.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSnapshots.kt
@@ -48,6 +48,7 @@ class LiseurSyncSnapshots(
     private val sessionDao: ReadingSessionDao,
     private val transmissionDao: SessionTransmissionDao,
     private val identityDao: WorkIdentityDao,
+    private val deviceKey: suspend () -> String,
     private val http: LiseurSyncHttp = LiseurSyncHttp(),
 ) {
     /** Duration support is available to sync-only tokens, unlike dashboard insights. */
@@ -64,7 +65,8 @@ class LiseurSyncSnapshots(
 
     suspend fun discover(): StatisticsContext? = optional {
         val account = serverDao.get()?.takeIf { it.kind == ServerKind.LISEUR_SYNC } ?: return@optional null
-        val credentials = account.credentials ?: return@optional null
+        val credentials = account.credentials
+            ?: return@optional refuse("the account has no key to ask with")
         if (!sameAccount(account)) return@optional null
         val json = try {
             http.get(LiseurSyncApi.url(account.baseUrl, CAPABILITIES), credentials)
@@ -74,10 +76,11 @@ class LiseurSyncSnapshots(
         }
         if (!sameAccount(account)) return@optional null
         if (!account.canReadInsights) serverDao.setCanReadInsights(true, account.liseurTokenCipher)
-        val capabilities = StatisticsCapabilities.parse(json) ?: return@optional null
+        val capabilities = StatisticsCapabilities.parse(json)
+            ?: return@optional refuse("the server did not say what statistics it can answer")
         if (capabilities.accountId != null && account.liseurAccountId != null &&
             account.liseurAccountId != capabilities.accountId
-        ) return@optional null
+        ) return@optional refuse("the server answered about a different account")
         StatisticsContext(account, capabilities)
     }
 
@@ -92,13 +95,23 @@ class LiseurSyncSnapshots(
             val account = context.account
             val capabilities = context.capabilities
             if (!sameAccount(account)) return@optional null
-            if ((capabilities.accountId ?: account.liseurAccountId).isNullOrBlank()) return@optional null
-            if (range == StatsRange.ALL_TIME && !capabilities.allTime) return@optional null
+            if ((capabilities.accountId ?: account.liseurAccountId).isNullOrBlank()) {
+                return@optional refuse("the account has no identity to check a reply against")
+            }
+            if (range == StatsRange.ALL_TIME && !capabilities.allTime) {
+                return@optional refuse("the server does not answer about all time")
+            }
+            // A sitting is named on the server by a key derived from
+            // this, so a blank one would quietly rebuild candidates the
+            // server cannot recognise and have it count them twice.
+            val key = deviceKey().takeIf { it.isNotBlank() }
+                ?: return@optional refuse("this device has no identity to name its own reading by")
             val from = range.startDate(today, weekStart)
             val recorded = statsSessions(sessions)
             val evidence = transmissionDao.forPeer(account.accountKey)
             val aliases = statsAliases(identityDao.aliasesFor(account.accountKey))
             val bySession = evidence.associateBy { it.sessionId }
+            val aliasByUrl = aliases.associateBy { it.bookUrl }
             val candidates = JSONArray()
             val candidateWorks = mutableSetOf<String>()
             val contributingIds = mutableSetOf<Long>()
@@ -110,22 +123,58 @@ class LiseurSyncSnapshots(
                 val day = Instant.ofEpochMilli(session.endedAt ?: session.lastCheckpointAt)
                     .atZone(capabilities.timezone).toLocalDate()
                 if (day <= today) days += day
-                if (days.size > capabilities.maxLocalActiveDays) return@optional null
+                if (days.size > capabilities.maxLocalActiveDays) {
+                    return@optional refuse("more reading days than the server will accept")
+                }
                 if (day > today || (from != null && day < from)) continue
                 if (session.endedAt == null || session.startProgression == null || session.endProgression == null) continue
                 contributingIds += session.id
-                if (session.legacyEvidenceUnknown) return@optional null
-                val transmission = bySession[session.id] ?: continue
-                if (transmission.deviceId.isEmpty()) return@optional null
-                candidateBytes += transmission.payload.toByteArray(Charsets.UTF_8).size
-                if (candidates.length() >= capabilities.maxCandidates || candidateBytes > capabilities.maxBodyBytes) return@optional null
-                val payload = JSONObject(transmission.payload)
-                val work = payload.getString("work_id")
-                if (workByUrl[session.bookUrl] != work) return@optional null
+                val transmission = bySession[session.id]
+                if (transmission == null && !session.legacyEvidenceUnknown) {
+                    // Nothing was ever offered for this sitting, and the
+                    // absence is trustworthy: since the evidence table
+                    // existed a request has been written down before it
+                    // is sent, so no server can be holding this. This
+                    // device's own figure is the whole of it.
+                    continue
+                }
+                // A sitting with no retained request may still be on the
+                // server: it was sent before that table existed, or the
+                // record of it was dropped when an account was
+                // disconnected. Neither the acknowledgement nor its
+                // absence settles that, so rebuild what would have been
+                // sent and let the server say. It answers on identity
+                // first, so a sitting it has never seen is ignored and
+                // counted here, one it holds is named in the overlap and
+                // counted once, and a rebuild it disagrees with is
+                // refused outright rather than guessed at (ADR-0021).
+                val payload = if (transmission != null) {
+                    transmission.payload
+                } else {
+                    val alias = aliasByUrl[session.bookUrl]
+                        ?: return@optional refuse("a sitting of unknown standing is of a book with no name here")
+                    SessionUploads.toJson(session, key, alias.workId, alias.editionSha)?.toString()
+                        ?: return@optional refuse("a sitting of unknown standing cannot be described again")
+                }
+                val device = transmission?.deviceId ?: account.accountId.orEmpty()
+                if (device.isEmpty()) {
+                    return@optional refuse("a sitting to account for names no device")
+                }
+                candidateBytes += payload.toByteArray(Charsets.UTF_8).size
+                if (candidates.length() >= capabilities.maxCandidates || candidateBytes > capabilities.maxBodyBytes) {
+                    return@optional refuse("more evidence than one request may carry")
+                }
+                val json = JSONObject(payload)
+                val work = json.getString("work_id")
+                if (workByUrl[session.bookUrl] != work) {
+                    return@optional refuse("a book was resolved to a different work since it was sent")
+                }
                 candidateWorks += work
-                candidates.put(payload.put("device_id", transmission.deviceId))
+                candidates.put(json.put("device_id", device))
             }
-            if (candidates.length() > capabilities.maxCandidates) return@optional null
+            if (candidates.length() > capabilities.maxCandidates) {
+                return@optional refuse("more candidates than the server will accept")
+            }
             val captured = CapturedStatsSessions(
                 recorded, evidence.filter { it.sessionId in contributingIds }, contributingIds.toSet(),
             )
@@ -149,7 +198,9 @@ class LiseurSyncSnapshots(
                 body.put("calendar_from", start.toString()).put("calendar_to", end.toString())
                 val raw = body.toString()
                 // Refuse the complete proof rather than silently dropping candidates or days.
-                if (raw.toByteArray(Charsets.UTF_8).size > capabilities.maxBodyBytes) return null
+                if (raw.toByteArray(Charsets.UTF_8).size > capabilities.maxBodyBytes) {
+                    return refuse("the evidence is larger than one request may carry")
+                }
                 if (!sameAccount(account)) return null
                 val response = try {
                     http.postRaw(
@@ -167,14 +218,14 @@ class LiseurSyncSnapshots(
             val first = page(initialFrom, today) ?: return@optional null
             val historyStart = from ?: listOfNotNull(first.firstActivity, firstLocalDay).minOrNull() ?: today
             if (historyStart > today || today.toEpochDay() - historyStart.toEpochDay() > MAX_CALENDAR_DAYS) {
-                return@optional null
+                return@optional refuse("a longer history than this screen will chart")
             }
             val calendar = first.totals.days.toMutableList()
             val overlapDays = first.totals.overlapDays.toMutableMap()
             if (historyStart < initialFrom) {
                 val missing = initialFrom.toEpochDay() - historyStart.toEpochDay()
                 if ((missing + capabilities.maxCalendarDays - 1) / capabilities.maxCalendarDays + 1 > MAX_CALENDAR_PAGES) {
-                    return@optional null
+                    return@optional refuse("more calendar requests than this screen will make")
                 }
                 for ((start, end) in calendarChunks(
                     historyStart, initialFrom.minusDays(1), capabilities.maxCalendarDays.toLong(),
@@ -183,7 +234,7 @@ class LiseurSyncSnapshots(
                     if (next.revision != first.revision || next.firstActivity != first.firstActivity ||
                         next.totals.copy(days = emptyList(), overlapDays = emptyMap()) !=
                         first.totals.copy(days = emptyList(), overlapDays = emptyMap())
-                    ) return@optional null
+                    ) return@optional refuse("the server's figures moved between calendar pages")
                     calendar += next.totals.days
                     overlapDays += next.totals.overlapDays
                 }
@@ -192,14 +243,14 @@ class LiseurSyncSnapshots(
             val byDay = calendar.associateBy { it.date }
             if (!sameMinutes(calendar.map { it.activeMinutes }, first.totals.summary.activeMinutes) ||
                 !sameMinutes(overlapDays.values, first.totals.overlapMinutes)
-            ) return@optional null
+            ) return@optional refuse("the server's calendar does not add up to its own total")
             val dense = generateSequence(historyStart) { it.plusDays(1).takeUnless { day -> day > today } }
                 .map { byDay[it] ?: InsightDay(it, 0.0) }.toList()
             val result = CompleteStatsSnapshot(
                 context, id, first.revision, today, captured, aliases,
                 first.totals.copy(days = dense, overlapDays = overlapDays),
             )
-            result.takeIf { isCurrent(it) }
+            result.takeIf { isCurrent(it) } ?: refuse("the reading moved while the server was answering")
         }
     }
 
@@ -212,6 +263,20 @@ class LiseurSyncSnapshots(
 
     private suspend fun sameAccount(account: RemoteServer): Boolean =
         serverDao.get()?.let(LiveIdentity::from) == LiveIdentity.from(account)
+
+    /**
+     * Gives up on the proof, and says why.
+     *
+     * The screen is unchanged by this — it shows what this device counted
+     * and says so — but a refusal that named nothing left the one reader
+     * who wanted to know why looking at a blank. Every one of these is a
+     * fact about evidence rather than an error, so it goes to the log and
+     * nowhere near the reader.
+     */
+    private fun <T> refuse(reason: String): T? {
+        Log.i(TAG, "Statistics count this device alone: $reason")
+        return null
+    }
 
     private data class Page(val revision: String, val firstActivity: LocalDate?, val totals: SnapshotTotals)
 
@@ -228,69 +293,81 @@ class LiseurSyncSnapshots(
         candidateCount: Int,
     ): Page? {
         val expectedAccount = (context.capabilities.accountId ?: context.account.liseurAccountId)
-            ?.takeIf { it.isNotBlank() } ?: return null
+            ?.takeIf { it.isNotBlank() } ?: return refuse("the account has no identity to check a reply against")
+        if (json.opt("complete") != true) {
+            // The one refusal the server explains itself: it names which
+            // piece of evidence it could not place.
+            return refuse(
+                "the server could not place this device's evidence" +
+                    json.optString("incomplete_reason").takeIf { it.isNotEmpty() }?.let { " ($it)" }.orEmpty(),
+            )
+        }
         if (json.nonnegativeCount("version") != 1 || json.nonnegativeCount("attribution_version") != 2 ||
-            json.opt("complete") != true ||
             json.opt("account_id") != expectedAccount ||
             json.optString("timezone") != context.capabilities.timezone.id ||
             json.optString("snapshot_id") != id || json.optString("today") != today.toString() ||
             json.optString("calendar_from") != calendarFrom.toString() ||
             json.optString("calendar_to") != calendarTo.toString()
-        ) return null
+        ) return refuse("the server answered about a different snapshot")
         if (from == null) {
-            if (!json.has("range_days") || json.nonnegativeCount("range_days") != 0) return null
-        } else if (json.optString("from") != from.toString() || json.optString("to") != today.toString()) return null
+            if (!json.has("range_days") || json.nonnegativeCount("range_days") != 0) {
+                return refuse("the server answered about a span with a beginning")
+            }
+        } else if (json.optString("from") != from.toString() || json.optString("to") != today.toString()) {
+            return refuse("the server answered about a different span")
+        }
         val revision = (json.opt("stats_revision") as? String)
-            ?.takeIf { it.isNotEmpty() && it.all { ch -> ch in '0'..'9' } && it.toLongOrNull() != null } ?: return null
-        if (!json.has("first_activity_day")) return null
+            ?.takeIf { it.isNotEmpty() && it.all { ch -> ch in '0'..'9' } && it.toLongOrNull() != null }
+            ?: return refuse("the server named no usable revision")
+        if (!json.has("first_activity_day")) return refuse("the server did not say when its history begins")
         val first = if (json.isNull("first_activity_day")) null else LocalDate.parse(json.getString("first_activity_day"))
-        if (first != null && first > today) return null
+        if (first != null && first > today) return refuse(INCOHERENT)
         val summary = json.getJSONObject("summary")
         val top = InsightsSummary(
             summary.minutes("total_active_minutes"), summary.count("sessions"), summary.count("streak_days"),
             summary.optDouble("speed_prog_per_hour").takeIf { it.isFinite() && it > 0 },
         )
-        if (top.activeMinutes > 0 && first == null) return null
+        if (top.activeMinutes > 0 && first == null) return refuse(INCOHERENT)
         val works = linkedMapOf<String, WorkInsights>()
         val array = json.getJSONArray("works")
         for (index in 0 until array.length()) {
             val item = array.getJSONObject(index)
-            val work = item.getString("work_id").takeIf { it.isNotEmpty() } ?: return null
-            val insight = parseWorkInsights(item)?.copy(workId = work) ?: return null
-            if (insight.activeMinutes > 0 && insight.lastReadAt == null) return null
-            if (works.put(work, insight) != null) return null
+            val work = item.getString("work_id").takeIf { it.isNotEmpty() } ?: return refuse(INCOHERENT)
+            val insight = parseWorkInsights(item)?.copy(workId = work) ?: return refuse(INCOHERENT)
+            if (insight.activeMinutes > 0 && insight.lastReadAt == null) return refuse(INCOHERENT)
+            if (works.put(work, insight) != null) return refuse(INCOHERENT)
         }
         val known = workByUrl.mapNotNull { (url, work) -> works[work]?.let { url to it } }.toMap()
         if (!sameMinutes(works.values.map { it.activeMinutes }, top.activeMinutes) ||
             works.values.sumOf { it.sessions.toLong() } != top.sessions.toLong()
-        ) return null
+        ) return refuse(INCOHERENT)
         val elsewhere = works.values.filter { it.workId !in workByUrl.values }
-        val days = parseDays(json.getJSONArray("days"), calendarFrom, calendarTo) ?: return null
+        val days = parseDays(json.getJSONArray("days"), calendarFrom, calendarTo) ?: return refuse(INCOHERENT)
         val overlap = json.getJSONObject("overlap")
         val overlapMinutes = overlap.minutes("total_active_minutes")
         val overlapSessions = overlap.count("sessions")
         if (exceedsMinutes(overlapMinutes, top.activeMinutes) || overlapSessions > top.sessions ||
             overlapSessions > candidateCount
-        ) return null
+        ) return refuse(INCOHERENT)
         val overlapWorks = linkedMapOf<String, Pair<Double, Int>>()
         val matches = overlap.getJSONArray("works")
         for (index in 0 until matches.length()) {
             val item = matches.getJSONObject(index)
             val work = item.getString("work_id")
-            if (work !in candidateWorks) return null
+            if (work !in candidateWorks) return refuse(INCOHERENT)
             val amount = item.minutes("total_active_minutes")
             val count = item.count("sessions")
-            val full = works[work] ?: return null
+            val full = works[work] ?: return refuse(INCOHERENT)
             if (exceedsMinutes(amount, full.activeMinutes) || count > full.sessions ||
                 overlapWorks.put(work, amount to count) != null
-            ) return null
+            ) return refuse(INCOHERENT)
         }
         if (!sameMinutes(overlapWorks.values.map { it.first }, overlapMinutes) ||
             overlapWorks.values.sumOf { it.second.toLong() } != overlapSessions.toLong()
-        ) return null
-        val matchedDays = parseDays(overlap.getJSONArray("days"), calendarFrom, calendarTo) ?: return null
+        ) return refuse(INCOHERENT)
+        val matchedDays = parseDays(overlap.getJSONArray("days"), calendarFrom, calendarTo) ?: return refuse(INCOHERENT)
         val fullDays = days.associateBy { it.date }
-        if (matchedDays.any { exceedsMinutes(it.activeMinutes, fullDays[it.date]?.activeMinutes ?: 0.0) }) return null
+        if (matchedDays.any { exceedsMinutes(it.activeMinutes, fullDays[it.date]?.activeMinutes ?: 0.0) }) return refuse(INCOHERENT)
         // Normalize only the accepted sub-millisecond excess. Otherwise integer
         // rounding could turn that noise into a negative residual in the union.
         return Page(
@@ -357,6 +434,8 @@ class LiseurSyncSnapshots(
         const val TAG = "liseur-sync-insights"
         const val CAPABILITIES = "/v1/insights/capabilities"
         const val SNAPSHOT = "/v1/insights/snapshot"
+        /** One reason for the whole family of "the server's figures disagree with themselves". */
+        const val INCOHERENT = "the server's figures do not add up to each other"
         // A resource refusal, not a truncated chart: unusually large histories remain local.
         const val MAX_CALENDAR_DAYS = 366_000L
         const val MAX_CALENDAR_PAGES = 128

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSnapshotsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSnapshotsTest.kt
@@ -62,6 +62,7 @@ class LiseurSyncSnapshotsTest {
     private var changeToken: (JSONObject) -> Unit = {}
     private var capabilitiesCode = 200
     private var duringRequest: suspend (JSONObject) -> Unit = {}
+    private val deviceKey = "this-device"
 
     @Before
     fun open() = runBlocking {
@@ -151,14 +152,64 @@ class LiseurSyncSnapshotsTest {
     }
 
     @Test
-    fun `pre-upgrade attempted identity is never reconstructed as proof`() = runTest {
-        sitting(unknown = true)
-        assertNull(read())
-        assertTrue(requests.isEmpty())
+    fun `a sitting of unknown standing is offered so the server can rule on it`() = runTest {
+        val id = sitting(unknown = true)
+        assertNotNull(read())
+        val candidate = requests.single().getJSONArray("candidates").getJSONObject(0)
+        // Rebuilt from the row, byte for byte what the upload would have
+        // been, so the server recognises its own copy if it has one.
+        assertEquals(SessionUploads.sessionIdFor(deviceKey, id), candidate.getString("session_id"))
+        assertEquals(
+            JSONObject(SessionUploads.toJson(db.readingSessionDao().get(id)!!, deviceKey, "work", null)!!.toString())
+                .put("device_id", "device").toString(),
+            candidate.toString(),
+        )
     }
 
     @Test
-    fun `out-of-window legacy sessions contribute active days but need no overlap proof`() = runTest {
+    fun `a sitting of unknown standing is offered even when nothing acknowledged it`() = runTest {
+        // An upload whose answer was lost leaves no acknowledgement, and
+        // a disconnected account clears the ones that were there, so the
+        // absence of one proves nothing and cannot excuse counting it here.
+        val id = sitting(unknown = true)
+        assertEquals(null, db.readingSessionDao().get(id)!!.uploadedAt)
+        assertNotNull(read())
+        assertEquals(1, requests.single().getJSONArray("candidates").length())
+    }
+
+    @Test
+    fun `a sitting of unknown standing that cannot be described again is not counted alone`() = runTest {
+        sitting(unknown = true)
+        db.workIdentityDao().forgetPeerAliases(account.accountKey)
+        assertNull(read())
+    }
+
+    @Test
+    fun `a sitting of unknown standing is not offered under a nameless device`() = runTest {
+        sitting(unknown = true)
+        db.remoteServerDao().upsert(account.copy(accountId = null))
+        assertNull(read())
+    }
+
+    @Test
+    fun `a pre-upgrade sitting sent since the upgrade is offered as it was sent`() = runTest {
+        val id = sitting(unknown = true)
+        val retained = transmit(id)
+        db.readingSessionDao().markUploaded(listOf(id), 42)
+        assertNotNull(read())
+        val candidates = requests.single().getJSONArray("candidates")
+        assertEquals(1, candidates.length())
+        // The retained bytes win over a rebuild: they are what the
+        // server was actually told.
+        assertEquals("device-original", candidates.getJSONObject(0).getString("device_id"))
+        assertEquals(
+            JSONObject(retained.payload).put("device_id", "device-original").toString(),
+            candidates.getJSONObject(0).toString(),
+        )
+    }
+
+    @Test
+    fun `out-of-window legacy sessions contribute active days and are proved over all time`() = runTest {
         val id = sitting(unknown = true)
         val old = db.readingSessionDao().get(id)!!
         db.readingSessionDao().deleteForBook("book")
@@ -170,7 +221,11 @@ class LiseurSyncSnapshotsTest {
         assertNotNull(read())
         assertEquals(1, requests.single().getJSONArray("candidates").length())
         assertEquals(2, requests.single().getJSONArray("local_active_days").length())
-        assertNull(read(StatsRange.ALL_TIME))
+        // Over all time the older sitting is in the window too, and its
+        // standing is unknown, so it is offered rather than assumed.
+        requests.clear()
+        assertNotNull(read(StatsRange.ALL_TIME))
+        assertEquals(2, requests.first().getJSONArray("candidates").length())
     }
 
     @Test
@@ -483,6 +538,47 @@ class LiseurSyncSnapshotsTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
+    fun `a sitting the server already holds is not counted twice in the union`() = runTest {
+        Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        val models = ViewModelStore()
+        try {
+            // Thirty minutes here, of unknown standing; ninety on the
+            // server, which the server says already includes this one.
+            sitting(unknown = true)
+            changeResponse = {
+                it.put("overlap", JSONObject().apply {
+                    put("total_active_minutes", 30)
+                    put("sessions", 1)
+                    put("works", JSONArray().put(
+                        JSONObject("""{"work_id":"work","total_active_minutes":30,"sessions":1}"""),
+                    ))
+                    put("days", JSONArray().put(day(today, 30, 1)))
+                })
+            }
+            val model = ReadingStatsViewModel(
+                db.readingSessionDao(), db.bookDao(), db.readingProgressDao(),
+                initialRange = StatsRange.THIS_MONTH, zone = { zone },
+                now = { today.atTime(1, 0).atZone(it) }, initialWeekStart = DayOfWeek.MONDAY,
+                snapshotSource = client(),
+                aliases = db.workIdentityDao().observeAliases(),
+                liveAccounts = db.remoteServerDao().observe().map { it?.let(LiveIdentity::from) },
+            )
+            models.put("owned", model)
+            model.refreshServerInsights()
+            val ready = model.state.first {
+                it is ReadingStatsUiState.Ready && it.provenance == StatsProvenance.ALL_DEVICES
+            } as ReadingStatsUiState.Ready
+            assertEquals(90 * 60_000L, ready.headline.totalMs)
+            assertEquals(90 * 60_000L, ready.stats.books.single().totalMs)
+            assertEquals(90 * 60_000L, ready.stats.recent.sumOf { it.totalMs })
+        } finally {
+            models.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
     fun `superseded range generation cannot publish its late snapshot`() = runTest {
         Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
         val models = ViewModelStore()
@@ -518,6 +614,7 @@ class LiseurSyncSnapshotsTest {
 
     private fun client() = LiseurSyncSnapshots(
         db.remoteServerDao(), db.readingSessionDao(), db.sessionTransmissionDao(), db.workIdentityDao(),
+        deviceKey = { deviceKey },
     )
 
     private suspend fun read(range: StatsRange = StatsRange.THIS_MONTH): CompleteStatsSnapshot? {
@@ -539,7 +636,7 @@ class LiseurSyncSnapshotsTest {
     }
 
     private suspend fun transmit(id: Long, deviceId: String = "device-original"): SessionTransmission {
-        val payload = SessionUploads.toJson(db.readingSessionDao().get(id)!!, "original-key", "work", null)!!
+        val payload = SessionUploads.toJson(db.readingSessionDao().get(id)!!, deviceKey, "work", null)!!
         return SessionTransmission(account.accountKey, id, deviceId, payload.toString()).also {
             db.sessionTransmissionDao().insert(it)
         }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncWireContractTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncWireContractTest.kt
@@ -91,6 +91,7 @@ class LiseurSyncWireContractTest {
                 )
                 val client = LiseurSyncSnapshots(
                     db.remoteServerDao(), db.readingSessionDao(), db.sessionTransmissionDao(), db.workIdentityDao(),
+                    deviceKey = { "wire-contract-device" },
                 )
                 val context = requireNotNull(client.discover()) { "Actual server capabilities were rejected" }
                 val result = requireNotNull(client.read(

--- a/docs/adr/0021-cross-device-reading-statistics.md
+++ b/docs/adr/0021-cross-device-reading-statistics.md
@@ -156,6 +156,42 @@ evidence also marks the remaining history unknown. New sessions can
 select measured `active_ms` only after capability negotiation; legacy
 attempts retain their original wire format and deterministic id.
 
+A sitting without retained evidence is not by itself a reason to abandon
+the merge, and treating it as one left every upgraded install counting
+one device for as long as the selected range reached back past the
+upgrade — for all time, permanently. What decides it is whether this
+peer can already hold the sitting, and only two answers to that are
+sound:
+
+- No evidence and the evidence for this sitting is *known*: nothing was
+  ever offered here. An upload writes its retained request before the
+  sitting leaves, so the absence is proof of absence. This device's
+  figure is the whole of it.
+- Evidence unknown: the sitting may be on the server. It predates the
+  evidence table, or `forgetSyncPeer` dropped the record when an account
+  was disconnected. An acknowledgement does not settle this either way:
+  an upload whose answer was lost never recorded one, and disconnecting
+  clears the ones that were there while the server keeps the sittings.
+  So the sitting is rebuilt as it would have been sent and offered as a
+  candidate, and the server rules on it.
+
+Letting the server rule is safe because it answers on identity first. A
+candidate whose `session_id` it has never seen is ignored and stays
+`complete`, so a sitting that was genuinely never sent is counted here.
+One it holds is matched and named in the overlap, so it is counted once.
+A rebuild it disagrees with is refused as `candidate_payload_mismatch`,
+and this app falls back to local-only rather than guessing. The rebuild
+is exact because the payload is a pure function of the stored row, the
+device key, and the work alias, and because the only field ever added to
+that payload, `active_ms`, is deliberately withheld from a sitting whose
+evidence is unknown.
+
+A rebuild therefore needs a work alias and a device id. Without either,
+the sitting cannot be offered and cannot be assumed absent, so the merge
+is refused rather than counted. A blank device key is refused for the
+same reason: it would derive ids the server cannot recognise, and every
+sitting would be silently counted twice.
+
 Calendars contain every date in their selected interval, including an
 empty today. All-time requests start at retained activity rather than an
 application release date and require nonoverlapping chunks of at most
@@ -176,8 +212,8 @@ identity, statistics stay local. Discovery does not rekey account state.
 Candidates include every transmitted local sitting contributing to the
 selected totals range. Older sittings still supply active-day evidence
 for the streak, but their payloads do not consume that range's candidate
-budget. Unknown legacy transmission identity only blocks a range to
-which that sitting contributes.
+budget. A sitting whose evidence is unknown is rebuilt and offered for
+the range it contributes to, and nothing else.
 Every page must echo the snapshot id, account timezone, today, selected
 bounds and `calendar_from`/`calendar_to`, and carry the same decimal-string
 `stats_revision`. Summary, works, overlap and earliest-activity metadata
@@ -191,8 +227,9 @@ are 4 MiB, 10,000 candidates and 25,000 active days. Histories beyond
 366,000 calendar days or 128
 calendar requests also use local-only statistics. These are resource
 refusals: neither path clips
-candidates or presents a partial chart. Unknown pre-upgrade transmission
-history and incompatible retained server rollups remain local-only.
+candidates or presents a partial chart. Incompatible retained server
+rollups remain local-only, as does a sitting of unknown standing that
+cannot be rebuilt or that the server says it recorded differently.
 
 The upload path reads `session_active_ms` from `GET /v1/token` before
 selecting a new payload. That endpoint also serves sync-only tokens;


### PR DESCRIPTION
## Summary

The reading stats screen can add up your reading across every device signed in to liseur-sync, but after upgrading it kept saying "Counting this device only". Sittings recorded before the upgrade have no record of where they were sent, and one of them inside the period being shown was enough to discard the combined figure. Every sitting predated the upgrade, so that happened for every period and the combined figure never appeared.

The server was fine. This is a client-only fix.

## Changes

- Judge each older sitting on its own instead of giving up on the whole period. One that was never sent anywhere is counted here, because nothing else can be holding it. One whose history is uncertain is described again and offered to the server, which is the only thing that knows whether it already has it: if it does, it is counted once, and if it does not, it is counted here. One sent since the upgrade carries its proof and counts as it always did, which it was wrongly denied before.
- Write the reason to the log whenever the combined figure cannot be worked out, including a reason the server gives, so a fallback to this device alone can be explained rather than guessed at.
- Update ADR-0021 with the new rule and why letting the server decide is safe.

The client never assumes a sitting is absent from the server. An upload flag proves nothing here, because disconnecting an account clears both the upload flags and the retained proof while the server keeps the sessions. Offering the sitting again is free of that problem: the description is rebuilt from the stored row and is byte-identical to what was originally sent, so the server recognises it and reports it once, ignores it if it has never seen it, and refuses it outright if the two disagree.

One case is knowingly left imprecise. A recent sitting that was uploaded and then had its proof cleared by a disconnect rebuilds slightly differently from what was sent, so the server declines to rule on it and the screen shows this device's figures alone. That is the same behaviour as before this change.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

Checked on an emulator against a liseur-sync instance run locally. The screen went from "Counting this device only" at 4 min to "Counting all your devices" at 34 min, with a book that exists only on the server appearing under "By book".

The double-counting risk was then tested directly. Sixteen sittings were put into the upgraded state, with no retained proof and no upload flag, two of which the server actually held. Over all time the screen reads "Counting all your devices" with 16 sittings and 50 min, which is this device's own set exactly. Had the server's two copies not been recognised it would have read 18 sittings. Both server replies the fix relies on were also checked directly against the running server.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

![Reading stats before the fix, saying it counts this device only](https://github.com/user-attachments/assets/25caf04c-2015-4843-b752-f45a81646f37)

![Reading stats after the fix, saying it counts all your devices](https://github.com/user-attachments/assets/1777123a-c86a-4d5a-890c-34040df88428)
