### PR TITLE
feat: let the reader tick which highlight colours the bar offers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,19 @@ emulator.
   `RemoteAccountRepository.forgetSyncPeer()`, never at a call site.
   Disconnecting, switching accounts and `forgetUnreadableAccount()` all
   go through that one door.
+- `HighlightPalette` holds which colours the selection bar offers (any
+  subset of the six, yellow/green/blue by default) and which one an
+  unpicked mark gets. It is presentation only: all six `HighlightTint`
+  names stay legal in the database and in both directions on the wire,
+  because the enum matches liseur-sync's palette. Never filter a stored
+  tint through the palette or rewrite one that has fallen outside it —
+  `chipsFor()` appends the selected mark's own colour precisely so
+  recolouring it stays possible. An empty set means the bar offers a
+  plain Highlight in the default colour, never no way to mark a passage,
+  and it is stored: an *absent* set is a reader who never chose and gets
+  the three, an *empty* one is a reader who chose none. The default is
+  not required to be offered, since notes and that plain Highlight need
+  it either way. See `docs/adr/0026-a-configurable-highlight-palette.md`.
 - A book only on this device can be sent to liseur-sync, where the
   server allows it: `BookUploader`, `ServerCapabilities.canUpload` (read
   from the `library-upload` scope) and `BookUploadWorker`, whose unique

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ boundaries.
 
 A footer shows time remaining in the chapter. Highlights, margin notes,
 bookmarks, and dictionary lookups are inline; book-level notes live in the
-notebook. Footnotes open as a card over the page rather than sending you to
-the back of the book.
+notebook. Marking a passage offers three colours, and you tick which of
+the six you want along with the colour new marks use. Footnotes open as a
+card over the page rather than sending you to the back of the book.
 
 The library is one shelf whatever the source: local folders, calibre-web,
 Komga, liseur-sync, Grimmory, or any OPDS catalog. Series are grouped into stacks tracking

