### PR TITLE
Sort Reading appearance the way the Aa sheet does

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,16 +335,22 @@ emulator.
 - Reader settings map to Readium `EpubPreferences`; reading themes
   (Light/Sepia/Dark/Black) are decoupled from the app's Material theme.
 - A new reading setting goes in the Advanced sheet
-  (`reader/chrome/AdvancedSheet.kt`), and directly on Settings -> Reading
+  (`reader/chrome/AdvancedSheet.kt`), and on Settings -> Reading
   appearance if it is about how the page *looks*, or on Settings ->
   Reading & navigation (`ui/settings/ReadingNavigationScreen.kt`) if it
-  is about how the book is turned, held or looked up. Reading &
-  navigation has its own Advanced section at the bottom
-  (`SettingsExpandableGroup`), closed on arrival, for the rows a reader
-  sets once if ever — the page turn, the page-turn sides, pinch to
-  resize. Reading appearance has none. The typography sheet is the short
-  list a reader changes often (theme, size, brightness, font, and how
-  the book is read), and it only grows for a setting that genuinely
+  is about how the book is turned, held or looked up. Both screens end
+  in an Advanced section, closed on arrival, for the rows a reader sets
+  once if ever: Reading & navigation's holds the page turn, the
+  page-turn sides and pinch to resize (`SettingsExpandableGroup`, a
+  card of `ListItem` rows), Reading appearance's holds the appearance
+  settings the Advanced sheet also keeps behind Advanced — line
+  spacing, margins, columns, the fine typography and the footer
+  (`SettingsExpandableSection`, no card, because that screen is
+  controls rather than rows). A setting shown on both surfaces is
+  everyday on both or advanced on both; they must not disagree. The
+  typography sheet is the
+  short list a reader changes often (theme, size, brightness, font, and
+  how the book is read), and it only grows for a setting that genuinely
   belongs there. Make that case in the pull request; the default is
   Advanced. It grew to eleven controls once, one reasonable row at a
   time. See `docs/adr/0001-advanced-reading-menu.md`.

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
@@ -22,6 +22,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -68,7 +72,9 @@ import com.chmouel.liseur.ui.windowWidth
  *
  * The preview at the top is the point of having this here rather than a
  * row of sentences: with no page behind them, these settings need
- * something to be true of.
+ * something to be true of. It stays above the Advanced section and goes
+ * on answering to what is inside it, so opening that is not a step away
+ * from the only page there is to look at.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -144,37 +150,47 @@ fun ReadingAppearanceScreen(
                     onImport = fontLibrary.pick,
                     onRemove = fontLibrary.remove,
                 )
