### PR TITLE
feat: choose how the page turns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,11 +338,28 @@ emulator.
   (`reader/chrome/AdvancedSheet.kt`), and directly on Settings -> Reading
   appearance if it is about how the page *looks*, or on Settings ->
   Reading & navigation (`ui/settings/ReadingNavigationScreen.kt`) if it
-  is about how the book is turned, held or looked up. Neither settings
-  screen has an Advanced section to collapse a row behind. The
-  typography sheet is the short list a reader changes often (theme,
-  size, brightness, font, and how the book is read), and it only grows
-  for a setting that genuinely belongs there. Make that case in the pull
-  request; the default is Advanced. It grew to eleven controls once, one
-  reasonable row at a time. See `docs/adr/0001-advanced-reading-menu.md`.
+  is about how the book is turned, held or looked up. Reading &
+  navigation has its own Advanced section at the bottom
+  (`SettingsExpandableGroup`), closed on arrival, for the rows a reader
+  sets once if ever — the page turn, the page-turn sides, pinch to
+  resize. Reading appearance has none. The typography sheet is the short
+  list a reader changes often (theme, size, brightness, font, and how
+  the book is read), and it only grows for a setting that genuinely
+  belongs there. Make that case in the pull request; the default is
+  Advanced. It grew to eleven controls once, one reasonable row at a
+  time. See `docs/adr/0001-advanced-reading-menu.md`.
+- How a page turns is one setting with three answers
+  (`PageTurnStyle`: lift, slide, none), not a boolean. `PageTurner`
+  already performed all three motions; it is told which by `style()`,
+  and electronic paper overrules the reader's choice with `NONE` in that
+  one lambda rather than anywhere else. The endpaper is drawn over the
+  book rather than navigated to, so only `LIFT` animates its arrival.
+  A sideways drag answers to the same setting: `PageTurnDrag` claims it
+  under `LIFT` and `NONE` and routes it through the same
+  `PageTurner.turn` a tap uses, leaving `SLIDE` to Readium, which is
+  what that motion already is. `R2WebView` moves the columns in its own
+  native gesture code, which a JavaScript `preventDefault()` cannot
+  stop, so the drag is claimed and consumed in `ReaderScreen`'s
+  `PointerEventPass.Initial` loop instead — the same route the image
+  viewer uses.
 - Bundled fonts must be under open licenses (OFL): Literata et al.

