### PR TITLE
fix: Keep counting every device when a book has no server name

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -207,9 +207,68 @@ persisted grant, so a stale grant does not reproduce the failure there.
 The fallback in `LocalLibraryRepository.addFolder` and the message that
 goes with it are for the devices where it does.
 
-## Releasing
+### Why the reading stats say "Counting this device only"
 
-`hack/release` does the whole thing: bump `versionCode` and
+The dashboard combines every device that has signed in to liseur-sync,
+but only when the merge can be *proved* exact. When it cannot, the
+screen silently shows what this device counted and says so. That is
+deliberate: ADR-0021 would rather report a smaller true number than a
+plausible wrong one, and a reader is never shown an error about it.
+
+The reason is written to the log instead, so the answer is one command
+away:
+
+```bash
+adb logcat -s liseur-sync-insights
+```
+
+Every refusal prints `Statistics count this device alone: <reason>`.
+The reasons are prose, not codes, and name the exact thing that could
+not be established, from the account having no identity to check a
+reply against, through a book resolved to a different work since it was
+sent, to a reason the server itself gave.
+
+The one worth recognising is `the server could not place this device's
+evidence (candidate_payload_mismatch)`. It means this app rebuilt the
+description of a sitting and the server disagreed with its own stored
+copy. In practice that means the device identity behind those uploads
+changed, since the server folds the device id into the fingerprint it
+compares. A reconnect with a password keeps the stored device id and is
+fine; a pasted token names nobody and gets a fresh one.
+
+Some background on why any of this needs rebuilding. Sessions have been
+uploaded since v0.6.0, but the table that retains the exact bytes of
+each request only arrived with the dashboard. Every sitting older than
+that is of unknown standing: the upload flag does not settle it either,
+because disconnecting an account clears the flags while the server
+keeps the sessions. So the sitting is described again from the stored
+row and offered as a candidate, and the server rules on it. That
+rebuild is byte-identical to the original because the payload is a pure
+function of the row, and the only field added since, `active_ms`, is
+withheld from exactly these sittings.
+
+Two cases are settled without asking. A sitting recorded since the
+evidence table existed and never sent is counted here, because a
+request is always written down before it goes out. A sitting of a book
+the server has no confident name for is also counted here, because
+sending reading up requires such a name and the upload query joins on
+it, so that sitting has never once been selected.
+
+Reproducing the upgraded state on an emulator is the quickest way to
+exercise all of this: flag the sittings, drop their retained requests
+and clear their upload flags.
+
+```bash
+adb shell "run-as com.chmouel.liseur sqlite3 databases/liseur.db \
+  'UPDATE reading_sessions SET legacy_evidence_unknown = 1, uploaded_at = NULL; \
+   DELETE FROM session_transmission;'"
+```
+
+The screen should still read "Counting all your devices", and the
+sitting count should equal this device's own, not that plus the
+server's. Never do this on a phone somebody reads on.
+
+## Releasing
 `versionName`, write the F-Droid changelog, run the tests, lint and a
 release build, commit, tag and push, publish the GitHub release, and
 update the F-Droid submission.

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSnapshots.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSnapshots.kt
@@ -151,8 +151,14 @@ class LiseurSyncSnapshots(
                 val payload = if (transmission != null) {
                     transmission.payload
                 } else {
-                    val alias = aliasByUrl[session.bookUrl]
-                        ?: return@optional refuse("a sitting of unknown standing is of a book with no name here")
+                    // A book with no usable name on this peer could
+                    // never have been sent: the upload query joins the
+                    // very same aliases, so it has never once selected
+                    // this sitting. Refusing the whole period over it
+                    // would strand every reader with a sideloaded book
+                    // the server could not name confidently, which is
+                    // the failure this change exists to end.
+                    val alias = aliasByUrl[session.bookUrl] ?: continue
                     SessionUploads.toJson(session, key, alias.workId, alias.editionSha)?.toString()
                         ?: return@optional refuse("a sitting of unknown standing cannot be described again")
                 }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSnapshotsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSnapshotsTest.kt
@@ -178,10 +178,15 @@ class LiseurSyncSnapshotsTest {
     }
 
     @Test
-    fun `a sitting of unknown standing that cannot be described again is not counted alone`() = runTest {
+    fun `a sitting of unknown standing of a book with no usable name is counted here`() = runTest {
+        // The upload query joins the same usable aliases, so a book
+        // without one was never once selected to be sent and the server
+        // cannot be holding it. Refusing the whole period over it was
+        // the very failure this rule exists to end.
         sitting(unknown = true)
         db.workIdentityDao().forgetPeerAliases(account.accountKey)
-        assertNull(read())
+        assertNotNull(read())
+        assertEquals(0, requests.single().getJSONArray("candidates").length())
     }
 
     @Test

--- a/docs/adr/0021-cross-device-reading-statistics.md
+++ b/docs/adr/0021-cross-device-reading-statistics.md
@@ -186,11 +186,17 @@ device key, and the work alias, and because the only field ever added to
 that payload, `active_ms`, is deliberately withheld from a sitting whose
 evidence is unknown.
 
-A rebuild therefore needs a work alias and a device id. Without either,
-the sitting cannot be offered and cannot be assumed absent, so the merge
-is refused rather than counted. A blank device key is refused for the
-same reason: it would derive ids the server cannot recognise, and every
-sitting would be silently counted twice.
+A rebuild therefore needs a work alias and a device id. A book with no
+usable alias on this peer is the one exception, and it needs no rebuild
+at all: the upload query joins the very same usable aliases, so such a
+sitting has never once been selected to be sent and the server cannot be
+holding it. It is counted here and the period carries on. Refusing over
+it would strand every reader with a sideloaded book the server could not
+name confidently, which is the failure this rule exists to end. Without a
+device id the sitting can be neither offered nor assumed absent, so the
+merge is refused rather than counted. A blank device key is refused for
+the same reason: it would derive ids the server cannot recognise, and
+every sitting would be silently counted twice.
 
 Calendars contain every date in their selected interval, including an
 empty today. All-time requests start at retained activity rather than an


### PR DESCRIPTION
## Summary

Follow-up to #164. That change made the reading stats screen combine every device again, but one case could still send it back to counting this device alone: a book the server has no confident name for.

Reading of such a book has never left the phone. Sending reading up requires a name the server agrees to, and the query that picks sittings to upload joins on exactly those names, so a book without one has never once been selected. No server can be holding it. It was nonetheless treated as unaccountable, and a single sitting of it discarded the combined figure for every period containing it.

This is likely to affect anyone with a sideloaded book matched only on its title and author, which is the common case for a copy that did not come from the server's own catalogue.

## Changes

- Count reading of an unnamed book here and carry on with the rest of the period, instead of giving up on the whole figure.
- Update ADR-0021 with the reasoning and why it cannot double count.

## Documentation

`DEVELOPER.md` gains a section on why the dashboard falls back to one device and how to find out which case you are in. The fallback is silent on purpose, and the reason goes to the log rather than the screen, but nothing said where to look. It now records the command, what the one refusal the server explains means, which cases are settled without asking the server at all, and how to reproduce the whole situation on an emulator.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [ ] Manually tested on a device or emulator, if applicable

Covered by a unit test that strips the server names from an account and checks the period is still worked out, with nothing offered for the unnamed book. The emulator run in #164 covers the surrounding behaviour and is unchanged by this.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

