### PR TITLE
Keep library ordering stable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ for user-facing goals.
 ## Build, test, lint
 
 Always use the wrapper (`./gradlew`), never a system-wide `gradle`.
-The project is pinned to Gradle 9.6.1 via `gradle/wrapper/`.
+Use the Gradle version pinned in `gradle/wrapper/gradle-wrapper.properties`.
 
 ```bash
 ./gradlew assembleDebug              # unsigned debug APK -> app/build/outputs/apk/debug/

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/ReadingProgress.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/ReadingProgress.kt
@@ -279,31 +279,6 @@ abstract class ReadingProgressDao {
         }
     }
 
-    /**
-     * Compatibility overload for callers that do not measure v2 pace.
-     *
-     * [readingSpeed] is deliberately ignored: it belongs to the biased v1
-     * estimator and must not seed the replacement.
-     */
-    suspend fun recordLocal(
-        bookUrl: String,
-        locatorJson: String,
-        progression: Double?,
-        @Suppress("UNUSED_PARAMETER") readingSpeed: Double?,
-        status: String?,
-        updatedAt: Long,
-    ) = recordLocal(
-        bookUrl = bookUrl,
-        locatorJson = locatorJson,
-        progression = progression,
-        readingSecondsPerPosition = null,
-        readingPaceSamples = null,
-        readingPaceElapsedMs = null,
-        readingPaceEvidence = null,
-        status = status,
-        updatedAt = updatedAt,
-    )
-
     // -- The pending remote state, and the feed's durability ---------------
 
     /**

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteRouter.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteRouter.kt
@@ -31,8 +31,6 @@ class RemoteRouter(
 ) {
     private suspend fun kind(): ServerKind? = serverDao.get()?.kind
 
-    suspend fun catalog(): CatalogSource? = kind()?.let(catalogs::get)
-
     /**
      * The catalog for a server already in hand.
      *
@@ -42,14 +40,10 @@ class RemoteRouter(
      */
     fun catalogFor(kind: ServerKind): CatalogSource? = catalogs[kind]
 
-    suspend fun files(): FileSource? = kind()?.let(files::get)
-
     /** The downloader for a server already in hand. See [catalogFor]. */
     fun filesFor(kind: ServerKind): FileSource? = files[kind]
 
     suspend fun positionSync(): PositionSync? = kind()?.let(positions::get)
-
-    suspend fun live(): LiveChanges? = kind()?.let(live::get)
 
     fun liveFor(kind: ServerKind): LiveChanges? = live[kind]
 

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/LibraryShelf.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/LibraryShelf.kt
@@ -70,19 +70,12 @@ private fun ShelfEntry.authorName(): String? = when (this) {
  */
 private fun ShelfEntry.recentRank(readAt: Map<String, Long>): Int = when (this) {
     is ShelfEntry.Single -> book.recentRank(readAt[book.url])
-    is ShelfEntry.Pile ->
-        shelf.volumes.minOfOrNull { it.book.recentRank(readAt[it.book.url]) } ?: 2
+    is ShelfEntry.Pile -> shelf.recentRank(readAt)
 }
 
 private fun ShelfEntry.recentAt(readAt: Map<String, Long>): Long = when (this) {
     is ShelfEntry.Single -> book.recentAt(readAt[book.url])
-    is ShelfEntry.Pile -> {
-        val rank = recentRank(readAt)
-        shelf.volumes.asSequence()
-            .filter { it.book.recentRank(readAt[it.book.url]) == rank }
-            .maxOfOrNull { it.book.recentAt(readAt[it.book.url]) }
-            ?: 0L
-    }
+    is ShelfEntry.Pile -> shelf.recentAt(readAt)
 }
 
 /** A pile joined the library when its newest volume did. */
@@ -140,11 +133,7 @@ private fun entryComparator(
             // plain shelf has always had it. Reversing reads the series
             // back to front but never a series' own volumes backwards.
             val bySeries = compareBy<ShelfEntry> { it.seriesSortKey() }
-            val ordered = if (reversed) {
-                compareByDescending<ShelfEntry> { it.seriesSortKey() }
-            } else {
-                bySeries
-            }
+            val ordered = if (reversed) bySeries.reversed() else bySeries
             compareBy<ShelfEntry> { if (it.seriesSortKey().isEmpty()) 1 else 0 }
                 .then(ordered)
                 .thenBy { (it as? ShelfEntry.Single)?.book?.seriesIndex == null }

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/LibrarySort.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/LibrarySort.kt
@@ -102,8 +102,8 @@ internal fun Book.recentAt(readAt: Long?): Long {
  *
  * [reversed] flips whichever direction the order reads in naturally:
  * newest first for dates, A to Z for names. Every order finishes on the
- * title, so two books that are otherwise equal keep the same places
- * between launches instead of swapping about.
+ * title and permanent book identity, so two books that are otherwise
+ * equal keep the same places between launches instead of swapping about.
  *
  * A book with no author files last whichever way round the list is: an
  * unknown author is not a name, and pretending it sorts before A only
@@ -114,7 +114,7 @@ fun List<Book>.arrangedBy(
     reversed: Boolean = false,
     readAt: Map<String, Long> = emptyMap(),
 ): List<Book> {
-    val byTitle = compareBy<Book> { sortKey(it.title) }
+    val byTitle = compareBy<Book>({ sortKey(it.title) }, { it.url })
 
     val comparator = when (sort) {
         LibrarySort.RECENT -> compareBy<Book> { it.recentRank(readAt[it.url]) }
@@ -138,19 +138,13 @@ fun List<Book>.arrangedBy(
             .then(byTitle)
 
         LibrarySort.SERIES -> {
-            val bySeries = compareBy<Book> { seriesKey(it.seriesName) }
+            val bySeriesName = compareBy<Book> { seriesKey(it.seriesName) }
+            val ordered = (if (reversed) bySeriesName.reversed() else bySeriesName)
                 // Within a series the numbers are the order, and
                 // reversing the shelf must not read a series backwards:
                 // book 3 before book 2 is not a useful view of anything.
                 .thenBy { it.seriesIndex == null }
                 .thenBy { it.seriesIndex ?: 0.0 }
-            val ordered = if (reversed) {
-                compareByDescending<Book> { seriesKey(it.seriesName) }
-                    .thenBy { it.seriesIndex == null }
-                    .thenBy { it.seriesIndex ?: 0.0 }
-            } else {
-                bySeries
-            }
             compareBy<Book> { if (it.seriesName.isNullOrBlank()) 1 else 0 }
                 .then(ordered)
                 .then(byTitle)

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/SeriesShelf.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/SeriesShelf.kt
@@ -188,28 +188,6 @@ data class SeriesContinuation(
 )
 
 /**
- * The book to offer once one is finished: the next volume along that
- * is in the library and has not been read.
- *
- * A volume already begun is still the next volume — continuing a series
- * means picking up where that book was left, not skipping it. Finished
- * and archived volumes are stepped over. A hole in the numbering is
- * reported separately as [SeriesContinuation.missingIndex] rather than
- * blocking the offer: #3 is still the next book in the library when #2
- * is not there.
- *
- * Null for anything uncertain: a book with no series, one with no
- * number, or nothing later on the shelf that can be opened. Whether the
- * file is on the device is not this function's business.
- */
-@Suppress("UNUSED_PARAMETER")
-fun nextInSeries(
-    finished: Book,
-    library: List<Book>,
-    progressions: Map<String, Double> = emptyMap(),
-): Book? = seriesContinuation(finished, library).next
-
-/**
  * The missing volume immediately after [finished], and the first later
  * volume in the library that can still be read.
  *
@@ -310,11 +288,11 @@ fun List<SeriesShelf>.arrangedBy(
 }
 
 /** Best availability/reading rank held by any volume on the shelf. */
-private fun SeriesShelf.recentRank(readAt: Map<String, Long>): Int =
+internal fun SeriesShelf.recentRank(readAt: Map<String, Long>): Int =
     volumes.minOfOrNull { volume -> volume.book.recentRank(readAt[volume.book.url]) } ?: 2
 
 /** Most recent timestamp among the volumes in the shelf's best rank. */
-private fun SeriesShelf.recentAt(readAt: Map<String, Long>): Long {
+internal fun SeriesShelf.recentAt(readAt: Map<String, Long>): Long {
     val rank = recentRank(readAt)
     return volumes.asSequence()
         .filter { volume -> volume.book.recentRank(readAt[volume.book.url]) == rank }

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/SeriesShelf.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/SeriesShelf.kt
@@ -105,6 +105,7 @@ private val byVolume: Comparator<SeriesVolume> =
     compareBy<SeriesVolume> { it.index == null }
         .thenBy { it.index ?: 0.0 }
         .thenBy { sortKey(it.book.title) }
+        .thenBy { it.book.url }
 
 /**
  * Gathers books into the series they belong to.

--- a/app/src/main/kotlin/com/chmouel/liseur/domain/SeriesShelf.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/domain/SeriesShelf.kt
@@ -122,13 +122,14 @@ fun List<Book>.groupedIntoSeries(
         .groupBy { seriesKey(it.seriesName) }
         .filterKeys { it.isNotEmpty() }
         .map { (key, books) ->
-            val volumes = books
+            val orderedBooks = books.sortedBy { it.url }
+            val volumes = orderedBooks
                 .map { SeriesVolume(it, progressions[it.url]) }
                 .sortedWith(byVolume)
             SeriesShelf(
                 key = key,
-                name = commonest(books.mapNotNull { it.seriesName }) ?: key,
-                author = commonest(books.mapNotNull { it.displayAuthor }),
+                name = commonest(orderedBooks.mapNotNull { it.seriesName }) ?: key,
+                author = commonest(orderedBooks.mapNotNull { it.displayAuthor }),
                 volumes = volumes,
                 nextUp = volumes.firstOrNull { it.inProgress }
                     ?: volumes.firstOrNull { !it.finished },

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/ReadingProgressFixtures.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/ReadingProgressFixtures.kt
@@ -1,0 +1,20 @@
+package com.chmouel.liseur.data.db
+
+suspend fun ReadingProgressDao.recordLocal(
+    bookUrl: String,
+    locatorJson: String,
+    progression: Double?,
+    @Suppress("UNUSED_PARAMETER") readingSpeed: Double?,
+    status: String?,
+    updatedAt: Long,
+) = recordLocal(
+    bookUrl = bookUrl,
+    locatorJson = locatorJson,
+    progression = progression,
+    readingSecondsPerPosition = null,
+    readingPaceSamples = null,
+    readingPaceElapsedMs = null,
+    readingPaceEvidence = null,
+    status = status,
+    updatedAt = updatedAt,
+)

--- a/app/src/test/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepositoryTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepositoryTest.kt
@@ -7,6 +7,7 @@ import com.chmouel.liseur.data.db.Book
 import com.chmouel.liseur.data.db.DownloadState
 import com.chmouel.liseur.data.db.LiseurDatabase
 import com.chmouel.liseur.data.db.RemoteServer
+import com.chmouel.liseur.data.db.recordLocal
 import com.chmouel.liseur.data.library.FinishedState
 import com.chmouel.liseur.data.remote.DeviceIdentityRepository
 import com.chmouel.liseur.data.remote.PositionSyncStatus

--- a/app/src/test/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSyncTest.kt
@@ -7,6 +7,7 @@ import com.chmouel.liseur.data.db.Book
 import com.chmouel.liseur.data.db.KosyncPeer
 import com.chmouel.liseur.data.db.RemoteServer
 import com.chmouel.liseur.data.db.LiseurDatabase
+import com.chmouel.liseur.data.db.recordLocal
 import com.chmouel.liseur.data.library.BookFingerprintStore
 import com.chmouel.liseur.data.library.FinishedState
 import com.chmouel.liseur.data.remote.DeviceIdentity

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
@@ -8,6 +8,7 @@ import com.chmouel.liseur.data.db.Book
 import com.chmouel.liseur.data.db.LiseurDatabase
 import com.chmouel.liseur.data.db.RemoteServer
 import com.chmouel.liseur.data.db.SessionTransmission
+import com.chmouel.liseur.data.db.recordLocal
 import com.chmouel.liseur.data.remote.ServerKind
 import com.chmouel.liseur.data.library.BookFingerprintStore
 import com.chmouel.liseur.data.library.FinishedState

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/LibraryShelfTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/LibraryShelfTest.kt
@@ -114,6 +114,31 @@ class LibraryShelfTest {
     }
 
     @Test
+    fun `a newer downloaded volume does not outrank an older reading volume`() {
+        val books = listOf(
+            book("Other reading", lastOpenedAt = 500),
+            book(
+                "Started",
+                series = "The Expanse",
+                index = 1.0,
+                addedAt = 10,
+                lastOpenedAt = 100,
+            ),
+            book("Downloaded", series = "The Expanse", index = 2.0, addedAt = 900),
+        )
+        val shelf = shelves(books)
+
+        assertEquals(
+            listOf("Other reading", "The Expanse"),
+            mixedShelf(books, shelf, LibrarySort.RECENT).names(),
+        )
+        assertEquals(
+            listOf("The Expanse", "Other reading"),
+            mixedShelf(books, shelf, LibrarySort.RECENT, reversed = true).names(),
+        )
+    }
+
+    @Test
     fun `added order dates a pile by its newest volume`() {
         val books = listOf(
             book("Anna Karenina", addedAt = 500),

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/LibrarySortTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/LibrarySortTest.kt
@@ -9,13 +9,14 @@ class LibrarySortTest {
 
     private fun book(
         title: String,
+        url: String = "https://example.test/$title",
         author: String? = null,
         addedAt: Long = 0,
         lastOpenedAt: Long? = null,
         downloadedAt: Long? = null,
         state: DownloadState = DownloadState.REMOTE,
     ) = Book(
-        url = "https://example.test/$title",
+        url = url,
         title = title,
         author = author,
         coverPath = null,
@@ -127,6 +128,22 @@ class LibrarySortTest {
         val again = books.shuffled().arrangedBy(LibrarySort.ADDED).titles()
         assertEquals(listOf("Alpha", "Beta", "Gamma"), once)
         assertEquals(once, again)
+    }
+
+    @Test
+    fun `identical titles use permanent identity independently of input order`() {
+        val first = book("Same title", url = "https://example.test/a", addedAt = 5)
+        val second = book("Same title", url = "https://example.test/b", addedAt = 5)
+
+        for (sort in LibrarySort.entries) {
+            val expected = listOf(first.url, second.url)
+            assertEquals(expected, listOf(first, second).arrangedBy(sort).map { it.url })
+            assertEquals(expected, listOf(second, first).arrangedBy(sort).map { it.url })
+        }
+        assertEquals(
+            listOf(second.url, first.url),
+            listOf(first, second).arrangedBy(LibrarySort.TITLE, reversed = true).map { it.url },
+        )
     }
 
     @Test
@@ -253,6 +270,20 @@ class LibrarySortTest {
         assertEquals(
             listOf("Dune Messiah", "Companion"),
             books.arrangedBy(LibrarySort.SERIES, reversed = false).titles(),
+        )
+    }
+
+    @Test
+    fun `equal and fractional series numbers keep title order`() {
+        val books = listOf(
+            inSeries("Second edition", "Dune", 1.5),
+            inSeries("First edition", "Dune", 1.5),
+            inSeries("Volume one", "Dune", 1.0),
+        )
+
+        assertEquals(
+            listOf("Volume one", "First edition", "Second edition"),
+            books.arrangedBy(LibrarySort.SERIES, reversed = true).titles(),
         )
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/SeriesShelfTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/SeriesShelfTest.kt
@@ -93,13 +93,28 @@ class SeriesShelfTest {
 
     @Test
     fun `equal volume titles use permanent identity independently of input order`() {
-        val first = book("Same title", url = "https://example.test/a", index = 1.0)
-        val second = book("Same title", url = "https://example.test/b", index = 1.0)
+        val first = book(
+            "Same title",
+            url = "https://example.test/a",
+            index = 1.0,
+            series = "The Series",
+            author = "Alice",
+        )
+        val second = book(
+            "Same title",
+            url = "https://example.test/b",
+            index = 1.0,
+            series = "the series",
+            author = "Bob",
+        )
+        val shelf = listOf(second, first).groupedIntoSeries().single()
 
         assertEquals(
             listOf(first.url, second.url),
-            listOf(second, first).groupedIntoSeries().single().volumes.map { it.book.url },
+            shelf.volumes.map { it.book.url },
         )
+        assertEquals("The Series", shelf.name)
+        assertEquals("Alice", shelf.author)
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/SeriesShelfTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/SeriesShelfTest.kt
@@ -12,6 +12,7 @@ class SeriesShelfTest {
 
     private fun book(
         title: String,
+        url: String = "https://example.test/$title",
         series: String? = "Wheel of Time",
         index: Double? = null,
         author: String? = "Robert Jordan",
@@ -19,7 +20,7 @@ class SeriesShelfTest {
         archivedAt: Long? = null,
         state: DownloadState = DownloadState.DOWNLOADED,
     ) = Book(
-        url = "https://example.test/$title",
+        url = url,
         title = title,
         author = author,
         coverPath = null,
@@ -87,6 +88,17 @@ class SeriesShelfTest {
         assertEquals(
             listOf("One", "One and a half", "Two", "Companion"),
             shelves.single().volumes.map { it.book.title },
+        )
+    }
+
+    @Test
+    fun `equal volume titles use permanent identity independently of input order`() {
+        val first = book("Same title", url = "https://example.test/a", index = 1.0)
+        val second = book("Same title", url = "https://example.test/b", index = 1.0)
+
+        assertEquals(
+            listOf(first.url, second.url),
+            listOf(second, first).groupedIntoSeries().single().volumes.map { it.book.url },
         )
     }
 

--- a/app/src/test/kotlin/com/chmouel/liseur/domain/SeriesShelfTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/domain/SeriesShelfTest.kt
@@ -245,7 +245,7 @@ class SeriesShelfTest {
     }
 }
 
-class NextInSeriesTest {
+class SeriesContinuationTest {
 
     private fun book(
         title: String,
@@ -273,7 +273,7 @@ class NextInSeriesTest {
         val one = book("One", index = 1.0, finishedAt = 1)
         val library = listOf(one, book("Three", index = 3.0), book("Two", index = 2.0))
 
-        assertEquals("Two", nextInSeries(one, library)?.title)
+        assertEquals("Two", seriesContinuation(one, library).next?.title)
     }
 
     @Test
@@ -289,19 +289,19 @@ class NextInSeriesTest {
     @Test
     fun `a book with no series has nothing next`() {
         val alone = book("Dune", series = null, finishedAt = 1)
-        assertNull(nextInSeries(alone, listOf(alone, book("Two", index = 2.0))))
+        assertNull(seriesContinuation(alone, listOf(alone, book("Two", index = 2.0))).next)
     }
 
     @Test
     fun `a book with no number has nothing next`() {
         val vague = book("Companion", finishedAt = 1)
-        assertNull(nextInSeries(vague, listOf(vague, book("Two", index = 2.0))))
+        assertNull(seriesContinuation(vague, listOf(vague, book("Two", index = 2.0))).next)
     }
 
     @Test
     fun `the last volume has nothing next`() {
         val last = book("Two", index = 2.0, finishedAt = 1)
-        assertNull(nextInSeries(last, listOf(book("One", index = 1.0), last)))
+        assertNull(seriesContinuation(last, listOf(book("One", index = 1.0), last)).next)
     }
 
     @Test
@@ -309,7 +309,7 @@ class NextInSeriesTest {
         val one = book("One", index = 1.0, finishedAt = 1)
         val library = listOf(one, book("Two", index = 2.0, finishedAt = 2), book("Three", index = 3.0))
 
-        assertEquals("Three", nextInSeries(one, library)?.title)
+        assertEquals("Three", seriesContinuation(one, library).next?.title)
     }
 
     @Test
@@ -327,7 +327,7 @@ class NextInSeriesTest {
             seriesName = "Wheel of Time",
             seriesIndex = 2.0,
         )
-        assertEquals("Two", nextInSeries(one, listOf(one, two))?.title)
+        assertEquals("Two", seriesContinuation(one, listOf(one, two)).next?.title)
     }
 
     @Test
@@ -347,15 +347,12 @@ class NextInSeriesTest {
     }
 
     @Test
-    fun `an in-progress volume is the next one to continue`() {
+    fun `an unfinished later volume is eligible`() {
         val one = book("One", index = 1.0, finishedAt = 1)
         val two = book("Two", index = 2.0)
         val library = listOf(one, two, book("Three", index = 3.0))
 
-        assertEquals(
-            "Two",
-            nextInSeries(one, library, progressions = mapOf(two.url to 0.3))?.title,
-        )
+        assertEquals("Two", seriesContinuation(one, library).next?.title)
     }
 
     @Test
@@ -363,7 +360,7 @@ class NextInSeriesTest {
         val one = book("One", index = 1.0, finishedAt = 1)
         val library = listOf(one, book("Two", index = 2.0, archivedAt = 9))
 
-        assertNull(nextInSeries(one, library))
+        assertNull(seriesContinuation(one, library).next)
     }
 
     @Test
@@ -371,7 +368,7 @@ class NextInSeriesTest {
         val one = book("One", index = 1.0, finishedAt = 1)
         val library = listOf(one, book("Dune Messiah", series = "Dune", index = 2.0))
 
-        assertNull(nextInSeries(one, library))
+        assertNull(seriesContinuation(one, library).next)
     }
 
     /**
@@ -395,7 +392,7 @@ class NextInSeriesTest {
         val seven = book("Seven", index = 7.0, finishedAt = 1)
         val library = listOf(seven, book("Novella", index = 7.5), book("Eight", index = 8.0))
 
-        assertEquals("Novella", nextInSeries(seven, library)?.title)
+        assertEquals("Novella", seriesContinuation(seven, library).next?.title)
     }
 
     @Test
@@ -403,7 +400,7 @@ class NextInSeriesTest {
         val novella = book("Novella", index = 7.5, finishedAt = 1)
         val library = listOf(book("Seven", index = 7.0), novella, book("Eight", index = 8.0))
 
-        assertEquals("Eight", nextInSeries(novella, library)?.title)
+        assertEquals("Eight", seriesContinuation(novella, library).next?.title)
         assertNull(seriesContinuation(novella, library).missingIndex)
     }
 


### PR DESCRIPTION
## Summary

Library shelves now keep their order when books tie on title or series position. Reopening a shelf no longer moves equivalent books around.

## Changes

- Keep series volumes in numeric order in either shelf direction.
- Use each book's permanent identity to break equal-title ties.
- Remove unused data-layer entry points and update test coverage.
- Clarify that builds use the version in gradle/wrapper/gradle-wrapper.properties.

## Testing

- [x] ./gradlew testDebugUnitTest
- [ ] ./gradlew lintDebug
- [ ] ./gradlew assembleDebug
- [ ] Manually tested on a device or emulator, if applicable

## Screenshots or recordings

Not applicable. This change affects ordering behavior and build documentation, not a dedicated visual state.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.