### PR TITLE
Summarise reading activity by calendar period

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/domain/StatsChart.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/StatsChart.kt
@@ -1,0 +1,41 @@
+package com.chmouel.liseur.domain
+
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
+
+/** One bar in the reading activity chart. */
+data class ReadingPeriod(
+    val from: LocalDate,
+    val to: LocalDate,
+    val totalMs: Long,
+)
+
+/**
+ * Adds daily reading into the calendar unit that suits [range].
+ *
+ * The first and last week of a month are clipped to that month. This
+ * keeps every bar inside the range the headline describes while still
+ * respecting the first day of the reader's local calendar week.
+ */
+fun readingPeriods(
+    days: List<ReadingDay>,
+    range: StatsRange,
+    weekStart: DayOfWeek,
+): List<ReadingPeriod> = days
+    .groupBy { day ->
+        when (range.chartPeriod) {
+            StatsChartPeriod.DAY -> day.date
+            StatsChartPeriod.WEEK -> day.date.with(TemporalAdjusters.previousOrSame(weekStart))
+            StatsChartPeriod.MONTH -> day.date.withDayOfMonth(1)
+            StatsChartPeriod.YEAR -> day.date.withDayOfYear(1)
+        }
+    }
+    .values
+    .map { period ->
+        ReadingPeriod(
+            from = period.first().date,
+            to = period.last().date,
+            totalMs = period.sumOf { it.totalMs },
+        )
+    }

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/StatsRange.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/StatsRange.kt
@@ -77,16 +77,14 @@ enum class StatsRange(val id: String) {
             ChronoUnit.DAYS.between(it, today).toInt() + 1
         }
 
-    /**
-     * Whether the span is short enough to read as a row of daily bars.
-     *
-     * Past this a bar per day is a picket fence nobody can read a
-     * weekday off, and the heatmap takes over. A week is always bars and
-     * a year never is; a month is bars right up to its thirty-first day,
-     * which is what [MAX_BAR_DAYS] is sized for.
-     */
-    fun suitsDailyBars(today: LocalDate, weekStart: DayOfWeek): Boolean =
-        (days(today, weekStart) ?: Int.MAX_VALUE) <= MAX_BAR_DAYS
+    /** The calendar unit used to summarise this span in the activity chart. */
+    val chartPeriod: StatsChartPeriod
+        get() = when (this) {
+            THIS_WEEK -> StatsChartPeriod.DAY
+            THIS_MONTH -> StatsChartPeriod.WEEK
+            THIS_YEAR -> StatsChartPeriod.MONTH
+            ALL_TIME -> StatsChartPeriod.YEAR
+        }
 
     /**
      * This span and the matching elapsed portion of the period before it.
@@ -144,9 +142,6 @@ enum class StatsRange(val id: String) {
     companion object {
         val Default = THIS_WEEK
 
-        /** As many bars as fit across a phone without becoming hatching. */
-        const val MAX_BAR_DAYS = 31
-
         /**
          * Spans that were once offered and are still on readers' disks.
          *
@@ -177,6 +172,9 @@ data class DateSpan(val from: LocalDate, val to: LocalDate)
 
 /** Which calendar period a comparison is against. */
 enum class ComparisonPeriod { WEEK, MONTH, YEAR }
