### PR TITLE
Drop reading statistics code nothing reaches

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSnapshots.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSnapshots.kt
@@ -178,9 +178,6 @@ class LiseurSyncSnapshots(
                 candidateWorks += work
                 candidates.put(json.put("device_id", device))
             }
-            if (candidates.length() > capabilities.maxCandidates) {
-                return@optional refuse("more candidates than the server will accept")
-            }
             val captured = CapturedStatsSessions(
                 recorded, evidence.filter { it.sessionId in contributingIds }, contributingIds.toSet(),
             )

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
@@ -14,7 +14,6 @@ import com.chmouel.liseur.data.db.ReadingSession
 import com.chmouel.liseur.data.db.WorkAlias
 import com.chmouel.liseur.data.remote.LiveIdentity
 import com.chmouel.liseur.data.liseursync.InsightDay
-import com.chmouel.liseur.data.liseursync.InsightsSummary
 import com.chmouel.liseur.data.liseursync.LiseurSyncSnapshots
 import com.chmouel.liseur.data.liseursync.CompleteStatsSnapshot
 import com.chmouel.liseur.data.liseursync.statsSessions
@@ -525,13 +524,12 @@ class ReadingStatsViewModel(
         }
         ReadingStatsUiState.Ready(
             stats = united?.stats ?: local.stats,
-            headline = united?.headline?.copy(comparison = comparison) ?: mergeHeadline(
-                merged = local.stats,
-                local = local.stats,
-                server = null,
-                spans = local.spans,
-                currentMs = local.currentMs,
-                previousMs = local.previousMs,
+            headline = united?.headline?.copy(comparison = comparison) ?: StatsHeadline(
+                totalMs = local.stats.totalMs,
+                sessions = local.stats.sessions,
+                streakDays = local.stats.streakDays,
+                progressionPerHour = local.stats.progressionPerHour,
+                comparison = comparison,
             ),
             range = window.range,
             provenance = if (united != null) StatsProvenance.ALL_DEVICES else StatsProvenance.THIS_DEVICE,
@@ -566,109 +564,6 @@ class ReadingStatsViewModel(
     companion object {
         /** Long enough to survive a rotation without recomputing. */
         private const val STOP_TIMEOUT_MS = 5_000L
-
-        /**
-         * Which devices the figures on screen counted.
-         *
-         * Any answer to the question the screen is asking means every
-         * device: the summary carries the headline, the per-book totals
-         * carry the list and the calendar carries the chart, and each is
-         * the same reading counted everywhere. All three refused is this
-         * device alone, and it makes no difference which of offline, a
-         * token without the scope or a server that has nothing to say
-         * produced the refusal — the figures are the same either way,
-         * and it is the reader's word for them that was missing.
-         *
-         * Not "is a server connected". That would claim a merge that did
-         * not happen: connected and unreachable is exactly the case the
-         * line exists to name.
-         */
-        internal fun provenanceOf(
-            summary: InsightsSummary?,
-            recent: List<InsightDay>?,
-            books: WorkTotals?,
-        ): StatsProvenance =
-            if (summary != null || recent != null || books != null) {
-                StatsProvenance.ALL_DEVICES
-            } else {
-                StatsProvenance.THIS_DEVICE
-            }
-
-        /**
-         * The one headline, from both sources.
-         *
-         * The total is the larger of what the server counted for this
-         * span and what the rows beneath add up to. Never the smaller,
-         * in either direction, and for two different reasons: sessions
-         * upload in the background, so a stretch read five minutes ago
-         * is real but not yet on the server; and a book read on another
-         * device may not be in this library at all, so it can never
-         * appear as a row. Taking the maximum keeps the headline at
-         * least as large as the list under it, which is the only
-         * relation between the two that reads correctly.
-         *
-         * Never the sum, either. The server's count already includes
-         * this device's uploads, so adding them would pay twice.
-         *
-         * Sittings, streak and pace come from the server when it
-         * answered, because it can see reading done elsewhere that no
-         * local arithmetic can produce. Each falls back independently: a
-         * server that reports a streak but no pace should not cost the
-         * reader the pace this device works out for itself.
-         *
-         * The comparison beneath it is the one figure on this screen the
-         * server does not touch, and that is deliberate. What the
-         * sentence claims is a *relationship* between two spans, and a
-         * relationship only holds between two figures gathered the same
-         * way. Both sides are therefore this device's own sittings, over
-         * spans that stop at the same time of day.
-         *
-         * Mixing the two sources within a side cannot be made safe here.
-         * A summary aggregates whole days, so the day that stops where
-         * the clock has got to is one no server can answer for, and the
-         * only way to use a server at all would be to add its whole days
-         * to this device's part-day. That sum is unsound twice over.
-         * Its days are the *server's* calendar days, and this device
-         * splits by its own zone, so an offset between the two leaves
-         * the two spans overlapping — reading counted once by the server
-         * and again in the part-day — or with a gap between them. And
-         * were one of the two requests to fail, one side would count
-         * every device while the other counted one, which is the
-         * evening-on-a-laptop reported as a change in the reader's
-         * habits that the whole comparison exists to avoid.
-         *
-         * The cost is that a reader with a second device is compared
-         * against themselves on this one. It is an undercount of both
-         * sides alike, which is what leaves the percentage between them
-         * standing, and the figure over it still counts everything.
-         *
-         * It is also why the comparison does not simply use [totalMs].
-         * That figure is the most complete one available and belongs
-         * over the screen, but it counts every device right up to this
-         * minute, and there is no baseline that can be built that way.
-         */
-        internal fun mergeHeadline(
-            merged: ReadingStats,
-            local: ReadingStats,
-            server: InsightsSummary?,
-            spans: ComparisonSpans? = null,
-            currentMs: Long = 0,
-            previousMs: Long = 0,
-        ): StatsHeadline {
-            val totalMs = maxOf(
-                merged.totalMs,
-                (server?.activeMinutes?.minutesAsMillis() ?: 0L) + local.pendingMs,
-            )
-            return StatsHeadline(
-                totalMs = totalMs,
-                sessions = maxOf(local.sessions, (server?.sessions ?: 0) + local.pendingSessions),
-                streakDays = maxOf(local.streakDays, server?.streakDays ?: 0),
-                progressionPerHour = server?.progressionPerHour ?: local.progressionPerHour,
-                comparison = spans?.let {
-                    compareReading(it.period, currentMs = currentMs, previousMs = previousMs)
-                },
-            )
-        }
 
         /**
          * Folds the server's aggregates into the local ones, never

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModelTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModelTest.kt
@@ -10,14 +10,11 @@ import com.chmouel.liseur.data.db.Book
 import com.chmouel.liseur.data.db.LiseurDatabase
 import com.chmouel.liseur.data.db.ReadingSession
 import com.chmouel.liseur.data.liseursync.InsightDay
-import com.chmouel.liseur.data.liseursync.InsightsSummary
 import com.chmouel.liseur.data.liseursync.WorkInsights
 import com.chmouel.liseur.data.liseursync.WorkTotals
 import com.chmouel.liseur.domain.BookReadingStats
 import com.chmouel.liseur.domain.ComparisonDirection
 import com.chmouel.liseur.domain.ComparisonPeriod
-import com.chmouel.liseur.domain.ComparisonSpans
-import com.chmouel.liseur.domain.DateSpan
 import com.chmouel.liseur.domain.ReadingDay
 import com.chmouel.liseur.domain.ReadingStats
 import com.chmouel.liseur.domain.StatsBook
@@ -135,7 +132,9 @@ class ReadingStatsViewModelTest {
         try {
             val url = "calibre:one"
             db.bookDao().upsert(book(url))
-            db.readingSessionDao().insert(session(url, today, 60_000))
+            db.readingSessionDao().insert(
+                session(url, today, 60_000).copy(startProgression = 0.1, endProgression = 0.11),
+            )
             val model = model()
 
             val loaded = model.state.first { it is ReadingStatsUiState.Ready }
@@ -146,6 +145,8 @@ class ReadingStatsViewModelTest {
             // This device can count both perfectly well.
             assertEquals(1, loaded.headline.sessions)
             assertEquals(1, loaded.headline.streakDays)
+            assertEquals(0.6, loaded.headline.progressionPerHour!!, 1e-9)
+            assertEquals(StatsProvenance.THIS_DEVICE, loaded.provenance)
         } finally {
             models.clear()
             Dispatchers.resetMain()
@@ -240,106 +241,6 @@ class ReadingStatsViewModelTest {
             models.clear()
             Dispatchers.resetMain()
         }
-    }
-
-    @Test
-    fun `the server's count wins over the local one and is never summed`() {
-        val local = localStats(totalMs = 60_000)
-        val server = InsightsSummary(
-            activeMinutes = 500.0,
-            sessions = 12,
-            streakDays = 4,
-        )
-        val headline = ReadingStatsViewModel.mergeHeadline(
-            merged = local,
-            local = local,
-            server = server,
-        )
-
-        // 500 minutes from the server, not 501 from adding the local one.
-        assertEquals(TimeUnit.MINUTES.toMillis(500), headline.totalMs)
-        assertEquals(4, headline.streakDays)
-        assertEquals(12, headline.sessions)
-    }
-
-    @Test
-    fun `a server behind on uploads cannot shrink what this device counted`() {
-        // The reader read for an hour ten minutes ago; the upload worker
-        // has not run yet, so the server has only forty minutes of it.
-        val local = localStats(totalMs = TimeUnit.MINUTES.toMillis(60)).copy(
-            sessions = 3,
-            streakDays = 9,
-        )
-        val server = InsightsSummary(
-            activeMinutes = 40.0,
-            sessions = 2,
-            streakDays = 8,
-        )
-
-        val headline = ReadingStatsViewModel.mergeHeadline(
-            merged = local,
-            local = local,
-            server = server,
-        )
-
-        assertEquals(TimeUnit.MINUTES.toMillis(60), headline.totalMs)
-        assertEquals(3, headline.sessions)
-        assertEquals(9, headline.streakDays)
-    }
-
-    @Test
-    fun `the headline is never smaller than the rows beneath it`() {
-        // A book read only on another device cannot appear as a row, so
-        // the server's total legitimately exceeds their sum.
-        val merged = localStats(totalMs = TimeUnit.MINUTES.toMillis(10))
-        val server = InsightsSummary(
-            activeMinutes = 90.0,
-            sessions = 5,
-            streakDays = 2,
-        )
-
-        val headline = ReadingStatsViewModel.mergeHeadline(
-            merged = merged,
-            local = merged,
-            server = server,
-        )
-
-        assertTrue(headline.totalMs >= merged.totalMs)
-        assertEquals(TimeUnit.MINUTES.toMillis(90), headline.totalMs)
-    }
-
-    @Test
-    fun `with no server the merge keeps this device's own figures`() {
-        val local = localStats(totalMs = 90_000).copy(
-            sessions = 4,
-            streakDays = 3,
-            progressionPerHour = 0.2,
-        )
-        val headline = ReadingStatsViewModel.mergeHeadline(
-            merged = local,
-            local = local,
-            server = null,
-        )
-        assertEquals(90_000L, headline.totalMs)
-        assertEquals(4, headline.sessions)
-        assertEquals(3, headline.streakDays)
-        assertEquals(0.2, headline.progressionPerHour!!, 1e-9)
-    }
-
-    @Test
-    fun `pace falls back to this device when the server reports none`() {
-        val local = localStats(totalMs = 90_000).copy(progressionPerHour = 0.15)
-        val headline = ReadingStatsViewModel.mergeHeadline(
-            merged = local,
-            local = local,
-            server = InsightsSummary(
-                activeMinutes = 2.0,
-                sessions = 1,
-                streakDays = 1,
-                progressionPerHour = null,
-            ),
-        )
-        assertEquals(0.15, headline.progressionPerHour!!, 1e-9)
     }
 
     @Test
@@ -485,13 +386,6 @@ class ReadingStatsViewModelTest {
         val known = mapOf(
             "book" to StatsBook("book", "A book", "An author", 0.5, finished = false),
         )
-        val server = InsightsSummary(
-            activeMinutes = 100.0,
-            sessions = 10,
-            streakDays = 0,
-            progressionPerHour = null,
-        )
-
         val merged = ReadingStatsViewModel.mergeDashboard(
             local = local,
             knownBooks = known,
@@ -511,10 +405,6 @@ class ReadingStatsViewModelTest {
         )
 
         assertEquals(11, merged.books.single().sessions)
-        assertEquals(
-            11,
-            ReadingStatsViewModel.mergeHeadline(merged, local, server).sessions,
-        )
     }
 
     /**
@@ -726,39 +616,6 @@ class ReadingStatsViewModelTest {
         assertEquals(30 * 60_000L, row.totalMs)
         assertEquals(false, row.isLocal)
         assertEquals(30 * 60_000L, merged.totalMs)
-    }
-
-    /**
-     * The screen has always been one device's or every device's and
-     * never said which, so the same blank meant "you are offline", "your
-     * token cannot ask" and "the server agreed" (ADR-0021). An answer to
-     * the question on screen is what makes it all of them; no answer at
-     * all is this device, whatever the reason.
-     */
-    @Test
-    fun `provenance follows whether an answer arrived, not whether a server exists`() {
-        assertEquals(
-            StatsProvenance.THIS_DEVICE,
-            ReadingStatsViewModel.provenanceOf(null, null, null),
-        )
-        assertEquals(
-            StatsProvenance.ALL_DEVICES,
-            ReadingStatsViewModel.provenanceOf(
-                InsightsSummary(activeMinutes = 10.0, sessions = 1, streakDays = 1),
-                null,
-                null,
-            ),
-        )
-        // The headline can have nothing to report for a span the list and
-        // the chart still answered for. That is still every device.
-        assertEquals(
-            StatsProvenance.ALL_DEVICES,
-            ReadingStatsViewModel.provenanceOf(null, emptyList(), null),
-        )
-        assertEquals(
-            StatsProvenance.ALL_DEVICES,
-            ReadingStatsViewModel.provenanceOf(null, null, WorkTotals.Empty),
-        )
     }
 
     /**
@@ -1204,129 +1061,6 @@ class ReadingStatsViewModelTest {
             Dispatchers.resetMain()
         }
     }
-
-    // ---- The two sides of the comparison ----------------------------
-
-    /**
-     * The comparison is this device's own reading, on both sides.
-     *
-     * The headline over it counts every device; the sentence under it
-     * cannot, because a summary aggregates whole days and neither side
-     * ends on one. Adding a server's whole days to this device's part
-     * day would either double-count the overlap between the server's
-     * calendar and this one's, or drop the gap between them, and would
-     * count one population on one side if a single request failed.
-     */
-    @Test
-    fun `the comparison ignores the server the headline is merged with`() {
-        val local = localStats(totalMs = TimeUnit.MINUTES.toMillis(60))
-        val headline = ReadingStatsViewModel.mergeHeadline(
-            merged = local,
-            local = local,
-            // A second device read four hours this one never saw.
-            server = InsightsSummary(activeMinutes = 240.0, sessions = 9, streakDays = 4),
-            spans = spans,
-            currentMs = TimeUnit.MINUTES.toMillis(60),
-            previousMs = TimeUnit.MINUTES.toMillis(30),
-        )
-
-        // The figure above counts the other device.
-        assertEquals(TimeUnit.MINUTES.toMillis(240), headline.totalMs)
-        // The sentence below compares like with like: sixty against thirty.
-        assertEquals(ComparisonDirection.MORE, headline.comparison!!.direction)
-        assertEquals(100, headline.comparison!!.percent)
-    }
-
-    /**
-     * A baseline of nothing leaves the direction without a figure.
-     *
-     * There is nothing to divide by, and "infinitely more than last
-     * week" is not a sentence to put under a reading total.
-     */
-    @Test
-    fun `a baseline of nothing reads as no percentage at all`() {
-        val local = localStats(totalMs = TimeUnit.MINUTES.toMillis(60))
-        val headline = ReadingStatsViewModel.mergeHeadline(
-            merged = local,
-            local = local,
-            server = null,
-            spans = spans,
-            currentMs = TimeUnit.MINUTES.toMillis(60),
-            previousMs = 0,
-        )
-
-        assertEquals(ComparisonDirection.MORE, headline.comparison!!.direction)
-        assertNull(headline.comparison!!.percent)
-    }
-
-    /**
-     * The headline's own figure is never one side of the comparison.
-     *
-     * On the first day of a period the two sides are a few hours each,
-     * and the difference between counting one device and counting them
-     * all is the whole sentence. A reader whose laptop did the reading
-     * would be told they had read six times more than a period in which
-     * they had in fact read exactly as much.
-     */
-    @Test
-    fun `the first day of a period compares two halves counted alike`() {
-        val local = localStats(totalMs = TimeUnit.MINUTES.toMillis(10))
-        val firstDay = ComparisonSpans(
-            period = ComparisonPeriod.MONTH,
-            current = DateSpan(LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 1)),
-            previous = DateSpan(LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 1)),
-            through = LocalTime.NOON,
-        )
-
-        val headline = ReadingStatsViewModel.mergeHeadline(
-            merged = local,
-            local = local,
-            // An hour today, fifty minutes of it on a device this one
-            // cannot see; the same hour on the first of last month.
-            server = InsightsSummary(activeMinutes = 60.0, sessions = 3, streakDays = 1),
-            spans = firstDay,
-            currentMs = TimeUnit.MINUTES.toMillis(10),
-            previousMs = TimeUnit.MINUTES.toMillis(10),
-        )
-
-        // The headline still says what every device read.
-        assertEquals(TimeUnit.MINUTES.toMillis(60), headline.totalMs)
-        // The sentence says the reader is level, which they are, and a
-        // level reader is given no figure to read into.
-        assertEquals(ComparisonDirection.SAME, headline.comparison!!.direction)
-        assertNull(headline.comparison!!.percent)
-    }
-
-    /** With no spans there is no comparison, whatever was counted. */
-    @Test
-    fun `a span with nothing before it keeps no comparison`() {
-        val local = localStats(totalMs = TimeUnit.MINUTES.toMillis(60))
-        val headline = ReadingStatsViewModel.mergeHeadline(
-            merged = local,
-            local = local,
-            server = null,
-            spans = null,
-            currentMs = TimeUnit.MINUTES.toMillis(60),
-            previousMs = TimeUnit.MINUTES.toMillis(30),
-        )
-
-        assertNull(headline.comparison)
-    }
-
-    private val spans = ComparisonSpans(
-        period = ComparisonPeriod.WEEK,
-        current = DateSpan(LocalDate.of(2026, 8, 3), LocalDate.of(2026, 8, 9)),
-        previous = DateSpan(LocalDate.of(2026, 7, 27), LocalDate.of(2026, 8, 2)),
-        through = LocalTime.MAX,
-    )
-
-    private fun localStats(totalMs: Long) = ReadingStats(
-        totalMs = totalMs,
-        booksRead = 1,
-        booksFinished = 0,
-        books = emptyList(),
-        recent = emptyList(),
-    )
 
     private fun session(
         url: String,


### PR DESCRIPTION
## Summary

The reading statistics screen stopped routing through an older merge helper when the cross-device snapshot took over that job. The helper, and a bounds check that could never fail, were left behind with nothing calling them. This removes both.

The screen shows exactly what it showed before. There is no user-visible change.

## Changes

- Remove the unused headline merge helper and the provenance helper from the reading statistics screen, inlining the one remaining call.
- Remove a candidate-count check in the sync snapshot builder that could never fail, because the loop above it already caps the count.
- Remove the tests that only exercised the unused helper. The behaviour they described is still covered by the tests that run against the code the screen actually uses.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [ ] Manually tested on a device or emulator, if applicable

## Screenshots or recordings

None. Nothing on screen changes.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.