### PR TITLE
Show reading comparisons across devices

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/InsightsSnapshot.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/InsightsSnapshot.kt
@@ -3,7 +3,10 @@ package com.chmouel.liseur.data.liseursync
 import com.chmouel.liseur.data.db.ReadingSession
 import com.chmouel.liseur.data.db.SessionTransmission
 import com.chmouel.liseur.data.db.WorkAlias
+import com.chmouel.liseur.domain.ComparisonPeriod
+import com.chmouel.liseur.domain.DateSpan
 import java.time.LocalDate
+import java.time.LocalTime
 
 /** Acknowledgements are bookkeeping, not a change to the captured reading. */
 internal fun statsSessions(sessions: List<ReadingSession>): List<ReadingSession> =
@@ -36,4 +39,16 @@ data class SnapshotTotals(
     val overlapBooks: Map<String, Pair<Double, Int>>,
     val overlapDays: Map<LocalDate, Double>,
     val combinedStreak: Int,
+    val comparison: SnapshotComparison? = null,
+)
+
+data class SnapshotComparison(
+    val period: ComparisonPeriod,
+    val current: DateSpan,
+    val previous: DateSpan,
+    val through: LocalTime,
+    val currentMinutes: Double,
+    val previousMinutes: Double,
+    val overlapCurrentMinutes: Double,
+    val overlapPreviousMinutes: Double,
 )

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSnapshots.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSnapshots.kt
@@ -11,6 +11,8 @@ import com.chmouel.liseur.data.remote.LiveIdentity
 import com.chmouel.liseur.data.remote.RemoteHttpFailure
 import com.chmouel.liseur.data.remote.ServerKind
 import com.chmouel.liseur.data.remote.SyncFailure
+import com.chmouel.liseur.domain.ComparisonSpans
+import com.chmouel.liseur.domain.DateSpan
 import com.chmouel.liseur.domain.StatsRange
 import com.chmouel.liseur.domain.calendarChunks
 import java.io.IOException
@@ -18,7 +20,10 @@ import java.time.DateTimeException
 import java.time.DayOfWeek
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 import kotlin.math.abs
 import kotlinx.coroutines.Dispatchers