-                ReadingLayoutControls(
-                    lineHeight = prefs.lineHeight,
-                    pageMargins = prefs.pageMargins,
-                    columnMode = prefs.columnMode,
-                    // The sheet hides this in a scrolled book, where
-                    // columns don't apply. There is no book here to
-                    // check, so the preference is always offered; the
-                    // reader surface decides whether to honor it.
-                    showColumns = true,
-                    enabled = true,
-                    onLineHeightChanged = onLineHeight,
-                    onPageMarginsChanged = onPageMargins,
-                    onColumnModeChanged = onColumnMode,
-                )
-                // No book is open here, so nothing is disabled and the
-                // wording names the writing systems a setting applies
-                // to rather than claiming anything about one book.
-                ReadingFineTypographyControls(
-                    prefs = prefs,
-                    css = ReadingCss.Unknown,
-                    actions = fineTypography,
-                )
-                ReadingFooterModeDropdown(
-                    selected = prefs.footerMode,
-                    onSelected = onFooterMode,
-                )
                 Text(
                     text = stringResource(R.string.settings_reading_appearance_detail),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                // Last, and closed, the way the "Aa" sheet's Advanced row
+                // is: the same settings should not be everyday on one
+                // surface and buried on the other.
+                var advancedOpen by remember { mutableStateOf(false) }
+                SettingsExpandableSection(
+                    title = stringResource(R.string.settings_advanced),
+                    expanded = advancedOpen,
+                    onExpandedChange = { advancedOpen = it },
+                ) {
+                    ReadingLayoutControls(
+                        lineHeight = prefs.lineHeight,
+                        pageMargins = prefs.pageMargins,
+                        columnMode = prefs.columnMode,
+                        // The sheet hides this in a scrolled book, where
+                        // columns don't apply. There is no book here to
+                        // check, so the preference is always offered; the
+                        // reader surface decides whether to honor it.
+                        showColumns = true,
+                        enabled = true,
+                        onLineHeightChanged = onLineHeight,
+                        onPageMarginsChanged = onPageMargins,
+                        onColumnModeChanged = onColumnMode,
+                    )
+                    // No book is open here, so nothing is disabled and the
+                    // wording names the writing systems a setting applies
+                    // to rather than claiming anything about one book.
+                    ReadingFineTypographyControls(
+                        prefs = prefs,
+                        css = ReadingCss.Unknown,
+                        actions = fineTypography,
+                    )
+                    ReadingFooterModeDropdown(
+                        selected = prefs.footerMode,
+                        onSelected = onFooterMode,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsRows.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/SettingsRows.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectableGroup
@@ -32,6 +33,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.chmouel.liseur.R
 
@@ -111,6 +113,67 @@ internal fun SettingsExpandableGroup(
     onExpandedChange: (Boolean) -> Unit,
     content: @Composable ColumnScope.() -> Unit,
 ) {
+    ExpandableHeader(
+        title = title,
+        expanded = expanded,
+        onExpandedChange = onExpandedChange,
+        topPadding = 24.dp,
+    )
+    AnimatedVisibility(visible = expanded) {
+        Card(Modifier.fillMaxWidth()) {
+            Column(content = content)
+        }
+    }
+}
+
+/**
+ * The same section, for a screen built out of controls rather than rows.
+ *
+ * Reading appearance is sliders, swatches and dropdowns laid straight
+ * down a spaced column, not [ListItem]s stacked in a card, so
+ * [SettingsExpandableGroup]'s rounded card would box a handful of
+ * controls that are not rows and give them an edge nothing above them
+ * has. The header is the one from there, unchanged — the reader is
+ * opening the same kind of thing either way — and only what it opens
+ * differs.
+ *
+ * The top padding is smaller because the column this sits in already
+ * spaces its children apart, where the card variant's does not.
+ */
+@Composable
+internal fun SettingsExpandableSection(
+    title: String,
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Column {
+        ExpandableHeader(
+            title = title,
+            expanded = expanded,
+            onExpandedChange = onExpandedChange,
+            topPadding = 4.dp,
+        )
+        AnimatedVisibility(visible = expanded) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(20.dp),
+                content = content,
+            )
+        }
+    }
+}
+
+/**
+ * The title and the chevron that open either kind of section, so the two
+ * cannot come to look or announce themselves differently.
+ */
+@Composable
+private fun ExpandableHeader(
+    title: String,
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    topPadding: Dp,
+) {
     val state = stringResource(
         if (expanded) R.string.settings_section_expanded else R.string.settings_section_collapsed,
     )
@@ -123,7 +186,12 @@ internal fun SettingsExpandableGroup(
                 onClick = { onExpandedChange(!expanded) },
             )
             .semantics(mergeDescendants = true) { stateDescription = state }
-            .padding(top = 24.dp, bottom = 8.dp),
+            // A label and a chevron come to about 32dp between them,
+            // and the column's own spacing sits outside what the
+            // header will accept a tap in. The card variant already
+            // clears this from its own padding and is unmoved by it.
+            .heightIn(min = 48.dp)
+            .padding(top = topPadding, bottom = 8.dp),
     ) {
         Text(
             text = title,
@@ -136,11 +204,6 @@ internal fun SettingsExpandableGroup(
             tint = MaterialTheme.colorScheme.primary,
             modifier = Modifier.padding(start = 4.dp).size(20.dp),
         )
-    }
-    AnimatedVisibility(visible = expanded) {
-        Card(Modifier.fillMaxWidth()) {
-            Column(content = content)
-        }
     }
 }
 

--- a/docs/adr/0001-advanced-reading-menu.md
+++ b/docs/adr/0001-advanced-reading-menu.md
@@ -82,14 +82,13 @@ cannot be empty. The rows that do not apply still hide themselves:
 auto-scroll only in a scrolled book, the page-turn animation only in a
 paginated one, columns only when there is width for two.
 
-Settings -> Reading appearance shows five of the six without a book (the
-just-this-book toggle needs a book to set apart, and there is none
-here) and not behind a collapsed section: that screen has nothing else
-competing for room, so there is no empty-sheet problem to avoid, and a
-reader who came looking for the margins should not have to open
-anything to find them. The typography sheet still collapses them, being
-the surface that stays Kindle-simple; the settings screen just lists
-them.
+Settings -> Reading appearance shows four of the six without a book,
+and behind an Advanced section of its own, closed on arrival. The
+just-this-book toggle needs a book to set apart and there is none here;
+the page-turn animation is on Reading & navigation, under the Advanced
+section there. It listed the four flat at first, on the argument that a
+screen with nothing else competing for room has no empty-sheet problem
+to avoid; that argument lost. See the second update below.
 
 New reading settings default to Advanced. `AGENTS.md` carries that as a
 convention, so the next reasonable row has to argue its way onto the
@@ -109,3 +108,37 @@ rows that only some devices show, so it moved behind a single row into
 section with it. Reading appearance is unchanged and still holds how
 the page looks; the tap-zone chip row named above is now on the new
 screen. `AGENTS.md` names both destinations.
+
+## Second update
+
+Reading appearance now collapses its advanced settings too, reversing
+the paragraph above that said it should not.
+
+The argument for listing them flat was about room, and room was never
+the problem. The problem is that the appearance settings the two
+surfaces share were sorted into everyday and rare with a book open, and
+not sorted at all without one, so a reader who learned the sheet
+learned nothing about the screen. Two ways into the same preferences
+that disagree about which of them are everyday teach the reader that
+the distinction is arbitrary — and if it is arbitrary, the sheet has no
+reason to keep hiding anything.
+
+So the screen takes the sheet's shape: the preview, the theme, the
+size, the light and the face at the top, and line spacing, margins,
+columns, the fine typography and the footer behind **Advanced** at the
+bottom, closed on every arrival. The preview stays above it and goes on
+answering to what is inside, so opening Advanced is not a step away
+from the only page there is to look at.
+
+Reading & navigation already had such a section, in a rounded card of
+`ListItem` rows. Reading appearance is sliders, swatches and dropdowns
+down a spaced column, so it gets `SettingsExpandableSection`: the same
+header, announced the same way, without the card that would box
+controls that are not rows.
+
+The convention that follows is the one `AGENTS.md` now carries: a
+setting that appears on both surfaces is everyday on both or advanced
+on both. Placing such a row on one of them is placing it on the other.
+
+*Where:* `ui/settings/ReadingAppearanceScreen.kt`,
+`ui/settings/SettingsRows.kt`.


### PR DESCRIPTION
## Summary

Settings -> Reading appearance listed all of its controls in one long
run, while the "Aa" sheet in the reader keeps a short list to hand and
hides the rest behind Advanced. The same settings were everyday on one
screen and rare on the other, so nothing a reader learned in the sheet
helped them on the settings screen.

Reading appearance now has the same shape as the sheet: the everyday
controls stay where they are, and the rest sit behind an Advanced
section at the bottom that arrives closed.

Nothing changes about what any of these settings do or where they are
stored.

## Changes

- Reading appearance keeps the preview, theme, size, brightness and
  typeface in view, and moves line spacing, margins, columns, the fine
  typography and the footer into a new Advanced section.
- The Advanced section is closed on every arrival and is not remembered
  between visits, the same as the one on Reading & navigation.
- The preview stays above it and goes on showing what is set inside, so
  opening Advanced is not a step away from the only page there is to
  look at.
- Reading & navigation already had such a section built from list rows
  in a card. Reading appearance is sliders and dropdowns rather than
  rows, so it gets a version without the card, sharing the same header
  so both announce themselves the same way to a screen reader.
- Updated `AGENTS.md` and ADR 0001, which had argued for the old
  arrangement.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

Checked on an emulator: the section arrives closed, opens and closes,
every control inside still works, and the preview updates from them.

## Screenshots or recordings

Reading appearance, Advanced closed and open:

![Reading appearance with the Advanced section closed](https://github.com/user-attachments/assets/6d2ccc1e-ea8b-4772-a192-5e47e9a1aef8)

![Reading appearance with the Advanced section open](https://github.com/user-attachments/assets/3d591105-68d3-4be8-9e16-bba063542c8b)

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
