### PR TITLE
Publish test builds as release candidates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,10 @@ jobs:
 
       - name: Verify release tag policy
         run: |
-          bash -n hack/release hack/verify-fdroid-tags hack/test-fdroid-tags
+          bash -n hack/release hack/verify-fdroid-tags hack/test-fdroid-tags \
+            hack/prune-prereleases hack/test-prune-prereleases
           hack/test-fdroid-tags
+          hack/test-prune-prereleases
 
       - name: Check for Android/Gradle changes
         id: changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,16 +45,27 @@ jobs:
           grep -Fq "versionName = \"$version\"" app/build.gradle.kts
           version_code=$(sed -nE 's/^[[:space:]]*versionCode = ([0-9]+)$/\1/p' \
             app/build.gradle.kts)
-          # A test release (hack/release --test) is built and signed like
-          # any other; what it skips is F-Droid. It updates no
-          # F-Droid listing, so it carries no F-Droid changelog, and
-          # nothing below asks it for one.
-          if [[ "$version" == *-test.* ]]; then
+          # RCs are built and signed like final releases, but skip F-Droid.
+          # The legacy test spelling remains recognizable so an old tag
+          # cannot accidentally be treated as final.
+          if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(rc|test)\.[0-9]+$ ]]; then
             printf 'prerelease=true\n' >> "$GITHUB_OUTPUT"
-          else
+            printf 'prerelease_kind=%s\n' "${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          elif [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             printf 'prerelease=false\n' >> "$GITHUB_OUTPUT"
+            printf 'prerelease_kind=final\n' >> "$GITHUB_OUTPUT"
             test -s "fastlane/metadata/android/en-US/changelogs/$version_code.txt"
+          else
+            printf 'Unsupported release version: %s\n' "$version" >&2
+            exit 1
           fi
+          play_requested=true
+          if [[ $(git cat-file -t "$RELEASE_TAG") == tag ]]; then
+            tag_message=$(git for-each-ref --format='%(contents)' \
+              "refs/tags/$RELEASE_TAG" | sed -n '1p')
+            [[ "$tag_message" != 'release:no-play' ]] || play_requested=false
+          fi
+          printf 'play_requested=%s\n' "$play_requested" >> "$GITHUB_OUTPUT"
           printf 'version_code=%s\n' "$version_code" >> "$GITHUB_OUTPUT"
 
       - name: Configure release signing
@@ -95,30 +106,42 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GH_TOKEN: ${{ github.token }}
+          PLAY_REQUESTED: ${{ steps.version.outputs.play_requested }}
           PRERELEASE: ${{ steps.version.outputs.prerelease }}