--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -323,10 +323,12 @@ private fun LiseurApp(settings: AppSettings) {
             BackHandler { back() }
             ReadingNavigationScreen(
                 settings = settings,
+                pageTurnStyle = readerPrefs.pageTurnStyle,
                 vendorName = context.container.eInkDisplay.vendor,
                 onVolumeKeys = { scope.launch { repository.setVolumeKeysTurnPages(it) } },
                 onTapZones = { scope.launch { repository.setTapZones(it) } },
                 onPinchToResize = { scope.launch { repository.setPinchToResize(it) } },
+                onPageTurnStyle = { scope.launch { readerPreferences.setPageTurnStyle(it) } },
                 onResumeLastBook = { scope.launch { repository.setResumeLastBook(it) } },
                 onScrollMode = { scope.launch { repository.setScrollMode(it) } },
                 onKeepScreenOn = { scope.launch { repository.setKeepScreenOn(it) } },
@@ -360,9 +362,6 @@ private fun LiseurApp(settings: AppSettings) {
                 onBrightness = { scope.launch { readerPreferences.setBrightness(it) } },
                 onColumnMode = { scope.launch { readerPreferences.setColumnMode(it) } },
                 onFooterMode = { scope.launch { readerPreferences.setFooterMode(it) } },
-                onPageTurnAnimation = {
-                    scope.launch { readerPreferences.setPageTurnAnimation(it) }
-                },
                 fineTypography = FineTypographyActions(
                     onTextAlignChanged = { scope.launch { readerPreferences.setTextAlign(it) } },
                     onHyphensChanged = { scope.launch { readerPreferences.setHyphens(it) } },

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
@@ -144,10 +144,10 @@ enum class DefinitionTarget(val id: String) {
  * @param volumeKeysTurnPages Volume keys page forward and back while reading.
  * @param tapZones Which side of a paginated page turns forward.
  * @param pinchToResize A two-finger pinch on the page changes the reading
- *   font size. On by default; it is here for a grip that produces stray
- *   two-finger touches, since a stray resize changes how every page looks
- *   from then on. Pinching an image to enlarge it is not covered: that one
- *   is one visible thing, dismissed with a tap.
+ *   font size. Off until asked for: a stray two-finger touch changes how
+ *   every page looks from then on, and the Size slider is the way in that
+ *   nobody triggers by accident. Pinching an image to enlarge it is not
+ *   covered: that one is one visible thing, dismissed with a tap.
  * @param resumeLastBook Opening the app goes back into the book you were in.
  * @param keepScreenOn The screen stays awake while a book is open. Off
  *   until asked for: it costs battery, and it overrides a device setting
@@ -180,7 +180,7 @@ data class AppSettings(
     val dynamicColor: Boolean = true,
     val volumeKeysTurnPages: Boolean = true,
     val tapZones: TapZones = TapZones.Default,
-    val pinchToResize: Boolean = true,
+    val pinchToResize: Boolean = false,
     val resumeLastBook: Boolean = true,
     val keepScreenOn: Boolean = false,
     val scrollMode: Boolean = false,
@@ -270,7 +270,7 @@ class AppSettingsRepository(private val context: Context) {
             dynamicColor = p[Keys.DYNAMIC_COLOR] ?: true,
             volumeKeysTurnPages = p[Keys.VOLUME_KEYS] ?: true,
             tapZones = TapZones.fromId(p[Keys.TAP_ZONES]),
-            pinchToResize = p[Keys.PINCH_TO_RESIZE] ?: true,
+            pinchToResize = p[Keys.PINCH_TO_RESIZE] ?: false,
             resumeLastBook = p[Keys.RESUME_LAST_BOOK] ?: true,
             keepScreenOn = p[Keys.KEEP_SCREEN_ON] ?: false,
             scrollMode = p[Keys.SCROLL_MODE] ?: false,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPreferencesRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPreferencesRepository.kt
@@ -34,7 +34,14 @@ class ReaderPreferencesRepository(private val store: DataStore<Preferences>) {
         val LINE_HEIGHT = doublePreferencesKey("line_height")
         val PAGE_MARGINS = doublePreferencesKey("page_margins")
         val BRIGHTNESS = floatPreferencesKey("brightness")
-        val PAGE_TURN_ANIMATION = booleanPreferencesKey("page_turn_animation")
+        val PAGE_TURN_STYLE = stringPreferencesKey("page_turn_style")
+
+        /**
+         * What the page turn was before it had three answers, kept only
+         * to be read: off meant the instant jump, and a reader who chose
+         * that should not find the page lifting again after an update.
+         */
+        val LEGACY_PAGE_TURN_ANIMATION = booleanPreferencesKey("page_turn_animation")
         val FOOTER_MODE = stringPreferencesKey("footer_mode")
         val COLUMN_MODE = stringPreferencesKey("column_mode")
         val AUTO_SCROLL_SPEED = floatPreferencesKey("auto_scroll_speed")
@@ -59,7 +66,10 @@ class ReaderPreferencesRepository(private val store: DataStore<Preferences>) {
             lineHeight = p[Keys.LINE_HEIGHT],
             pageMargins = p[Keys.PAGE_MARGINS],
             brightness = p[Keys.BRIGHTNESS],
-            pageTurnAnimation = p[Keys.PAGE_TURN_ANIMATION] ?: true,
+            pageTurnStyle = pageTurnStyleFrom(
+                stored = p[Keys.PAGE_TURN_STYLE],
+                legacyAnimation = p[Keys.LEGACY_PAGE_TURN_ANIMATION],
+            ),
             footerMode = FooterMode.fromId(p[Keys.FOOTER_MODE]),
             columnMode = ColumnMode.fromId(p[Keys.COLUMN_MODE]),
             autoScrollSpeed = p[Keys.AUTO_SCROLL_SPEED] ?: AutoScrollPreference.DEFAULT_STEP,
@@ -98,8 +108,8 @@ class ReaderPreferencesRepository(private val store: DataStore<Preferences>) {
         }
     }
 
-    suspend fun setPageTurnAnimation(enabled: Boolean) {
-        store.edit { it[Keys.PAGE_TURN_ANIMATION] = enabled }
+    suspend fun setPageTurnStyle(style: PageTurnStyle) {
+        store.edit { it[Keys.PAGE_TURN_STYLE] = style.id }
     }
 
     suspend fun setFooterMode(mode: FooterMode) {
@@ -152,4 +162,21 @@ class ReaderPreferencesRepository(private val store: DataStore<Preferences>) {
             if (value == null) it.remove(key) else it[key] = value
         }
     }
+}
+
+/**
+ * The stored page turn, reading a store written before it had three
+ * answers.
+ *
+ * [stored] wins whenever it is there, including when it names something
+ * this version does not know — [PageTurnStyle.fromId] answers that with
+ * the default, and falling through to the old boolean instead would let
+ * a setting from a newer version be quietly rewritten by a much older
+ * one. [legacyAnimation] only ever said yes or no, and no meant the
+ * instant jump.
+ */
+internal fun pageTurnStyleFrom(stored: String?, legacyAnimation: Boolean?): PageTurnStyle = when {
+    stored != null -> PageTurnStyle.fromId(stored)
+    legacyAnimation == false -> PageTurnStyle.NONE
+    else -> PageTurnStyle.Default
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPrefs.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPrefs.kt
@@ -237,6 +237,36 @@ enum class ColumnMode(val id: String, val displayName: String) {
 }
 
 /**
+ * How a tapped page gets out of the way.
+ *
+ * [LIFT] is the one the app was built around: the page that is leaving
+ * is photographed, the book jumps underneath it, and the photograph
+ * slides off with a shadow along its edge, the way a sheet of paper is
+ * lifted off a stack.
+ *
+ * [SLIDE] is the navigator's own move, which is the motion a finger
+ * already gets by dragging the page across — the two pages travel
+ * together, and nothing is lifted off anything. Asked for in #156 by a
+ * reader who wanted that seamless slide on a tap, not only on a drag.
+ *
+ * [NONE] is the page simply being the next one. It is what electronic
+ * paper gets whatever is set here, because a photograph dragged across
+ * such a screen arrives as a trail of half-erased pages.
+ */
+enum class PageTurnStyle(val id: String) {
+    LIFT("lift"),
+    SLIDE("slide"),
+    NONE("none"),
+    ;
+
+    companion object {
+        val Default = LIFT
+
+        fun fromId(id: String?): PageTurnStyle = entries.firstOrNull { it.id == id } ?: Default
+    }
+}
+
+/**
  * Which notch the auto-scroll slider sits on, as it is stored.
  *
  * The bounds live here rather than beside the scrolling loop because
@@ -559,7 +589,7 @@ private fun isRtlLanguage(language: String?): Boolean {
  * @param lineHeight Line height multiplier (1.0–2.0), null keeps publisher styles.
  * @param pageMargins Page margin multiplier (0.5–2.0), null keeps publisher styles.
  * @param brightness Screen brightness override 0.0–1.0, null follows the system.
- * @param pageTurnAnimation Slide animation when turning pages; instant jump when off.
+ * @param pageTurnStyle How a tapped page gets out of the way.
  * @param footerMode What the reading footer shows.
  * @param columnMode How many columns of text a wide page is broken into.
  * @param autoScrollSpeed Which notch the auto-scroll slider sits on, from
@@ -583,7 +613,7 @@ data class ReaderPrefs(
     val lineHeight: Double? = null,
     val pageMargins: Double? = null,
     val brightness: Float? = null,
-    val pageTurnAnimation: Boolean = true,
+    val pageTurnStyle: PageTurnStyle = PageTurnStyle.Default,
     val footerMode: FooterMode = FooterMode.Default,
     val columnMode: ColumnMode = ColumnMode.Default,
     val autoScrollSpeed: Float = AutoScrollPreference.DEFAULT_STEP,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
@@ -388,7 +388,7 @@ class ReaderActivity : FragmentActivity() {
                                             setLineHeight = viewModel::setLineHeight,
                                             setPageMargins = viewModel::setPageMargins,
                                             setBrightness = viewModel::setBrightness,
-                                            setPageTurnAnimation = viewModel::setPageTurnAnimation,
+                                            setPageTurnStyle = viewModel::setPageTurnStyle,
                                             setColumnMode = viewModel::setColumnMode,
                                             setAutoScrollSpeed = viewModel::setAutoScrollSpeed,
                                             setTypographyIsOwn = viewModel::setTypographyIsOwn,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -114,6 +114,7 @@ import com.chmouel.liseur.reader.dictionary.WiktionaryClient
 import com.chmouel.liseur.reader.footnotes.FootnoteLayout
 import com.chmouel.liseur.data.settings.FooterMode
 import com.chmouel.liseur.data.settings.ColumnMode
+import com.chmouel.liseur.data.settings.PageTurnStyle
 import com.chmouel.liseur.data.settings.ReadingFont
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.readingCssFor
@@ -126,6 +127,7 @@ import com.chmouel.liseur.reader.chrome.AdvancedSheet
 import com.chmouel.liseur.reader.chrome.AutoScrollSpeed
 import com.chmouel.liseur.reader.chrome.AutoScrollTicker
 import com.chmouel.liseur.reader.chrome.JumpBackPill
+import com.chmouel.liseur.reader.chrome.PageTurnDrag
 import com.chmouel.liseur.reader.chrome.PageTurnEffectState
 import com.chmouel.liseur.reader.chrome.PageTurnOverlay
 import com.chmouel.liseur.reader.chrome.PageTurner
@@ -400,6 +402,7 @@ fun ReaderScreen(
     val reflowableText = remember(publication) {
         publication.metadata.layout != Layout.FIXED
     }
+    val reflowableTextNow by rememberUpdatedState(reflowableText)
     // The chrome's answer, and the container's, which are not the same
     // one and must not be merged: see [chromeScrolls]/[containerScrolls].
     val effectiveScrolling = chromeScrolls(reflowableText, scrollMode, verticalText)
@@ -753,16 +756,19 @@ fun ReaderScreen(
     val pageTurnEffect = remember { PageTurnEffectState(effectScope) }
     val viewedImageNow by rememberUpdatedState(viewedImage)
     val openingImageNow by rememberUpdatedState(openingImage)
+    // The sliding page is a snapshot dragged across the screen, which is
+    // the one thing electronic paper cannot draw: it arrives as a trail
+    // of half-erased pages. The instant jump is what e-paper wants
+    // anyway, and it overrules whatever is set here rather than being
+    // one more thing to set. Taps and drags read the style from here, so
+    // the two ways of turning a page cannot disagree about it.
+    val turnStyle: () -> PageTurnStyle = {
+        if (eInkNow) PageTurnStyle.NONE else prefsFlow.value.pageTurnStyle
+    }
     val pageTurner = remember {
         PageTurner(
             effect = pageTurnEffect,
-            // The sliding page is a snapshot dragged across the screen,
-            // which is the one thing electronic paper cannot draw: it
-            // arrives as a trail of half-erased pages. The instant jump
-            // the preference already had is what e-paper wants anyway.
-            // A scrolled book has no page to lift off, and reads the same
-            // answer as whether its scrolling glides or jumps.
-            isAnimated = { prefsFlow.value.pageTurnAnimation && !eInkNow },
+            style = turnStyle,
             isEffectSuppressed = { chromeVisibleNow },
             // Vertical text is scrolled whatever the setting says, so
             // this is the derived answer and not the preference: a
@@ -793,6 +799,33 @@ fun ReaderScreen(
                 )
             },
             onMoveDropped = moves::cancel,
+        )
+    }
+
+    // Two fingers on the page are never a page turn, and lifting out of
+    // a pinch leaves one of them behind for a moment. Shared with the
+    // tap zones, which refuse a tap for the same reason (ADR 22).
+    val isPinching = {
+        pinchStart.value != null || pinchHeld ||
+            SystemClock.uptimeMillis() - pinchSettledAt.longValue < PinchResize.GUARD_MS
+    }
+    val pageTurnDrag = remember {
+        PageTurnDrag(
+            style = turnStyle,
+            canTurn = {
+                // A scrolled book has no page to turn and a
+                // fixed-layout one is dragged to look around, not to
+                // turn. A picture over the page takes the book out of
+                // reach, as it does for every other way of turning it.
+                !effectiveScrollingNow && reflowableTextNow &&
+                    !isPinching() && selection == null &&
+                    viewedImageNow == null && !openingImageNow
+            },
+            isRtl = {
+                navigatorNow?.overflow?.value?.readingProgression == ReadingProgression.RTL
+            },
+            density = { view.resources.displayMetrics.density },
+            onTurnPage = pageTurner::turn,
         )
     }
 
@@ -1597,10 +1630,6 @@ fun ReaderScreen(
         pageTurner.publication = publication
         onPageTurnerChanged(if (nav != null) pageTurner else null)
         val listeners = nav?.let {
-            val isPinching = {
-                pinchStart.value != null || pinchHeld ||
-                    SystemClock.uptimeMillis() - pinchSettledAt.longValue < PinchResize.GUARD_MS
-            }
             listOf(
                 ReaderTapZones(
                     navigator = it,
@@ -1949,11 +1978,35 @@ fun ReaderScreen(
                                 touch.startedAt = SystemClock.uptimeMillis()
                                 touch.claim.begin(touch.startedAt)
                                 pinchHeld = false
+                                pageTurnDrag.reset()
                                 probeUnderFinger(down[0].position)
                             }
 
                             (down[0].position - touch.downAt).getDistance() > slop ->
                                 touch.moved = true
+                        }
+                        /*
+                         * A sideways drag under Lift or None is a page
+                         * turn in the style the reader chose, and it is
+                         * taken here because there is nowhere else to
+                         * take it: the columns are moved by the web
+                         * view's own native gesture code, which neither
+                         * the page's scripts nor the navigator can call
+                         * off. Consuming the touch is what stops them,
+                         * the way the image viewer stops the long press
+                         * that opened it from also reaching the page.
+                         */
+                        if (down.isEmpty()) {
+                            if (pageTurnDrag.release()) {
+                                event.changes.forEach { it.consume() }
+                                continue
+                            }
+                        } else if (touch.moved) {
+                            val travelled = down[0].position - touch.downAt
+                            if (pageTurnDrag.offer(down.size, travelled.x, travelled.y)) {
+                                event.changes.forEach { it.consume() }
+                                continue
+                            }
                         }
                         // What is under the fingers decides which gesture
                         // this is, and holds until they lift. Asked here
@@ -2629,7 +2682,7 @@ fun ReaderScreen(
             onPageMarginsChanged = onPrefsAction.setPageMargins,
             onColumnModeChanged = onPrefsAction.setColumnMode,
             onFooterModeChanged = onProgressAction.setFooterMode,
-            onPageTurnAnimationChanged = onPrefsAction.setPageTurnAnimation,
+            onPageTurnStyleChanged = onPrefsAction.setPageTurnStyle,
             onAutoScrollChanged = { autoScrollArmed = it },
             onAutoScrollSpeedChanged = onPrefsAction.setAutoScrollSpeed,
             onTypographyIsOwnChanged = onPrefsAction.setTypographyIsOwn,
@@ -2906,7 +2959,7 @@ class ReaderPrefsActions(
     val setLineHeight: (Double?) -> Unit,
     val setPageMargins: (Double?) -> Unit,
     val setBrightness: (Float?) -> Unit,
-    val setPageTurnAnimation: (Boolean) -> Unit,
+    val setPageTurnStyle: (PageTurnStyle) -> Unit,
     val setColumnMode: (ColumnMode) -> Unit,
     val setAutoScrollSpeed: (Float) -> Unit,
     val setTypographyIsOwn: (Boolean) -> Unit,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -817,7 +817,9 @@ fun ReaderScreen(
                 // fixed-layout one is dragged to look around, not to
                 // turn. A picture over the page takes the book out of
                 // reach, as it does for every other way of turning it.
-                !effectiveScrollingNow && reflowableTextNow &&
+                // Chrome up means the scrubber is on the page, and a
+                // drag across it is a seek, not a turn.
+                !chromeVisibleNow && !effectiveScrollingNow && reflowableTextNow &&
                     !isPinching() && selection == null &&
                     viewedImageNow == null && !openingImageNow
             },

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -2003,7 +2003,12 @@ fun ReaderScreen(
                                 event.changes.forEach { it.consume() }
                                 continue
                             }
-                        } else if (touch.moved) {
+                        } else if (down.size > 1 || touch.moved) {
+                            // Asked while a second finger is down even if
+                            // nothing has moved yet: that finger settles
+                            // the gesture, and one that lands and leaves
+                            // without travelling would otherwise never be
+                            // seen at all.
                             val travelled = down[0].position - touch.downAt
                             if (pageTurnDrag.offer(down.size, travelled.x, travelled.y)) {
                                 event.changes.forEach { it.consume() }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -50,6 +50,7 @@ import com.chmouel.liseur.sync.SyncScope
 import com.chmouel.liseur.sync.PositionUpdate
 import com.chmouel.liseur.sync.ReadingPositionPublisher
 import com.chmouel.liseur.data.settings.ColumnMode
+import com.chmouel.liseur.data.settings.PageTurnStyle
 import com.chmouel.liseur.data.settings.ReaderFontWeight
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.ReaderTextAlign
@@ -1624,8 +1625,8 @@ class ReaderViewModel(
 
     fun setBrightness(value: Float?) = viewModelScope.launch { prefsRepo.setBrightness(value) }
 
-    fun setPageTurnAnimation(enabled: Boolean) =
-        viewModelScope.launch { prefsRepo.setPageTurnAnimation(enabled) }
+    fun setPageTurnStyle(style: PageTurnStyle) =
+        viewModelScope.launch { prefsRepo.setPageTurnStyle(style) }
 
     /**
      * Answers the screen question for this book alone.

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
@@ -28,6 +28,7 @@ import com.chmouel.liseur.R
 import com.chmouel.liseur.data.settings.AutoScrollPreference
 import com.chmouel.liseur.data.settings.ColumnMode
 import com.chmouel.liseur.data.settings.FooterMode
+import com.chmouel.liseur.data.settings.PageTurnStyle
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.ReadingCss
 import com.chmouel.liseur.ui.LiseurModalBottomSheet
@@ -37,7 +38,7 @@ import com.chmouel.liseur.ui.reading.FixedLayoutNotice
 import com.chmouel.liseur.ui.reading.ReadingFineTypographyControls
 import com.chmouel.liseur.ui.reading.ReadingFooterModeDropdown
 import com.chmouel.liseur.ui.reading.ReadingLayoutControls
-import com.chmouel.liseur.ui.reading.ReadingPageTurnAnimationToggle
+import com.chmouel.liseur.ui.reading.ReadingPageTurnStyleControl
 import com.chmouel.liseur.ui.reading.ReadingSectionLabel
 import com.chmouel.liseur.ui.windowWidth
 
@@ -51,12 +52,12 @@ import com.chmouel.liseur.ui.windowWidth
  * typography, and dismissing that lands back on the page.
  *
  * What it holds is what a reader sets once, if ever: the shape of the
- * text block, what the footer says, whether pages turn with an
- * animation, whether the page moves on its own, and whether any of it is
- * this book's alone. The rest of what belongs here — finer typography,
- * read-aloud, imported fonts — arrives with its own issue, and the shape
- * of the sheet is the point: five rows, or ten, it is the same sheet and
- * the reader learns it once.
+ * text block, what the footer says, how a page gets out of the way when
+ * it is turned, whether the page moves on its own, and whether any of
+ * it is this book's alone. The rest of what belongs here — finer
+ * typography, read-aloud, imported fonts — arrives with its own issue,
+ * and the shape of the sheet is the point: five rows, or ten, it is the
+ * same sheet and the reader learns it once.
  *
  * [scrolling] is whether the text runs rather than turns, which is not
  * only the reader's own choice: vertical text is laid out that way
@@ -69,7 +70,7 @@ import com.chmouel.liseur.ui.windowWidth
  * [readingCss] is what this book can honour. A fixed-layout book greys
  * the line spacing, the margins and the columns along with the fine
  * typography rows, under the one line at the top. The footer, the
- * page-turn animation and "just this book" are Liseur's own and know
+ * page turn and "just this book" are Liseur's own and know
  * nothing about layout, so they stay live. See
  * `docs/adr/0020-fixed-layout-reading-settings.md`.
  *
@@ -89,7 +90,7 @@ fun AdvancedSheet(
     onPageMarginsChanged: (Double?) -> Unit,
     onColumnModeChanged: (ColumnMode) -> Unit,
     onFooterModeChanged: (FooterMode) -> Unit,
-    onPageTurnAnimationChanged: (Boolean) -> Unit,
+    onPageTurnStyleChanged: (PageTurnStyle) -> Unit,
     onAutoScrollChanged: (Boolean) -> Unit,
     onAutoScrollSpeedChanged: (Float) -> Unit,
     onTypographyIsOwnChanged: (Boolean) -> Unit,
@@ -130,11 +131,11 @@ fun AdvancedSheet(
                 onSelected = onFooterModeChanged,
             )
             // Nothing lifts off the screen when the text is scrolled, so
-            // the animation has no page to describe.
+            // there is no page whose motion this could describe.
             if (!scrolling) {
-                ReadingPageTurnAnimationToggle(
-                    enabled = prefs.pageTurnAnimation,
-                    onChanged = onPageTurnAnimationChanged,
+                ReadingPageTurnStyleControl(
+                    selected = prefs.pageTurnStyle,
+                    onSelected = onPageTurnStyleChanged,
                 )
             }
             if (scrolling) {

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnDrag.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnDrag.kt
@@ -1,0 +1,111 @@
+package com.chmouel.liseur.reader.chrome
+
+import com.chmouel.liseur.data.settings.PageTurnStyle
+import kotlin.math.abs
+
+/**
+ * Makes a sideways drag turn the page the way the reader asked for.
+ *
+ * Readium's answer to a drag is the seamless slide: the columns follow
+ * the finger and snap when it lifts. That is one of the three page-turn
+ * styles, not all of them, and a reader who chose the lifted page or the
+ * instant jump got the slide back the moment they used a thumb instead
+ * of tapping. So under [PageTurnStyle.SLIDE] this stands aside and the
+ * drag stays Readium's; under the other two it takes the gesture over
+ * and hands it to the same [PageTurner] a tap uses.
+ *
+ * Taking it over means taking the touches themselves. The columns are
+ * moved by `R2WebView`'s own native gesture code — its own slop, its own
+ * velocity tracker, its own scroller — which answers to nothing the page
+ * or the navigator can say. The only thing above it is the pointer loop
+ * in `ReaderScreen`, which sees every touch before the web view does and
+ * can consume it, exactly as the image viewer already does. So this is a
+ * plain state machine driven from there rather than an `InputListener`.
+ *
+ * What is left is a swipe: nothing follows the finger, and lifting it
+ * after [SWIPE_DP] turns the page. A drag that sets off up or down the
+ * page is never claimed, and a second finger arriving hands the gesture
+ * back, so scrolling, pinching and stretching a selection are untouched.
+ */
+class PageTurnDrag(
+    private val style: () -> PageTurnStyle,
+    private val canTurn: () -> Boolean,
+    private val isRtl: () -> Boolean,
+    private val density: () -> Float,
+    private val onTurnPage: (forward: Boolean) -> Unit,
+) {
+
+    private var claimed = false
+    private var travel = 0f
+
+    /**
+     * Offers a gesture in progress: [pointers] fingers are down, and the
+     * first has travelled [dx] across and [dy] down from where it
+     * landed. Answers whether the gesture is ours, and so whether the
+     * caller should consume it.
+     *
+     * Only worth asking once the finger has passed the touch slop: below
+     * it a drag has no direction to read, and the web view has not begun
+     * to move the columns either.
+     */
+    fun offer(pointers: Int, dx: Float, dy: Float): Boolean {
+        if (pointers != 1) {
+            claimed = false
+            return false
+        }
+        if (!claimed) {
+            claimed = style() != PageTurnStyle.SLIDE && canTurn() && sideways(dx, dy)
+        }
+        if (claimed) travel = dx
+        return claimed
+    }
+
+    /**
+     * The fingers have left. Turns the page if the swipe went far
+     * enough, and answers whether the gesture was ours at all — a
+     * gesture that was, is consumed to the end, so that the lift out of
+     * a swipe is never also read as a tap on the page.
+     */
+    fun release(): Boolean {
+        if (!claimed) return false
+        val turn = forward(travel, SWIPE_DP * density(), isRtl())
+        reset()
+        turn?.let(onTurnPage)
+        return true
+    }
+
+    /** Forgets a gesture: a fresh touch owes nothing to the last one. */
+    fun reset() {
+        claimed = false
+        travel = 0f
+    }
+
+    companion object {
+        /**
+         * How far sideways a swipe has to go to turn the page. Short
+         * enough not to need a run-up, long enough that a thumb resting
+         * on the page and shifting slightly leaves it alone.
+         */
+        const val SWIPE_DP = 48f
+
+        /**
+         * Whether a drag that has moved [dx] across and [dy] down is one
+         * going sideways.
+         */
+        fun sideways(dx: Float, dy: Float): Boolean = abs(dx) > abs(dy)
+
+        /**
+         * Which way a swipe of [travel] pixels across turns the page, or
+         * null if it did not go far enough to turn it at all.
+         *
+         * Dragging leftwards brings in what lies to the right of the
+         * page, which is the next page in a book read left to right and
+         * the previous one in a book read the other way.
+         */
+        fun forward(travel: Float, threshold: Float, rtl: Boolean): Boolean? = when {
+            abs(travel) < threshold -> null
+            rtl -> travel > 0f
+            else -> travel < 0f
+        }
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnDrag.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnDrag.kt
@@ -35,6 +35,7 @@ class PageTurnDrag(
     private val onTurnPage: (forward: Boolean) -> Unit,
 ) {
 
+    private var decided = false
     private var claimed = false
     private var travel = 0f
 
@@ -47,13 +48,21 @@ class PageTurnDrag(
      * Only worth asking once the finger has passed the touch slop: below
      * it a drag has no direction to read, and the web view has not begun
      * to move the columns either.
+     *
+     * The answer is decided once and then kept until [reset]. A gesture
+     * that set off downwards is the web view's for as long as it lasts,
+     * however it curves later, and a second finger settles it for good:
+     * taking a gesture over halfway through would cancel a touch the web
+     * view is already acting on, and turn a page nobody asked to turn.
      */
     fun offer(pointers: Int, dx: Float, dy: Float): Boolean {
         if (pointers != 1) {
+            decided = true
             claimed = false
             return false
         }
-        if (!claimed) {
+        if (!decided) {
+            decided = true
             claimed = style() != PageTurnStyle.SLIDE && canTurn() && sideways(dx, dy)
         }
         if (claimed) travel = dx
@@ -76,6 +85,7 @@ class PageTurnDrag(
 
     /** Forgets a gesture: a fresh touch owes nothing to the last one. */
     fun reset() {
+        decided = false
         claimed = false
         travel = 0f
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnEffect.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnEffect.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
+import com.chmouel.liseur.data.settings.PageTurnStyle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.readium.r2.navigator.OverflowableNavigator
@@ -83,10 +84,12 @@ fun PageTurnOverlay(state: PageTurnEffectState, modifier: Modifier = Modifier) {
 }
 
 /**
- * Performs page turns for taps and volume keys. When the animation
- * preference is on and the effect is available, the turn uses the
- * sliding snapshot; otherwise it falls back to the navigator's plain
- * slide, or an instant jump when animations are disabled.
+ * Performs page turns for taps and volume keys. Which of the three
+ * motions a turn uses is [style]'s answer: the lifted snapshot, the
+ * navigator's own slide, or no motion at all. The lifted one still
+ * falls back to the plain slide when the snapshot cannot be taken —
+ * the chrome is up, a turn is already running, the view has no size
+ * yet.
  *
  * A scrolled book is a different movement altogether, and [isScrolling]
  * says so: see [scrollScreenful].
@@ -98,7 +101,7 @@ fun PageTurnOverlay(state: PageTurnEffectState, modifier: Modifier = Modifier) {
 @OptIn(ExperimentalReadiumApi::class)
 class PageTurner(
     private val effect: PageTurnEffectState,
-    private val isAnimated: () -> Boolean,
+    private val style: () -> PageTurnStyle,
     private val isEffectSuppressed: () -> Boolean,
     private val isScrolling: () -> Boolean = { false },
     private val isVerticalText: () -> Boolean = { false },
@@ -187,9 +190,19 @@ class PageTurner(
     }
 
     private fun turnPaginated(nav: OverflowableNavigator, forward: Boolean, token: Int) {
-        if (!isAnimated()) {
-            navigate(nav, forward, animated = false, token = token)
-            return
+        when (style()) {
+            PageTurnStyle.NONE -> {
+                navigate(nav, forward, animated = false, token = token)
+                return
+            }
+            // The navigator's own move, which is the one a drag across
+            // the page already performs. Nothing is photographed, so
+            // none of the reasons the lifted page falls back apply.
+            PageTurnStyle.SLIDE -> {
+                navigate(nav, forward, animated = true, token = token)
+                return
+            }
+            PageTurnStyle.LIFT -> Unit
         }
         val win = window
         val view = nav.publicationView
@@ -214,6 +227,11 @@ class PageTurner(
      * The extra turn after the last line: lift the last page off and
      * leave the endpaper underneath, the same motion every other turn
      * already makes.
+     *
+     * Only under [PageTurnStyle.LIFT]. The endpaper is drawn over the
+     * book rather than navigated to, so there is no move for the
+     * navigator's own slide to animate; under the other two styles the
+     * endpaper simply arrives.
      */
     private fun revealEnd() {
         if (showingEnd() || pendingEnd) return
@@ -225,7 +243,7 @@ class PageTurner(
             pendingEnd = false
             onReachedEnd()
         }
-        if (nav == null || win == null || view == null || !isAnimated() ||
+        if (nav == null || win == null || view == null || style() != PageTurnStyle.LIFT ||
             isEffectSuppressed() || effect.isRunning ||
             view.width <= 0 || view.height <= 0
         ) {
@@ -337,7 +355,10 @@ class PageTurner(
         }
         val script = scrollScreenfulScript(
             forward = forward,
-            smooth = isAnimated(),
+            // A scrolled book has no page to lift off, so the only
+            // question it can answer is whether the movement glides or
+            // jumps: both of the moving styles glide.
+            smooth = style() != PageTurnStyle.NONE,
             vertical = isVerticalText(),
         )
         web.evaluateJavascript(script) { result ->

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/reading/ReadingAppearanceControls.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/reading/ReadingAppearanceControls.kt
@@ -35,7 +35,6 @@ import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -56,6 +55,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.chmouel.liseur.R
 import com.chmouel.liseur.data.settings.ColumnMode
+import com.chmouel.liseur.data.settings.PageTurnStyle
 import com.chmouel.liseur.data.settings.FooterMode
 import com.chmouel.liseur.data.settings.ReaderFont
 import com.chmouel.liseur.data.settings.ReaderPrefs
@@ -576,22 +576,55 @@ fun ReadingLayoutControls(
     }
 }
 
+/**
+ * How a tapped page gets out of the way, in the three motions it can
+ * make.
+ *
+ * A segmented row rather than a switch because the answer stopped being
+ * yes or no: a reader who wanted the seamless slide a finger drag gives
+ * had no way to ask for it on a tap (#156). What the names describe is
+ * the movement, not the machinery behind it — the reader is choosing
+ * between a page being lifted, a page sliding across, and a page simply
+ * being the next one.
+ */
 @Composable
-fun ReadingPageTurnAnimationToggle(enabled: Boolean, onChanged: (Boolean) -> Unit) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable { onChanged(!enabled) },
-    ) {
+fun ReadingPageTurnStyleControl(
+    selected: PageTurnStyle,
+    onSelected: (PageTurnStyle) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        ReadingSectionLabel(stringResource(R.string.reader_page_turn_style))
+        SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
+            val options = PageTurnStyle.entries
+            options.forEachIndexed { index, style ->
+                SegmentedButton(
+                    selected = selected == style,
+                    onClick = { onSelected(style) },
+                    shape = SegmentedButtonDefaults.itemShape(index, options.size),
+                ) { Text(stringResource(style.label)) }
+            }
+        }
         Text(
-            text = stringResource(R.string.reader_page_turn_animation),
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.weight(1f),
+            text = stringResource(selected.detail),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        Switch(checked = enabled, onCheckedChange = onChanged)
     }
 }
+
+private val PageTurnStyle.label: Int
+    get() = when (this) {
+        PageTurnStyle.LIFT -> R.string.reader_page_turn_style_lift
+        PageTurnStyle.SLIDE -> R.string.reader_page_turn_style_slide
+        PageTurnStyle.NONE -> R.string.reader_page_turn_style_none
+    }
+
+private val PageTurnStyle.detail: Int
+    get() = when (this) {
+        PageTurnStyle.LIFT -> R.string.reader_page_turn_style_lift_detail
+        PageTurnStyle.SLIDE -> R.string.reader_page_turn_style_slide_detail
+        PageTurnStyle.NONE -> R.string.reader_page_turn_style_none_detail
+    }
 
 internal fun ReaderFont.composeFamily(assets: android.content.res.AssetManager): FontFamily? =
     when (this) {

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
@@ -53,7 +53,6 @@ import com.chmouel.liseur.ui.reading.previewFontWeight
 import com.chmouel.liseur.ui.reading.previewLetterSpacing
 import com.chmouel.liseur.ui.reading.previewParagraphGapSp
 import com.chmouel.liseur.ui.reading.previewTextAlign
-import com.chmouel.liseur.ui.reading.ReadingPageTurnAnimationToggle
 import com.chmouel.liseur.ui.reading.ReadingSectionLabel
 import com.chmouel.liseur.ui.reading.ReadingThemeRow
 import com.chmouel.liseur.ui.reading.composeFamily
@@ -84,7 +83,6 @@ fun ReadingAppearanceScreen(
     onBrightness: (Float?) -> Unit,
     onColumnMode: (ColumnMode) -> Unit,
     onFooterMode: (FooterMode) -> Unit,
-    onPageTurnAnimation: (Boolean) -> Unit,
     fineTypography: FineTypographyActions,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
@@ -171,10 +169,6 @@ fun ReadingAppearanceScreen(
                 ReadingFooterModeDropdown(
                     selected = prefs.footerMode,
                     onSelected = onFooterMode,
-                )
-                ReadingPageTurnAnimationToggle(
-                    enabled = prefs.pageTurnAnimation,
-                    onChanged = onPageTurnAnimation,
                 )
                 Text(
                     text = stringResource(R.string.settings_reading_appearance_detail),

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingNavigationScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingNavigationScreen.kt
@@ -43,12 +43,14 @@ import com.chmouel.liseur.R
 import com.chmouel.liseur.data.settings.AppSettings
 import com.chmouel.liseur.data.settings.DefinitionTarget
 import com.chmouel.liseur.data.settings.EInkMode
+import com.chmouel.liseur.data.settings.PageTurnStyle
 import com.chmouel.liseur.data.settings.TapZones
 import com.chmouel.liseur.domain.DictionaryUrl
 import com.chmouel.liseur.domain.WiktionaryEditions
 import com.chmouel.liseur.reader.dictionary.WiktionaryClient
 import com.chmouel.liseur.ui.LocalEInk
 import com.chmouel.liseur.ui.contentWidthCap
+import com.chmouel.liseur.ui.reading.ReadingPageTurnStyleControl
 import com.chmouel.liseur.ui.windowWidth
 
 /**
@@ -66,10 +68,12 @@ import com.chmouel.liseur.ui.windowWidth
 @Composable
 fun ReadingNavigationScreen(
     settings: AppSettings,
+    pageTurnStyle: PageTurnStyle,
     vendorName: String?,
     onVolumeKeys: (Boolean) -> Unit,
     onTapZones: (TapZones) -> Unit,
     onPinchToResize: (Boolean) -> Unit,
+    onPageTurnStyle: (PageTurnStyle) -> Unit,
     onResumeLastBook: (Boolean) -> Unit,
     onScrollMode: (Boolean) -> Unit,
     onKeepScreenOn: (Boolean) -> Unit,
@@ -119,36 +123,6 @@ fun ReadingNavigationScreen(
                         subtitle = stringResource(R.string.settings_volume_keys_detail),
                         checked = settings.volumeKeysTurnPages,
                         onCheckedChange = onVolumeKeys,
-                    )
-                    RowDivider()
-                    ChipRow(
-                        title = stringResource(R.string.settings_tap_zones),
-                        subtitle = stringResource(R.string.settings_tap_zones_detail),
-                        options = TapZones.entries,
-                        selected = settings.tapZones,
-                        label = { stringResource(it.label) },
-                        onSelected = onTapZones,
-                    )
-                    RowDivider()
-                    // The switch stays visible rather than disappearing
-                    // on e-paper: a row that is simply gone reads as a
-                    // setting the app never had, and this one is off for
-                    // a reason worth giving. The way back is the E-ink
-                    // row in the group below, which is on the same
-                    // screen.
-                    val pinchOffForEInk = LocalEInk.current
-                    SwitchRow(
-                        title = stringResource(R.string.settings_pinch_to_resize),
-                        subtitle = stringResource(
-                            if (pinchOffForEInk) {
-                                R.string.settings_pinch_to_resize_eink
-                            } else {
-                                R.string.settings_pinch_to_resize_detail
-                            },
-                        ),
-                        checked = settings.pinchToResize && !pinchOffForEInk,
-                        onCheckedChange = onPinchToResize,
-                        enabled = !pinchOffForEInk,
                     )
                     RowDivider()
                     SwitchRow(
@@ -234,8 +208,64 @@ fun ReadingNavigationScreen(
                         }
                     }
                 }
+
+                var advancedOpen by remember { mutableStateOf(false) }
+                SettingsExpandableGroup(
+                    title = stringResource(R.string.settings_advanced),
+                    expanded = advancedOpen,
+                    onExpandedChange = { advancedOpen = it },
+                ) {
+                    PageTurnStyleRow(selected = pageTurnStyle, onSelected = onPageTurnStyle)
+                    RowDivider()
+                    ChipRow(
+                        title = stringResource(R.string.settings_tap_zones),
+                        subtitle = stringResource(R.string.settings_tap_zones_detail),
+                        options = TapZones.entries,
+                        selected = settings.tapZones,
+                        label = { stringResource(it.label) },
+                        onSelected = onTapZones,
+                    )
+                    RowDivider()
+                    // The switch stays visible rather than disappearing
+                    // on e-paper: a row that is simply gone reads as a
+                    // setting the app never had, and this one is off for
+                    // a reason worth giving. The way back is the E-ink
+                    // row in the Screen group above, which is on the
+                    // same screen.
+                    val pinchOffForEInk = LocalEInk.current
+                    SwitchRow(
+                        title = stringResource(R.string.settings_pinch_to_resize),
+                        subtitle = stringResource(
+                            if (pinchOffForEInk) {
+                                R.string.settings_pinch_to_resize_eink
+                            } else {
+                                R.string.settings_pinch_to_resize_detail
+                            },
+                        ),
+                        checked = settings.pinchToResize && !pinchOffForEInk,
+                        onCheckedChange = onPinchToResize,
+                        enabled = !pinchOffForEInk,
+                    )
+                }
             }
         }
+    }
+}
+
+/**
+ * How a tapped page gets out of the way, on the settings screen.
+ *
+ * The same control the reader's Advanced sheet shows, wrapped so it sits
+ * on the axis the rows around it use: the title where a headline would
+ * be, the choice where supporting text would go, as [ChipRow] does.
+ */
+@Composable
+private fun PageTurnStyleRow(
+    selected: PageTurnStyle,
+    onSelected: (PageTurnStyle) -> Unit,
+) {
+    Column(Modifier.padding(horizontal = 16.dp, vertical = 10.dp)) {
+        ReadingPageTurnStyleControl(selected = selected, onSelected = onSelected)
     }
 }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsRows.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsRows.kt
@@ -28,8 +28,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
+import com.chmouel.liseur.R
 
 /**
  * The rows the settings screens are built out of.
@@ -107,6 +111,9 @@ internal fun SettingsExpandableGroup(
     onExpandedChange: (Boolean) -> Unit,
     content: @Composable ColumnScope.() -> Unit,
 ) {
+    val state = stringResource(
+        if (expanded) R.string.settings_section_expanded else R.string.settings_section_collapsed,
+    )
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
@@ -115,6 +122,7 @@ internal fun SettingsExpandableGroup(
                 role = Role.Button,
                 onClick = { onExpandedChange(!expanded) },
             )
+            .semantics(mergeDescendants = true) { stateDescription = state }
             .padding(top = 24.dp, bottom = 8.dp),
     ) {
         Text(

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsRows.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsRows.kt
@@ -1,5 +1,6 @@
 package com.chmouel.liseur.ui.settings
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -11,6 +12,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ExpandLess
+import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.HelpOutline
 import androidx.compose.material3.Card
 import androidx.compose.material3.FilterChip
@@ -79,6 +82,57 @@ internal fun SettingsGroup(
     }
     Card(Modifier.fillMaxWidth()) {
         Column(content = content)
+    }
+}
+
+/**
+ * A section that arrives closed, for the settings a reader sets once if
+ * ever.
+ *
+ * The reader's own sheet learned this first: the short list stays short
+ * and everything rarer lives a tap further in
+ * (`docs/adr/0001-advanced-reading-menu.md`). A settings screen has the
+ * same problem, and the same answer — except that here the tap opens a
+ * section in place rather than a second sheet, so what was hidden is
+ * still on the screen it belongs to.
+ *
+ * Whether it is open is the screen's own state and is deliberately not
+ * remembered anywhere: a section that stays open is no longer an
+ * advanced section, only a long one.
+ */
+@Composable
+internal fun SettingsExpandableGroup(
+    title: String,
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(
+                role = Role.Button,
+                onClick = { onExpandedChange(!expanded) },
+            )
+            .padding(top = 24.dp, bottom = 8.dp),
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Icon(
+            imageVector = if (expanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(start = 4.dp).size(20.dp),
+        )
+    }
+    AnimatedVisibility(visible = expanded) {
+        Card(Modifier.fillMaxWidth()) {
+            Column(content = content)
+        }
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -596,6 +596,8 @@
     <string name="settings_reading_navigation_scrolling">Read by scrolling.</string>
     <string name="settings_screen">Screen</string>
     <string name="settings_advanced">Advanced</string>
+    <string name="settings_section_expanded">Expanded</string>
+    <string name="settings_section_collapsed">Collapsed</string>
     <string name="settings_volume_keys">Volume keys turn pages</string>
     <string name="settings_volume_keys_detail">Volume down goes forward, volume up goes back.</string>
     <string name="settings_tap_zones">Page-turn sides</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -507,7 +507,13 @@
     <string name="reader_columns_auto">Auto</string>
     <string name="reader_columns_one">1</string>
     <string name="reader_columns_two">2</string>
-    <string name="reader_page_turn_animation">Page turn animation</string>
+    <string name="reader_page_turn_style">Page turn</string>
+    <string name="reader_page_turn_style_lift">Lift</string>
+    <string name="reader_page_turn_style_slide">Slide</string>
+    <string name="reader_page_turn_style_none">None</string>
+    <string name="reader_page_turn_style_lift_detail">The page you finished lifts off the one underneath, the way a sheet of paper comes off a stack.</string>
+    <string name="reader_page_turn_style_slide_detail">Both pages travel together, the way they do when you drag the page across with a finger.</string>
+    <string name="reader_page_turn_style_none_detail">The next page is simply there. This is what an e-ink screen gets whichever of the three is chosen.</string>
 
     <!-- Fine typography: alignment, hyphenation, weight and spacing. -->
     <string name="reader_text_align">Alignment</string>
@@ -589,6 +595,7 @@
     <string name="settings_reading_navigation_paged">Paged. Page-turn sides: %1$s</string>
     <string name="settings_reading_navigation_scrolling">Read by scrolling.</string>
     <string name="settings_screen">Screen</string>
+    <string name="settings_advanced">Advanced</string>
     <string name="settings_volume_keys">Volume keys turn pages</string>
     <string name="settings_volume_keys_detail">Volume down goes forward, volume up goes back.</string>
     <string name="settings_tap_zones">Page-turn sides</string>
@@ -596,8 +603,8 @@
     <string name="tap_zones_standard">Standard</string>
     <string name="tap_zones_swapped">Swapped</string>
     <string name="settings_pinch_to_resize">Pinch to resize text</string>
-    <string name="settings_pinch_to_resize_detail">A two-finger pinch on the page makes the text bigger or smaller, without opening the menu. Turn it off if the way you hold the phone sets it off by accident. Pinching an image to enlarge it still works either way.</string>
-    <string name="settings_pinch_to_resize_eink">Off on electronic paper. The pinch works by showing you the size while your fingers move, and a preview that redraws many times a second is what such a screen handles worst. Without it you would be aiming blind, and every attempt costs a full repaint of the page, so the Size slider does the job better. Pinching an image to enlarge it still works. Turn E-ink screen off below if this is not that kind of screen.</string>
+    <string name="settings_pinch_to_resize_detail">A two-finger pinch on the page makes the text bigger or smaller, without opening the menu. Off until you ask for it, because a grip that produces stray two-finger touches resizes the text of every book by accident. Pinching an image to enlarge it still works either way.</string>
+    <string name="settings_pinch_to_resize_eink">Off on electronic paper. The pinch works by showing you the size while your fingers move, and a preview that redraws many times a second is what such a screen handles worst. Without it you would be aiming blind, and every attempt costs a full repaint of the page, so the Size slider does the job better. Pinching an image to enlarge it still works. Turn E-ink screen off above if this is not that kind of screen.</string>
     <string name="settings_resume">Open on the book you were reading</string>
     <string name="settings_resume_detail">Skip the library when you left off mid-book.</string>
     <string name="settings_keep_screen_on">Keep the screen on</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/BookTypographyTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/BookTypographyTest.kt
@@ -1,6 +1,7 @@
 package com.chmouel.liseur.data.db
 
 import com.chmouel.liseur.data.settings.FooterMode
+import com.chmouel.liseur.data.settings.PageTurnStyle
 import com.chmouel.liseur.data.settings.ReaderFont
 import com.chmouel.liseur.data.settings.ReaderFontWeight
 import com.chmouel.liseur.data.settings.ReadingFont
@@ -27,7 +28,7 @@ class BookTypographyTest {
         lineHeight = 1.4,
         pageMargins = 1.0,
         brightness = 0.3f,
-        pageTurnAnimation = false,
+        pageTurnStyle = PageTurnStyle.NONE,
         footerMode = FooterMode.SMART,
     )
 
@@ -58,7 +59,7 @@ class BookTypographyTest {
         val effective = shared.withTypographyOf(own)
         assertEquals(ReaderThemeChoice.DARK, effective.themeChoice)
         assertEquals(0.3f, effective.brightness!!, 0f)
-        assertEquals(false, effective.pageTurnAnimation)
+        assertEquals(PageTurnStyle.NONE, effective.pageTurnStyle)
         assertEquals(FooterMode.SMART, effective.footerMode)
     }
 

--- a/app/src/test/kotlin/com/chmouel/liseur/data/settings/PageTurnStyleTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/settings/PageTurnStyleTest.kt
@@ -1,0 +1,61 @@
+package com.chmouel.liseur.data.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The three page turns, as they are stored and as a store written
+ * before there were three of them reads back.
+ */
+class PageTurnStyleTest {
+
+    @Test
+    fun `every style is named by an id that reads back to it`() {
+        PageTurnStyle.entries.forEach { style ->
+            assertEquals(style, PageTurnStyle.fromId(style.id))
+        }
+    }
+
+    @Test
+    fun `a name from nowhere is the lifted page`() {
+        assertEquals(PageTurnStyle.LIFT, PageTurnStyle.fromId(null))
+        assertEquals(PageTurnStyle.LIFT, PageTurnStyle.fromId("flip"))
+    }
+
+    @Test
+    fun `a store that never had the setting turns pages the way it always did`() {
+        assertEquals(PageTurnStyle.LIFT, pageTurnStyleFrom(stored = null, legacyAnimation = null))
+    }
+
+    @Test
+    fun `an old store with the animation off keeps the instant jump`() {
+        assertEquals(PageTurnStyle.NONE, pageTurnStyleFrom(stored = null, legacyAnimation = false))
+    }
+
+    @Test
+    fun `an old store with the animation on gets the lifted page`() {
+        assertEquals(PageTurnStyle.LIFT, pageTurnStyleFrom(stored = null, legacyAnimation = true))
+    }
+
+    /**
+     * A newer version wrote a style this one has never heard of, and the
+     * old boolean is still lying beside it. Reading the boolean instead
+     * would let this build quietly overwrite the newer choice with an
+     * answer nobody gave.
+     */
+    @Test
+    fun `a style this version does not know still beats the old boolean`() {
+        assertEquals(
+            PageTurnStyle.LIFT,
+            pageTurnStyleFrom(stored = "curl", legacyAnimation = false),
+        )
+    }
+
+    @Test
+    fun `the stored style wins over the old boolean`() {
+        assertEquals(
+            PageTurnStyle.SLIDE,
+            pageTurnStyleFrom(stored = PageTurnStyle.SLIDE.id, legacyAnimation = false),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/settings/ReaderPreferencesRepositoryTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/settings/ReaderPreferencesRepositoryTest.kt
@@ -66,6 +66,31 @@ class ReaderPreferencesRepositoryTest {
     }
 
     @Test
+    fun `the page turn is written under its own key`() = runTest {
+        val data = store()
+        val repo = ReaderPreferencesRepository(data)
+        repo.setPageTurnStyle(PageTurnStyle.SLIDE)
+
+        assertEquals("slide", data.data.first()[stringPreferencesKey("page_turn_style")])
+        assertEquals(PageTurnStyle.SLIDE, repo.prefs.first().pageTurnStyle)
+    }
+
+    @Test
+    fun `a store from before the page turn had three answers keeps its own`() = runTest {
+        // Written by a build that only knew the boolean. Off meant the
+        // instant jump, and a reader who chose that should not find the
+        // page lifting again after an update.
+        val data = store()
+        data.edit { it[booleanPreferencesKey("page_turn_animation")] = false }
+
+        val repo = ReaderPreferencesRepository(data)
+        assertEquals(PageTurnStyle.NONE, repo.prefs.first().pageTurnStyle)
+
+        repo.setPageTurnStyle(PageTurnStyle.LIFT)
+        assertEquals(PageTurnStyle.LIFT, repo.prefs.first().pageTurnStyle)
+    }
+
+    @Test
     fun `no two settings share a key`() = runTest {
         // Six new keys of two types, written one at a time and read back
         // raw: a swapped pair passes every test that goes through the

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/PageTurnDragTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/PageTurnDragTest.kt
@@ -1,5 +1,6 @@
 package com.chmouel.liseur.reader.chrome
 
+import com.chmouel.liseur.data.settings.PageTurnStyle
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -39,4 +40,78 @@ class PageTurnDragTest {
         assertEquals(false, PageTurnDrag.forward(travel = -60f, threshold = 48f, rtl = true))
         assertEquals(true, PageTurnDrag.forward(travel = 60f, threshold = 48f, rtl = true))
     }
+
+    @Test
+    fun `a sideways swipe past the threshold turns one page`() {
+        val turns = mutableListOf<Boolean>()
+        val drag = drag(turns)
+        assertTrue(drag.offer(pointers = 1, dx = -30f, dy = 2f))
+        assertTrue(drag.offer(pointers = 1, dx = -200f, dy = 6f))
+        assertTrue(drag.release())
+        assertEquals(listOf(true), turns)
+    }
+
+    @Test
+    fun `a gesture that set off down the page is never claimed later`() {
+        val turns = mutableListOf<Boolean>()
+        val drag = drag(turns)
+        assertFalse(drag.offer(pointers = 1, dx = 2f, dy = -40f))
+        // The finger curves until it has gone further across than down.
+        assertFalse(drag.offer(pointers = 1, dx = -200f, dy = -60f))
+        assertFalse(drag.release())
+        assertTrue(turns.isEmpty())
+    }
+
+    @Test
+    fun `a second finger settles the gesture for good`() {
+        val turns = mutableListOf<Boolean>()
+        val drag = drag(turns)
+        assertTrue(drag.offer(pointers = 1, dx = -200f, dy = 4f))
+        assertFalse(drag.offer(pointers = 2, dx = -200f, dy = 4f))
+        // One finger leaves, the other keeps moving across the page.
+        assertFalse(drag.offer(pointers = 1, dx = -300f, dy = 4f))
+        assertFalse(drag.release())
+        assertTrue(turns.isEmpty())
+    }
+
+    @Test
+    fun `a fresh touch starts over`() {
+        val turns = mutableListOf<Boolean>()
+        val drag = drag(turns)
+        assertFalse(drag.offer(pointers = 2, dx = -200f, dy = 4f))
+        drag.reset()
+        assertTrue(drag.offer(pointers = 1, dx = -200f, dy = 4f))
+        assertTrue(drag.release())
+        assertEquals(listOf(true), turns)
+    }
+
+    @Test
+    fun `the slide is left to the navigator`() {
+        val turns = mutableListOf<Boolean>()
+        val drag = drag(turns, style = PageTurnStyle.SLIDE)
+        assertFalse(drag.offer(pointers = 1, dx = -200f, dy = 4f))
+        assertFalse(drag.release())
+        assertTrue(turns.isEmpty())
+    }
+
+    @Test
+    fun `a page that cannot be turned is left alone`() {
+        val turns = mutableListOf<Boolean>()
+        val drag = drag(turns, canTurn = false)
+        assertFalse(drag.offer(pointers = 1, dx = -200f, dy = 4f))
+        assertFalse(drag.release())
+        assertTrue(turns.isEmpty())
+    }
+
+    private fun drag(
+        turns: MutableList<Boolean>,
+        style: PageTurnStyle = PageTurnStyle.LIFT,
+        canTurn: Boolean = true,
+    ) = PageTurnDrag(
+        style = { style },
+        canTurn = { canTurn },
+        isRtl = { false },
+        density = { 1f },
+        onTurnPage = { turns += it },
+    )
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/PageTurnDragTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/PageTurnDragTest.kt
@@ -1,0 +1,42 @@
+package com.chmouel.liseur.reader.chrome
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PageTurnDragTest {
+
+    @Test
+    fun `a drag that sets off across the page is claimed`() {
+        assertTrue(PageTurnDrag.sideways(dx = -20f, dy = 4f))
+        assertTrue(PageTurnDrag.sideways(dx = 20f, dy = -4f))
+    }
+
+    @Test
+    fun `a drag that sets off up or down the page is left alone`() {
+        assertFalse(PageTurnDrag.sideways(dx = 4f, dy = -20f))
+        assertFalse(PageTurnDrag.sideways(dx = 0f, dy = 20f))
+        // A perfect diagonal is nobody's page turn.
+        assertFalse(PageTurnDrag.sideways(dx = 10f, dy = 10f))
+    }
+
+    @Test
+    fun `a short swipe turns nothing`() {
+        assertNull(PageTurnDrag.forward(travel = -47f, threshold = 48f, rtl = false))
+        assertNull(PageTurnDrag.forward(travel = 47f, threshold = 48f, rtl = true))
+    }
+
+    @Test
+    fun `dragging left goes forwards in a book read left to right`() {
+        assertEquals(true, PageTurnDrag.forward(travel = -60f, threshold = 48f, rtl = false))
+        assertEquals(false, PageTurnDrag.forward(travel = 60f, threshold = 48f, rtl = false))
+    }
+
+    @Test
+    fun `dragging left goes back in a book read right to left`() {
+        assertEquals(false, PageTurnDrag.forward(travel = -60f, threshold = 48f, rtl = true))
+        assertEquals(true, PageTurnDrag.forward(travel = 60f, threshold = 48f, rtl = true))
+    }
+}

--- a/docs/adr/0022-pinch-on-the-page.md
+++ b/docs/adr/0022-pinch-on-the-page.md
@@ -448,6 +448,15 @@ Settings -> Reading & navigation beside the other rows about how the
 book is turned and held, not in Reading appearance: it is not how the
 page looks, it is what the hands do (ADR 1, ADR 9).
 
+Amended after the release candidates: the switch starts **off**, and it
+now sits inside that screen's Advanced section. The failure it guards
+against is silent and cumulative — a resize nobody meant is not noticed
+until every book looks wrong — and a gesture that undiscoverable is a
+poor thing to have on by default. The Size slider is still there for
+everyone; the pinch is for the reader who went looking for it. The
+setting had only ever shipped in release candidates, so the default was
+changed without a migration.
+
 ### On electronic paper
 
 Deferred to [#153](https://github.com/chmouel/liseur/issues/153) and

--- a/docs/adr/0025-page-turn-styles.md
+++ b/docs/adr/0025-page-turn-styles.md
@@ -1,0 +1,171 @@
+# 25. Three page turns, and an Advanced section to keep them behind
+
+Status: accepted
+GitHub issue: [#156](https://github.com/chmouel/liseur/issues/156)
+
+## Context
+
+A reader coming from Libby asked for its page turn: the two pages travel
+together, edge to edge, the way a photograph slides under a finger.
+Liseur's turn lifts the finished page off the one underneath instead,
+which is Kindle's motion and was chosen deliberately.
+
+The answer was already in the app twice over. Dragging the page across
+with a finger gives exactly the movement asked for — that is Readium's
+own animated move, and the reporter said so: they wanted it *on a tap*,
+not only on a drag. And `PageTurner` already performed all three
+motions, because the lifted page falls back to the plain slide whenever
+the snapshot cannot be taken, and to no motion at all when the reader
+had turned the animation off. What was missing was a way to ask for one.
+
+So the setting was a boolean with three behaviours behind it, two of
+which nobody could choose.
+
+## Decision
+
+`ReaderPrefs.pageTurnAnimation: Boolean` becomes
+`pageTurnStyle: PageTurnStyle`, with three values named for what the
+reader sees:
+
+- **Lift** — the finished page comes off the stack. The default, and
+  what the app has always done.
+- **Slide** — the navigator's own move: both pages travel together, the
+  motion a drag already gives.
+- **None** — the next page is simply there.
+
+`PageTurner` takes a `style: () -> PageTurnStyle` in place of its
+`isAnimated: () -> Boolean`. Nothing else about it changes: the lifted
+page keeps every fallback it had, since a snapshot that cannot be taken
+is still a turn that has to happen.
+
+Electronic paper overrules the choice with **None** in that one lambda,
+where `&& !eInkNow` used to sit. A trail of half-erased pages is what a
+photograph dragged across such a screen actually looks like, and that is
+a fact about the panel, not a preference.
+
+The endpaper animates only under **Lift**. It is drawn over the book
+rather than navigated to, so there is no navigator move for **Slide** to
+animate — it would have to be faked, and a faked slide onto a screen
+that is not a page is worse than no slide.
+
+A scrolled book has no page to lift, so it reads the one question it can
+answer: **None** jumps, the other two glide.
+
+### The drag answers to the setting as well
+
+Readium's reply to a sideways drag is the slide, always: the columns
+follow the finger and snap when it lifts. That is one of the three
+styles, so a reader who asked for the lifted page or the instant jump
+got the slide back the moment they used a thumb instead of tapping —
+the same book turning two different ways depending on how it was
+touched.
+
+`PageTurnDrag` claims the gesture under **Lift** and **None** and hands
+it to the same `PageTurner.turn` a tap uses.
+
+Claiming it means taking the touches themselves, in Compose. Readium's
+gesture script does ask before it moves anything, and a `true` from an
+`InputListener` becomes a `preventDefault()` — but that governs only the
+JavaScript. The columns are moved by `R2WebView`'s own native gesture
+code, with its own slop, velocity tracker and scroller, which answers to
+nothing the page or the navigator can say; a drag refused in JS still
+turned the page, and at a resource edge turned two. The one thing above
+it is the pointer loop `ReaderScreen` already runs over the reader —
+`awaitPointerEvent(PointerEventPass.Initial)`, the same loop the image
+viewer uses to swallow a pinch. Consuming there cancels the touch on the
+way down, so neither the web view nor the pager ever sees it. That makes
+`PageTurnDrag` a plain state machine — `offer`, `release`, `reset` — with
+no Android or Readium types in it at all, and testable as arithmetic.
+
+What is lost under those two styles is the finger tracking: the page no
+longer travels with the thumb and cannot be pulled halfway and put back.
+It becomes a swipe, committed on release after 48dp. That is the honest
+reading of the setting — a reader who asked for no motion cannot also
+have the page follow their finger — and **Slide**, which is that
+tracking, is one tap away.
+
+The claim is decided once, on the first move past the touch slop, and
+only for a drag that sets off across the page. A second finger hands the
+gesture back, so a pinch is untouched, as is a selection being stretched
+and a scrolled book being scrolled; a fixed-layout page, which is dragged
+to look around rather than to turn, is left to Readium entirely.
+
+Storage is a new `page_turn_style` key. When it is absent the old
+`page_turn_animation` boolean is read once — `false` means **None** — so
+a reader who turned the animation off does not find pages lifting again
+after an update. A stored style always wins, including one this build
+has never heard of, so an older build cannot quietly overwrite a newer
+choice.
+
+### An Advanced section on Settings -> Reading & navigation
+
+The reader's own sheet has had one since [ADR 1](0001-advanced-reading-menu.md):
+the short list stays short and everything rarer lives a tap further in.
+The settings screen had the same problem and no such answer — the page
+that opens with "Volume keys turn pages" was eight rows deep in things
+nobody changes twice.
+
+So it gets a collapsible group at the bottom, closed on arrival, holding
+the three settings a reader sets once if ever: the page turn, the
+page-turn sides ([ADR 9](0009-tap-zone-customization.md)), and pinch to
+resize ([ADR 22](0022-pinch-on-the-page.md)). Whether it is open is
+screen-local state and is deliberately not remembered: a section that
+stays open is not an advanced section, only a long one.
+
+The page turn moves off Settings -> Reading appearance to get there.
+That screen is how the page *looks*; how it gets out of the way when it
+is turned is what the hands do, which is the split ADR 1 and ADR 9 draw
+between the two screens. It stays in the reader's Advanced sheet, where
+it always was.
+
+## Alternatives
+
+**A drag-to-turn gesture instead of a setting.** It already exists —
+that is what the reporter was doing. The request was for the tap.
+
+**Leaving the drag as Readium's under every style.** Simplest, and what
+the first cut did. It also meant the setting quietly described only half
+of how the book is turned.
+
+**Animating the lift under the finger.** A page that tracks the thumb
+and lifts on release, so nothing is lost. It needs the snapshot taken at
+touch-down, held for the length of an open-ended gesture, and thrown
+away if the drag turns into a selection or a pinch — a lot of machinery
+for a style whose point is that the page comes off the stack, not that
+it follows anything.
+
+**Interpolating the slide ourselves.** Readium animates its own move; a
+second animation over the top of it would have to agree with the first
+about duration, easing and direction, and would drift the moment the
+toolkit changed either.
+
+**Keeping the boolean and adding a second setting for the style.** Two
+overlapping settings where one has three answers, and a state
+("animation on, style none") that means nothing.
+
+## Consequences
+
+Three names have to describe three motions to someone who has not seen
+them. Lift, Slide and None are the best short ones available, and each
+carries a line of its own underneath.
+
+The Advanced section hides three settings that were findable by
+scrolling. The Settings landing page still names the current page-turn
+side in its subtitle, which is what makes the section worth opening.
+
+Pinch to resize moving into Advanced compounds its default going off
+(ADR 22, amended): a reader who had it and liked it has to go looking.
+It only ever shipped in release candidates, which is what made that
+affordable.
+
+#156 also asks for pages-left-in-chapter progress and a partial progress
+bar. Not decided here.
+
+*Where:* `data/settings/ReaderPrefs.kt`,
+`data/settings/ReaderPreferencesRepository.kt`,
+`data/settings/AppSettings.kt`, `reader/chrome/PageTurnEffect.kt`,
+`reader/chrome/PageTurnDrag.kt`, `reader/ReaderScreen.kt`,
+`reader/chrome/AdvancedSheet.kt`,
+`ui/reading/ReadingAppearanceControls.kt`, `ui/settings/SettingsRows.kt`,
+`ui/settings/ReadingNavigationScreen.kt`,
+`ui/settings/ReadingAppearanceScreen.kt`.

--- a/docs/adr/0025-page-turn-styles.md
+++ b/docs/adr/0025-page-turn-styles.md
@@ -85,10 +85,15 @@ have the page follow their finger — and **Slide**, which is that
 tracking, is one tap away.
 
 The claim is decided once, on the first move past the touch slop, and
-only for a drag that sets off across the page. A second finger hands the
-gesture back, so a pinch is untouched, as is a selection being stretched
-and a scrolled book being scrolled; a fixed-layout page, which is dragged
-to look around rather than to turn, is left to Readium entirely.
+only for a drag that sets off across the page. That decision then stands
+for the rest of the gesture: a drag that set off downwards stays the web
+view's however it curves later, because taking it over halfway through
+would cancel a touch the web view is already acting on. A second finger
+settles it the same way, so a pinch is untouched, as is a selection being
+stretched and a scrolled book being scrolled. A fixed-layout page, which
+is dragged to look around rather than to turn, is left to Readium
+entirely, and so is anything dragged while the chrome is up, where a
+sideways drag belongs to the progress scrubber.
 
 Storage is a new `page_turn_style` key. When it is absent the old
 `page_turn_animation` boolean is read once — `false` means **None** — so


### PR DESCRIPTION
## Summary

The page turn was a switch: animated or not. It now has three answers.
**Lift** is what you have today, the finished page coming off the one
underneath. **Slide** is the seamless side-to-side motion you already
got by dragging the page with a finger, now available on a tap.
**None** is the instant jump. This is the page-turn half of #156; the
progress-bar half of that issue is still open.

A sideways drag follows the same choice, so a book turns the same way
whether you tap it or swipe it. Under Slide the page keeps tracking
your finger as before; under Lift and None the drag becomes a swipe
that commits when you let go.

Settings -> Reading & navigation gained an Advanced section at the
bottom, closed when you arrive, for the three things a reader sets once
if ever. Pinch to resize text moved into it and is now off until you
ask for it, because a grip that produces stray two-finger touches
resized the text of every book by accident. Pinching an image to
enlarge it is unaffected.

## Changes

- Page turn is `PageTurnStyle` (lift, slide, none) instead of a
  boolean. E-ink still forces the instant jump.
- A sideways drag routes through the same page turn a tap uses, unless
  the style is Slide, which is what Readium's drag already does.
- New Advanced section on Settings -> Reading & navigation holding the
  page turn, page-turn sides and pinch to resize.
- Page turn moved off Settings -> Reading appearance. It stays in the
  reader's own Advanced sheet.
- Pinch to resize text defaults to off.
- An old `page_turn_animation` set to off reads as None, so nobody gets
  animation back after updating.
- `docs/adr/0025-page-turn-styles.md` records the reasoning.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

Checked all three styles on an emulator by tap and by drag, and on a
phone through `make dev-install`.

## Screenshots or recordings

![Reading & navigation with Advanced closed](./03-advanced-closed.png)
![The Advanced section open](./05-advanced-open.png)

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

![Reading & navigation with Advanced closed](https://github.com/user-attachments/assets/ac7e29e6-85f6-4a4e-855e-51104e2f0d34)

![The Advanced section open, showing the page turn, page-turn sides and pinch to resize](https://github.com/user-attachments/assets/e2d72b93-01f4-4b2b-9214-828df18c4f02)