+
+/** The unit represented by one activity-chart bar. */
+enum class StatsChartPeriod { DAY, WEEK, MONTH, YEAR }
 
 /**
  * A span and the one it is measured against.

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
@@ -82,9 +82,12 @@ import com.chmouel.liseur.domain.ComparisonPeriod
 import com.chmouel.liseur.domain.ComparisonScope
 import com.chmouel.liseur.domain.ReadingComparison
 import com.chmouel.liseur.domain.ReadingDay
+import com.chmouel.liseur.domain.ReadingPeriod
 import com.chmouel.liseur.domain.ReadingStats
+import com.chmouel.liseur.domain.StatsChartPeriod
 import com.chmouel.liseur.domain.StatsRange
 import com.chmouel.liseur.domain.localeWeekStart
+import com.chmouel.liseur.domain.readingPeriods
 import com.chmouel.liseur.ui.BusyIndicator
 import com.chmouel.liseur.ui.LocalEInk
 import com.chmouel.liseur.ui.contentWidthCap
@@ -187,7 +190,12 @@ fun ReadingStatsScreen(
                     ProvenanceLine(ready.provenance)
                 }
                 item {
-                    ActivityCard(stats = stats, range = ready.range, today = ready.today)
+                    ActivityCard(stats = stats, range = ready.range)
+                }
+                if (ready.range != StatsRange.THIS_WEEK) {
+                    item {
+                        DailyActivityCard(stats.recent)
+                    }
                 }
                 if (stats.books.isNotEmpty()) {
                     item {
@@ -454,25 +462,23 @@ private fun BentoTile(
 /**
  * The chart, in a card with its own heading.
  *
- * Bars while a day is still a readable unit, a grid once it is not.
- * Both draw the same days; only the span the reader asked for decides
- * which can be read. "This week" is only true when it is one — thirty
- * bars under that heading is the screen telling the reader something it
- * can see is false.
+ * Each range uses the calendar unit beneath it: days in a week, weeks
+ * in a month, months in a year and years over all time. The separate
+ * heatmap below keeps the daily shape of longer spans available.
  */
 @Composable