--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -362,6 +362,11 @@ private fun LiseurApp(settings: AppSettings) {
                 onBrightness = { scope.launch { readerPreferences.setBrightness(it) } },
                 onColumnMode = { scope.launch { readerPreferences.setColumnMode(it) } },
                 onFooterMode = { scope.launch { readerPreferences.setFooterMode(it) } },
+                highlightPalette = settings.highlightPalette,
+                onHighlightTintToggled = { scope.launch { repository.toggleHighlightTint(it) } },
+                onHighlightDefaultTint = {
+                    scope.launch { repository.setHighlightDefaultTint(it) }
+                },
                 fineTypography = FineTypographyActions(
                     onTextAlignChanged = { scope.launch { readerPreferences.setTextAlign(it) } },
                     onHyphensChanged = { scope.launch { readerPreferences.setHyphens(it) } },

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
@@ -5,12 +5,16 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.chmouel.liseur.domain.DictionaryUrl
 import com.chmouel.liseur.domain.LibraryFilters
 import com.chmouel.liseur.domain.LibrarySort
 import com.chmouel.liseur.domain.StatsRange
+import com.chmouel.liseur.reader.annotations.HighlightPalette
+import com.chmouel.liseur.reader.annotations.HighlightTint
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -174,6 +178,8 @@ enum class DefinitionTarget(val id: String) {
  * @param dictionaryBaseUrl The site definitions are fetched from. Any
  *   Wiktionary works, so a reader can pick their own language's edition or
  *   a mirror instead of the default.
+ * @param highlightPalette Which colours the bar over a selected passage
+ *   offers, and which one a mark made without picking gets.
  */
 data class AppSettings(
     val themeMode: ThemeMode = ThemeMode.Default,
@@ -195,6 +201,7 @@ data class AppSettings(
     val dictionaryBaseUrl: String = DictionaryUrl.DEFAULT_BASE_URL,
     val uploadPolicy: UploadPolicy = UploadPolicy.Default,
     val statsRange: StatsRange = StatsRange.Default,
+    val highlightPalette: HighlightPalette = HighlightPalette(),
 )
 
 /**
@@ -247,6 +254,8 @@ class AppSettingsRepository(private val context: Context) {
         val ACCOUNT_LOST = booleanPreferencesKey("calibre_account_lost_to_restore")
         val UPLOAD_POLICY = stringPreferencesKey("upload_policy")
         val STATS_RANGE = stringPreferencesKey("stats_range")
+        val HIGHLIGHT_TINTS = stringSetPreferencesKey("highlight_tints_offered")
+        val HIGHLIGHT_TINT_DEFAULT = stringPreferencesKey("highlight_tint_default")
     }
 
     /**
@@ -289,6 +298,10 @@ class AppSettingsRepository(private val context: Context) {
                 ?: DictionaryUrl.DEFAULT_BASE_URL,
             uploadPolicy = UploadPolicy.fromId(p[Keys.UPLOAD_POLICY]),
             statsRange = StatsRange.fromId(p[Keys.STATS_RANGE]),
+            highlightPalette = HighlightPalette.of(
+                offeredNames = p[Keys.HIGHLIGHT_TINTS],
+                defaultName = p[Keys.HIGHLIGHT_TINT_DEFAULT],
+            ),
         )
     }
 
@@ -397,5 +410,31 @@ class AppSettingsRepository(private val context: Context) {
     suspend fun setDictionaryBaseUrl(url: String) {
         val normalised = DictionaryUrl.normalise(url) ?: DictionaryUrl.DEFAULT_BASE_URL
         context.appSettingsStore.edit { it[Keys.DICTIONARY_BASE_URL] = normalised }
+    }
+
+    /**
+     * Offers [tint] when it was not offered, and stops offering it when
+     * it was.
+     *
+     * The toggle happens inside the edit, against the set that is
+     * actually stored, as `editLibraryFilters` does: two swatches tapped
+     * faster than DataStore writes would otherwise both be worked out
+     * from the same stale set, and the second would undo the first.
+     *
+     * The empty set is a legal answer, and a different one from never
+     * having chosen: the bar then offers a plain Highlight in the
+     * default colour instead of chips. Only names this build knows are
+     * written, so nothing can be stored that has no swatch to untick it
+     * with.
+     */
+    suspend fun toggleHighlightTint(tint: HighlightTint) {
+        context.appSettingsStore.edit { p ->
+            val next = HighlightPalette.of(p[Keys.HIGHLIGHT_TINTS], null).toggled(tint)
+            p[Keys.HIGHLIGHT_TINTS] = next.offered.map { it.name }.toSet()
+        }
+    }
+
+    suspend fun setHighlightDefaultTint(tint: HighlightTint) {
+        context.appSettingsStore.edit { it[Keys.HIGHLIGHT_TINT_DEFAULT] = tint.name }
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderActivity.kt
@@ -371,6 +371,11 @@ class ReaderActivity : FragmentActivity() {
                                     onScrollModeChanged = viewModel::setScrollMode,
                                     tapZonesFlow = viewModel.tapZones,
                                     pinchToResizeFlow = viewModel.pinchToResize,
+                                    highlightPaletteFlow = viewModel.highlightPalette,
+                                    onHighlightTintToggled =
+                                        viewModel::toggleHighlightTint,
+                                    onHighlightDefaultTintChanged =
+                                        viewModel::setHighlightDefaultTint,
                                     // Dialogs of this activity's own,
                                     // drawn over the reader. The page
                                     // must not carry on scrolling under

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -100,6 +100,7 @@ import com.chmouel.liseur.data.db.BookAnnotation
 import com.chmouel.liseur.data.settings.DefinitionTarget
 import com.chmouel.liseur.reader.annotations.BookmarkRibbon
 import com.chmouel.liseur.reader.annotations.DECORATION_GROUP
+import com.chmouel.liseur.reader.annotations.HighlightPalette
 import com.chmouel.liseur.reader.annotations.HighlightTint
 import com.chmouel.liseur.reader.annotations.NoteDialog
 import com.chmouel.liseur.reader.annotations.SelectionActions
@@ -362,6 +363,9 @@ fun ReaderScreen(
     onScrollModeChanged: (Boolean) -> Unit,
     tapZonesFlow: StateFlow<TapZones>,
     pinchToResizeFlow: StateFlow<Boolean>,
+    highlightPaletteFlow: StateFlow<HighlightPalette>,
+    onHighlightTintToggled: (HighlightTint) -> Unit,
+    onHighlightDefaultTintChanged: (HighlightTint) -> Unit,
     // The activity draws dialogs of its own over this screen — a link
     // out of the book, a sync, an offer to send the book up — and a tap
     // on a link never reaches the tap zones, so the screen would
@@ -388,6 +392,7 @@ fun ReaderScreen(
     val tapZones by tapZonesFlow.collectAsStateWithLifecycle()
     val swappedZonesNow by rememberUpdatedState(tapZones.swapped)
     val pinchToResize by pinchToResizeFlow.collectAsStateWithLifecycle()
+    val highlightPalette by highlightPaletteFlow.collectAsStateWithLifecycle()
     // Readium reads vertical text off the book rather than off the
     // reader: it cannot paginate lines that run down the page, so such a
     // book is scrolled whatever the setting says. Everything that asks
@@ -2564,6 +2569,7 @@ fun ReaderScreen(
         SelectionPopup(
             offset = active.popupOffset(),
             activeTint = active.existing?.tint?.let(HighlightTint::fromName),
+            palette = highlightPalette,
             actions = remember(active, dictionary) {
                 SelectionActions(
                     onHighlight = { tint ->
@@ -2690,6 +2696,9 @@ fun ReaderScreen(
             onColumnModeChanged = onPrefsAction.setColumnMode,
             onFooterModeChanged = onProgressAction.setFooterMode,
             onPageTurnStyleChanged = onPrefsAction.setPageTurnStyle,
+            highlightPalette = highlightPalette,
+            onHighlightTintToggled = onHighlightTintToggled,
+            onHighlightDefaultTintChanged = onHighlightDefaultTintChanged,
             onAutoScrollChanged = { autoScrollArmed = it },
             onAutoScrollSpeedChanged = onPrefsAction.setAutoScrollSpeed,
             onTypographyIsOwnChanged = onPrefsAction.setTypographyIsOwn,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -63,6 +63,7 @@ import com.chmouel.liseur.domain.seriesIdForExtras
 import com.chmouel.liseur.domain.DictionaryUrl
 import com.chmouel.liseur.domain.isSamePassage
 import com.chmouel.liseur.domain.exportNotebookMarkdown
+import com.chmouel.liseur.reader.annotations.HighlightPalette
 import com.chmouel.liseur.reader.annotations.HighlightTint
 import com.chmouel.liseur.reader.annotations.locator
 import com.chmouel.liseur.reader.annotations.markedPassage
@@ -825,6 +826,18 @@ class ReaderViewModel(
         .map { it.pinchToResize }
         .stateIn(viewModelScope, SharingStarted.Eagerly, true)
 
+    /**
+     * The colours a passage may be marked in, app-wide.
+     *
+     * Read eagerly because a mark can be made before anything has
+     * collected it — the bar is drawn from the reader's first selection
+     * — and because [annotation] and [addNote] take the default colour
+     * from its value rather than from a constant.
+     */
+    val highlightPalette: StateFlow<HighlightPalette> = appSettings.settings
+        .map { it.highlightPalette }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, HighlightPalette())
+
     /** Most recent position, used to persist progress and to survive recreation. */
     var lastLocator: Locator? = null
         private set
@@ -1419,7 +1432,7 @@ class ReaderViewModel(
             annotation(locator, AnnotationKind.NOTE).copy(
                 id = existing?.id ?: UUID.randomUUID().toString(),
                 note = note,
-                tint = existing?.tint ?: HighlightTint.DEFAULT.name,
+                tint = existing?.tint ?: highlightPalette.value.default.name,
                 createdAt = existing?.createdAt ?: System.currentTimeMillis(),
             ),
         )
@@ -1538,7 +1551,11 @@ class ReaderViewModel(
             kind = kind.name,
             locatorJson = locator.toJSON().toString(),
             text = locator.text.highlight?.takeIf { it.isNotBlank() },
-            tint = if (kind == AnnotationKind.BOOKMARK) null else HighlightTint.DEFAULT.name,
+            tint = if (kind == AnnotationKind.BOOKMARK) {
+                null
+            } else {
+                highlightPalette.value.default.name
+            },
             chapter = position?.let { chapterTitleAtPosition(it) } ?: locator.title,
             position = position,
             totalProgression = progression,
@@ -1653,6 +1670,14 @@ class ReaderViewModel(
 
     fun setColumnMode(mode: ColumnMode) =
         viewModelScope.launch { prefsRepo.setColumnMode(mode) }
+
+    /** Offers a colour on the bar, or stops offering it, app-wide. */
+    fun toggleHighlightTint(tint: HighlightTint) =
+        viewModelScope.launch { appSettings.toggleHighlightTint(tint) }
+
+    /** Which colour a mark made without picking one comes out in. */
+    fun setHighlightDefaultTint(tint: HighlightTint) =
+        viewModelScope.launch { appSettings.setHighlightDefaultTint(tint) }
 
     fun setAutoScrollSpeed(step: Float) =
         viewModelScope.launch { prefsRepo.setAutoScrollSpeed(step) }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/HighlightPalette.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/HighlightPalette.kt
@@ -1,0 +1,93 @@
+package com.chmouel.liseur.reader.annotations
+
+/**
+ * Which colours a passage may be marked in, and which one is meant when
+ * no colour was picked.
+ *
+ * [HighlightTint] has six entries because that is what liseur-sync's
+ * palette is, and a colour arriving from another device must have a
+ * name here or it would be rewritten on the way in. That is a reason
+ * about *storage*. It says nothing about how many chips belong in a bar
+ * drawn over the passage the reader is trying to look at, and six of
+ * them, plus Note, Look up, Search, Share and sometimes Delete, is more
+ * bar than passage on a phone.
+ *
+ * So the bar is the reader's to set, and this is the whole of the rule
+ * it follows. Everything else stays where it was: a mark whose colour
+ * this palette does not offer is still drawn over the page, still
+ * listed with its own dot, and still sent and received under its own
+ * name. Hiding a chip hides a *choice*, never a mark.
+ */
+data class HighlightPalette(
+    val offered: Set<HighlightTint> = DEFAULT_OFFERED,
+    val default: HighlightTint = HighlightTint.DEFAULT,
+) {
+
+    /**
+     * The colours the bar offers, in the order [HighlightTint] declares
+     * them.
+     *
+     * Declaration order rather than the order they were ticked, or the
+     * default first: the reader picks a set, and a set that rearranges
+     * itself costs the muscle memory of anyone who marks by position.
+     * Ticking a colour slots it in beside its neighbours and leaves the
+     * others where they were.
+     */
+    val shown: List<HighlightTint> = HighlightTint.entries.filter { it in offered }
+
+    /** Whether the bar has no colours to offer and needs a plain action instead. */
+    val isEmpty: Boolean = shown.isEmpty()
+
+    /**
+     * The chips to draw for the mark in hand.
+     *
+     * A mark can already be in a colour the palette no longer offers —
+     * made here before a colour was unticked, or made on a device
+     * showing all six. Leaving it out would show a highlight whose own
+     * colour is nowhere in the bar that recolours it: the reader could
+     * not see which one it was, and one tap anywhere would lose it with
+     * no way back. So it joins the end, for as long as that mark is
+     * selected.
+     */
+    fun chipsFor(active: HighlightTint?): List<HighlightTint> =
+        if (active == null || active in shown) shown else shown + active
+
+    /** The palette with [tint] offered, or no longer offered. */
+    fun toggled(tint: HighlightTint): HighlightPalette =
+        copy(offered = if (tint in offered) offered - tint else offered + tint)
+
+    companion object {
+        val MAX_COUNT = HighlightTint.entries.size
+
+        /**
+         * Three, which is what the bar offers until it is asked for
+         * more.
+         *
+         * Enough to separate a quotation from a doubt from a word to
+         * look up later, and few enough that the bar still fits beside
+         * the actions next to it.
+         */
+        val DEFAULT_OFFERED: Set<HighlightTint> =
+            setOf(HighlightTint.YELLOW, HighlightTint.GREEN, HighlightTint.BLUE)
+
+        /**
+         * A palette read back from storage, made safe to use.
+         *
+         * The store is a file on a device and this is the only door its
+         * contents come through, as `AutoScrollPreference.sanitize` is
+         * for the scroll pace. A name this build does not know is
+         * dropped rather than refused, since the set is what the reader
+         * ticks and a name with no swatch has nothing to be. An absent
+         * set means the reader has never chosen, which is not the same
+         * as choosing none: an empty set that was *stored* is honoured.
+         */
+        fun of(offeredNames: Set<String>?, defaultName: String?): HighlightPalette =
+            HighlightPalette(
+                offered = offeredNames
+                    ?.mapNotNull { name -> HighlightTint.entries.firstOrNull { it.name == name } }
+                    ?.toSet()
+                    ?: DEFAULT_OFFERED,
+                default = HighlightTint.fromName(defaultName),
+            )
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/SelectionPopup.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/SelectionPopup.kt
@@ -50,12 +50,19 @@ class SelectionActions(
  * It is placed just above the selection where there is room and just below
  * it otherwise, so it never covers the words being acted on — the one thing
  * that makes an in-page menu feel wrong.
+ *
+ * [palette] is how much of the bar is colours. It is the reader's to
+ * set, because six chips and five actions over the passage they are
+ * trying to look at is more bar than passage on a phone. When it offers
+ * none, a plain Highlight takes their place: a bar with no way to mark
+ * a passage would be a regression wearing a setting's clothes.
  */
 @Composable
 fun SelectionPopup(
     offset: IntOffset,
     actions: SelectionActions,
     activeTint: HighlightTint?,
+    palette: HighlightPalette,
     onDismiss: () -> Unit,
 ) {
     Popup(
@@ -85,11 +92,18 @@ fun SelectionPopup(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
             ) {
-                HighlightTint.entries.forEach { tint ->
+                val chips = palette.chipsFor(activeTint)
+                chips.forEach { tint ->
                     TintChip(
                         tint = tint,
                         selected = tint == activeTint,
                         onClick = { actions.onHighlight(tint) },
+                    )
+                }
+                if (palette.isEmpty) {
+                    PopupAction(
+                        label = stringResource(R.string.annotation_highlight),
+                        onClick = { actions.onHighlight(palette.default) },
                     )
                 }
                 PopupAction(

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/AdvancedSheet.kt
@@ -31,12 +31,15 @@ import com.chmouel.liseur.data.settings.FooterMode
 import com.chmouel.liseur.data.settings.PageTurnStyle
 import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.ReadingCss
+import com.chmouel.liseur.reader.annotations.HighlightPalette
+import com.chmouel.liseur.reader.annotations.HighlightTint
 import com.chmouel.liseur.ui.LiseurModalBottomSheet
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.reading.FineTypographyActions
 import com.chmouel.liseur.ui.reading.FixedLayoutNotice
 import com.chmouel.liseur.ui.reading.ReadingFineTypographyControls
 import com.chmouel.liseur.ui.reading.ReadingFooterModeDropdown
+import com.chmouel.liseur.ui.reading.ReadingHighlightPaletteControls
 import com.chmouel.liseur.ui.reading.ReadingLayoutControls
 import com.chmouel.liseur.ui.reading.ReadingPageTurnStyleControl
 import com.chmouel.liseur.ui.reading.ReadingSectionLabel
@@ -52,9 +55,10 @@ import com.chmouel.liseur.ui.windowWidth
  * typography, and dismissing that lands back on the page.
  *
  * What it holds is what a reader sets once, if ever: the shape of the
- * text block, what the footer says, how a page gets out of the way when
- * it is turned, whether the page moves on its own, and whether any of
- * it is this book's alone. The rest of what belongs here — finer
+ * text block, what the footer says, which colours a passage may be
+ * marked in, how a page gets out of the way when it is turned, whether
+ * the page moves on its own, and whether any of it is this book's
+ * alone. The rest of what belongs here — finer
  * typography, read-aloud, imported fonts — arrives with its own issue,
  * and the shape of the sheet is the point: five rows, or ten, it is the
  * same sheet and the reader learns it once.
@@ -91,6 +95,9 @@ fun AdvancedSheet(
     onColumnModeChanged: (ColumnMode) -> Unit,
     onFooterModeChanged: (FooterMode) -> Unit,
     onPageTurnStyleChanged: (PageTurnStyle) -> Unit,
+    highlightPalette: HighlightPalette,
+    onHighlightTintToggled: (HighlightTint) -> Unit,
+    onHighlightDefaultTintChanged: (HighlightTint) -> Unit,
     onAutoScrollChanged: (Boolean) -> Unit,
     onAutoScrollSpeedChanged: (Float) -> Unit,
     onTypographyIsOwnChanged: (Boolean) -> Unit,
@@ -129,6 +136,14 @@ fun AdvancedSheet(
             ReadingFooterModeDropdown(
                 selected = prefs.footerMode,
                 onSelected = onFooterModeChanged,
+            )
+            // Not about the page but about what is done to it, so it
+            // sits after everything that shapes the text and before the
+            // motion rows.
+            ReadingHighlightPaletteControls(
+                palette = highlightPalette,
+                onTintToggled = onHighlightTintToggled,
+                onDefaultChanged = onHighlightDefaultTintChanged,
             )
             // Nothing lifts off the screen when the text is scrolled, so
             // there is no page whose motion this could describe.

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/reading/ReadingHighlightPaletteControls.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/reading/ReadingHighlightPaletteControls.kt
@@ -1,0 +1,193 @@
+package com.chmouel.liseur.ui.reading
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.unit.dp
+import com.chmouel.liseur.R
+import com.chmouel.liseur.reader.annotations.HighlightPalette
+import com.chmouel.liseur.reader.annotations.HighlightTint
+
+/**
+ * Which colours the bar over a selected passage offers, and which one a
+ * mark gets when none was picked.
+ *
+ * One control shown in two places — the reader's Advanced sheet and
+ * Settings → Reading appearance → Advanced — so that the two cannot
+ * drift, as `ReadingPageTurnStyleControl` is.
+ *
+ * All six are always on screen, ticked or not, because a set is a
+ * clearer thing to be shown than a count: the row is the bar, at the
+ * size the bar will be, and a colour missing from it is missing where
+ * the reader can see the gap and fill it. A number would have made the
+ * reader work out which three "3" meant.
+ *
+ * The default rides on the same swatch, under a long press, rather than
+ * a second row of six repeating the first. It is the rarer choice by
+ * far, and two rows of the same colours invite the reader to think the
+ * rows disagree about something.
+ *
+ * The row wraps rather than being a fixed one: six 44dp targets and
+ * their gaps want 284dp, which a 320dp phone does not have once the
+ * sheet has taken its padding, and neither does a narrow split-screen
+ * window. Shrinking the swatches instead would put the touch target
+ * under the 44dp that makes it reachable, so a second line is the one
+ * that gives way.
+ */
+@Composable
+fun ReadingHighlightPaletteControls(
+    palette: HighlightPalette,
+    onTintToggled: (HighlightTint) -> Unit,
+    onDefaultChanged: (HighlightTint) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        ReadingSectionLabel(stringResource(R.string.reader_highlight_colours))
+        FlowRow(
+            Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            HighlightTint.entries.forEach { tint ->
+                HighlightTintSwatch(
+                    tint = tint,
+                    offered = tint in palette.offered,
+                    isDefault = tint == palette.default,
+                    onToggle = { onTintToggled(tint) },
+                    onMakeDefault = { onDefaultChanged(tint) },
+                )
+            }
+        }
+        ReadingSupportingText(
+            stringResource(
+                if (palette.isEmpty) {
+                    R.string.reader_highlight_colours_none
+                } else {
+                    R.string.reader_highlight_colours_help
+                },
+                palette.default.name(),
+            ),
+        )
+    }
+}
+
+/**
+ * One colour, on or off, and ringed when it is the default.
+ *
+ * Off is drawn hollow rather than faded: a dimmed yellow is still a
+ * yellow, and the reader would have to compare it against its
+ * neighbours to know it was off. An outline is unmistakable at a glance
+ * and survives the sepia and black reading themes, which a fixed
+ * opacity does not.
+ *
+ * The default's ring sits outside the swatch rather than replacing its
+ * border, because the default is not required to be offered and a
+ * hollow swatch wearing a ring in the theme's colour would have lost
+ * the only thing that said which colour it was.
+ *
+ * The long press is also a TalkBack custom action, since a screen
+ * reader user cannot see the line that explains it, and the tick and
+ * the ring both go into the spoken state rather than being left to the
+ * eye.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun HighlightTintSwatch(
+    tint: HighlightTint,
+    offered: Boolean,
+    isDefault: Boolean,
+    onToggle: () -> Unit,
+    onMakeDefault: () -> Unit,
+) {
+    val name = tint.name()
+    val state = stringResource(
+        when {
+            offered && isDefault -> R.string.reader_highlight_state_offered_default
+            offered -> R.string.reader_highlight_state_offered
+            isDefault -> R.string.reader_highlight_state_hidden_default
+            else -> R.string.reader_highlight_state_hidden
+        },
+    )
+    val makeDefault = stringResource(R.string.reader_highlight_make_default)
+    Box(
+        Modifier
+            .size(44.dp)
+            .semantics {
+                contentDescription = name
+                stateDescription = state
+            }
+            .clip(CircleShape)
+            .border(
+                width = if (isDefault) 2.dp else 0.dp,
+                color = if (isDefault) {
+                    MaterialTheme.colorScheme.onSurface
+                } else {
+                    Color.Transparent
+                },
+                shape = CircleShape,
+            )
+            .combinedClickable(
+                role = Role.Checkbox,
+                onClick = onToggle,
+                onLongClickLabel = makeDefault,
+                onLongClick = onMakeDefault,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            Modifier
+                .size(32.dp)
+                .clip(CircleShape)
+                .background(if (offered) tint.color else Color.Transparent)
+                .border(
+                    width = if (offered) 0.dp else 2.dp,
+                    color = if (offered) Color.Transparent else tint.color,
+                    shape = CircleShape,
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (offered) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = null,
+                    tint = Color.Black.copy(alpha = 0.55f),
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+    }
+}
+
+/** The colour's own name, without the "Highlight in" the popup needs. */
+@Composable
+private fun HighlightTint.name(): String = stringResource(
+    when (this) {
+        HighlightTint.YELLOW -> R.string.colour_yellow
+        HighlightTint.GREEN -> R.string.colour_green
+        HighlightTint.BLUE -> R.string.colour_blue
+        HighlightTint.PINK -> R.string.colour_pink
+        HighlightTint.PURPLE -> R.string.colour_purple
+        HighlightTint.ORANGE -> R.string.colour_orange
+    },
+)

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ReadingAppearanceScreen.kt
@@ -42,6 +42,8 @@ import com.chmouel.liseur.data.settings.ReaderPrefs
 import com.chmouel.liseur.data.settings.fonts.UserFont
 import com.chmouel.liseur.data.settings.ReaderTheme
 import com.chmouel.liseur.data.settings.ReaderThemeChoice
+import com.chmouel.liseur.reader.annotations.HighlightPalette
+import com.chmouel.liseur.reader.annotations.HighlightTint
 import com.chmouel.liseur.ui.contentWidthCap
 import com.chmouel.liseur.ui.reading.ReadingBrightnessSlider
 import com.chmouel.liseur.ui.reading.ReadingFontDropdown
@@ -49,6 +51,7 @@ import com.chmouel.liseur.ui.reading.readingFamily
 import com.chmouel.liseur.ui.reading.rememberFontLibrary
 import com.chmouel.liseur.ui.reading.ReadingFontSizeSlider
 import com.chmouel.liseur.ui.reading.ReadingFooterModeDropdown
+import com.chmouel.liseur.ui.reading.ReadingHighlightPaletteControls
 import com.chmouel.liseur.data.settings.ReadingCss
 import com.chmouel.liseur.ui.reading.FineTypographyActions
 import com.chmouel.liseur.ui.reading.ReadingFineTypographyControls
@@ -89,6 +92,9 @@ fun ReadingAppearanceScreen(
     onBrightness: (Float?) -> Unit,
     onColumnMode: (ColumnMode) -> Unit,
     onFooterMode: (FooterMode) -> Unit,
+    highlightPalette: HighlightPalette,
+    onHighlightTintToggled: (HighlightTint) -> Unit,
+    onHighlightDefaultTint: (HighlightTint) -> Unit,
     fineTypography: FineTypographyActions,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
@@ -189,6 +195,11 @@ fun ReadingAppearanceScreen(
                     ReadingFooterModeDropdown(
                         selected = prefs.footerMode,
                         onSelected = onFooterMode,
+                    )
+                    ReadingHighlightPaletteControls(
+                        palette = highlightPalette,
+                        onTintToggled = onHighlightTintToggled,
+                        onDefaultChanged = onHighlightDefaultTint,
                     )
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -380,6 +380,13 @@
     <string name="annotation_tint_pink">Highlight in pink</string>
     <string name="annotation_tint_purple">Highlight in purple</string>
     <string name="annotation_tint_orange">Highlight in orange</string>
+    <string name="annotation_highlight">Highlight</string>
+    <string name="colour_yellow">Yellow</string>
+    <string name="colour_green">Green</string>
+    <string name="colour_blue">Blue</string>
+    <string name="colour_pink">Pink</string>
+    <string name="colour_purple">Purple</string>
+    <string name="colour_orange">Orange</string>
     <string name="annotation_note">Note</string>
     <string name="annotation_note_title">Note</string>
     <string name="annotation_note_hint">What did this make you think?</string>
@@ -514,6 +521,16 @@
     <string name="reader_page_turn_style_lift_detail">The page you finished lifts off the one underneath, the way a sheet of paper comes off a stack.</string>
     <string name="reader_page_turn_style_slide_detail">Both pages travel together, the way they do when you drag the page across with a finger.</string>
     <string name="reader_page_turn_style_none_detail">The next page is simply there. This is what an e-ink screen gets whichever of the three is chosen.</string>
+
+    <!-- The colours offered when a passage is marked. -->
+    <string name="reader_highlight_colours">Available colours</string>
+    <string name="reader_highlight_colours_help">Tap a colour to offer it when you mark a passage. Hold one to make it the default, which is %1$s: notes get it, and so does a highlight made without picking.</string>
+    <string name="reader_highlight_colours_none">No colours are offered, so marking a passage highlights it in %1$s. Tap a colour to bring the choice back.</string>
+    <string name="reader_highlight_state_offered">Offered</string>
+    <string name="reader_highlight_state_offered_default">Offered, and the default</string>
+    <string name="reader_highlight_state_hidden">Not offered</string>
+    <string name="reader_highlight_state_hidden_default">Not offered, but the default</string>
+    <string name="reader_highlight_make_default">Make it the default</string>
 
     <!-- Fine typography: alignment, hyphenation, weight and spacing. -->
     <string name="reader_text_align">Alignment</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/annotations/HighlightPaletteTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/annotations/HighlightPaletteTest.kt
@@ -1,0 +1,144 @@
+package com.chmouel.liseur.reader.annotations
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The rule the selection bar is drawn from.
+ *
+ * Worth pinning rather than reading off the screen: the ordering is
+ * what keeps a reader's muscle memory when the set changes, and the
+ * hidden-colour case is the one where getting it wrong loses a mark the
+ * reader made.
+ */
+class HighlightPaletteTest {
+
+    @Test
+    fun `three colours by default`() {
+        val palette = HighlightPalette()
+
+        assertEquals(
+            listOf(HighlightTint.YELLOW, HighlightTint.GREEN, HighlightTint.BLUE),
+            palette.shown,
+        )
+    }
+
+    @Test
+    fun `the bar keeps the palette's own order, not the order of choosing`() {
+        val palette = HighlightPalette(
+            offered = setOf(HighlightTint.ORANGE, HighlightTint.GREEN, HighlightTint.YELLOW),
+        )
+
+        assertEquals(
+            listOf(HighlightTint.YELLOW, HighlightTint.GREEN, HighlightTint.ORANGE),
+            palette.shown,
+        )
+    }
+
+    @Test
+    fun `the default does not jump the queue, and need not be offered at all`() {
+        val palette = HighlightPalette(
+            offered = setOf(HighlightTint.YELLOW, HighlightTint.PINK),
+            default = HighlightTint.PINK,
+        )
+
+        assertEquals(listOf(HighlightTint.YELLOW, HighlightTint.PINK), palette.shown)
+        assertEquals(
+            listOf(HighlightTint.YELLOW),
+            palette.toggled(HighlightTint.PINK).shown,
+        )
+    }
+
+    @Test
+    fun `adding a colour leaves the others where they were`() {
+        val three = HighlightPalette()
+        val four = three.toggled(HighlightTint.PINK)
+
+        assertEquals(three.shown, four.shown.take(3))
+        assertEquals(4, four.shown.size)
+    }
+
+    @Test
+    fun `toggling a colour twice gets back to where it started`() {
+        val palette = HighlightPalette()
+
+        assertEquals(palette, palette.toggled(HighlightTint.PURPLE).toggled(HighlightTint.PURPLE))
+        assertEquals(palette, palette.toggled(HighlightTint.YELLOW).toggled(HighlightTint.YELLOW))
+    }
+
+    @Test
+    fun `the whole palette can be offered`() {
+        val palette = HighlightPalette(offered = HighlightTint.entries.toSet())
+
+        assertEquals(HighlightPalette.MAX_COUNT, palette.shown.size)
+        assertEquals(HighlightTint.entries.toList(), palette.shown)
+    }
+
+    @Test
+    fun `no colours at all is a palette the bar has to answer for`() {
+        val palette = HighlightPalette(offered = emptySet())
+
+        assertEquals(emptyList<HighlightTint>(), palette.shown)
+        assertTrue(palette.isEmpty)
+        assertFalse(HighlightPalette().isEmpty)
+    }
+
+    @Test
+    fun `a mark in a hidden colour keeps a chip of its own`() {
+        val palette = HighlightPalette(
+            offered = setOf(HighlightTint.YELLOW, HighlightTint.GREEN),
+        )
+
+        assertEquals(
+            listOf(HighlightTint.YELLOW, HighlightTint.GREEN, HighlightTint.ORANGE),
+            palette.chipsFor(HighlightTint.ORANGE),
+        )
+    }
+
+    @Test
+    fun `a mark in a colour already offered adds nothing`() {
+        val palette = HighlightPalette(
+            offered = setOf(HighlightTint.YELLOW, HighlightTint.GREEN),
+        )
+
+        assertEquals(palette.shown, palette.chipsFor(HighlightTint.GREEN))
+        assertEquals(palette.shown, palette.chipsFor(null))
+    }
+
+    @Test
+    fun `an unmarked passage at no colours still shows nothing`() {
+        val none = HighlightPalette(offered = emptySet())
+
+        assertEquals(emptyList<HighlightTint>(), none.chipsFor(null))
+    }
+
+    @Test
+    fun `a mark selected at no colours still shows its own`() {
+        val none = HighlightPalette(offered = emptySet())
+
+        assertTrue(none.isEmpty)
+        assertEquals(listOf(HighlightTint.ORANGE), none.chipsFor(HighlightTint.ORANGE))
+    }
+
+    @Test
+    fun `having chosen none is not the same as never having chosen`() {
+        assertEquals(HighlightPalette.DEFAULT_OFFERED, HighlightPalette.of(null, null).offered)
+        assertEquals(emptySet<HighlightTint>(), HighlightPalette.of(emptySet(), null).offered)
+    }
+
+    @Test
+    fun `a colour name this build does not know is dropped from the set`() {
+        val palette = HighlightPalette.of(setOf("YELLOW", "CHARTREUSE"), null)
+
+        assertEquals(setOf(HighlightTint.YELLOW), palette.offered)
+    }
+
+    @Test
+    fun `a default this build does not know falls back`() {
+        assertEquals(HighlightTint.DEFAULT, HighlightPalette.of(null, "CHARTREUSE").default)
+        assertEquals(HighlightTint.DEFAULT, HighlightPalette.of(null, null).default)
+        assertEquals(HighlightTint.PURPLE, HighlightPalette.of(null, "PURPLE").default)
+    }
+}

--- a/docs/adr/0026-a-configurable-highlight-palette.md
+++ b/docs/adr/0026-a-configurable-highlight-palette.md
@@ -1,0 +1,125 @@
+# 26. A palette the reader sets, three colours wide
+
+Status: accepted
+
+## Context
+
+Selecting a passage put eleven things over it: six colour chips, Note,
+Define, Search, Share, and Delete when the passage was already marked.
+On a phone that bar is wider than the sentence it belongs to, and it is
+drawn precisely over the words the reader is looking at — the one thing
+`SelectionPopup` was written to avoid, and it was defeating itself with
+its own palette.
+
+Six colours exist for a reason that is worth restating, because it is
+not this one. `HighlightTint` matches liseur-sync's palette entry for
+entry so that a highlight another device made always has a name here; a
+colour this app could not name would arrive rewritten, and a sync that
+quietly changes what it carries is worse than a colour too many. That
+argument is about **storage**. It says nothing whatever about how many
+chips belong in a bar, and it was being used as though it did.
+
+Most readers use one colour, some use two or three — a quotation, a
+doubt, a word to come back to. The other three are paid for on every
+selection by everybody.
+
+## Decision
+
+Which colours the bar offers is the reader's to set: any subset of the
+six, and **yellow, green and blue by default**. Which colour a mark gets
+when none was picked is theirs to set too.
+
+`HighlightPalette` holds both, and holds the whole of the rule:
+
+```kotlin
+val shown = HighlightTint.entries.filter { it in offered }
+```
+
+A set rather than a count, because a count leaves the reader working out
+which three "3" meant, and because the first three are not obviously the
+three anyone wants. Declaration order rather than the order of ticking,
+or the default first, which has one deliberate consequence: **ticking a
+colour slots it in beside its neighbours and leaves the others where
+they were**, so a reader who marks by position rather than by name keeps
+their muscle memory when they change their mind.
+
+The default need not be offered. It is what a note gets, and what the
+plain Highlight action uses when nothing is ticked, so it has to mean
+something even when it is nowhere on the bar. Making it offer itself
+would be the setting quietly overruling a tick the reader made.
+
+### Nothing about a mark changes
+
+`toDecorations()`, the annotations list, the database and every sync
+path are untouched. All six names remain legal in both directions on
+the wire, a highlight in a colour the bar no longer offers is still
+drawn over the page in that colour and still listed with its own dot,
+and nothing anywhere rewrites a stored tint to the default because it
+fell out of `shown`.
+
+Hiding a chip hides a **choice**, never a mark. That distinction is the
+whole safety argument for the feature, and it is why the palette is a
+presentation concern that happens to also supply a default, rather than
+a filter over the enum.
+
+### A mark in a colour that is not offered
+
+`chipsFor(active)` appends the selected mark's own colour when the
+palette has left it out — made here before a colour was unticked, or
+made on a device showing all six. Without it, recolouring such a
+highlight would offer a bar in which its own colour did not appear: the
+reader could not see which one it was, and any tap would lose it with no
+way back.
+
+### None
+
+An empty set is a legal answer, and it does not mean "you may no longer
+highlight". The chips are replaced by a plain **Highlight** action that
+marks in the default colour — one word where six circles were, which is
+what a reader who never changes colour actually wants. A bar with no way
+to mark a passage would be a regression wearing a setting's clothes.
+
+Choosing none is stored, and it is not the same as never having chosen.
+`HighlightPalette.of` gives the three defaults for an absent set and an
+empty bar for a set that was written empty; reading them the same way
+would mean a reader who wanted no chips got three back on next launch.
+
+### Where it is set
+
+The reader's Advanced sheet, and Settings → Reading appearance →
+Advanced, through one shared control so the two cannot drift. Advanced
+on both surfaces, as ADR 0001 requires: this is a thing a reader sets
+once, if ever, and the typography sheet is not to grow for it.
+
+All six are drawn whatever is ticked, at the size the bar will draw
+them, so the control is the bar rather than a description of it and a
+colour that is missing is missing where the gap can be seen and filled.
+Ticked swatches are filled and carry a check; unticked ones are hollow
+rings, not dimmed, because a dimmed yellow is still a yellow and a
+reader would have to compare it against its neighbours to know.
+
+The default rides on the same swatch, under a long press, rather than a
+second row repeating the first six: it is much the rarer choice, and two
+rows of the same colours invite the reader to think the rows disagree
+about something. A long press is not discoverable, so the line under the
+row says it and names the current default, and the swatch carries the
+press as a TalkBack custom action for readers who cannot see that line.
+
+## Consequences
+
+Every existing reader loses three chips the first time they select a
+passage after upgrading. That is the change, and it is why the release
+note has to name the way back rather than only the new default: a
+setting nobody is told about is a feature that reads as a bug.
+
+The alternative — new installs start at three, existing ones keep six —
+was rejected. A setting that means different things depending on when
+the app was installed cannot be explained in one sentence, and this one
+has to be.
+
+`AppSettings` now references `reader.annotations`, as
+`ReadingPaceRepository` already references `reader.progress`. The
+palette is app-wide and deliberately not part of `ReaderPrefs`: it is
+not typography, and "just this book" must not apply to it. A colour
+scheme that changed as you moved between books would be a way to make
+marks you could not find again.


### PR DESCRIPTION
## Summary

Selecting a passage drew all six highlight colours, every time, on top
of Note, Define, Search, Share and sometimes Delete. On a phone that is
a wider bar than the sentence it belongs to, and it lands over the very
words the reader is looking at. Most people use one colour, maybe two.

The bar now offers three, and the reader ticks which of the six they
want. Holding a colour makes it the default, which is what a note gets
and what a highlight comes out in when no chip was picked.

Six colours exist because that is liseur-sync's palette, and a colour
this app could not name would come back rewritten. That is a fact about
storage, not about how many chips have to be on screen. Nothing stored,
synced or already marked changes.

**Release note.** Marking a passage now offers three colours rather than
six. Settings → Reading appearance → Advanced is where you tick which
ones you want, and the Aa sheet's Advanced has the same row while you
read. Tick all six for the old bar. Highlights already made keep their
colour.

## Changes

- The palette is a set, not a count. Ticking a colour slots it in beside
  its neighbours and leaves the others where they were, so anyone who
  marks by position keeps their muscle memory.
- Untick everything and a plain **Highlight** action takes the chips'
  place, marking in the default colour. None is a tidier bar, never a
  reader who can no longer mark a passage. Choosing none is remembered
  as a choice, and is not confused with never having chosen.
- A mark whose colour the bar no longer offers, made before a colour was
  unticked or synced from a phone showing all six, gets a chip of its
  own while it is selected. So its colour stays visible and re-pickable.
  A stored tint is never rewritten, and all six names remain legal in
  the database and on the wire.
- The default does not have to be one of the offered colours, since
  notes and the plain Highlight need it either way. Its ring sits
  outside the swatch so a colour that is off still shows what colour it
  is.
- One shared control on both Advanced surfaces, so the Aa sheet and
  Settings cannot drift apart.
- ADR 0026 records why the palette shrank and why storage and sync were
  left alone. README and AGENTS.md updated.
- Follow-up for making the six hues themselves editable: #178.

Everyone drops to three on upgrade, deliberately. A setting that means
one thing on old installs and another on new ones is a setting nobody
can be told about.

## Testing

- [x] `./gradlew testDebugUnitTest` — 13 `HighlightPaletteTest` cases
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

Walked an emulator through it: three chips by default; ticking pink to
get four and seeing the bar follow; holding purple to make it the
default while it stayed off the bar; unticking everything and getting
the plain Highlight; and both Advanced surfaces driving the same
setting.

## Screenshots or recordings

Before, six colours, with Share pushed off the edge:

![The selection bar before](https://github.com/user-attachments/assets/b3b13096-283b-48d9-bbb9-6c5f0a706367)

After, three:

![The selection bar now](https://github.com/user-attachments/assets/e5a7299f-4554-467c-a56b-0892f6d380cb)

The control in the reader's Aa sheet, under Advanced:

![Highlight colours in the reader Advanced sheet](https://github.com/user-attachments/assets/b524b997-718c-4e7c-bf16-6cf56112cf67)

The same control in Settings → Reading appearance → Advanced:

![The same control in Settings](https://github.com/user-attachments/assets/b3718566-ef51-407c-8355-d1900a18a4db)

Four ticked, and purple held down to be the default without being on the
bar:

![A default that is not offered](https://github.com/user-attachments/assets/97f9b08a-fd20-476a-8595-aab12b3a8b3f)

Nothing ticked, and the plain Highlight that replaces the chips:

![No colours offered](https://github.com/user-attachments/assets/db5cc50d-6306-45ac-bc6a-2f8327b4c5d7)

![A plain Highlight action](https://github.com/user-attachments/assets/6f7dad57-55ff-4910-8367-a36e7426ce8a)

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