@@ -35,6 +40,7 @@ internal data class CompleteStatsSnapshot(
     val revision: String,
     val today: LocalDate,
     val captured: CapturedStatsSessions,
+    val comparisonCaptured: CapturedStatsSessions?,
     val aliases: List<StatsAlias>,
     val totals: SnapshotTotals,
 ) {
@@ -90,6 +96,7 @@ class LiseurSyncSnapshots(
         range: StatsRange,
         today: LocalDate,
         weekStart: DayOfWeek,
+        through: LocalTime = LocalTime.MAX,
     ): CompleteStatsSnapshot? = withContext(Dispatchers.Default) {
         optional {
             val account = context.account
@@ -107,15 +114,16 @@ class LiseurSyncSnapshots(
             val key = deviceKey().takeIf { it.isNotBlank() }
                 ?: return@optional refuse("this device has no identity to name its own reading by")
             val from = range.startDate(today, weekStart)
+            var comparison = if (capabilities.comparison) {
+                range.comparison(today, weekStart, through.truncatedTo(ChronoUnit.MILLIS))
+            } else {
+                null
+            }
             val recorded = statsSessions(sessions)
             val evidence = transmissionDao.forPeer(account.accountKey)
             val aliases = statsAliases(identityDao.aliasesFor(account.accountKey))
             val bySession = evidence.associateBy { it.sessionId }
             val aliasByUrl = aliases.associateBy { it.bookUrl }
-            val candidates = JSONArray()
-            val candidateWorks = mutableSetOf<String>()
-            val contributingIds = mutableSetOf<Long>()
-            var candidateBytes = 0L
             val days = sortedSetOf<LocalDate>()
             val workByUrl = aliases.associate { it.bookUrl to it.workId }
             for (session in recorded) {
@@ -126,76 +134,120 @@ class LiseurSyncSnapshots(
                 if (days.size > capabilities.maxLocalActiveDays) {
                     return@optional refuse("more reading days than the server will accept")
                 }
-                if (day > today || (from != null && day < from)) continue
-                if (session.endedAt == null || session.startProgression == null || session.endProgression == null) continue
-                contributingIds += session.id
-                val transmission = bySession[session.id]
-                if (transmission == null && !session.legacyEvidenceUnknown) {
-                    // Nothing was ever offered for this sitting, and the
-                    // absence is trustworthy: since the evidence table
-                    // existed a request has been written down before it
-                    // is sent, so no server can be holding this. This
-                    // device's own figure is the whole of it.
-                    continue
-                }
-                // A sitting with no retained request may still be on the
-                // server: it was sent before that table existed, or the
-                // record of it was dropped when an account was
-                // disconnected. Neither the acknowledgement nor its
-                // absence settles that, so rebuild what would have been
-                // sent and let the server say. It answers on identity
-                // first, so a sitting it has never seen is ignored and
-                // counted here, one it holds is named in the overlap and
-                // counted once, and a rebuild it disagrees with is
-                // refused outright rather than guessed at (ADR-0021).
-                val payload = if (transmission != null) {
-                    transmission.payload
-                } else {
-                    // A book with no usable name on this peer could
-                    // never have been sent: the upload query joins the
-                    // very same aliases, so it has never once selected
-                    // this sitting. Refusing the whole period over it
-                    // would strand every reader with a sideloaded book
-                    // the server could not name confidently, which is
-                    // the failure this change exists to end.
-                    val alias = aliasByUrl[session.bookUrl] ?: continue
-                    SessionUploads.toJson(session, key, alias.workId, alias.editionSha)?.toString()
-                        ?: return@optional refuse("a sitting of unknown standing cannot be described again")
-                }
-                val device = transmission?.deviceId ?: account.accountId.orEmpty()
-                if (device.isEmpty()) {
-                    return@optional refuse("a sitting to account for names no device")
-                }
-                candidateBytes += payload.toByteArray(Charsets.UTF_8).size
-                if (candidates.length() >= capabilities.maxCandidates || candidateBytes > capabilities.maxBodyBytes) {
-                    return@optional refuse("more evidence than one request may carry")
-                }
-                val json = JSONObject(payload)
-                val work = json.getString("work_id")
-                if (workByUrl[session.bookUrl] != work) {
-                    return@optional refuse("a book was resolved to a different work since it was sent")
-                }
-                candidateWorks += work
-                candidates.put(json.put("device_id", device))
             }
-            val captured = CapturedStatsSessions(
-                recorded, evidence.filter { it.sessionId in contributingIds }, contributingIds.toSet(),
+            fun ReadingSession.inComparison(spans: ComparisonSpans): Boolean {
+                val ended = endedAt ?: return false
+                return listOf(spans.current, spans.previous).any { span ->
+                    val start = span.from.atStartOfDay(capabilities.timezone).toInstant().toEpochMilli()
+                    val cutoff = span.to.atTime(spans.through).atZone(capabilities.timezone)
+                        .toInstant().toEpochMilli()
+                    ended >= start && startedAt < cutoff
+                }
+            }
+            data class Candidates(
+                val json: JSONArray,
+                val works: Set<String>,
+                val sessionIds: Set<Long>,
+                val headlineSessionIds: Set<Long>,
             )
+            fun candidatesFor(spans: ComparisonSpans?): Candidates? {
+                val result = JSONArray()
+                val candidateWorks = mutableSetOf<String>()
+                val contributingIds = mutableSetOf<Long>()
+                val headlineIds = mutableSetOf<Long>()
+                var candidateBytes = 0L
+                for (session in recorded) {
+                    if (session.durationMs <= 0) continue
+                    val day = Instant.ofEpochMilli(session.endedAt ?: session.lastCheckpointAt)
+                        .atZone(capabilities.timezone).toLocalDate()
+                    val inHeadline = day <= today && (from == null || day >= from)
+                    if (!inHeadline && (spans == null || !session.inComparison(spans))) continue
+                    if (session.endedAt == null ||
+                        session.startProgression == null || session.endProgression == null
+                    ) continue
+                    contributingIds += session.id
+                    if (inHeadline) headlineIds += session.id
+                    val transmission = bySession[session.id]
+                    if (transmission == null && !session.legacyEvidenceUnknown) continue
+                    val payload = if (transmission != null) {
+                        transmission.payload
+                    } else {
+                        val alias = aliasByUrl[session.bookUrl] ?: continue
+                        SessionUploads.toJson(session, key, alias.workId, alias.editionSha)?.toString()
+                            ?: return null
+                    }
+                    val device = transmission?.deviceId ?: account.accountId.orEmpty()
+                    if (device.isEmpty()) return null
+                    candidateBytes += payload.toByteArray(Charsets.UTF_8).size
+                    if (result.length() >= capabilities.maxCandidates ||
+                        candidateBytes > capabilities.maxBodyBytes
+                    ) return null
+                    val json = JSONObject(payload)
+                    val work = json.getString("work_id")
+                    if (workByUrl[session.bookUrl] != work) return null
+                    candidateWorks += work
+                    result.put(json.put("device_id", device))
+                }
+                return Candidates(result, candidateWorks, contributingIds, headlineIds)
+            }
+            var proof = candidatesFor(comparison)
+            if (proof == null && comparison != null) {
+                comparison = null
+                proof = candidatesFor(null)
+            }
+            var candidates = proof
+                ?: return@optional refuse("more evidence than one request may carry")
             val firstLocalDay = days.firstOrNull()
             val initialFrom = maxOf(
                 from ?: firstLocalDay ?: today,
                 today.minusDays(capabilities.maxCalendarDays.toLong() - 1),
             )
             val id = UUID.randomUUID().toString()
-            val body = JSONObject().apply {
+            fun requestBody(): JSONObject = JSONObject().apply {
                 put("snapshot_id", id)
                 put("timezone", capabilities.timezone.id)
                 if (from == null) put("range", "all") else {
                     put("from", from.toString())
                     put("to", today.toString())
                 }
-                put("candidates", candidates)
+                comparison?.let { spans ->
+                    put("comparison", JSONObject().apply {
+                        put("current_from", spans.current.from.toString())
+                        put("current_to", spans.current.to.toString())
+                        put("previous_from", spans.previous.from.toString())
+                        put("previous_to", spans.previous.to.toString())
+                        put("through", spans.through.format(COMPARISON_TIME))
+                    })
+                }
+                put("candidates", candidates.json)
                 put("local_active_days", JSONArray(days.map(LocalDate::toString)))
+            }
+            var body = requestBody().apply {
+                put("calendar_from", initialFrom.toString())
+                put("calendar_to", today.toString())
+            }
+            if (body.toString().toByteArray(Charsets.UTF_8).size > capabilities.maxBodyBytes &&
+                comparison != null
+            ) {
+                comparison = null
+                candidates = candidatesFor(null)
+                    ?: return@optional refuse("more evidence than one request may carry")
+                body = requestBody().apply {
+                    put("calendar_from", initialFrom.toString())
+                    put("calendar_to", today.toString())
+                }
+            }
+            val captured = CapturedStatsSessions(
+                recorded,
+                evidence.filter { it.sessionId in candidates.headlineSessionIds },
+                candidates.headlineSessionIds,
+            )
+            val comparisonCaptured = comparison?.let {
+                CapturedStatsSessions(
+                    recorded,
+                    evidence.filter { row -> row.sessionId in candidates.sessionIds },
+                    candidates.sessionIds,
+                )
             }
             suspend fun page(start: LocalDate, end: LocalDate): Page? {
                 body.put("calendar_from", start.toString()).put("calendar_to", end.toString())
@@ -216,7 +268,10 @@ class LiseurSyncSnapshots(
                     throw e
                 }
                 if (!sameAccount(account)) return null
-                return parsePage(response, context, id, from, today, start, end, workByUrl, candidateWorks, candidates.length())
+                return parsePage(
+                    response, context, id, from, today, start, end, workByUrl,
+                    candidates.works, candidates.json.length(), comparison,
+                )
             }
             val first = page(initialFrom, today) ?: return@optional null
             val historyStart = from ?: listOfNotNull(first.firstActivity, firstLocalDay).minOrNull() ?: today
@@ -225,6 +280,7 @@ class LiseurSyncSnapshots(
             }
             val calendar = first.totals.days.toMutableList()
             val overlapDays = first.totals.overlapDays.toMutableMap()
+            var acceptedComparison = first.totals.comparison
             if (historyStart < initialFrom) {
                 val missing = initialFrom.toEpochDay() - historyStart.toEpochDay()
                 if ((missing + capabilities.maxCalendarDays - 1) / capabilities.maxCalendarDays + 1 > MAX_CALENDAR_PAGES) {
@@ -235,9 +291,13 @@ class LiseurSyncSnapshots(
                 )) {
                     val next = page(start, end) ?: return@optional null
                     if (next.revision != first.revision || next.firstActivity != first.firstActivity ||
-                        next.totals.copy(days = emptyList(), overlapDays = emptyMap()) !=
-                        first.totals.copy(days = emptyList(), overlapDays = emptyMap())
+                        next.totals.copy(
+                            days = emptyList(), overlapDays = emptyMap(), comparison = null,
+                        ) != first.totals.copy(
+                            days = emptyList(), overlapDays = emptyMap(), comparison = null,
+                        )
                     ) return@optional refuse("the server's figures moved between calendar pages")
+                    if (next.totals.comparison != acceptedComparison) acceptedComparison = null
                     calendar += next.totals.days
                     overlapDays += next.totals.overlapDays
                 }
@@ -250,8 +310,10 @@ class LiseurSyncSnapshots(
             val dense = generateSequence(historyStart) { it.plusDays(1).takeUnless { day -> day > today } }
                 .map { byDay[it] ?: InsightDay(it, 0.0) }.toList()
             val result = CompleteStatsSnapshot(
-                context, id, first.revision, today, captured, aliases,
-                first.totals.copy(days = dense, overlapDays = overlapDays),
+                context, id, first.revision, today, captured, comparisonCaptured, aliases,
+                first.totals.copy(
+                    days = dense, overlapDays = overlapDays, comparison = acceptedComparison,
+                ),
             )
             result.takeIf { isCurrent(it) } ?: refuse("the reading moved while the server was answering")
         }
@@ -263,6 +325,15 @@ class LiseurSyncSnapshots(
             snapshot.aliases == statsAliases(identityDao.aliasesFor(snapshot.peer)) &&
             sameAccount(snapshot.context.account)
     }
+
+    internal suspend fun isComparisonCurrent(snapshot: CompleteStatsSnapshot): Boolean =
+        withContext(Dispatchers.Default) {
+            val captured = snapshot.comparisonCaptured ?: return@withContext false
+            sameAccount(snapshot.context.account) &&
+                captured.matches(sessionDao.allOnce(), transmissionDao.forPeer(snapshot.peer)) &&
+                snapshot.aliases == statsAliases(identityDao.aliasesFor(snapshot.peer)) &&
+                sameAccount(snapshot.context.account)
+        }
 
     private suspend fun sameAccount(account: RemoteServer): Boolean =
         serverDao.get()?.let(LiveIdentity::from) == LiveIdentity.from(account)
@@ -294,6 +365,7 @@ class LiseurSyncSnapshots(
         workByUrl: Map<String, String>,
         candidateWorks: Set<String>,
         candidateCount: Int,
+        requestedComparison: ComparisonSpans?,
     ): Page? {
         val expectedAccount = (context.capabilities.accountId ?: context.account.liseurAccountId)
             ?.takeIf { it.isNotBlank() } ?: return refuse("the account has no identity to check a reply against")
@@ -373,6 +445,7 @@ class LiseurSyncSnapshots(
         if (matchedDays.any { exceedsMinutes(it.activeMinutes, fullDays[it.date]?.activeMinutes ?: 0.0) }) return refuse(INCOHERENT)
         // Normalize only the accepted sub-millisecond excess. Otherwise integer
         // rounding could turn that noise into a negative residual in the union.
+        val comparison = parseComparison(json, requestedComparison)
         return Page(
             revision, first,
             SnapshotTotals(
@@ -384,8 +457,47 @@ class LiseurSyncSnapshots(
                     it.date to minOf(it.activeMinutes, fullDays[it.date]?.activeMinutes ?: 0.0)
                 },
                 json.count("combined_streak_days"),
+                comparison,
             ),
         )
+    }
+
+    private fun parseComparison(
+        json: JSONObject,
+        requested: ComparisonSpans?,
+    ): SnapshotComparison? {
+        if (requested == null || !json.has("comparison")) return null
+        return try {
+            val totals = json.getJSONObject("comparison")
+            val overlap = json.getJSONObject("overlap").getJSONObject("comparison")
+            val through = LocalTime.parse(totals.getString("through"), COMPARISON_TIME)
+            val current = DateSpan(
+                LocalDate.parse(totals.getString("current_from")),
+                LocalDate.parse(totals.getString("current_to")),
+            )
+            val previous = DateSpan(
+                LocalDate.parse(totals.getString("previous_from")),
+                LocalDate.parse(totals.getString("previous_to")),
+            )
+            if (current != requested.current || previous != requested.previous ||
+                through != requested.through
+            ) return null
+            val currentMinutes = totals.minutes("current_active_minutes")
+            val previousMinutes = totals.minutes("previous_active_minutes")
+            val overlapCurrent = overlap.minutes("current_active_minutes")
+            val overlapPrevious = overlap.minutes("previous_active_minutes")
+            if (exceedsMinutes(overlapCurrent, currentMinutes) ||
+                exceedsMinutes(overlapPrevious, previousMinutes)
+            ) return null
+            SnapshotComparison(
+                requested.period, current, previous, through,
+                currentMinutes, previousMinutes, overlapCurrent, overlapPrevious,
+            )
+        } catch (_: JSONException) {
+            null
+        } catch (_: DateTimeException) {
+            null
+        }
     }
 
     private fun parseDays(array: JSONArray, from: LocalDate, to: LocalDate): List<InsightDay>? {
@@ -442,5 +554,6 @@ class LiseurSyncSnapshots(
         // A resource refusal, not a truncated chart: unusually large histories remain local.
         const val MAX_CALENDAR_DAYS = 366_000L
         const val MAX_CALENDAR_PAGES = 128
+        val COMPARISON_TIME: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS")
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSnapshots.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSnapshots.kt
@@ -196,7 +196,7 @@ class LiseurSyncSnapshots(
                 proof = candidatesFor(null)
             }
             var candidates = proof
-                ?: return@optional refuse("more evidence than one request may carry")
+                ?: return@optional refuse("could not prepare complete snapshot evidence")
             val firstLocalDay = days.firstOrNull()
             val initialFrom = maxOf(
                 from ?: firstLocalDay ?: today,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/StatisticsCapabilities.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/StatisticsCapabilities.kt
@@ -12,6 +12,7 @@ data class StatisticsCapabilities(
     val accountId: String?,
     val maxBodyBytes: Int,
     val maxLocalActiveDays: Int,
+    val comparison: Boolean,
 ) {
     companion object {
         internal fun parse(json: JSONObject): StatisticsCapabilities? {
@@ -32,6 +33,7 @@ data class StatisticsCapabilities(
                 // Version 1 defines range=all; honor an explicit opt-out when supplied.
                 !json.has("all_time") || json.opt("all_time") == true,
                 account, minOf(bytes, 4 * 1024 * 1024), minOf(activeDays, 25_000),
+                json.opt("comparison") == true,
             )
         }
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/ReadingStats.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/ReadingStats.kt
@@ -448,6 +448,8 @@ private fun SessionSpan.countedBy(cutoff: Long): Long {
 /** Which way a period went against the one before it. */
 enum class ComparisonDirection { MORE, LESS, SAME }
 
+enum class ComparisonScope { THIS_DEVICE, ALL_DEVICES }
+
 /**
  * How this period's reading compares with the last one's.
  *
@@ -460,6 +462,7 @@ data class ReadingComparison(
     val period: ComparisonPeriod,
     val direction: ComparisonDirection,
     val percent: Int?,
+    val scope: ComparisonScope = ComparisonScope.THIS_DEVICE,
 )
 
 /**

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
@@ -79,6 +79,7 @@ import com.chmouel.liseur.R
 import com.chmouel.liseur.domain.BookReadingStats
 import com.chmouel.liseur.domain.ComparisonDirection
 import com.chmouel.liseur.domain.ComparisonPeriod
+import com.chmouel.liseur.domain.ComparisonScope
 import com.chmouel.liseur.domain.ReadingComparison
 import com.chmouel.liseur.domain.ReadingDay
 import com.chmouel.liseur.domain.ReadingStats
@@ -973,13 +974,9 @@ private val StatsRange.caption: Int
  * apart, because a quiet week is not an error state. Both take
  * `onSurfaceVariant`, the same weight as the caption below.
  *
- * Every one of those sentences names this device, and it is not
- * decoration. The figure above is every device's reading and says so in
- * the caption below; this line is a comparison, and a comparison holds
- * only between two figures gathered the same way, so both of its halves
- * are this device's own sittings. Saying "12% less than last week" over
- * an all-device total would be a claim about a reader's month that the
- * arithmetic underneath has not made. See ADR 18.
+ * The local fallback names this device. A comparison proved by the
+ * server counts every device, matching the headline and its provenance
+ * caption, so it needs no second scope qualifier.
  */
 @Composable
 private fun ComparisonLine(comparison: ReadingComparison) {
@@ -991,18 +988,37 @@ private fun ComparisonLine(comparison: ReadingComparison) {
         },
     )
     val percent = comparison.percent
+    val allDevices = comparison.scope == ComparisonScope.ALL_DEVICES
     val text = when {
         comparison.direction == ComparisonDirection.SAME ->
-            stringResource(R.string.reading_stats_compare_same, period)
+            stringResource(
+                if (allDevices) R.string.reading_stats_compare_same_all
+                else R.string.reading_stats_compare_same,
+                period,
+            )
 
         // No baseline to divide by. An infinity, or a number in the
         // hundreds of thousands, is not a fact about the reader's week.
-        percent == null -> stringResource(R.string.reading_stats_compare_more_than, period)
+        percent == null -> stringResource(
+            if (allDevices) R.string.reading_stats_compare_more_than_all
+            else R.string.reading_stats_compare_more_than,
+            period,
+        )
 
         comparison.direction == ComparisonDirection.MORE ->
-            stringResource(R.string.reading_stats_compare_more, percent, period)
+            stringResource(
+                if (allDevices) R.string.reading_stats_compare_more_all
+                else R.string.reading_stats_compare_more,
+                percent,
+                period,
+            )
 
-        else -> stringResource(R.string.reading_stats_compare_less, percent, period)
+        else -> stringResource(
+            if (allDevices) R.string.reading_stats_compare_less_all
+            else R.string.reading_stats_compare_less,
+            percent,
+            period,
+        )
     }
     Row(
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsViewModel.kt
@@ -23,6 +23,7 @@ import com.chmouel.liseur.data.liseursync.WorkTotals
 import com.chmouel.liseur.data.settings.AppSettingsRepository
 import com.chmouel.liseur.domain.BookReadingStats
 import com.chmouel.liseur.domain.ComparisonSpans
+import com.chmouel.liseur.domain.ComparisonScope
 import com.chmouel.liseur.domain.ReadingComparison
 import com.chmouel.liseur.domain.ReadingDay
 import com.chmouel.liseur.domain.ReadingStats
@@ -37,6 +38,7 @@ import com.chmouel.liseur.domain.localeWeekStart
 import com.chmouel.liseur.domain.readingStats
 import com.chmouel.liseur.domain.readingStatusFor
 import com.chmouel.liseur.domain.readingTotals
+import com.chmouel.liseur.domain.unionMinutes
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalTime
@@ -122,7 +124,8 @@ sealed interface BookReadingStatsUiState {
  * as a running total anywhere. A supported liseur-sync snapshot supplies
  * one coherent set of aggregates and actual overlap with captured local
  * sessions. All dashboard figures use that generation or fall back
- * together. Comparisons remain local in the phone timezone.
+ * together. A supported snapshot also supplies the comparison in the
+ * account timezone; otherwise the comparison remains local.
  *
  * Both sources are asked about the same [StatsRange], which is the whole
  * point of the range living in one place: while the server was pinned to
@@ -150,9 +153,15 @@ class ReadingStatsViewModel(
         try {
             coroutineScope {
                 launch {
+                    var elapsed = 0L
                     while (isActive) {
-                        delay(60_000)
+                        delay(CLOCK_SAMPLE_MS)
                         resampleClock()
+                        elapsed += CLOCK_SAMPLE_MS
+                        if (elapsed >= COMPARISON_REFRESH_MS) {
+                            elapsed = 0L
+                            refreshServerInsights()
+                        }
                     }
                 }
                 combine(liveInvalidations, liveAccounts.distinctUntilChanged()) { tick, account ->
@@ -338,12 +347,20 @@ class ReadingStatsViewModel(
             val at = now(context.capabilities.timezone)
             val result = source.read(
                 context, sessionDao.allOnce(), window.range, at.toLocalDate(), window.weekStart,
+                at.toLocalTime(),
             ) ?: return@launch
             resampleClock()
             if (source.isCurrent(result) && token == generation &&
                 _window.value.asked() == window.asked() && now(result.zone).toLocalDate() == result.today
             ) {
-                _snapshot.value = Answered(window, result)
+                val publish = if (result.totals.comparison != null &&
+                    !source.isComparisonCurrent(result)
+                ) {
+                    result.copy(totals = result.totals.copy(comparison = null))
+                } else {
+                    result
+                }
+                _snapshot.value = Answered(window, publish)
             }
         }
     }
@@ -519,8 +536,32 @@ class ReadingStatsViewModel(
             )
             uniteSnapshot(inAccountZone, local.books, local.firstReadAtByUrl, it.totals)
         }
-        val comparison = local.spans?.let {
+        val localComparison = local.spans?.let {
             compareReading(it.period, local.currentMs, local.previousMs)
+        }
+        val comparison = if (united != null) {
+            snapshot?.totals?.comparison?.let { remote ->
+                val localCurrent = readingTotals(
+                    local.sessionSpans, snapshot.zone, remote.current, remote.through,
+                ).totalMs
+                val localPrevious = readingTotals(
+                    local.sessionSpans, snapshot.zone, remote.previous, remote.through,
+                ).totalMs
+                val current = unionMinutes(
+                    remote.currentMinutes, localCurrent, remote.overlapCurrentMinutes,
+                )
+                val previous = unionMinutes(
+                    remote.previousMinutes, localPrevious, remote.overlapPreviousMinutes,
+                )
+                if (current != null && previous != null) {
+                    compareReading(remote.period, current, previous)
+                        .copy(scope = ComparisonScope.ALL_DEVICES)
+                } else {
+                    null
+                }
+            } ?: localComparison
+        } else {
+            localComparison
         }
         ReadingStatsUiState.Ready(
             stats = united?.stats ?: local.stats,
@@ -564,6 +605,8 @@ class ReadingStatsViewModel(
     companion object {
         /** Long enough to survive a rotation without recomputing. */
         private const val STOP_TIMEOUT_MS = 5_000L
+        private const val CLOCK_SAMPLE_MS = 60_000L
+        private const val COMPARISON_REFRESH_MS = 5 * 60_000L
 
         /**
          * Folds the server's aggregates into the local ones, never

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -732,6 +732,10 @@
     <string name="reading_stats_compare_less">%1$d%% less than %2$s, on this device</string>
     <string name="reading_stats_compare_more_than">More than %1$s, on this device</string>
     <string name="reading_stats_compare_same">Same as %1$s, on this device</string>
+    <string name="reading_stats_compare_more_all">%1$d%% more than %2$s</string>
+    <string name="reading_stats_compare_less_all">%1$d%% less than %2$s</string>
+    <string name="reading_stats_compare_more_than_all">More than %1$s</string>
+    <string name="reading_stats_compare_same_all">Same as %1$s</string>
     <string name="reading_stats_period_week">last week</string>
     <string name="reading_stats_period_month">last month</string>
     <string name="reading_stats_period_year">last year</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSnapshotsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncSnapshotsTest.kt
@@ -14,6 +14,7 @@ import com.chmouel.liseur.data.remote.ServerKind
 import com.chmouel.liseur.data.remote.LiveIdentity
 import com.chmouel.liseur.domain.StatsRange
 import com.chmouel.liseur.domain.ComparisonDirection
+import com.chmouel.liseur.domain.ComparisonScope
 import com.chmouel.liseur.ui.stats.ReadingStatsUiState
 import com.chmouel.liseur.ui.stats.ReadingStatsViewModel
 import com.chmouel.liseur.ui.stats.StatsProvenance
@@ -121,6 +122,76 @@ class LiseurSyncSnapshotsTest {
         assertEquals(90.0, result.totals.summary.activeMinutes, 0.0)
         assertEquals(today, result.totals.days.last().date)
         assertEquals(11, result.totals.combinedStreak)
+    }
+
+    @Test
+    fun `snapshot asks for and accepts one coherent comparison`() = runTest {
+        changeCapabilities = { it.put("comparison", true) }
+        val result = read()!!
+        val requested = requests.single().getJSONObject("comparison")
+        assertEquals("2026-09-01", requested.getString("current_from"))
+        assertEquals("2026-08-01", requested.getString("previous_from"))
+        assertEquals("23:59:59.999", requested.getString("through"))
+        assertEquals(60.0, result.totals.comparison!!.currentMinutes, 0.0)
+        assertEquals(120.0, result.totals.comparison!!.previousMinutes, 0.0)
+    }
+
+    @Test
+    fun `old server keeps the local comparison request unchanged`() = runTest {
+        val result = read()!!
+        assertFalse(requests.single().has("comparison"))
+        assertNull(result.totals.comparison)
+    }
+
+    @Test
+    fun `malformed optional comparison does not discard the headline`() = runTest {
+        changeCapabilities = { it.put("comparison", true) }
+        changeResponse = { it.getJSONObject("comparison").put("through", "not-a-time") }
+        val result = read()
+        assertNotNull(result)
+        assertNull(result!!.totals.comparison)
+        assertEquals(90.0, result.totals.summary.activeMinutes, 0.0)
+    }
+
+    @Test
+    fun `baseline evidence is included so uploaded reading is not counted twice`() = runTest {
+        changeCapabilities = { it.put("comparison", true) }
+        val id = sitting(unknown = true)
+        val old = db.readingSessionDao().get(id)!!
+        db.readingSessionDao().deleteForBook("book")
+        val baseline = today.minusMonths(1).atTime(12, 0).atZone(zone).toInstant().toEpochMilli()
+        val baselineId = db.readingSessionDao().insert(
+            old.copy(id = 0, startedAt = baseline - 600_000, endedAt = baseline, lastCheckpointAt = baseline),
+        )
+        transmit(baselineId)
+
+        assertNotNull(read())
+        assertEquals(1, requests.single().getJSONArray("candidates").length())
+    }
+
+    @Test
+    fun `baseline evidence changing in flight preserves the headline only`() = runTest {
+        changeCapabilities = { it.put("comparison", true) }
+        sitting()
+        val id = sitting(unknown = true)
+        val old = db.readingSessionDao().get(id)!!
+        db.readingSessionDao().deleteForBook("book")
+        sitting()
+        val baseline = today.minusMonths(1).atTime(12, 0).atZone(zone).toInstant().toEpochMilli()
+        val baselineId = db.readingSessionDao().insert(
+            old.copy(id = 0, startedAt = baseline - 600_000, endedAt = baseline, lastCheckpointAt = baseline),
+        )
+        duringRequest = { transmit(baselineId) }
+
+        val client = client()
+        val context = client.discover()!!
+        val result = client.read(
+            context, db.readingSessionDao().allOnce(), StatsRange.THIS_MONTH,
+            today, DayOfWeek.MONDAY,
+        )
+        assertNotNull(result)
+        assertTrue(client.isCurrent(result!!))
+        assertFalse(client.isComparisonCurrent(result))
     }
 
     @Test
@@ -560,6 +631,7 @@ class LiseurSyncSnapshotsTest {
                     put("days", JSONArray().put(day(today, 30, 1)))
                 })
             }
+
             val model = ReadingStatsViewModel(
                 db.readingSessionDao(), db.bookDao(), db.readingProgressDao(),
                 initialRange = StatsRange.THIS_MONTH, zone = { zone },
@@ -576,6 +648,37 @@ class LiseurSyncSnapshotsTest {
             assertEquals(90 * 60_000L, ready.headline.totalMs)
             assertEquals(90 * 60_000L, ready.stats.books.single().totalMs)
             assertEquals(90 * 60_000L, ready.stats.recent.sumOf { it.totalMs })
+        } finally {
+            models.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `comparison counts every device and subtracts local overlap`() = runTest {
+        Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        val models = ViewModelStore()
+        try {
+            changeCapabilities = { it.put("comparison", true) }
+            val id = sitting(unknown = true)
+            transmit(id)
+            val model = ReadingStatsViewModel(
+                db.readingSessionDao(), db.bookDao(), db.readingProgressDao(),
+                initialRange = StatsRange.THIS_MONTH, zone = { zone },
+                now = { today.atTime(13, 0).atZone(it) }, initialWeekStart = DayOfWeek.MONDAY,
+                snapshotSource = client(),
+                aliases = db.workIdentityDao().observeAliases(),
+                liveAccounts = db.remoteServerDao().observe().map { it?.let(LiveIdentity::from) },
+            )
+            models.put("comparison", model)
+            model.refreshServerInsights()
+            val ready = model.state.first {
+                it is ReadingStatsUiState.Ready && it.provenance == StatsProvenance.ALL_DEVICES
+            } as ReadingStatsUiState.Ready
+            assertEquals(ComparisonScope.ALL_DEVICES, ready.headline.comparison!!.scope)
+            assertEquals(ComparisonDirection.LESS, ready.headline.comparison!!.direction)
+            assertEquals(50, ready.headline.comparison!!.percent)
         } finally {
             models.clear()
             Dispatchers.resetMain()
@@ -676,7 +779,20 @@ class LiseurSyncSnapshotsTest {
                     if (hasOverlap) put(JSONObject("""{"work_id":"work","total_active_minutes":10,"sessions":1}"""))
                 })
                 put("days", JSONArray().apply { if (hasOverlap && today in start..end) put(day(today, 10, 1)) })
+                if (request.has("comparison")) {
+                    put("comparison", JSONObject().apply {
+                        put("current_active_minutes", if (hasOverlap) 30 else 0)
+                        put("previous_active_minutes", 0)
+                    })
+                }
             })
+            if (request.has("comparison")) {
+                val comparison = request.getJSONObject("comparison")
+                put("comparison", JSONObject(comparison.toString()).apply {
+                    put("current_active_minutes", 60)
+                    put("previous_active_minutes", 120)
+                })
+            }
             put("combined_streak_days", 11)
         }
         return response

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ComparisonWordingTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/stats/ComparisonWordingTest.kt
@@ -4,25 +4,13 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.chmouel.liseur.R
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
-/**
- * The comparison names the device it was counted on.
- *
- * The total above it is every device's reading and its caption says so.
- * The sentence beneath is not: both of its halves are this device's own
- * sittings, because a comparison only holds between two figures gathered
- * the same way and a server cannot be asked about a day that stops where
- * the clock has got to. See ADR 18.
- *
- * A reader who does all their reading on one machine loses nothing by
- * being told so. A reader with two would otherwise read a claim about
- * their month that the arithmetic never made — and the drift is silent,
- * which is why this is a test and not a comment.
- */
+/** Both comparison paths state only the scope their arithmetic proves. */
 @Config(sdk = [35], application = android.app.Application::class)
 @RunWith(RobolectricTestRunner::class)
 class ComparisonWordingTest {
@@ -40,6 +28,20 @@ class ComparisonWordingTest {
 
         for (sentence in sentences) {
             assertTrue(sentence, sentence.contains("this device"))
+        }
+    }
+
+    @Test
+    fun `all-device comparison sentences need no second scope label`() {
+        val sentences = listOf(
+            context.getString(R.string.reading_stats_compare_more_all, 25, "last week"),
+            context.getString(R.string.reading_stats_compare_less_all, 25, "last month"),
+            context.getString(R.string.reading_stats_compare_more_than_all, "last year"),
+            context.getString(R.string.reading_stats_compare_same_all, "last week"),
+        )
+
+        for (sentence in sentences) {
+            assertFalse(sentence, sentence.contains("this device"))
         }
     }
 

--- a/docs/adr/0018-period-over-period-reading-comparison.md
+++ b/docs/adr/0018-period-over-period-reading-comparison.md
@@ -3,6 +3,11 @@
 Status: accepted
 GitHub issue: [#120](https://github.com/chmouel/liseur/issues/120)
 
+The local-only comparison decision is superseded by
+[ADR-0024](0024-cross-device-reading-comparison.md) when liseur-sync can
+provide one coherent comparison snapshot. The local calculation and its
+explicit wording remain the fallback.
+
 ## Context
 
 The statistics screen says how long the reader has read in the selected

--- a/docs/adr/0024-cross-device-reading-comparison.md
+++ b/docs/adr/0024-cross-device-reading-comparison.md
@@ -1,0 +1,63 @@
+# 24. Cross-device reading comparison
+
+Status: accepted
+
+## Context
+
+ADR-0018 kept period comparisons on this device because the old server
+summary did not identify its timezone and current and previous periods
+would have required independent requests. Either limitation could make
+the two sides count different reading.
+
+The statistics snapshot introduced for ADR-0021 answers in the account
+timezone and binds totals, local overlap and a statistics revision in one
+response. It can therefore carry both comparison periods without mixing
+generations or counting an uploaded sitting twice.
+
+The last day still needs special treatment. A comparison at lunchtime
+must stop both periods at lunchtime. Raw sessions can be prorated at that
+wall-clock cutoff. A daily rollup cannot show how much happened before
+the cutoff.
+
+## Decision
+
+When liseur-sync advertises comparison support, the Android client asks
+for the current and previous spans in the existing snapshot request. The
+request includes one millisecond-precision wall-clock cutoff in the
+server's account timezone.
+
+The server calculates both totals and their overlap from the same database
+snapshot and revision. Raw sessions that cross the cutoff contribute the
+same estimated share used by the client:
+
+`active duration * elapsed wall time before cutoff / session wall-clock extent`
+
+Both implementations round each contribution to milliseconds before
+adding it. The account timezone resolves daylight-saving gaps and repeated
+hours. Sessions remain assigned whole to their ending day everywhere else.
+
+The comparison is optional within an otherwise complete statistics
+snapshot. If compacted data cannot prove a boundary contribution, evidence
+is too large, or the comparison block is malformed, the server omits it.
+It does not invalidate the headline. The client then uses the existing
+local comparison and retains the "on this device" wording.
+
+When the proof is available, the client combines each side as:
+
+`server + captured local - actual server overlap`
+
+The client validates the echoed spans and cutoff and requires both sides
+to pass. It never shows a comparison with mixed provenance. The
+all-device wording omits a second scope suffix because the provenance line
+under the same headline already says the figures count every device.
+
+## Consequences
+
+Week, month and year comparisons can represent reading across all devices
+without a second network request. Older periods may fall back to this
+device when session compaction removed the timestamps needed to split the
+boundary day.
+
+The capability is additive. Older servers receive the old request and the
+client continues to show its local comparison. All-time statistics still
+have no comparison.


### PR DESCRIPTION
## Summary

Reading comparisons now cover every device when liseur-sync can provide a
complete snapshot. The comparison uses the same cutoff for both periods and
subtracts sessions already present on the server, so this phone is not counted
twice.

Older servers, offline use, and incomplete comparison evidence keep the
existing device-only calculation and wording.

Server support: chmouel/liseur-sync#41

## Changes

- Request and parse optional comparison totals from liseur-sync.
- Combine server and local reading without double-counting uploaded sessions.
- Show plain comparison wording for all-device totals.
- Keep the existing "on this device" wording for fallback results.
- Refresh the comparison while the statistics screen remains open.
- Document the behavior and add regression coverage.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

## Screenshots or recordings

![Monthly reading comparison across all devices](./cross-device-reading-comparison.png)

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

![Monthly reading comparison across all devices](https://github.com/user-attachments/assets/d9e6fe00-16cb-4c31-af9d-93bdf1ead2e0)