-private fun ActivityCard(stats: ReadingStats, range: StatsRange, today: LocalDate) {
-    val weekStart = localeWeekStart(LocalLocale.current.platformLocale)
-    val daily = range.suitsDailyBars(today, weekStart)
+private fun ActivityCard(stats: ReadingStats, range: StatsRange) {
+    val periods = readingPeriods(
+        days = stats.recent,
+        range = range,
+        weekStart = localeWeekStart(LocalLocale.current.platformLocale),
+    )
     Surface(
         shape = RoundedCornerShape(18.dp),
         color = MaterialTheme.colorScheme.surfaceContainerLow,
         modifier = Modifier.fillMaxWidth(),
     ) {
         Column(
-            // Narrower at the sides than at the top and bottom: every dp
-            // taken off the width here comes out of the bars, and a
-            // month of them has none to spare.
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 16.dp),
         ) {
             Row(
@@ -482,20 +488,14 @@ private fun ActivityCard(stats: ReadingStats, range: StatsRange, today: LocalDat
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = stringResource(
-                        if (daily && range == StatsRange.THIS_WEEK) {
-                            R.string.reading_stats_recent
-                        } else {
-                            R.string.reading_stats_calendar
-                        },
-                    ),
+                    text = stringResource(range.chartHeading),
                     style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
                     color = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.weight(1f),
                 )
                 // The week's own sum, next to its heading, so the chart
                 // can be read without adding seven bars in one's head.
-                if (daily && range == StatsRange.THIS_WEEK) {
+                if (range == StatsRange.THIS_WEEK) {
                     val weekMs = stats.recent.sumOf { it.totalMs }
                     if (weekMs > 0) {
                         Surface(
@@ -518,66 +518,65 @@ private fun ActivityCard(stats: ReadingStats, range: StatsRange, today: LocalDat
                 }
             }
             Spacer(Modifier.height(16.dp))
-            if (daily) {
-                WeekBars(stats.recent)
-            } else {
-                ReadingHeatmap(stats.recent)
-            }
+            PeriodBars(periods, range.chartPeriod)
+        }
+    }
+}
+
+/** The daily calendar retained alongside the range-sized summary bars. */
+@Composable
+private fun DailyActivityCard(days: List<ReadingDay>) {
+    Surface(
+        shape = RoundedCornerShape(18.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 16.dp)) {
+            Text(
+                text = stringResource(R.string.reading_stats_calendar),
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(horizontal = 4.dp),
+            )
+            Spacer(Modifier.height(16.dp))
+            ReadingHeatmap(days)
         }
     }
 }
 
 /**
- * A short span of reading, one bar a day.
+ * A range of reading summarised in calendar-sized bars.
  *
  * Bars rather than a line: a week is too few days for a line to mean
  * anything, and a bar of nothing reads correctly as a day with no
  * reading in it, which a line would smooth over.
  *
- * At a week or less, each bar with reading on it carries its own
- * figure, because "how long on Tuesday" is the question the chart
- * exists to answer and a height alone answers it only relatively. Past
- * a week there is no room for figures, and the heights go back to
- * speaking for themselves.
+ * When seven or fewer bars are present, each one carries its own figure.
  *
- * Today's bar is drawn in full and the rest a shade quieter — not as a
- * grade, but as a cursor: the eye needs to know which bar it is living
- * in before it can count backwards. The longest day is still not
- * singled out; the height already says which day was the longest.
- *
- * The gap between bars narrows as they multiply, because the bars are
- * weighted and the gaps are not: thirty-one fixed 8dp gaps eat almost
- * the whole width of a phone and leave hatching where the chart was.
- *
- * Only some of the bars are captioned once there are more than a
- * week of them. Three letters under a column a few millimetres wide
- * wrap to one letter a line, which is not a label but a puzzle; a
- * caption every seventh bar names the same weekday down the chart and
- * lets the reader count from it.
+ * The last bar is drawn in full and the rest a shade quieter, marking
+ * the calendar period currently in progress.
  */
 @Composable
-private fun WeekBars(days: List<ReadingDay>) {
-    val busiest = days.maxOfOrNull { it.totalMs }?.coerceAtLeast(1) ?: 1
+private fun PeriodBars(periods: List<ReadingPeriod>, unit: StatsChartPeriod) {
+    val busiest = periods.maxOfOrNull { it.totalMs }?.coerceAtLeast(1) ?: 1
     // Read as observable state, so the letters change with the language
     // rather than staying in whatever it was when the screen was built.
     val locale = LocalLocale.current.platformLocale
-    // Counted back from the end so the last bar — today — is always one
-    // of the captioned ones.
-    val lastIndex = days.lastIndex
-    val everyBar = days.size <= DAYS_IN_WEEK
+    val lastIndex = periods.lastIndex
+    val showAmounts = periods.size <= DAYS_IN_WEEK
     // Gradients dither into stripes on an e-ink panel; flat ink reads.
     val eInk = LocalEInk.current
     val gap = when {
-        days.size <= DAYS_IN_WEEK -> 8.dp
-        days.size <= DAYS_IN_WEEK * 2 -> 5.dp
-        days.size <= DAYS_IN_WEEK * 3 -> 3.dp
+        periods.size <= DAYS_IN_WEEK -> 8.dp
+        periods.size <= DAYS_IN_WEEK * 2 -> 5.dp
+        periods.size <= DAYS_IN_WEEK * 3 -> 3.dp
         else -> 2.dp
     }
-    // A 6dp radius on a bar 6dp wide is a lozenge, not a bar.
-    val corner = if (days.size <= DAYS_IN_WEEK) 6.dp else 2.dp
+    val corner = if (periods.size <= DAYS_IN_WEEK) 6.dp else 2.dp
     // The figures above the bars need headroom of their own, or the
     // tallest bar pushes its label out of the card.
-    val chartHeight = if (everyBar) 150.dp else 130.dp
+    val chartHeight = if (showAmounts) 150.dp else 130.dp
+    val dateFormat = lastReadFormat()
 
     Row(
         modifier = Modifier
@@ -586,27 +585,27 @@ private fun WeekBars(days: List<ReadingDay>) {
         horizontalArrangement = Arrangement.spacedBy(gap),
         verticalAlignment = Alignment.Bottom,
     ) {
-        days.forEachIndexed { index, day ->
-            val captioned = everyBar || (lastIndex - index) % DAYS_IN_WEEK == 0
-            val isToday = index == lastIndex
-            val amount = readingDuration(day.totalMs)
-            val weekday = day.date.dayOfWeek.getDisplayName(TextStyle.SHORT, locale)
-            val barHeight = if (day.totalMs > 0) {
-                (92.dp * (day.totalMs.toFloat() / busiest)).coerceAtLeast(8.dp)
+        periods.forEachIndexed { index, period ->
+            val isCurrent = index == lastIndex
+            val amount = readingDuration(period.totalMs)
+            val label = period.shortLabel(unit, locale)
+            val spokenPeriod = period.spokenLabel(unit, locale, dateFormat)
+            val barHeight = if (period.totalMs > 0) {
+                (92.dp * (period.totalMs.toFloat() / busiest)).coerceAtLeast(8.dp)
             } else {
                 4.dp
             }
-            val spoken = if (day.totalMs > 0) {
-                stringResource(R.string.reading_stats_day_read, amount, weekday)
+            val spoken = if (period.totalMs > 0) {
+                stringResource(R.string.reading_stats_period_read, amount, spokenPeriod)
             } else {
-                stringResource(R.string.reading_stats_no_reading_day, weekday)
+                stringResource(R.string.reading_stats_no_reading_period, spokenPeriod)
             }
             val primary = MaterialTheme.colorScheme.primary
             val barBrush = when {
-                day.totalMs <= 0 -> SolidColor(MaterialTheme.colorScheme.surfaceContainerHighest)
-                eInk || isToday -> SolidColor(primary)
-                // Yesterday and before fade towards their base, so the
-                // week reads as a shape with today at its leading edge.
+                period.totalMs <= 0 -> SolidColor(MaterialTheme.colorScheme.surfaceContainerHighest)
+                eInk || isCurrent -> SolidColor(primary)
+                // Earlier periods fade towards their base, leaving the
+                // current calendar period as the visual cursor.
                 else -> Brush.verticalGradient(
                     listOf(primary.copy(alpha = 0.8f), primary.copy(alpha = 0.45f)),
                 )
@@ -621,13 +620,13 @@ private fun WeekBars(days: List<ReadingDay>) {
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Bottom,
             ) {
-                if (everyBar) {
+                if (showAmounts) {
                     Text(
-                        text = compactDuration(day.totalMs).orEmpty(),
+                        text = compactDuration(period.totalMs).orEmpty(),
                         style = MaterialTheme.typography.labelSmall.copy(
-                            fontWeight = if (isToday) FontWeight.Bold else FontWeight.Medium,
+                            fontWeight = if (isCurrent) FontWeight.Bold else FontWeight.Medium,
                         ),
-                        color = if (isToday) {
+                        color = if (isCurrent) {
                             MaterialTheme.colorScheme.primary
                         } else {
                             MaterialTheme.colorScheme.onSurfaceVariant
@@ -650,11 +649,11 @@ private fun WeekBars(days: List<ReadingDay>) {
                 )
                 Spacer(Modifier.height(8.dp))
                 Text(
-                    text = if (captioned) weekday else "",
+                    text = label,
                     style = MaterialTheme.typography.labelSmall.copy(
-                        fontWeight = if (isToday && everyBar) FontWeight.Bold else FontWeight.Normal,
+                        fontWeight = if (isCurrent) FontWeight.Bold else FontWeight.Normal,
                     ),
-                    color = if (isToday && everyBar) {
+                    color = if (isCurrent) {
                         MaterialTheme.colorScheme.primary
                     } else {
                         MaterialTheme.colorScheme.onSurfaceVariant
@@ -666,6 +665,41 @@ private fun WeekBars(days: List<ReadingDay>) {
             }
         }
     }
+}
+
+private val StatsRange.chartHeading: Int
+    get() = when (chartPeriod) {
+        StatsChartPeriod.DAY -> R.string.reading_stats_by_day
+        StatsChartPeriod.WEEK -> R.string.reading_stats_by_week
+        StatsChartPeriod.MONTH -> R.string.reading_stats_by_month
+        StatsChartPeriod.YEAR -> R.string.reading_stats_by_year
+    }
+
+private fun ReadingPeriod.shortLabel(unit: StatsChartPeriod, locale: java.util.Locale): String =
+    when (unit) {
+        StatsChartPeriod.DAY -> from.dayOfWeek.getDisplayName(TextStyle.SHORT, locale)
+        StatsChartPeriod.WEEK -> if (from == to) {
+            from.dayOfMonth.toString()
+        } else {
+            "${from.dayOfMonth}\u2013${to.dayOfMonth}"
+        }
+        StatsChartPeriod.MONTH -> from.month.getDisplayName(TextStyle.SHORT, locale)
+        StatsChartPeriod.YEAR -> from.year.toString()
+    }
+
+private fun ReadingPeriod.spokenLabel(
+    unit: StatsChartPeriod,
+    locale: java.util.Locale,
+    dateFormat: DateTimeFormatter,
+): String = when (unit) {
+    StatsChartPeriod.DAY -> from.format(dateFormat)
+    StatsChartPeriod.WEEK -> if (from == to) {
+        from.format(dateFormat)
+    } else {
+        "${from.format(dateFormat)} \u2013 ${to.format(dateFormat)}"
+    }
+    StatsChartPeriod.MONTH -> from.month.getDisplayName(TextStyle.FULL, locale) + " " + from.year
+    StatsChartPeriod.YEAR -> from.year.toString()
 }
 
 /** Days in a week, and so the spacing of the bar chart's captions. */

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -580,6 +581,9 @@ private fun PeriodBars(periods: List<ReadingPeriod>, unit: StatsChartPeriod) {
     val chartHeight = if (showAmounts) 150.dp else 130.dp
     val dateFormat = lastReadFormat()
     val scrollState = rememberScrollState()
+    LaunchedEffect(periods, scrollable) {
+        if (scrollable) scrollState.scrollTo(scrollState.maxValue)
+    }
 
     Row(
         modifier = Modifier

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,6 +19,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -92,7 +94,6 @@ import com.chmouel.liseur.ui.BusyIndicator
 import com.chmouel.liseur.ui.LocalEInk
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.windowWidth
-import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.time.format.TextStyle
@@ -564,6 +565,7 @@ private fun PeriodBars(periods: List<ReadingPeriod>, unit: StatsChartPeriod) {
     val locale = LocalLocale.current.platformLocale
     val lastIndex = periods.lastIndex
     val showAmounts = periods.size <= DAYS_IN_WEEK
+    val scrollable = periods.size > DAYS_IN_WEEK
     // Gradients dither into stripes on an e-ink panel; flat ink reads.
     val eInk = LocalEInk.current
     val gap = when {
@@ -577,11 +579,13 @@ private fun PeriodBars(periods: List<ReadingPeriod>, unit: StatsChartPeriod) {
     // tallest bar pushes its label out of the card.
     val chartHeight = if (showAmounts) 150.dp else 130.dp
     val dateFormat = lastReadFormat()
+    val scrollState = rememberScrollState()
 
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(chartHeight),
+            .height(chartHeight)
+            .then(if (scrollable) Modifier.horizontalScroll(scrollState) else Modifier),
         horizontalArrangement = Arrangement.spacedBy(gap),
         verticalAlignment = Alignment.Bottom,
     ) {
@@ -612,7 +616,7 @@ private fun PeriodBars(periods: List<ReadingPeriod>, unit: StatsChartPeriod) {
             }
             Column(
                 modifier = Modifier
-                    .weight(1f)
+                    .then(if (scrollable) Modifier.width(40.dp) else Modifier.weight(1f))
                     .fillMaxHeight()
                     // The bar and its letter are one fact, and read out
                     // separately they are two thirds of a sentence.

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/stats/ReadingStatsScreen.kt
@@ -581,7 +581,7 @@ private fun PeriodBars(periods: List<ReadingPeriod>, unit: StatsChartPeriod) {
     val chartHeight = if (showAmounts) 150.dp else 130.dp
     val dateFormat = lastReadFormat()
     val scrollState = rememberScrollState()
-    LaunchedEffect(periods, scrollable) {
+    LaunchedEffect(periods, scrollable, scrollState.maxValue) {
         if (scrollable) scrollState.scrollTo(scrollState.maxValue)
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -701,7 +701,6 @@
     <string name="reading_stats_total">Time spent reading</string>
     <string name="reading_stats_books_read">Books read from</string>
     <string name="reading_stats_books_finished">Books finished</string>
-    <string name="reading_stats_recent">This week</string>
     <string name="reading_stats_by_book">By book</string>
     <string name="reading_stats_from_this_device">Counting this device only</string>
     <string name="reading_stats_from_all_devices">Counting all your devices</string>
@@ -709,7 +708,6 @@
     <string name="reading_stats_empty_title">Nothing recorded yet.</string>
     <string name="reading_stats_empty_detail">Liseur starts counting from the moment you open a book. Reading you did before this arrived is not here, because there is no honest way to work out how long it took.</string>
     <string name="reading_stats_book_empty">You have not read any of this one yet.</string>
-    <string name="reading_stats_no_reading_day">Nothing read on %1$s</string>
     <string name="reading_stats_last_read">Last read %1$s</string>
     <string name="reading_stats_last_read_label">Last read</string>
     <string name="reading_stats_started_label">Started</string>
@@ -718,7 +716,8 @@
     <string name="reading_stats_reading_for_one_day">1 day</string>
     <string name="reading_stats_week_total">%1$s this week</string>
     <string name="reading_stats_progress">%1$d%% through</string>
-    <string name="reading_stats_day_read">%1$s on %2$s</string>
+    <string name="reading_stats_period_read">%1$s during %2$s</string>
+    <string name="reading_stats_no_reading_period">Nothing read during %1$s</string>
     <string name="reading_stats_this_week">This week, on every device</string>
     <string name="reading_stats_this_week_local">This week</string>
     <string name="reading_stats_this_month">This month, on every device</string>
@@ -747,6 +746,10 @@
     <string name="reading_stats_range_this_month">This month</string>
     <string name="reading_stats_range_this_year">This year</string>
     <string name="reading_stats_range_all">All time</string>
+    <string name="reading_stats_by_day">Day by day</string>
+    <string name="reading_stats_by_week">Week by week</string>
+    <string name="reading_stats_by_month">Month by month</string>
+    <string name="reading_stats_by_year">Year by year</string>
     <string name="reading_stats_calendar">Day by day</string>
     <string name="reading_stats_pace">Pace</string>
     <string name="reading_stats_pace_value">%1$d%%/h</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/StatsChartTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/StatsChartTest.kt
@@ -1,0 +1,68 @@
+package com.chmouel.liseur.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.DayOfWeek
+import java.time.LocalDate
+
+class StatsChartTest {
+
+    @Test
+    fun `a month is added into locale aligned weeks clipped to the month`() {
+        val days = (1..19).map { day ->
+            ReadingDay(LocalDate.of(2026, 8, day), day.toLong())
+        }
+
+        val periods = readingPeriods(days, StatsRange.THIS_MONTH, DayOfWeek.MONDAY)
+
+        assertEquals(
+            listOf(
+                ReadingPeriod(LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 2), 3),
+                ReadingPeriod(LocalDate.of(2026, 8, 3), LocalDate.of(2026, 8, 9), 42),
+                ReadingPeriod(LocalDate.of(2026, 8, 10), LocalDate.of(2026, 8, 16), 91),
+                ReadingPeriod(LocalDate.of(2026, 8, 17), LocalDate.of(2026, 8, 19), 54),
+            ),
+            periods,
+        )
+
+        assertEquals(
+            ReadingPeriod(LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 1), 1),
+            readingPeriods(days, StatsRange.THIS_MONTH, DayOfWeek.SUNDAY).first(),
+        )
+    }
+
+    @Test
+    fun `a year is added into months including empty days`() {
+        val days = listOf(
+            ReadingDay(LocalDate.of(2026, 1, 30), 10),
+            ReadingDay(LocalDate.of(2026, 1, 31), 20),
+            ReadingDay(LocalDate.of(2026, 2, 1), 0),
+            ReadingDay(LocalDate.of(2026, 2, 2), 40),
+        )
+
+        assertEquals(
+            listOf(
+                ReadingPeriod(LocalDate.of(2026, 1, 30), LocalDate.of(2026, 1, 31), 30),
+                ReadingPeriod(LocalDate.of(2026, 2, 1), LocalDate.of(2026, 2, 2), 40),
+            ),
+            readingPeriods(days, StatsRange.THIS_YEAR, DayOfWeek.SUNDAY),
+        )
+    }
+
+    @Test
+    fun `all time is added into years`() {
+        val days = listOf(
+            ReadingDay(LocalDate.of(2024, 12, 31), 10),
+            ReadingDay(LocalDate.of(2025, 1, 1), 20),
+            ReadingDay(LocalDate.of(2025, 1, 2), 30),
+        )
+
+        assertEquals(
+            listOf(
+                ReadingPeriod(LocalDate.of(2024, 12, 31), LocalDate.of(2024, 12, 31), 10),
+                ReadingPeriod(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 1, 2), 50),
+            ),
+            readingPeriods(days, StatsRange.ALL_TIME, DayOfWeek.MONDAY),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/StatsRangeTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/StatsRangeTest.kt
@@ -64,18 +64,6 @@ class StatsRangeTest {
     }
 
     @Test
-    fun `a partial week is always short enough to draw as bars`() {
-        for (offset in 0L..6L) {
-            assertTrue(
-                StatsRange.THIS_WEEK.suitsDailyBars(
-                    LocalDate.of(2026, 8, 3).plusDays(offset),
-                    DayOfWeek.MONDAY,
-                ),
-            )
-        }
-    }
-
-    @Test
     fun `the calendar spans ignore the locale except for the week`() {
         for (weekStart in DayOfWeek.entries) {
             assertEquals(
@@ -91,14 +79,11 @@ class StatsRangeTest {
     }
 
     @Test
-    fun `a month is drawn as bars right up to its last day`() {
-        // Thirty-one days is what MAX_BAR_DAYS is sized for. A month that
-        // fell back to the heatmap on the 31st would change shape once a
-        // quarter for no reason the reader could see.
-        val lastOfMarch = LocalDate.of(2026, 3, 31)
-        assertEquals(31, StatsRange.THIS_MONTH.days(lastOfMarch, DayOfWeek.MONDAY))
-        assertTrue(StatsRange.THIS_MONTH.suitsDailyBars(lastOfMarch, DayOfWeek.MONDAY))
-        assertTrue(!StatsRange.THIS_YEAR.suitsDailyBars(lastOfMarch, DayOfWeek.MONDAY))
+    fun `each range uses the calendar unit beneath it`() {
+        assertEquals(StatsChartPeriod.DAY, StatsRange.THIS_WEEK.chartPeriod)
+        assertEquals(StatsChartPeriod.WEEK, StatsRange.THIS_MONTH.chartPeriod)
+        assertEquals(StatsChartPeriod.MONTH, StatsRange.THIS_YEAR.chartPeriod)
+        assertEquals(StatsChartPeriod.YEAR, StatsRange.ALL_TIME.chartPeriod)
     }
 
     @Test


### PR DESCRIPTION
## Summary

The activity chart now matches the selected time range, making longer reading histories easier to scan without losing the daily calendar.

## Changes

- Shows daily bars for the current week, weekly bars for the current month, monthly bars for the current year, and yearly bars for all time.
- Keeps extended histories readable with fixed-width bars that open at the current period.
- Keeps a day-by-day calendar below the summary chart for monthly, yearly, and all-time views.
- Adds unit coverage for calendar grouping and chart-range selection.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on an emulator

## Screenshots or recordings

![Weekly activity bars](https://github.com/user-attachments/assets/828be0c1-b75a-4a46-85f3-4e423229e9c4)

The monthly view groups activity into locale-aligned weeks while retaining the daily calendar below it.

## Checklist

- [x] I have kept this change focused and documented the user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.