+          PRERELEASE_KIND: ${{ steps.version.outputs.prerelease_kind }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           notes="$RUNNER_TEMP/notes.md"
-          # The written notes are drafted from the F-Droid changelog a
-          # test release does not have, and nobody wants a model's prose
-          # about a build made to try one thing out. The commits in it
-          # are the whole story.
+          # Prereleases have no F-Droid changelog. Their commits are the
+          # whole story, without generated prose.
           if [[ "$PRERELEASE" == true ]]; then
             previous=$(git describe --tags --abbrev=0 \
-              --match 'v[0-9]*.[0-9]*.[0-9]*' --exclude '*-test.*' \
+              --match 'v[0-9]*.[0-9]*.[0-9]*' \
+              --exclude '*-rc.*' --exclude '*-test.*' \
               "$RELEASE_TAG^" 2>/dev/null || true)
             range="$RELEASE_TAG"
             [[ -z "$previous" ]] || range="$previous..$RELEASE_TAG"
             {
-              printf 'A test build. It carries the release signature, so it\n'
+              if [[ "$PRERELEASE_KIND" == rc ]]; then
+                printf 'A release candidate. It carries the release signature, so it\n'
+              else
+                printf 'A legacy test build. It carries the release signature, so it\n'
+              fi
               printf 'installs over a copy that came from F-Droid, and F-Droid\n'
               printf 'updates over it once the next real release reaches it.\n\n'
-              printf 'It is on Google Play testing tracks (Internal/Testing) and\n'
-              printf 'GitHub prerelease, but not on F-Droid or Google Play production.\n\n'
+              if [[ "$PLAY_REQUESTED" == true ]]; then
+                printf 'It is on Google Play testing tracks (Internal/Testing) and\n'
+                printf 'GitHub prerelease, but not on F-Droid or Google Play production.\n\n'
+              else
+                printf 'It is a GitHub prerelease, but is not on F-Droid or Google Play.\n\n'
+              fi
               printf '### Commits%s\n\n' "${previous:+ since $previous}"
               git log --no-decorate --pretty='- %s' \
-                --invert-grep --grep='^chore: test release ' "$range"
+                --invert-grep \
+                --grep='^chore: release candidate ' \
+                --grep='^chore: test release ' \
+                "$range"
             } > "$notes"
           else
             hack/generate-release-notes --output "$notes" "$RELEASE_TAG"
@@ -147,6 +170,15 @@ jobs:
             "${flags[@]}" \
             "$RELEASE_APK"
 
+      - name: Prune obsolete prerelease pages
+        if: steps.version.outputs.prerelease == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if ! hack/prune-prereleases; then
+            printf '::warning::The prerelease was published, but old GitHub release pages could not be pruned.\n'
+          fi
+
       # Everything below is Google Play, and only Google Play. It runs
       # after the release above on purpose: the GitHub artefact and the
       # F-Droid submission are the primary channels, so a rejected upload
@@ -156,10 +188,14 @@ jobs:
       - name: Check for the Play credential
         id: play
         env:
+          PLAY_REQUESTED: ${{ steps.version.outputs.play_requested }}
           SERVICE_ACCOUNT: ${{ secrets.LISEUR_PLAY_SERVICE_ACCOUNT_JSON }}
         run: |
           set -euo pipefail
-          if [[ -n "$SERVICE_ACCOUNT" ]]; then
+          if [[ "$PLAY_REQUESTED" != true ]]; then
+            printf 'enabled=false\n' >> "$GITHUB_OUTPUT"
+            printf 'This tag opts out of Google Play; skipping.\n'
+          elif [[ -n "$SERVICE_ACCOUNT" ]]; then
             printf 'enabled=true\n' >> "$GITHUB_OUTPUT"
           else
             printf 'enabled=false\n' >> "$GITHUB_OUTPUT"
@@ -181,6 +217,7 @@ jobs:
         continue-on-error: true
         env:
           PRERELEASE: ${{ steps.version.outputs.prerelease }}
+          PRERELEASE_KIND: ${{ steps.version.outputs.prerelease_kind }}
           RELEASE_TAG: ${{ github.ref_name }}
           SERVICE_ACCOUNT: ${{ secrets.LISEUR_PLAY_SERVICE_ACCOUNT_JSON }}
           VERSION_CODE: ${{ steps.version.outputs.version_code }}
@@ -193,7 +230,11 @@ jobs:
           (umask 077 && printf '%s' "$SERVICE_ACCOUNT" > "$key")
           changelog="fastlane/metadata/android/en-US/changelogs/$VERSION_CODE.txt"
           if [[ "$PRERELEASE" == true && ! -f "$changelog" ]]; then
-            printf 'Test release %s\n' "$RELEASE_TAG" > "$changelog"
+            if [[ "$PRERELEASE_KIND" == rc ]]; then
+              printf 'Release candidate %s\n' "$RELEASE_TAG" > "$changelog"
+            else
+              printf 'Test release %s\n' "$RELEASE_TAG" > "$changelog"
+            fi
           fi
           gem install fastlane -v 2.238.0 --no-document
           SUPPLY_JSON_KEY="$key" fastlane android internal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,8 +131,9 @@ jobs:
               printf 'installs over a copy that came from F-Droid, and F-Droid\n'
               printf 'updates over it once the next real release reaches it.\n\n'
               if [[ "$PLAY_REQUESTED" == true ]]; then
-                printf 'It is on Google Play testing tracks (Internal/Testing) and\n'
-                printf 'GitHub prerelease, but not on F-Droid or Google Play production.\n\n'
+                printf 'The workflow will also try to put it on Google Play testing\n'
+                printf 'tracks (Internal/Testing). It is not sent to F-Droid or\n'
+                printf 'Google Play production.\n\n'
               else
                 printf 'It is a GitHub prerelease, but is not on F-Droid or Google Play.\n\n'
               fi

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -297,7 +297,7 @@ hack/release --no-play 0.2.1 "..."   # leave Google Play out of this one
 `-n` (`--non-interactive`, `--yes`) answers the confirmation prompts,
 and any run with nothing on stdin needs it: the prompt reads
 end-of-file as no and the release stops without having done anything.
-That applies to `--test` too.
+That applies to `--rc` too.
 
 It refuses to run on a dirty tree, off `main`, out of sync with the
 remote, on a version that is not newer, or with release notes over the
@@ -321,10 +321,10 @@ otherwise:
 hack/release --no-play 0.9.0 "..."
 ```
 
-That is the only way to keep Play out of a release once the credential
-has been uploaded once. Deleting the secret by hand does not do it:
-`hack/release` reads one missing secret as a stale environment and
-uploads them all again from `pass`, Play credential included.
+The script records that per-release choice in the annotated tag, so an
+already configured Play credential cannot override it. Deleting the
+secret by hand is neither necessary nor useful: a later ordinary release
+will restore a missing credential from `pass`.
 
 `hack/release` creates the environment and uploads whichever secrets are
 missing straight from `pass`, so an unlocked password store is the only
@@ -338,22 +338,24 @@ hack/release --sync-secrets
 Signing a build on your own machine is a separate matter, covered under
 [Signing a release build](#signing-a-release-build-optional) above.
 
-### Test releases
+### Release candidates
 
-A test release is the same build, signed with the same release key, put
-where a handful of people can install it from and nowhere else:
+A release candidate is the same build, signed with the same release key,
+put where a handful of people can install it before the final release:
 
 ```bash
-hack/release --test          # the next patch: v0.9.4-test.1, then .2
-hack/release --test 0.10.0   # a version you are working towards
-hack/release --no-play --test # skip Google Play testing tracks
+hack/release --rc             # the next patch: v0.15.0-rc.1, then .2
+hack/release --rc 0.16.0      # a version you are working towards
+hack/release --no-play --rc   # skip Google Play testing tracks
 ```
 
 It publishes a GitHub **prerelease** with the signed APK attached, uploads
 the app bundle to Google Play's **internal** and **closed** (`Testing`)
 tracks, and stops there: no F-Droid merge request, no changelog to
-write, and no local test, lint or reproducibility run. The point of a
-test release is to be quick. Pass `--no-play` to leave Google Play out.
+write, and no Google Play production upload. Before the tag is pushed,
+the generated RC commit must pass the JVM tests, Android lint, and the
+release build in its detached worktree. The reproducibility check remains
+part of the final release path. Pass `--no-play` to leave Google Play out.
 
 The signature is what makes it worth doing. It is the one F-Droid
 publishes under, through the dual-signing flow, so the APK installs
@@ -361,11 +363,11 @@ straight over a copy that came from F-Droid, with no uninstall and no
 lost library, and F-Droid offers the next real release over it afterwards,
 as an ordinary update.
 
-That last part is only true because the test build takes a
+That last part is only true because the RC takes a
 `versionCode` and the next real release lands above it. `hack/release`
 counts the next code from the highest one across `main` **and every
-tag**, so a test release at 18 pushes the following real release to 19,
-and F-Droid sees an upgrade. Nobody who installed a test build is stuck,
+tag**, so an RC at 32 pushes the following real release to 33, and
+F-Droid sees an upgrade. Nobody who installed an RC is stuck,
 but they are on it until the next release goes out, since F-Droid
 will not offer a lower `versionCode`.
 
@@ -374,23 +376,36 @@ only through its tag, so `main` stays a history of real releases and the
 next one still bumps from the last real version. Run it from any branch,
 as long as the tree is clean.
 
-F-Droid is told nothing about a test release, but it reads the public tags:
-`v0.9.4-test.1` was once picked up by their `checkupdates` bot, which
+F-Droid is told nothing about an RC, but it reads the public tags.
+`v0.9.4-test.1`, the old prerelease spelling, was once picked up by its
+`checkupdates` bot, which
 opened a merge request proposing it as the current version. The
 fdroiddata metadata therefore filters what the bot looks at, with
-`UpdateCheckMode: Tags ^v[0-9.]+$`; a test tag no longer matches. Before
-any release tag is pushed or submitted, `hack/release` runs
+`UpdateCheckMode: Tags ^v[0-9.]+$`; neither `-rc.N` nor the legacy
+`-test.N` spelling matches. Its `AutoUpdateMode: None` also means builds
+are submitted only by `hack/release`, but the tag filter remains necessary:
+the update checker and build submission are separate mechanisms. Before
+any final or RC tag is pushed or submitted, `hack/release` runs
 `hack/verify-fdroid-tags` against that live metadata. It fails closed if a
-final tag would be missed or a test tag would be discovered, so a future
-metadata or tag-format change cannot silently put a test build on F-Droid.
+final tag would be missed or either prerelease spelling would be discovered,
+so a future metadata or tag-format change cannot silently put an RC on
+F-Droid.
 
 Run `make verify-fdroid-tags` for the deterministic local regression checks,
-or run `hack/verify-fdroid-tags v0.10.0 v0.10.0-test.1` to check the live
-fdroiddata filter directly. A change to the test-tag format or the
+or run
+`hack/verify-fdroid-tags v0.15.0 v0.15.0-rc.1 v0.15.0-test.1`
+to check the live fdroiddata filter directly. A change to the RC tag format or the
 `UpdateCheckMode` pattern must update and rerun this policy check.
 
 To install one, download the APK from the release page and
 `adb install -r`, or hand it to whoever is testing.
+
+GitHub release pages are retained more narrowly than their tags. After an
+RC is published, `hack/prune-prereleases` deletes every legacy `-test.N`
+release page and keeps only the highest `-rc.N` page for each target
+version. Its APK goes with the page. The tags are never deleted: they keep
+`versionCode` allocation monotonic, number later candidates correctly, and
+remain burned names under GitHub's immutable-release rules.
 
 ### Google Play
 
@@ -423,8 +438,9 @@ than a replacement, which is also why the Play step in
 `.github/workflows/release.yml` is `continue-on-error` and skips itself
 entirely when the service account secret is absent. A fork, or a rejected
 upload, must not be what makes a release fail. `hack/release --no-play`
-turns that skip into something you can ask for, by leaving the credential
-off the release environment instead of topping it up.
+turns that skip into something you can ask for: its annotated tag carries
+`release:no-play`, and the workflow checks that marker before it considers
+the stored credential.
 
 The upload runs `fastlane android internal` with
 `SUPPLY_JSON_KEY` pointing at a service account credential written to
@@ -624,7 +640,7 @@ GEMINI_API_KEY=$(pass show google/gemini-api) \
 gh release edit v0.2.0 --notes-file notes.md
 ```
 
-### Never delete a release
+### Never delete a final release or release tag
 
 Releases are immutable once published, and that goes further than the
 assets: **a tag that has carried a release can never be used again**,
@@ -632,9 +648,15 @@ even after deleting both the release and the tag, and even with the
 feature turned off. GitHub does this so that a trusted artifact can
 never be swapped for another under the same name.
 
-So a release that went out wrong is not fixed by deleting it. Bump the
-patch version and release again. `v0.1.0` was burned exactly this way
+So a final release that went out wrong is not fixed by deleting it. Bump
+the patch version and release again. `v0.1.0` was burned exactly this way
 and is why the first published version is 0.1.1.
+
+The deliberate exception is the GitHub **release record** for a prerelease.
+`hack/prune-prereleases` removes obsolete RC pages and their APK assets to
+keep the releases list useful, but never removes the tag. The name remains
+burned and the source commit remains reachable, which is also why neither
+the script nor the workflow ever uses `gh release delete --cleanup-tag`.
 
 ### What F-Droid checks
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -344,7 +344,7 @@ A release candidate is the same build, signed with the same release key,
 put where a handful of people can install it before the final release:
 
 ```bash
-hack/release --rc             # the next patch: v0.15.0-rc.1, then .2
+hack/release --rc             # the next patch, numbered -rc.1, then .2
 hack/release --rc 0.16.0      # a version you are working towards
 hack/release --no-play --rc   # skip Google Play testing tracks
 ```

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ DEV_PACKAGE := $(PACKAGE).dev
 DEV_ACTIVITY := $(DEV_PACKAGE)/$(PACKAGE).MainActivity
 DEV_APK := app/build/outputs/apk/dev/app-dev.apk
 
-.PHONY: help build debug release bundle test lint check verify-fdroid-tags e2e clean emulator stop shutdown install run run-bg reset screenshots icon feature-graphic store-status dev dev-install dev-run dev-uninstall dev-logcat
+.PHONY: help build debug release bundle test lint check verify-release-tools verify-fdroid-tags e2e clean emulator stop shutdown install run run-bg reset screenshots icon feature-graphic store-status dev dev-install dev-run dev-uninstall dev-logcat
 
 help:
 	@printf '%s\n' \
@@ -31,6 +31,7 @@ help:
 		'make test              Run JVM unit tests' \
 		'make lint              Run Android Lint' \
 		'make check             Run tests, lint, and debug build' \
+		'make verify-release-tools Check release tag and retention policies' \
 		'make verify-fdroid-tags Check the F-Droid release-tag policy' \
 		'make e2e               Run the device scenarios in tests/' \
 		'make emulator          Start the configured Android emulator' \
@@ -70,7 +71,10 @@ test:
 lint:
 	$(GRADLE) lintDebug
 
-check: test lint build verify-fdroid-tags
+check: test lint build verify-release-tools
+
+verify-release-tools: verify-fdroid-tags
+	hack/test-prune-prereleases
 
 verify-fdroid-tags:
 	hack/test-fdroid-tags

--- a/hack/README.md
+++ b/hack/README.md
@@ -67,9 +67,16 @@ target wrapping them. Run `make help` for the short list. See
 - `install-release`: Builds the release APK, signs it with the
   release key from `pass`, and installs it on a device picked via `fzf`.
 - `release`: Runs the release process: bumps `versionCode`/
-  `versionName`, checks that F-Droid will see final tags but not test tags,
+  `versionName`, checks that F-Droid will see final tags but not RC tags,
   tags, builds, publishes the GitHub release, and submits the F-Droid
-  update. See `DEVELOPER.md` for the full workflow and flags.
+  update. `--rc` publishes only to a GitHub prerelease and Google Play's
+  testing tracks. See `DEVELOPER.md` for the full workflow and flags.
+- `prune-prereleases`: Deletes every legacy `vX.Y.Z-test.N` GitHub release
+  page and all but the newest `vX.Y.Z-rc.N` page for each target version.
+  It never deletes tags. The release workflow runs it after publishing an
+  RC.
+- `test-prune-prereleases`: Runs the deterministic mocked-GitHub tests for
+  prerelease retention. It is part of `make check` and CI.
 - `verify-fdroid-tags`: Reads the live F-Droid metadata and fails closed
   unless a plain `vX.Y.Z` tag is discoverable and the supplied non-final tags
   are not. The release script runs it before pushing or submitting a tag.

--- a/hack/generate-release-notes
+++ b/hack/generate-release-notes
@@ -59,10 +59,10 @@ changelog_for_tag() {
 }
 
 previous_tag() {
-    # Test releases (hack/release --test) are tagged off main and never
-    # in a release's ancestry, but the glob would still match one.
+    # Prereleases are tagged off main and never in a final release's
+    # ancestry, but the glob would still match one.
     git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' \
-        --exclude '*-test.*' "$1^" 2>/dev/null || true
+        --exclude '*-rc.*' --exclude '*-test.*' "$1^" 2>/dev/null || true
 }
 
 pull_requests_for_range() {
@@ -244,7 +244,7 @@ main() {
 
     if [[ -z "$tag" ]]; then
         tag=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' \
-            --exclude '*-test.*') ||
+            --exclude '*-rc.*' --exclude '*-test.*') ||
             die "no tag to write notes for"
     fi
     git rev-parse --verify --quiet "$tag^{commit}" >/dev/null ||

--- a/hack/prune-prereleases
+++ b/hack/prune-prereleases
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Remove obsolete GitHub prerelease records without deleting their tags.
+#
+# Every legacy vX.Y.Z-test.N release is removed. For vX.Y.Z-rc.N releases,
+# only the highest numeric iteration for each X.Y.Z base is retained.
+
+set -euo pipefail
+
+repo=${GH_REPO:-chmouel/liseur}
+dry_run=false
+
+usage() {
+    cat <<'EOF'
+Usage:
+  hack/prune-prereleases [--repo OWNER/REPO] [--dry-run]
+
+Deletes every legacy vX.Y.Z-test.N GitHub prerelease and all but the newest
+vX.Y.Z-rc.N prerelease for each base version. Git tags are never deleted.
+EOF
+}
+
+die() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null || die "missing required command: $1"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)
+            [[ $# -ge 2 ]] || die "--repo needs OWNER/REPO"
+            repo=$2
+            shift 2
+            ;;
+        --dry-run)
+            dry_run=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown argument: $1"
+            ;;
+    esac
+done
+
+[[ "$repo" == */* ]] || die "repository must use OWNER/REPO format"
+require_command gh
+require_command jq
+
+release_pages=$(gh api --paginate --slurp \
+    "repos/$repo/releases?per_page=100") ||
+    die "could not list GitHub releases for $repo"
+
+obsolete=$(printf '%s' "$release_pages" | jq -r '
+    (add // [])
+    | [
+        .[]
+        | .tag_name as $tag
+        | (
+            $tag
+            | try capture(
+                "^v(?<base>[0-9]+\\.[0-9]+\\.[0-9]+)-(?<series>rc|test)\\.(?<iteration>[0-9]+)$"
+            ) catch null
+          ) as $parsed
+        | select($parsed != null)
+        | {
+            tag: $tag,
+            base: $parsed.base,
+            series: $parsed.series,
+            iteration: ($parsed.iteration | tonumber),
+            prerelease: .prerelease
+          }
+      ] as $prereleases
+    | (
+        [$prereleases[] | select(.series == "test") | .tag]
+        +
+        [
+          $prereleases
+          | map(select(.series == "rc" and .prerelease == true))
+          | group_by(.base)[]
+          | sort_by(.iteration)
+          | .[0:-1][]
+          | .tag
+        ]
+      )
+    | sort
+    | .[]
+') || die "could not classify GitHub prereleases"
+
+if [[ -z "$obsolete" ]]; then
+    printf 'GitHub prereleases already satisfy the retention policy.\n'
+    exit 0
+fi
+
+while IFS= read -r tag; do
+    [[ -n "$tag" ]] || continue
+    if [[ "$dry_run" == true ]]; then
+        printf 'Would delete GitHub release %s (tag retained).\n' "$tag"
+        continue
+    fi
+    printf 'Deleting GitHub release %s; retaining its tag.\n' "$tag"
+    gh release delete "$tag" --repo "$repo" --yes
+done <<<"$obsolete"

--- a/hack/prune-prereleases
+++ b/hack/prune-prereleases
@@ -74,8 +74,7 @@ obsolete=$(printf '%s' "$release_pages" | jq -r '
             tag: $tag,
             base: $parsed.base,
             series: $parsed.series,
-            iteration: ($parsed.iteration | tonumber),
-            prerelease: .prerelease
+            iteration: ($parsed.iteration | tonumber)
           }
       ] as $prereleases
     | (
@@ -83,7 +82,7 @@ obsolete=$(printf '%s' "$release_pages" | jq -r '
         +
         [
           $prereleases
-          | map(select(.series == "rc" and .prerelease == true))
+          | map(select(.series == "rc"))
           | group_by(.base)[]
           | sort_by(.iteration)
           | .[0:-1][]

--- a/hack/release
+++ b/hack/release
@@ -32,11 +32,8 @@ readonly REQUIRED_SECRETS=(
     GEMINI_API_KEY
     LISEUR_PLAY_SERVICE_ACCOUNT_JSON
 )
-# Set by --no-play. The release workflow skips Google Play entirely when
-# it finds no service account, so leaving the credential off the release
-# environment is the whole of the opt-out — but only if this script does
-# not put it back, which it otherwise does the moment it notices it
-# missing.
+# Set by --no-play. The tag records the per-release decision so an existing
+# environment credential cannot accidentally override it.
 skip_play=false
 
 usage() {
@@ -44,7 +41,7 @@ usage() {
 Usage:
   hack/release [--no-fdroid] [--no-play]
   hack/release [-n] [--no-fdroid] [--no-play] VERSION RELEASE NOTES...
-  hack/release [-n] [--no-play] --test [VERSION]
+  hack/release [-n] [--no-play] --rc [VERSION]
   hack/release --fdroid-only VERSION
   hack/release [--no-play] --sync-secrets
 
@@ -57,9 +54,9 @@ Examples:
   hack/release -n 0.2.1 "Fix page fitting on tall screens."
   hack/release --no-fdroid 0.1.0 "The first release."
   hack/release --no-play 0.2.2 "Leave Google Play out of this one."
-  hack/release --test
-  hack/release -n --test 0.3.0
-  hack/release --no-play --test 0.3.0
+  hack/release --rc
+  hack/release -n --rc 0.3.0
+  hack/release --no-play --rc 0.3.0
   hack/release --fdroid-only 0.2.1
   hack/release --sync-secrets
 
@@ -70,19 +67,19 @@ end-of-file as no, exits having done nothing. It does not conjure up an
 answer that has no default: picking a version and writing a changelog
 still need a terminal, so a run with no VERSION refuses either way.
 
---test builds the same signed APK and publishes it as a GitHub
-prerelease and uploads it to the Google Play testing tracks (unless
---no-play is given), without telling F-Droid about it. Because it
+--rc builds the same signed APK and publishes it as a GitHub prerelease
+and uploads it to the Google Play testing tracks (unless --no-play is
+given), without telling F-Droid about it. Because it
 carries the release signature, it installs over a copy that came from
 F-Droid or Google Play, and F-Droid updates over it once a real release
 goes out above its versionCode. VERSION is the version being worked towards
-(the next patch by default) and the tag numbers the attempts: v0.3.0-test.1,
-then v0.3.0-test.2. The version bump is committed but never pushed to a
+(the next patch by default) and the tag numbers the candidates: v0.3.0-rc.1,
+then v0.3.0-rc.2. The version bump is committed but never pushed to a
 branch — only the tag that points at it — so main keeps a history of
-real releases. There is no changelog to write and no local test, lint or
-reproducibility run: the point of a test release is to be quick.
-Before pushing the tag, the live F-Droid tag filter is checked and the
-release stops if it would discover this non-final tag.
+real releases. There is no changelog to write, but the JVM tests, Android
+lint and release build must pass against the candidate commit before its
+tag is pushed. Before pushing it, the live F-Droid tag filter is checked
+and the release stops if it would discover this non-final tag.
 
 The F-Droid step opens (or updates) a fdroiddata merge request carrying
 the new build entry plus the signature extracted from the released APK:
@@ -98,11 +95,10 @@ Play upload credential under android/google.play.service.serviceaccount. Any
 release secret missing from the GitHub release environment is uploaded
 from there, so a fresh clone needs nothing but an unlocked password store.
 
---no-play leaves the Play credential alone: it is neither required nor
-uploaded, and the release workflow skips Google Play whenever it finds
-none. Use it while the Play listing is not ready to receive builds. It
-changes nothing else — the GitHub release and the F-Droid submission go
-out as usual.
+--no-play records the opt-out in the tag and leaves the Play credential
+alone. The release workflow skips Google Play for that tag even when the
+environment already holds the credential. It changes nothing else — the
+GitHub release and the F-Droid submission go out as usual.
 EOF
 }
 
@@ -131,11 +127,11 @@ read_version_code() {
 }
 
 # The highest versionCode anything has ever been released under: this
-# branch, and every tag. The tags matter because a test release is
+# branch, and every tag. The tags matter because a prerelease is
 # tagged off main and takes a versionCode with it without bumping
 # anything on main. A real release that then reused that code would be
 # one F-Droid could not offer as an update to whoever installed the
-# test build, so the next code is counted from here rather than from
+# prerelease build, so the next code is counted from here rather than from
 # the file.
 highest_version_code() {
     local highest tag code
@@ -153,15 +149,15 @@ highest_version_code() {
     printf '%s' "$highest"
 }
 
-# Test releases of one version are numbered: v0.3.0-test.1, then .2.
-next_test_iteration() {
+# Release candidates of one version are numbered: v0.3.0-rc.1, then .2.
+next_rc_iteration() {
     local base=$1 highest=0 tag iteration
 
     while IFS= read -r tag; do
-        iteration=${tag##*-test.}
+        iteration=${tag##*-rc.}
         [[ "$iteration" =~ ^[0-9]+$ ]] || continue
         (( iteration > highest )) && highest=$iteration
-    done < <(git tag --list "v$base-test.*")
+    done < <(git tag --list "v$base-rc.*")
 
     printf '%s' $((highest + 1))
 }
@@ -300,6 +296,41 @@ github_release_is_published() {
     is_draft=$(printf '%s' "$release" | jq -r .isDraft)
     published_at=$(printf '%s' "$release" | jq -r .publishedAt)
     [[ "$is_draft" == false && "$published_at" != null ]]
+}
+
+create_release_tag() {
+    local tag=$1
+    local commit=${2:-}
+    local -a target=()
+    [[ -z "$commit" ]] || target+=("$commit")
+
+    if [[ "$skip_play" == true ]]; then
+        git -c tag.gpgSign=false tag --annotate \
+            --message='release:no-play' "$tag" "${target[@]}"
+    else
+        git -c tag.gpgSign=false tag "$tag" "${target[@]}"
+    fi
+}
+
+tag_skips_play() {
+    local tag=$1
+    [[ $(git cat-file -t "$tag") == tag ]] || return 1
+    [[ $(git for-each-ref --format='%(contents)' "refs/tags/$tag" |
+        sed -n '1p') == 'release:no-play' ]]
+}
+
+ensure_local_tag_play_policy() {
+    local tag=$1 actual=false commit
+    tag_skips_play "$tag" && actual=true
+    [[ "$actual" == "$skip_play" ]] && return
+
+    if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+        die "$tag is already on origin with a different Google Play policy"
+    fi
+
+    commit=$(git rev-parse "$tag^{commit}")
+    git tag -d "$tag" >/dev/null
+    create_release_tag "$tag" "$commit"
 }
 
 # Everything below drives `hack/release` with no arguments: show what
@@ -452,7 +483,8 @@ choose_release() {
     [[ -n "$current" ]] || die "could not read the current app version"
 
     last_tag=$(git describe --tags --abbrev=0 \
-        --match 'v[0-9]*.[0-9]*.[0-9]*' --exclude '*-test.*' 2>/dev/null || true)
+        --match 'v[0-9]*.[0-9]*.[0-9]*' \
+        --exclude '*-rc.*' --exclude '*-test.*' 2>/dev/null || true)
     if [[ -n "$last_tag" ]]; then
         range="$last_tag..HEAD"
         printf '\nSince %s, %s ago:\n\n' "$last_tag" \
@@ -485,18 +517,18 @@ choose_release() {
         die "release cancelled"
 }
 
-# The version bump a test release is built from, committed without
+# The version bump a release candidate is built from, committed without
 # moving whatever branch you are on: a detached worktree makes the edit,
 # the tag ends up pointing at what comes out of it, and the tree you
 # were working in is never touched. Prints the commit.
-write_test_commit() {
+write_rc_commit() {
     local version=$1 version_code=$2
     local workdir worktree sha
 
     workdir=$(mktemp -d)
     worktree="$workdir/tree"
     git worktree add --quiet --detach "$worktree" HEAD ||
-        die "could not create a worktree for the test release commit"
+        die "could not create a worktree for the release candidate commit"
 
     if ! (
         cd "$worktree"
@@ -509,24 +541,26 @@ write_test_commit() {
         [[ $(read_version_name) == "$version" ]] || exit 1
         [[ $(read_version_code) == "$version_code" ]] || exit 1
         git add "$BUILD_FILE"
-        git commit --quiet -m "chore: test release v$version"
+        git commit --quiet -m "chore: release candidate v$version"
+        ./gradlew testDebugUnitTest lintDebug assembleRelease --console=plain
     ) >&2; then
         git worktree remove --force "$worktree" >/dev/null 2>&1 || true
         rm -rf "$workdir"
-        die "could not commit the test release version"
+        die "the release candidate commit did not pass its checks"
     fi
 
     sha=$(git -C "$worktree" rev-parse HEAD)
     git worktree remove --force "$worktree" >/dev/null 2>&1 || true
     rm -rf "$workdir"
 
-    [[ -n "$sha" ]] || die "could not read the test release commit"
+    [[ -n "$sha" ]] || die "could not read the release candidate commit"
     printf '%s' "$sha"
 }
 
-# A test release is the real APK — same build, same release key — put
+# A release candidate is the real APK — same build, same release key — put
 # somewhere a handful of people can install it from, and nowhere else:
-# a GitHub prerelease, no F-Droid merge request, no Play upload.
+# a GitHub prerelease and the Google Play testing tracks, with no F-Droid
+# merge request and no Play production upload.
 #
 # The signature is the whole point. It is the one F-Droid publishes
 # under (the dual-signing flow), so this installs over a copy that came
@@ -537,7 +571,7 @@ write_test_commit() {
 # Nothing is pushed to main. The commit carrying the bump is reachable
 # only through its tag, so main's history stays a list of real releases
 # and the next one still bumps from the last real version.
-create_test_release() {
+create_rc_release() {
     local base=${1:-}
     local current version version_code iteration tag last_tag range commit_sha
 
@@ -552,8 +586,8 @@ create_test_release() {
 
     [[ -z $(git status --porcelain) ]] || die "the working tree is not clean"
 
-    iteration=$(next_test_iteration "$base")
-    version="$base-test.$iteration"
+    iteration=$(next_rc_iteration "$base")
+    version="$base-rc.$iteration"
     tag="v$version"
     version_code=$(highest_version_code)
     [[ "$version_code" =~ ^[0-9]+$ ]] ||
@@ -564,17 +598,19 @@ create_test_release() {
 
     # F-Droid scans public tags independently of this script. Fail closed
     # before asking for confirmation or syncing secrets if its live filter
-    # would discover the test tag.
-    "./$FDROID_TAG_POLICY_SCRIPT" "v$base" "$tag"
+    # would discover the RC tag. Check the historical spelling too while
+    # it still exists in the public tag history.
+    "./$FDROID_TAG_POLICY_SCRIPT" "v$base" "$tag" "v$base-test.1"
 
     last_tag=$(git describe --tags --abbrev=0 \
-        --match 'v[0-9]*.[0-9]*.[0-9]*' --exclude '*-test.*' 2>/dev/null || true)
+        --match 'v[0-9]*.[0-9]*.[0-9]*' \
+        --exclude '*-rc.*' --exclude '*-test.*' 2>/dev/null || true)
     range=HEAD
     [[ -z "$last_tag" ]] || range="$last_tag..HEAD"
     printf '\nIn this build%s:\n\n' "${last_tag:+, since $last_tag}"
     show_changes_since "$range"
 
-    printf 'Test release %s as versionCode %s, from %s (%s).\n' \
+    printf 'Release candidate %s as versionCode %s, from %s (%s).\n' \
         "$version" "$version_code" "$(git rev-parse --short HEAD)" \
         "$(git branch --show-current || printf 'detached')"
     printf 'It is signed with the release key and published as a GitHub\n'
@@ -586,10 +622,9 @@ create_test_release() {
     fi
     confirm
 
+    commit_sha=$(write_rc_commit "$version" "$version_code")
     sync_release_secrets
-
-    commit_sha=$(write_test_commit "$version" "$version_code")
-    git tag "$tag" "$commit_sha"
+    create_release_tag "$tag" "$commit_sha"
     if ! git push origin "refs/tags/$tag"; then
         git tag -d "$tag" >/dev/null
         die "could not push $tag"
@@ -597,7 +632,7 @@ create_test_release() {
 
     wait_for_github_release "$tag"
 
-    printf '\nTest release %s is ready:\n  %s\n' "$tag" \
+    printf '\nRelease candidate %s is ready:\n  %s\n' "$tag" \
         "https://github.com/$GH_REPO/releases/tag/$tag"
     printf 'It installs over an F-Droid copy, and F-Droid will offer an update\n'
     printf 'once a release above versionCode %s reaches it.\n' "$version_code"
@@ -964,7 +999,7 @@ assume_yes=false
 fdroid_only=false
 skip_fdroid=false
 sync_secrets_only=false
-test_release=false
+rc_release=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -972,8 +1007,8 @@ while [[ $# -gt 0 ]]; do
             assume_yes=true
             shift
             ;;
-        --test)
-            test_release=true
+        --rc)
+            rc_release=true
             shift
             ;;
         --fdroid-only)
@@ -1014,8 +1049,8 @@ if [[ "$sync_secrets_only" == true ]]; then
         die "--sync-secrets and --fdroid-only are mutually exclusive"
     [[ "$skip_fdroid" == false ]] ||
         die "--sync-secrets and --no-fdroid are mutually exclusive"
-    [[ "$test_release" == false ]] ||
-        die "--sync-secrets and --test are mutually exclusive"
+    [[ "$rc_release" == false ]] ||
+        die "--sync-secrets and --rc are mutually exclusive"
     [[ $# -eq 0 ]] || die "--sync-secrets does not take any argument"
     for command in gh pass; do
         require_command "$command"
@@ -1025,13 +1060,13 @@ if [[ "$sync_secrets_only" == true ]]; then
     exit 0
 fi
 
-# A test release goes nowhere near F-Droid, so it needs none of its
+# A release candidate goes nowhere near F-Droid, so it needs none of its
 # tooling or credentials, and none of the checks that keep main a
 # straight line of releases apply to a tag that is not on it.
-if [[ "$test_release" == true ]]; then
+if [[ "$rc_release" == true ]]; then
     [[ "$fdroid_only" == false ]] ||
-        die "--test and --fdroid-only are mutually exclusive"
-    [[ $# -le 1 ]] || die "--test takes at most a version"
+        die "--rc and --fdroid-only are mutually exclusive"
+    [[ $# -le 1 ]] || die "--rc takes at most a version"
 
     for command in git gh jq sed awk pass curl python3; do
         require_command "$command"
@@ -1042,7 +1077,7 @@ if [[ "$test_release" == true ]]; then
     [[ -f "$BUILD_FILE" ]] || die "run this script from the Liseur repository"
 
     git fetch --quiet origin --tags
-    create_test_release "${1:-}"
+    create_rc_release "${1:-}"
     exit 0
 fi
 
@@ -1109,7 +1144,7 @@ if [[ "$fdroid_only" == true ]]; then
     [[ "$tag_version" == "$version" && -n "$tag_version_code" ]] ||
         die "$tag does not contain app version $version"
 
-    "./$FDROID_TAG_POLICY_SCRIPT" "$tag" "$tag-test.1"
+    "./$FDROID_TAG_POLICY_SCRIPT" "$tag" "$tag-rc.1" "$tag-test.1"
     update_fdroid_submission "$version" "$tag_version_code" "$commit_sha"
     exit
 fi
@@ -1138,7 +1173,7 @@ fi
 
 # F-Droid scans public tags independently of the submission step. Check
 # both sides of the policy before changing secrets or pushing a release.
-"./$FDROID_TAG_POLICY_SCRIPT" "$tag" "$tag-test.1"
+"./$FDROID_TAG_POLICY_SCRIPT" "$tag" "$tag-rc.1" "$tag-test.1"
 
 sync_release_secrets
 ensure_local_release_signing
@@ -1204,7 +1239,7 @@ if [[ "$current_version" != "$version" ]]; then
         die "the release build is not reproducible; the release commit was undone"
     fi
 
-    git tag "$tag"
+    create_release_tag "$tag"
     current_version_code=$new_version_code
     new_release=true
 else
@@ -1222,10 +1257,11 @@ else
             printf 'First release: tagging HEAD, which already declares %s.\n' \
                 "$version"
         fi
-        git tag "$tag"
+        create_release_tag "$tag"
     fi
-    tag_commit=$(git rev-parse "$tag^{commit}")
     if ! github_release_is_published "$tag"; then
+        ensure_local_tag_play_policy "$tag"
+        tag_commit=$(git rev-parse "$tag^{commit}")
         [[ "$tag_commit" == $(git rev-parse HEAD) ]] ||
             die "$tag does not point to HEAD and has no published GitHub release"
     fi

--- a/hack/test-fdroid-tags
+++ b/hack/test-fdroid-tags
@@ -24,12 +24,19 @@ UpdateCheckMode: Tags ^v[0-9.]+$
 EOF
 "$here/verify-fdroid-tags" --metadata "$metadata" \
     v0.10.0 v0.10.0-test.1 v0.10.0-rc.1 >/dev/null
+"$here/verify-fdroid-tags" --metadata "$metadata" v0.10.0 >/dev/null
 
 cat > "$metadata" <<'EOF'
 UpdateCheckMode: Tags ^v[0-9.]+(-test\.[0-9]+)?$
 EOF
 expect_rejected --metadata "$metadata" \
     v0.10.0 v0.10.0-test.1
+
+cat > "$metadata" <<'EOF'
+UpdateCheckMode: Tags ^v[0-9.]+(-rc\.[0-9]+)?$
+EOF
+expect_rejected --metadata "$metadata" \
+    v0.10.0 v0.10.0-rc.1
 
 cat > "$metadata" <<'EOF'
 UpdateCheckMode: Tags

--- a/hack/test-prune-prereleases
+++ b/hack/test-prune-prereleases
@@ -34,6 +34,7 @@ cat > "$fixture" <<'EOF'
   {"tag_name":"v0.15.0-rc.1","prerelease":true},
   {"tag_name":"v0.14.0-rc.2","prerelease":true},
   {"tag_name":"v0.14.0-rc.1","prerelease":true},
+  {"tag_name":"v0.14.0-rc.0","prerelease":false},
   {"tag_name":"v0.15.0-test.4","prerelease":true},
   {"tag_name":"v0.14.0-test.2","prerelease":true},
   {"tag_name":"v0.15.0","prerelease":false},
@@ -54,6 +55,7 @@ actual=$(sed -nE 's/^release delete ([^ ]+) --repo example\/liseur --yes$/\1/p' 
     "$calls" | sort)
 expected=$(printf '%s\n' \
     v0.14.0-rc.1 \
+    v0.14.0-rc.0 \
     v0.14.0-test.2 \
     v0.15.0-rc.1 \
     v0.15.0-rc.2 \

--- a/hack/test-prune-prereleases
+++ b/hack/test-prune-prereleases
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Deterministic tests for hack/prune-prereleases.
+
+set -euo pipefail
+
+here=$(dirname "$(readlink -f "$0")")
+workdir=$(mktemp -d -t liseur-prerelease-retention.XXXXXX)
+trap 'rm -rf "$workdir"' EXIT
+
+mkdir -p "$workdir/bin"
+calls="$workdir/calls"
+fixture="$workdir/releases.json"
+
+cat > "$workdir/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$MOCK_GH_CALLS"
+if [[ "$1" == api ]]; then
+    cat "$MOCK_GH_FIXTURE"
+elif [[ "$1" == release && "$2" == delete ]]; then
+    exit 0
+else
+    printf 'unexpected gh call: %s\n' "$*" >&2
+    exit 1
+fi
+EOF
+chmod +x "$workdir/bin/gh"
+
+cat > "$fixture" <<'EOF'
+[[
+  {"tag_name":"v0.15.0-rc.10","prerelease":true},
+  {"tag_name":"v0.15.0-rc.2","prerelease":true},
+  {"tag_name":"v0.15.0-rc.1","prerelease":true},
+  {"tag_name":"v0.14.0-rc.2","prerelease":true},
+  {"tag_name":"v0.14.0-rc.1","prerelease":true},
+  {"tag_name":"v0.15.0-test.4","prerelease":true},
+  {"tag_name":"v0.14.0-test.2","prerelease":true},
+  {"tag_name":"v0.15.0","prerelease":false},
+  {"tag_name":"v0.13.0-test.1","prerelease":false},
+  {"tag_name":"v0.15.0-rc.bad","prerelease":true},
+  {"tag_name":"not-a-release","prerelease":true}
+]]
+EOF
+
+PATH="$workdir/bin:$PATH" \
+MOCK_GH_CALLS="$calls" \
+MOCK_GH_FIXTURE="$fixture" \
+    "$here/prune-prereleases" --repo example/liseur >/dev/null
+
+grep -Fxq 'api --paginate --slurp repos/example/liseur/releases?per_page=100' "$calls"
+
+actual=$(sed -nE 's/^release delete ([^ ]+) --repo example\/liseur --yes$/\1/p' \
+    "$calls" | sort)
+expected=$(printf '%s\n' \
+    v0.14.0-rc.1 \
+    v0.14.0-test.2 \
+    v0.15.0-rc.1 \
+    v0.15.0-rc.2 \
+    v0.15.0-test.4 \
+    v0.13.0-test.1 | sort)
+[[ "$actual" == "$expected" ]] || {
+    printf 'unexpected releases deleted:\n%s\n' "$actual" >&2
+    exit 1
+}
+
+! grep -q -- '--cleanup-tag' "$calls"
+! grep -q 'release delete v0.15.0 ' "$calls"
+! grep -q 'release delete v0.15.0-rc.10 ' "$calls"
+! grep -q 'release delete v0.14.0-rc.2 ' "$calls"
+
+: > "$calls"
+cat > "$fixture" <<'EOF'
+[[
+  {"tag_name":"v0.15.0-rc.10","prerelease":true},
+  {"tag_name":"v0.14.0-rc.2","prerelease":true},
+  {"tag_name":"v0.15.0","prerelease":false}
+]]
+EOF
+
+output=$(PATH="$workdir/bin:$PATH" \
+    MOCK_GH_CALLS="$calls" \
+    MOCK_GH_FIXTURE="$fixture" \
+    "$here/prune-prereleases" --repo example/liseur)
+grep -Fq 'already satisfy the retention policy' <<<"$output"
+! grep -q '^release delete ' "$calls"
+
+printf 'GitHub prerelease retention tests passed.\n'

--- a/hack/verify-fdroid-tags
+++ b/hack/verify-fdroid-tags
@@ -63,7 +63,7 @@ done
     die "final tag must use vX.Y.Z format: $final_tag"
 
 if [[ ${#excluded_tags[@]} -eq 0 ]]; then
-    excluded_tags+=("$final_tag-test.1")
+    excluded_tags+=("$final_tag-rc.1" "$final_tag-test.1")
 fi
 
 if [[ -n "$metadata_file" ]]; then


### PR DESCRIPTION
## Summary

Replace the old test-release command with numbered release candidates. Each candidate passes unit tests, Android lint, and a release build before publication.

RCs publish to GitHub prereleases and Google Play testing tracks. The live F-Droid tag filter is checked before push, and RCs never enter the F-Droid submission path or Google Play production.

## Changes

- Add `hack/release --rc` with `vX.Y.Z-rc.N` tags.
- Keep the newest RC page for each target version, remove legacy test-release pages, and retain every Git tag.
- Make `--no-play` a per-release setting recorded in the tag.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] `./gradlew assembleRelease`
- [x] Release tag and prerelease retention policy tests
- [ ] Manually tested on a device or emulator, if applicable

## Screenshots or recordings

Not applicable. This changes release tooling only.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.