### PR TITLE
fix: keep imported reading in the order it was read

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,31 @@ emulator.
   exact spot. All three go
   through `domain/ReadingStateMerge.kt`; write conflict rules there, once,
   not per provider.
+- A position carries two times and they are not interchangeable.
+  `updated_at` is when *this* device wrote the row, and it goes out as
+  an op's `client_ts` and as kosync's `timestamp`, so it is part of a
+  derived op id — do not repurpose it. `read_at` is when the reading
+  happened, on whatever device did it: a pull takes it from the remote
+  time (clamped to now, since it is a peer's clock), a page turn here
+  takes the local one. The Recent shelf and Continue Reading order by
+  `COALESCE(read_at, updated_at)`. Importing old state must reproduce
+  the other device's order, never invent one from arrival times. A row
+  with neither a progression nor a locator records no reading and must
+  report none. See `docs/adr/0026-imported-reading-keeps-its-own-time.md`.
+- Naming a book is rationed by what naming costs, not by a single
+  number: resolving from file hashes opens the file, resolving a
+  catalog book is one request. A run that leaves books unnamed or
+  unseeded returns `SyncOutcome.Incomplete`, and
+  `PositionSyncCoordinator` carries it on — there, not at any call
+  site, since a fresh connection is synced from app start, a refresh,
+  connecting an account and Settings alike. Only a run that made
+  *durable* progress may ask for another, or the chain never ends:
+  re-asking a question this device already has an answer to is not
+  progress. A refusal worth retrying keeps the run a failure, because
+  its retry covers the shortfall too; one that is not must not strand
+  the rest of the library. Several books to seed are seeded from one
+  `GET /v1/heads`, which is a seed and not a pull: it must not move the
+  cursor.
 - One server is connected at a time. Anything provider-shaped belongs
   behind a `data/remote/` contract, not in a `when (kind)` at the call
   site.

--- a/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/49.json
+++ b/app/schemas/com.chmouel.liseur.data.db.LiseurDatabase/49.json
@@ -1,0 +1,1509 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 49,
+    "identityHash": "3cee1b0a453b59a17ae5e3b9e8a964b7",
+    "entities": [
+      {
+        "tableName": "reading_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `total_progression` REAL, `reading_speed` REAL, `reading_seconds_per_position` REAL, `reading_pace_samples` INTEGER NOT NULL DEFAULT 0, `reading_pace_elapsed_ms` INTEGER NOT NULL DEFAULT 0, `reading_pace_evidence` REAL NOT NULL DEFAULT 0, `updated_at` INTEGER NOT NULL, `read_at` INTEGER, `status` TEXT, `synced_at` INTEGER, `local_revision` INTEGER NOT NULL DEFAULT 0, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `agreed_account` TEXT, `pending_progression` REAL, `pending_locator_json` TEXT, `pending_status` TEXT, `pending_updated_at` INTEGER, `pending_account` TEXT, `owner_account` TEXT, `remote_updated_at` INTEGER, `finished_override` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSpeed",
+            "columnName": "reading_speed",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingSecondsPerPosition",
+            "columnName": "reading_seconds_per_position",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "readingPaceSamples",
+            "columnName": "reading_pace_samples",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceElapsedMs",
+            "columnName": "reading_pace_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "readingPaceEvidence",
+            "columnName": "reading_pace_evidence",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readAt",
+            "columnName": "read_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localRevision",
+            "columnName": "local_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "agreedAccount",
+            "columnName": "agreed_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingLocatorJson",
+            "columnName": "pending_locator_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingAccount",
+            "columnName": "pending_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ownerAccount",
+            "columnName": "owner_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "finishedOverride",
+            "columnName": "finished_override",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `cover_path` TEXT, `source` TEXT, `added_at` INTEGER NOT NULL, `last_opened_at` INTEGER, `local_uri` TEXT, `remote_uuid` TEXT, `remote_book_id` INTEGER, `cover_url` TEXT, `download_href` TEXT, `download_state` TEXT NOT NULL, `remote_updated_at` INTEGER, `downloaded_at` INTEGER, `file_modified_at` INTEGER, `work_id` TEXT, `finished_at` INTEGER, `archived_at` INTEGER, `remote_page_count` INTEGER, `size_bytes` INTEGER, `series_name` TEXT, `series_index` REAL, `file_series_name` TEXT, `file_series_index` REAL, `series_id` TEXT, `series_checked` INTEGER NOT NULL, `catalog_series_name` TEXT, `catalog_series_index` REAL, `catalog_folder_id` TEXT, `catalog_series_source` TEXT, `user_series_name` TEXT, `user_series_index` REAL, `series_override` INTEGER NOT NULL, `user_series_updated_at` INTEGER, `series_claim_pending` INTEGER NOT NULL, `series_claim_reset` INTEGER NOT NULL, `personal_series_updated_at` INTEGER, `series_index_override` INTEGER NOT NULL, `catalog_missing_since` INTEGER, `hidden_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "last_opened_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localUri",
+            "columnName": "local_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUuid",
+            "columnName": "remote_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteBookId",
+            "columnName": "remote_book_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadHref",
+            "columnName": "download_href",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadState",
+            "columnName": "download_state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloaded_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finished_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archived_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remotePageCount",
+            "columnName": "remote_page_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "size_bytes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fileSeriesName",
+            "columnName": "file_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileSeriesIndex",
+            "columnName": "file_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesChecked",
+            "columnName": "series_checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSeriesName",
+            "columnName": "catalog_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesIndex",
+            "columnName": "catalog_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "catalogFolderId",
+            "columnName": "catalog_folder_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogSeriesSource",
+            "columnName": "catalog_series_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesName",
+            "columnName": "user_series_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userSeriesIndex",
+            "columnName": "user_series_index",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seriesOverridden",
+            "columnName": "series_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userSeriesUpdatedAt",
+            "columnName": "user_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesClaimPending",
+            "columnName": "series_claim_pending",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesClaimReset",
+            "columnName": "series_claim_reset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personalSeriesUpdatedAt",
+            "columnName": "personal_series_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "indexOverridden",
+            "columnName": "series_index_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogMissingSince",
+            "columnName": "catalog_missing_since",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hiddenAt",
+            "columnName": "hidden_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_books_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_books_url` ON `${TABLE_NAME}` (`url`)"
+          },
+          {
+            "name": "index_books_series_name",
+            "unique": false,
+            "columnNames": [
+              "series_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_series_name` ON `${TABLE_NAME}` (`series_name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "library_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `added_at` INTEGER NOT NULL, PRIMARY KEY(`url`))",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "url"
+          ]
+        }
+      },
+      {
+        "tableName": "remote_server",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `kind` TEXT NOT NULL, `base_url` TEXT NOT NULL, `catalog_url` TEXT, `username` TEXT, `password_cipher` TEXT, `api_key_cipher` TEXT, `account_id` TEXT, `user_id` INTEGER, `kobo_token` TEXT, `can_download` INTEGER NOT NULL, `can_manage_library` INTEGER NOT NULL, `can_upload` INTEGER NOT NULL, `can_delete` INTEGER NOT NULL, `can_read_insights` INTEGER NOT NULL, `can_admin` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `catalog_synced_at` INTEGER, `position_synced_at` INTEGER, `sync_token` TEXT, `liseur_token_cipher` TEXT, `liseur_account_id` TEXT, `sync_cursor_seq` INTEGER NOT NULL DEFAULT 0, `annotation_cursor_seq` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogUrl",
+            "columnName": "catalog_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "passwordCipher",
+            "columnName": "password_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiKeyCipher",
+            "columnName": "api_key_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "koboTokenCipher",
+            "columnName": "kobo_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "canDownload",
+            "columnName": "can_download",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canManageLibrary",
+            "columnName": "can_manage_library",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canUpload",
+            "columnName": "can_upload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canDelete",
+            "columnName": "can_delete",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canReadInsights",
+            "columnName": "can_read_insights",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canAdmin",
+            "columnName": "can_admin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogSyncedAt",
+            "columnName": "catalog_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "positionSyncedAt",
+            "columnName": "position_synced_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncToken",
+            "columnName": "sync_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurTokenCipher",
+            "columnName": "liseur_token_cipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liseurAccountId",
+            "columnName": "liseur_account_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncCursorSeq",
+            "columnName": "sync_cursor_seq",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "annotationCursorSeq",
+            "columnName": "annotation_cursor_seq",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `book_id` TEXT NOT NULL, `kind` TEXT NOT NULL, `locator_json` TEXT NOT NULL, `text` TEXT, `note` TEXT, `tint` TEXT, `chapter` TEXT, `position` INTEGER, `total_progression` REAL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJson",
+            "columnName": "locator_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tint",
+            "columnName": "tint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapter",
+            "columnName": "chapter",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalProgression",
+            "columnName": "total_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_typography",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `font` TEXT NOT NULL, `font_size` REAL NOT NULL, `line_height` REAL, `page_margins` REAL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "font",
+            "columnName": "font",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "font_size",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineHeight",
+            "columnName": "line_height",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pageMargins",
+            "columnName": "page_margins",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_screen",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `keep_screen_on` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keepScreenOn",
+            "columnName": "keep_screen_on",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "book_reading_mode",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `scroll` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scroll",
+            "columnName": "scroll",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `book_url` TEXT NOT NULL, `started_at` INTEGER NOT NULL, `ended_at` INTEGER, `last_checkpoint_at` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `start_progression` REAL, `end_progression` REAL, `idle_ms` INTEGER, `uploaded_at` INTEGER, `legacy_evidence_unknown` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "ended_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastCheckpointAt",
+            "columnName": "last_checkpoint_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startProgression",
+            "columnName": "start_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "endProgression",
+            "columnName": "end_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "idleMs",
+            "columnName": "idle_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "uploadedAt",
+            "columnName": "uploaded_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "legacyEvidenceUnknown",
+            "columnName": "legacy_evidence_unknown",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_sessions_book_url",
+            "unique": false,
+            "columnNames": [
+              "book_url"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_book_url` ON `${TABLE_NAME}` (`book_url`)"
+          },
+          {
+            "name": "index_reading_sessions_started_at",
+            "unique": false,
+            "columnNames": [
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_sessions_started_at` ON `${TABLE_NAME}` (`started_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_peer_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `acked_revision` INTEGER NOT NULL DEFAULT 0, `agreed_progression` REAL, `agreed_status` TEXT, `pending_progression` REAL, `pending_locator_json` TEXT, `pending_edition_sha` TEXT, `pending_status` TEXT, `pending_updated_at` INTEGER, `has_pending` INTEGER NOT NULL DEFAULT 0, `remote_updated_at` INTEGER, `synced_at` INTEGER, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ackedRevision",
+            "columnName": "acked_revision",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agreedProgression",
+            "columnName": "agreed_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "agreedStatus",
+            "columnName": "agreed_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingProgression",
+            "columnName": "pending_progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pendingLocatorJson",
+            "columnName": "pending_locator_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingEditionSha",
+            "columnName": "pending_edition_sha",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingStatus",
+            "columnName": "pending_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingUpdatedAt",
+            "columnName": "pending_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasPending",
+            "columnName": "has_pending",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "remoteUpdatedAt",
+            "columnName": "remote_updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "synced_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_peer_state_peer_id",
+            "unique": false,
+            "columnNames": [
+              "peer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_peer_state_peer_id` ON `${TABLE_NAME}` (`peer_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_fingerprint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `sha256` TEXT NOT NULL, `partial_md5` TEXT NOT NULL, `file_size` INTEGER NOT NULL, `file_modified_at` INTEGER, `computed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256",
+            "columnName": "sha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partialMd5",
+            "columnName": "partial_md5",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileModifiedAt",
+            "columnName": "file_modified_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "computedAt",
+            "columnName": "computed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url"
+          ]
+        }
+      },
+      {
+        "tableName": "work_alias",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_id` TEXT NOT NULL, `confidence` TEXT NOT NULL, `confirmed` INTEGER NOT NULL, `seeded` INTEGER NOT NULL DEFAULT 0, `source_sent` INTEGER NOT NULL DEFAULT 0, `edition_sha` TEXT, `annotations_reconciled_at` INTEGER NOT NULL DEFAULT 0, `resolved_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confirmed",
+            "columnName": "confirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seeded",
+            "columnName": "seeded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceSent",
+            "columnName": "source_sent",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "editionSha",
+            "columnName": "edition_sha",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "annotationsReconciledAt",
+            "columnName": "annotations_reconciled_at",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "resolvedAt",
+            "columnName": "resolved_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "work_ambiguity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `work_ids` TEXT NOT NULL, `noticed_at` INTEGER NOT NULL, PRIMARY KEY(`book_url`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workIds",
+            "columnName": "work_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noticedAt",
+            "columnName": "noticed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_extra",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`series_id` TEXT NOT NULL, `summary` TEXT, `status` TEXT, `total_book_count` INTEGER, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`series_id`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "series_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalBookCount",
+            "columnName": "total_book_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "series_id"
+          ]
+        }
+      },
+      {
+        "tableName": "annotation_sync",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `book_id` TEXT NOT NULL, `work_id` TEXT NOT NULL, `rev` INTEGER NOT NULL, `seq` INTEGER NOT NULL, `acked_fingerprint` TEXT, `pending_kind` TEXT, `pending_json` TEXT, `pending_rev` INTEGER NOT NULL, `pending_fingerprint` TEXT, `rejected_fingerprint` TEXT, `retry_not_before` INTEGER NOT NULL, PRIMARY KEY(`id`, `peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "work_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rev",
+            "columnName": "rev",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seq",
+            "columnName": "seq",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ackedFingerprint",
+            "columnName": "acked_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingKind",
+            "columnName": "pending_kind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingJson",
+            "columnName": "pending_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingRev",
+            "columnName": "pending_rev",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pendingFingerprint",
+            "columnName": "pending_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "rejectedFingerprint",
+            "columnName": "rejected_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "retryNotBefore",
+            "columnName": "retry_not_before",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotation_sync_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotation_sync_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          },
+          {
+            "name": "index_annotation_sync_work_id",
+            "unique": false,
+            "columnNames": [
+              "work_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotation_sync_work_id` ON `${TABLE_NAME}` (`work_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kosync_peer",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `base_url` TEXT NOT NULL, `username` TEXT NOT NULL, `key_cipher` TEXT NOT NULL, `added_at` INTEGER NOT NULL, `position_synced_at` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keyCipher",
+            "columnName": "key_cipher",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSyncedAt",
+            "columnName": "position_synced_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "upload_refusal",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_url` TEXT NOT NULL, `account_key` TEXT NOT NULL, `refused_at` INTEGER NOT NULL, `kind` TEXT NOT NULL, `reason` TEXT, `content_sha256` TEXT, `seen_at` INTEGER, PRIMARY KEY(`book_url`, `account_key`), FOREIGN KEY(`book_url`) REFERENCES `books`(`url`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookUrl",
+            "columnName": "book_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountKey",
+            "columnName": "account_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "refusedAt",
+            "columnName": "refused_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reason",
+            "columnName": "reason",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentSha256",
+            "columnName": "content_sha256",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seenAt",
+            "columnName": "seen_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_url",
+            "account_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_upload_refusal_account_key_seen_at",
+            "unique": false,
+            "columnNames": [
+              "account_key",
+              "seen_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_upload_refusal_account_key_seen_at` ON `${TABLE_NAME}` (`account_key`, `seen_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "book_url"
+            ],
+            "referencedColumns": [
+              "url"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "session_refusal",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`peer_id` TEXT NOT NULL, `session_id` INTEGER NOT NULL, `wire_session_id` TEXT NOT NULL, `code` TEXT, `refused_at` INTEGER NOT NULL, PRIMARY KEY(`peer_id`, `session_id`), FOREIGN KEY(`session_id`) REFERENCES `reading_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wireSessionId",
+            "columnName": "wire_session_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "refusedAt",
+            "columnName": "refused_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "peer_id",
+            "session_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_session_refusal_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_refusal_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "reading_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "session_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "session_transmission",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`peer_id` TEXT NOT NULL, `session_id` INTEGER NOT NULL, `device_id` TEXT NOT NULL, `payload` TEXT NOT NULL, PRIMARY KEY(`peer_id`, `session_id`), FOREIGN KEY(`session_id`) REFERENCES `reading_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "peer_id",
+            "session_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_session_transmission_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_transmission_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "reading_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "session_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3cee1b0a453b59a17ae5e3b9e8a964b7')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -405,6 +405,7 @@ class AppContainer(context: Context) {
         CompositePositionSync(
             listOf(RoutedPositionSync(remoteRouter), kosyncSync),
         ),
+        carryOn = { PositionSyncWorker.continueBootstrap(context.applicationContext) },
     )
 
     private val latestPositionSync = LatestPositionSync(

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/Book.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/Book.kt
@@ -241,6 +241,11 @@ interface BookDao {
      * The book to carry on with: the one read most recently anywhere,
      * not merely the one opened last on this device. Reading arriving
      * from another phone counts, which is the whole point of syncing it.
+     *
+     * "Most recently" is when the reading happened, not when this device
+     * heard about it, so a fresh install that has just imported a whole
+     * history offers the book that was actually left open rather than
+     * whichever one the sync mentioned last.
      */
     @Query(MOST_RECENT)
     fun observeMostRecent(): Flow<Book?>
@@ -862,7 +867,7 @@ interface BookDao {
               )
             ORDER BY MAX(
                 COALESCE(books.last_opened_at, 0),
-                COALESCE(reading_progress.updated_at, 0)
+                COALESCE(reading_progress.read_at, reading_progress.updated_at, 0)
             ) DESC
             LIMIT 1
         """

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/LiseurDatabase.kt
@@ -29,7 +29,7 @@ import androidx.sqlite.execSQL
         SessionRefusal::class,
         SessionTransmission::class,
     ],
-    version = 48,
+    version = 49,
     exportSchema = true,
 )
 abstract class LiseurDatabase : RoomDatabase() {
@@ -1282,6 +1282,61 @@ abstract class LiseurDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Tells the moment a book was read from the moment this device
+         * heard about it.
+         *
+         * `updated_at` still means what it always did — when this device
+         * last wrote the row — but the shelf used to order by it, and a
+         * pull writes it with the local clock. So importing a year of
+         * reading from another phone filed every book as read just now,
+         * and the next batch to arrive shuffled them all again.
+         *
+         * The backfill can tell the two apart because both pull paths
+         * set `synced_at` and `updated_at` to the same instant in one
+         * statement, while a page turn here moves only `updated_at` and
+         * an acknowledgement moves only `synced_at`. Equality therefore
+         * holds exactly for a row whose position last came from a pull,
+         * which is the row carrying an import timestamp. Anything else
+         * keeps a null `read_at` and falls back to `updated_at`, which
+         * for those rows is the truth already.
+         *
+         * Deliberately conservative: it repairs only what it can prove.
+         * Two kinds of pulled row are left alone rather than guessed at,
+         * because the evidence for them is gone.
+         *
+         * `retireAccountState` clears `synced_at` on every row when an
+         * account is dropped, so a device that has switched accounts has
+         * no equality left to test and keeps the shelf it has. And
+         * `setStatusOnly` — someone marking a book read elsewhere
+         * without opening it — moves `remote_updated_at` past
+         * `updated_at` without touching the position, which the
+         * `remote_updated_at <= updated_at` guard then rejects. Filing
+         * such a row under the time somebody pressed a button is worse
+         * than leaving it where it is.
+         *
+         * Both cases keep exactly today's behaviour, and both correct
+         * themselves the next time the book is read or its position
+         * pulled again. The alternative is inventing a reading time out
+         * of a timestamp that does not record one.
+         */
+        val MIGRATION_48_49 = object : Migration(48, 49) {
+            override fun migrate(connection: SQLiteConnection) {
+                connection.execSQL("ALTER TABLE reading_progress ADD COLUMN read_at INTEGER")
+                connection.execSQL(
+                    """
+                    UPDATE reading_progress
+                    SET read_at = remote_updated_at
+                    WHERE remote_updated_at IS NOT NULL
+                      AND remote_updated_at > 0
+                      AND remote_updated_at <= updated_at
+                      AND synced_at IS NOT NULL
+                      AND synced_at = updated_at
+                    """.trimIndent(),
+                )
+            }
+        }
+
         val MIGRATIONS: Array<Migration> get() = arrayOf(
             MIGRATION_1_2,
             MIGRATION_2_3,
@@ -1330,6 +1385,7 @@ abstract class LiseurDatabase : RoomDatabase() {
             MIGRATION_45_46,
             MIGRATION_46_47,
             MIGRATION_47_48,
+            MIGRATION_48_49,
         )
     }
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/ReadingProgress.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/ReadingProgress.kt
@@ -49,6 +49,20 @@ data class ReadingProgress(
     val readingPaceEvidence: Double = 0.0,
     /** When this device last touched the position. */
     @ColumnInfo(name = "updated_at") val updatedAt: Long,
+    /**
+     * When the reading this position records actually happened, on
+     * whichever device did it. Null when nothing better than
+     * [updatedAt] is known.
+     *
+     * [updatedAt] is when this device last wrote the row, which for a
+     * position taken from a server is when it heard about the reading
+     * rather than when the reading happened. Ordering a shelf by that
+     * files a year of imported history under "just now", and files it
+     * again in a different order the next time a batch arrives. So a
+     * pull records the other device's own timestamp here, and the shelf
+     * reads this.
+     */
+    @ColumnInfo(name = "read_at") val readAt: Long? = null,
     /** Reading status as calibre-web's Kobo sync understands it. */
     @ColumnInfo(name = "status") val status: String? = null,
     /** When this position was last agreed with the server, if ever. */
@@ -103,7 +117,7 @@ data class ReadingProgress(
 /** When a book was last read, on this device or another one. */
 data class BookReadAt(
     @ColumnInfo(name = "book_url") val bookUrl: String,
-    @ColumnInfo(name = "updated_at") val updatedAt: Long,
+    @ColumnInfo(name = "read_at") val readAt: Long,
 )
 
 /** How far through a book the reader is, if anything is known. */
@@ -151,9 +165,36 @@ abstract class ReadingProgressDao {
      * When each book was last read. The position is written both by
      * turning a page here and by taking one from the server, so this is
      * the last time a book was read anywhere, not just on this device.
+     *
+     * It is the reading's own time, not the time this device wrote it
+     * down: a position pulled from another phone keeps the timestamp
+     * that phone recorded, so importing old reading reproduces the
+     * order it was read in instead of inventing one from the moment the
+     * sync happened to run.
+     *
+     * A row with neither a progression nor a locator is left out. Such a
+     * row records no reading — it is made to exist by a pull that then
+     * declined to apply, or by a remote state waiting to be settled —
+     * and reporting one would tell the shelf the book is being read.
      */
-    @Query("SELECT book_url, updated_at FROM reading_progress")
+    @Query(
+        """
+        SELECT book_url, COALESCE(read_at, updated_at) AS read_at
+        FROM reading_progress
+        WHERE total_progression IS NOT NULL OR locator_json != '{}'
+        """,
+    )
     abstract fun observeReadAt(): kotlinx.coroutines.flow.Flow<List<BookReadAt>>
+
+    /** [observeReadAt], asked once, for deciding what to sync first. */
+    @Query(
+        """
+        SELECT book_url, COALESCE(read_at, updated_at) AS read_at
+        FROM reading_progress
+        WHERE total_progression IS NOT NULL OR locator_json != '{}'
+        """,
+    )
+    abstract suspend fun readAtOnce(): List<BookReadAt>
 
     /**
      * How far through each book the reader is, watched.
@@ -198,6 +239,7 @@ abstract class ReadingProgressDao {
             reading_pace_evidence =
                 COALESCE(:readingPaceEvidence, reading_pace_evidence),
             updated_at = :updatedAt,
+            read_at = :updatedAt,
             status = :status,
             local_revision = local_revision + 1
         WHERE book_url = :bookUrl
@@ -221,12 +263,12 @@ abstract class ReadingProgressDao {
             book_url, locator_json, total_progression, reading_speed,
             reading_seconds_per_position, reading_pace_samples,
             reading_pace_elapsed_ms, reading_pace_evidence,
-            updated_at, status, synced_at, local_revision, acked_revision
+            updated_at, read_at, status, synced_at, local_revision, acked_revision
         )
         VALUES (:bookUrl, :locatorJson, :progression, NULL,
                 :readingSecondsPerPosition, COALESCE(:readingPaceSamples, 0),
                 COALESCE(:readingPaceElapsedMs, 0), COALESCE(:readingPaceEvidence, 0),
-                :updatedAt, :status, NULL, 1, 0)
+                :updatedAt, :updatedAt, :status, NULL, 1, 0)
         """,
     )
     abstract suspend fun insertLocal(
@@ -418,6 +460,7 @@ abstract class ReadingProgressDao {
             account = account,
             remoteUpdatedAt = remoteUpdatedAt,
             now = now,
+            readAt = readAtFor(remoteUpdatedAt, now),
             locatorJson = locatorJson,
         )
         if (applied > 0) clearPending(bookUrl)
@@ -431,6 +474,7 @@ abstract class ReadingProgressDao {
             locator_json = COALESCE(:locatorJson, '{}'),
             status = :status,
             updated_at = :now,
+            read_at = :readAt,
             synced_at = :now,
             remote_updated_at = :remoteUpdatedAt,
             agreed_progression = :progression,
@@ -450,6 +494,7 @@ abstract class ReadingProgressDao {
         account: String,
         remoteUpdatedAt: Long?,
         now: Long,
+        readAt: Long,
         locatorJson: String?,
     ): Int
 
@@ -699,6 +744,7 @@ abstract class ReadingProgressDao {
             progression = progression,
             status = status,
             now = now,
+            readAt = readAtFor(remoteUpdatedAt, now),
             locatorJson = locatorJson,
             remoteUpdatedAt = remoteUpdatedAt,
         ) > 0
@@ -722,6 +768,7 @@ abstract class ReadingProgressDao {
             locator_json = COALESCE(:locatorJson, '{}'),
             status = :status,
             updated_at = :now,
+            read_at = :readAt,
             synced_at = :now,
             remote_updated_at = :remoteUpdatedAt,
             local_revision = local_revision + 1
@@ -734,6 +781,7 @@ abstract class ReadingProgressDao {
         progression: Double,
         status: String,
         now: Long,
+        readAt: Long,
         locatorJson: String?,
         remoteUpdatedAt: Long?,
     ): Int
@@ -907,3 +955,20 @@ abstract class ReadingProgressDao {
     )
     abstract suspend fun ownedByOther(account: String): List<ReadingProgress>
 }
+
+/**
+ * The moment the reading being adopted happened, as well as it can be
+ * known.
+ *
+ * A server reports when the reading was recorded on the device that did
+ * it, and that is what the shelf wants: importing a year of history must
+ * reproduce the other device's order rather than file everything under
+ * the minute the sync ran. Nothing better exists when the server says
+ * nothing, so the local clock stands in.
+ *
+ * Clamped to [now] because the timestamp is another device's wall clock.
+ * One running fast would otherwise pin a book to the top of the shelf
+ * until it caught up.
+ */
+internal fun readAtFor(remoteUpdatedAt: Long?, now: Long): Long =
+    remoteUpdatedAt?.takeIf { it > 0 }?.coerceAtMost(now) ?: now

--- a/app/src/main/kotlin/com/chmouel/liseur/data/db/WorkIdentity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/db/WorkIdentity.kt
@@ -223,6 +223,17 @@ interface WorkIdentityDao {
     @Upsert
     suspend fun upsert(ambiguity: WorkAmbiguity)
 
+    /**
+     * The books this server could not tell apart from another.
+     *
+     * A naming pass reads these so that a question already on file is
+     * not mistaken for one it has just raised: an ambiguity is filed on
+     * its own rather than as an alias, so without this a book the server
+     * cannot place looks unasked about on every single run.
+     */
+    @Query("SELECT * FROM work_ambiguity WHERE peer_id = :peerId")
+    suspend fun ambiguitiesFor(peerId: String): List<WorkAmbiguity>
+
     @Query("SELECT COUNT(*) FROM work_ambiguity WHERE peer_id = :peerId")
     suspend fun ambiguityCount(peerId: String): Int
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncApi.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncApi.kt
@@ -67,6 +67,14 @@ object LiseurSyncApi {
     fun positions(baseUrl: String, workId: String, limit: Int): String =
         url(baseUrl, "/v1/works/$workId/positions?limit=$limit")
 
+    /**
+     * The newest position the account holds for each of its works.
+     *
+     * The resync route, which is also the cheapest way to tell a device
+     * that has just named a whole library where every book stands.
+     */
+    fun heads(baseUrl: String): String = url(baseUrl, HEADS)
+
     /** One page of the annotation feed, tombstones included (ADR-0028). */
     fun annotationChanges(baseUrl: String, since: Long, limit: Int): String =
         url(baseUrl, "$ANNOTATIONS/changes?since=$since&limit=$limit")

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
@@ -451,7 +451,8 @@ class LiseurSyncPositionSync(
 
         // Names first: an op is about a work id, so a book with no name
         // can neither receive what arrived nor send what is owed.
-        val aliases = name(account, books, single = book != null, trouble)
+        val named = name(account, books, single = book != null, trouble)
+        val aliases = named.aliases
 
         /**
          * Gives up when the server has stopped answering.
@@ -539,14 +540,24 @@ class LiseurSyncPositionSync(
         return if (firstFailure == null) {
             forAccount(account) { serverDao.setPositionSyncedAt(at) }
             reporting.report(PositionSyncStatus.Synced(at))
-            SyncOutcome.Success
+            named.outcome()
         } else {
             Log.i(TAG, "Some positions did not settle: ${firstFailure.label}")
             reporting.report(PositionSyncStatus.Failed(firstFailure))
-            if (pulled > 0 || pushed > 0 || marked > 0) {
-                SyncOutcome.Partial(firstFailure)
-            } else {
-                SyncOutcome.Failure(firstFailure)
+            when {
+                // A refusal that will still be a refusal in an hour
+                // must not take the rest of the library down with it.
+                // One stale book among six hundred is exactly the
+                // shape of this: nothing is going to come of retrying
+                // it, and the other five hundred and ninety-nine are
+                // still owed a name. The reader has already been told
+                // what failed — that is the report just above, not the
+                // outcome — so carrying on costs them nothing.
+                !firstFailure.worthRetrying && named.owing > 0 && named.done > 0 ->
+                    SyncOutcome.Incomplete
+
+                pulled > 0 || pushed > 0 || marked > 0 -> SyncOutcome.Partial(firstFailure)
+                else -> SyncOutcome.Failure(firstFailure)
             }
         }
     }
@@ -629,21 +640,46 @@ class LiseurSyncPositionSync(
     /**
      * Makes sure the books of interest have a name on this server.
      *
-     * Resolving costs a request and, the first time, reading the whole
-     * file to hash it. So a full run resolves only a handful of unnamed
-     * books each time, newest reading first, and the rest catch up over
-     * the following runs — whereas asking about one book on purpose
-     * resolves that book whatever it costs, because somebody is waiting.
+     * Resolving costs a request, and for a book this server does not
+     * catalog it also costs reading the whole file to hash it. So the
+     * two are rationed apart: a full run hashes only a handful of files,
+     * newest reading first, and the rest catch up over the following
+     * runs — while a book the server already holds is named freely,
+     * since the server reads the identifiers off its own record and
+     * nothing here has to be opened.
+     *
+     * That distinction is what lets a fresh device finish. Every book on
+     * one connected to liseur-sync came from its catalog, and rationing
+     * those to a handful a run is what made the shelf arrive in batches.
+     *
+     * Asking about one book on purpose resolves that book whatever it
+     * costs, because somebody is waiting.
      */
     private suspend fun name(
         account: Account,
         books: List<Book>,
         single: Boolean,
         trouble: Trouble,
-    ): List<Pair<Book, WorkAlias>> {
+    ): Named {
         val known = identityDao.aliasesFor(account.peerId).associateBy { it.bookUrl }
+        // A book whose question is already on file. That question may be
+        // filed on its own, as an ambiguity, or as a name the server was
+        // not sure enough of to use — either way the reader has already
+        // been asked, and asking again is not getting anywhere.
+        val asked = buildSet {
+            identityDao.ambiguitiesFor(account.peerId).mapTo(this) { it.bookUrl }
+            known.values.filter { it.awaitingAnswer }.mapTo(this) { it.bookUrl }
+        }
         val out = mutableListOf<Pair<Book, WorkAlias>>()
-        var budget = if (single) books.size else MAX_RESOLVES_PER_RUN
+        // Books that have just been given a name and have yet to be told
+        // where they stand. Collected rather than asked about one at a
+        // time: on a fresh device that is every book in the library, and
+        // one request can answer for all of them.
+        val owed = mutableListOf<Pair<Book, WorkAlias>>()
+        var files = if (single) books.size else MAX_FILE_RESOLVES_PER_RUN
+        var catalogued = if (single) books.size else MAX_CATALOG_RESOLVES_PER_RUN
+        var deferred = 0
+        var fresh = 0
 
         /** Notes why something could not be had, and whether it was the network. */
         fun note(cause: IOException?) {
@@ -651,7 +687,37 @@ class LiseurSyncPositionSync(
             trouble.failed(cause, reason)
         }
 
-        val ordered = books.sortedByDescending { it.lastOpenedAt ?: 0 }
+        /**
+         * Whether there is still room to ask about [book], spending it
+         * if so. Which purse it comes out of is the file's: hashing one
+         * is the cost worth rationing, and a catalog book has none.
+         */
+        fun afford(book: Book): Boolean {
+            val catalog = works.catalogIdOf(book) != null
+            val left = if (catalog) catalogued else files
+            if (left <= 0) {
+                deferred++
+                return false
+            }
+            if (catalog) catalogued-- else files--
+            return true
+        }
+
+        // Newest reading first, wherever it was done. Before there was a
+        // read time to sort on this used the last time the book was
+        // opened here, which on a fresh device is null for every book —
+        // so the promise of "newest first" was really title order.
+        val readAt = progressDao.readAtOnce().associate { it.bookUrl to it.readAt }
+        // A book the server has already failed to place goes last. It
+        // is still worth asking about — another device may have named
+        // it since — but not out of the same purse as a book nobody has
+        // asked about at all, or a library with more open questions than
+        // budget would spend every run repeating them and never reach
+        // the books behind them.
+        val ordered = books.sortedWith(
+            compareBy<Book> { it.url in asked }
+                .thenByDescending { maxOf(readAt[it.url] ?: 0, it.lastOpenedAt ?: 0) },
+        )
         for (candidate in ordered) {
             if (trouble.unreachable != null) break
             val cached = known[candidate.url]
@@ -662,12 +728,18 @@ class LiseurSyncPositionSync(
                 // can match on the catalog entry instead of asking the
                 // reader. Failing is fine: the cached name still works,
                 // and the debt stands until it is paid.
-                if (works.owesSource(cached, candidate) && budget > 0) {
-                    budget--
+                if (works.owesSource(cached, candidate) && afford(candidate)) {
                     val refreshed =
                         works.resolve(candidate, account.peerId, account.baseUrl, account.credentials)
                     if (refreshed is WorkResolution.Named) {
                         alias = refreshed.alias
+                        // Paying that debt is getting somewhere, and it
+                        // can only be paid once: the next run finds
+                        // nothing owed and asks nothing. A re-resolve
+                        // that left the debt standing is not, or a
+                        // server that keeps saying no would look like
+                        // progress for ever.
+                        if (!works.owesSource(alias, candidate)) fresh++
                     } else {
                         note((refreshed as? WorkResolution.Unresolved)?.cause)
                     }
@@ -677,35 +749,217 @@ class LiseurSyncPositionSync(
                 // a doubtful match confirmed by hand — still owes
                 // it: whatever the server heard before the name was
                 // usable is behind the cursor.
-                if (!alias.seeded && budget > 0 && trouble.unreachable == null) {
-                    budget--
-                    note(seed(account, candidate, alias))
-                }
+                if (!alias.seeded) owed += candidate to alias
                 continue
             }
             // A guess the file or the catalog id could settle is worth
             // asking about again; any other unusable alias has asked
             // its question and waits for the answer.
             if (cached != null && !works.retryable(cached, candidate)) continue
-            if (budget <= 0) continue
-            budget--
+            if (!afford(candidate)) continue
             when (
                 val resolved =
                     works.resolve(candidate, account.peerId, account.baseUrl, account.credentials)
             ) {
                 is WorkResolution.Named -> {
                     out += candidate to resolved.alias
+                    fresh++
                     // Everything that happened to this book before it had
-                    // a name is behind the cursor, so it is asked for
-                    // once, directly.
-                    note(seed(account, candidate, resolved.alias))
+                    // a name is behind the cursor, so it has to be asked
+                    // for outright rather than waited for.
+                    owed += candidate to resolved.alias
                 }
 
-                is WorkResolution.NeedsConfirming, is WorkResolution.Ambiguous -> Unit
+                // Not a name, but an answer, and one that is written
+                // down — as an alias awaiting confirmation, or as an
+                // ambiguity: the reader is now being asked about this
+                // book rather than nothing being known about it. That
+                // counts as getting somewhere the *first* time it
+                // happens and never again. A question this run merely
+                // repeated leaves the next run facing exactly what this
+                // one faced, and calling that progress is how a chain
+                // of runs would never end.
+                is WorkResolution.NeedsConfirming, is WorkResolution.Ambiguous ->
+                    if (cached == null && candidate.url !in asked) fresh++
                 is WorkResolution.Unresolved -> note(resolved.cause)
             }
         }
-        return out
+        val seeded = seedAll(account, owed, single, trouble)
+        return Named(
+            aliases = out,
+            done = fresh + seeded.done,
+            owing = deferred + seeded.owing,
+        )
+    }
+
+    /**
+     * What a naming pass managed, and what it left for the next one.
+     *
+     * Together these are what let a fresh connection finish by itself.
+     * [owing] is what is still to do — a book with no name, or one named
+     * but not yet told where it stands; either leaves the shelf
+     * incomplete. [done] is what this run actually got through, and
+     * requiring it is what makes the chain stop: a run that achieved
+     * nothing would only achieve nothing again, however much is owed.
+     *
+     * Both count work finished rather than work attempted, so a step
+     * that keeps failing cannot pass for progress.
+     */
+    private data class Named(
+        val aliases: List<Pair<Book, WorkAlias>>,
+        val done: Int,
+        val owing: Int,
+    ) {
+        /**
+         * Whether a run that went well has reason to ask for another.
+         *
+         * Both halves matter. Something owed without anything done
+         * would be a run repeating itself for as long as the phone is
+         * on; something done without anything owed is simply finished.
+         */
+        fun outcome(): SyncOutcome =
+            if (owing > 0 && done > 0) SyncOutcome.Incomplete else SyncOutcome.Success
+    }
+
+    /** What a seeding pass got through, and what it left owed. */
+    private data class Seeded(val done: Int, val owing: Int)
+
+    /** What the account's heads answered, and what it answered unreadably. */
+    private data class Heads(
+        val newest: Map<String, SyncOp>,
+        val unreadable: Set<String>,
+    )
+
+    /**
+     * Tells every newly named book where it stands.
+     *
+     * `GET /v1/heads` answers for the whole account at once — the newest
+     * position per work — which is exactly the shape of this question
+     * when a fresh device has just named its entire library. Asking per
+     * book instead would be one request each, and the run would be
+     * rationed all over again by a limit that was only ever about
+     * hashing files.
+     *
+     * The cursor is deliberately not moved. A seed is not a pull: the
+     * snapshot the heads were read from says nothing about the pages
+     * this device has reconciled, and the cursor only ever advances in
+     * the transaction that writes the page it covers.
+     *
+     * Falling back to the per-book route matters for a server too old to
+     * have heads and for the single-book run, where one answer is all
+     * that is wanted and somebody is waiting for it.
+     */
+    private suspend fun seedAll(
+        account: Account,
+        owed: List<Pair<Book, WorkAlias>>,
+        single: Boolean,
+        trouble: Trouble,
+    ): Seeded {
+        if (owed.isEmpty()) return Seeded(done = 0, owing = 0)
+        if (trouble.unreachable != null) return Seeded(done = 0, owing = owed.size)
+
+        if (!single && owed.size > 1) {
+            val heads = try {
+                headOps(account)
+            } catch (e: IOException) {
+                Log.i(TAG, "Could not read the account's heads; seeding one by one", e)
+                // Not handed to Trouble as a failure: the per-book route
+                // below is about to ask the same question, and its
+                // answer is the one worth reporting.
+                null
+            }
+            if (heads != null) {
+                // A work whose newest record could not be read is asked
+                // about on its own below. Heads carries only the newest,
+                // and an older op behind an unreadable one may still
+                // hold a position this device can use — which is the
+                // window the per-book route already scans. Sealing an
+                // empty answer over one of those would lose a reading
+                // that was there to be had, and `markSeeded` is not
+                // asked twice.
+                val (doubtful, plain) = owed.partition { (_, alias) ->
+                    alias.workId in heads.unreadable
+                }
+                forAccount(account) {
+                    for ((book, alias) in plain) {
+                        heads.newest[alias.workId]?.let { land(account, book.url, it) }
+                        // An empty answer is still an answer, exactly as
+                        // it is for a single seed: the server has heard
+                        // nothing about this work.
+                        identityDao.markSeeded(book.url, account.peerId)
+                    }
+                }
+                if (doubtful.isEmpty()) return Seeded(done = owed.size, owing = 0)
+                val rest = seedEach(account, doubtful, single, trouble)
+                return Seeded(done = plain.size + rest.done, owing = rest.owing)
+            }
+        }
+
+        return seedEach(account, owed, single, trouble)
+    }
+
+    /**
+     * Tells newly named books where they stand, one request each.
+     *
+     * The route for a server too old to have heads, for the single-book
+     * run where somebody is waiting on one answer, and for the work
+     * whose head came back unreadable — that last one because this asks
+     * for a window of ops rather than only the newest, and so can find
+     * a position behind a record this device cannot read.
+     */
+    private suspend fun seedEach(
+        account: Account,
+        owed: List<Pair<Book, WorkAlias>>,
+        single: Boolean,
+        trouble: Trouble,
+    ): Seeded {
+        // One at a time, and rationed, because each is a request. What
+        // is left over is owed rather than forgotten: a book that has a
+        // name but has never asked where it stands will not find out
+        // from the delta pull, whose cursor has long since passed the
+        // answer.
+        var done = 0
+        var budget = if (single) owed.size else MAX_SEEDS_PER_RUN
+        for ((index, entry) in owed.withIndex()) {
+            val (book, alias) = entry
+            if (trouble.unreachable != null || budget-- <= 0) {
+                return Seeded(done = done, owing = owed.size - index)
+            }
+            val failure = seed(account, book, alias)
+            if (failure == null) done++ else trouble.failed(failure, reasonFor(failure))
+        }
+        return Seeded(done = done, owing = owed.size - done)
+    }
+
+    /**
+     * The newest position the account holds for each of its works, and
+     * the works whose newest record could not be read.
+     *
+     * Those are kept apart rather than dropped. Heads answers with the
+     * newest op per work and device, so a work whose head is unreadable
+     * has nothing left in this answer to fall back on, and treating it
+     * as "the server has heard nothing" would seal an empty seed over a
+     * position an older op still holds.
+     */
+    private suspend fun headOps(account: Account): Heads {
+        val array = http.get(LiseurSyncApi.heads(account.baseUrl), account.credentials)
+            .optJSONArray("ops")
+        val newest = mutableMapOf<String, SyncOp>()
+        val unreadable = mutableSetOf<String>()
+        for (index in 0 until (array?.length() ?: 0)) {
+            val json = array?.optJSONObject(index) ?: continue
+            val op = SyncOps.fromJson(json)
+            if (op == null) {
+                // The work is named at the top of the record, so which
+                // book to ask about again is known even when the
+                // position inside it is not.
+                json.optString("work_id").takeIf { it.isNotEmpty() }?.let(unreadable::add)
+                continue
+            }
+            val held = newest[op.workId]
+            if (held == null || op.seq > held.seq) newest[op.workId] = op
+        }
+        return Heads(newest = newest, unreadable = unreadable)
     }
 
     /**
@@ -1791,7 +2045,34 @@ class LiseurSyncPositionSync(
          * top of a good one, not an attempt to reconstruct history.
          */
         const val LATEST_WINDOW = 20
-        const val MAX_RESOLVES_PER_RUN = 25
+
+        /**
+         * How many files one run will open and hash to name their books.
+         *
+         * The cost being rationed is reading a whole book off the disk,
+         * not the request that follows it.
+         */
+        const val MAX_FILE_RESOLVES_PER_RUN = 25
+
+        /**
+         * How many books this server already catalogs one run will name.
+         *
+         * Far higher, because the server reads the identifiers off its
+         * own record and nothing here is opened: the cost is one small
+         * request each. High enough that an ordinary library is named in
+         * a single run, which is what stops a fresh device receiving its
+         * shelf in batches — and still a limit, so a library of tens of
+         * thousands does not turn one refresh into an afternoon.
+         */
+        const val MAX_CATALOG_RESOLVES_PER_RUN = 500
+
+        /**
+         * How many books one run will ask about individually when the
+         * whole-account route is unavailable. Only the fallback path
+         * spends this; a server with `/v1/heads` answers for every book
+         * at once.
+         */
+        const val MAX_SEEDS_PER_RUN = 25
         val ACCEPTED = setOf("applied", "duplicate")
         const val CONFLICT = "conflict"
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/PeerPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/PeerPositionSync.kt
@@ -177,6 +177,17 @@ class CompositePositionSync(private val peers: List<PeerPositionSync>) : Positio
      * has to keep saying so. One peer succeeding does not make a
      * failure elsewhere go away: it makes the run partial, which is
      * retried while still leaving what did settle settled.
+     *
+     * A peer with more to fetch has to be heard over one that is
+     * finished, or a connection still finding its feet would look
+     * complete because the peer beside it had nothing to do. A failure
+     * worth retrying wins over it: that retry covers the shortfall too.
+     * One that is not worth retrying does not, and must not — the
+     * outcome decides nothing else for such a reason, since a partial
+     * run that will not be retried and a run carrying on both end the
+     * worker without a backoff, and letting it through would leave a
+     * fresh connection half-named for as long as some unrelated
+     * account stayed locked out.
      */
     private fun fold(outcomes: List<SyncOutcome>): SyncOutcome {
         if (outcomes.isEmpty()) return SyncOutcome.NotApplicable
@@ -187,11 +198,22 @@ class CompositePositionSync(private val peers: List<PeerPositionSync>) : Positio
                 else -> null
             }
         }
-        val anySuccess = outcomes.any { it == SyncOutcome.Success || it is SyncOutcome.Partial }
+        val anyIncomplete = outcomes.any { it == SyncOutcome.Incomplete }
+        val anySuccess = outcomes.any {
+            it == SyncOutcome.Success || it == SyncOutcome.Incomplete || it is SyncOutcome.Partial
+        }
+        val retryable = outcomes.any {
+            it is SyncOutcome.Failure && it.reason.worthRetrying ||
+                it is SyncOutcome.Partial && it.reason.worthRetrying
+        }
         return when {
-            reason == null ->
-                if (anySuccess) SyncOutcome.Success else SyncOutcome.NotApplicable
+            reason == null -> when {
+                anyIncomplete -> SyncOutcome.Incomplete
+                anySuccess -> SyncOutcome.Success
+                else -> SyncOutcome.NotApplicable
+            }
 
+            anyIncomplete && !retryable -> SyncOutcome.Incomplete
             anySuccess -> SyncOutcome.Partial(reason)
             else -> SyncOutcome.Failure(reason)
         }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/PositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/PositionSync.kt
@@ -27,6 +27,21 @@ sealed interface SyncOutcome {
     data object Success : SyncOutcome
 
     /**
+     * Everything the run asked for worked, and there is more to fetch.
+     *
+     * A device connecting to an account for the first time has to give
+     * every book in the library a name on the server before it can be
+     * synced, and a run will only do so many at a time. Saying so is
+     * what lets another run be scheduled straight away, so the shelf
+     * settles by itself instead of arriving in batches for as long as
+     * the reader keeps pulling to refresh.
+     *
+     * Nothing went wrong, so this is not a failure and must not be
+     * reported as one.
+     */
+    data object Incomplete : SyncOutcome
+
+    /**
      * Some books settled and some did not. The ones that did not are
      * still marked as having reading the server has not seen, so the next
      * run picks them up. Reported apart from success so a retry is

--- a/app/src/main/kotlin/com/chmouel/liseur/sync/PositionSyncCoordinator.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/sync/PositionSyncCoordinator.kt
@@ -49,7 +49,20 @@ sealed interface SyncScope {
  * Two identical requests waiting at the same time share one run, because
  * otherwise they would do the same work twice in a row.
  */
-class PositionSyncCoordinator(private val sync: PositionSync) {
+class PositionSyncCoordinator(
+    private val sync: PositionSync,
+    /**
+     * Asks for another run, for a connection that got somewhere and
+     * still has work it knows how to do.
+     *
+     * Here rather than at the call sites because a fresh connection is
+     * synced from half a dozen of them — app start, pull to refresh,
+     * connecting an account, Settings' sync now — and every one of them
+     * would otherwise have to remember to carry on, which one of them
+     * eventually would not.
+     */
+    private val carryOn: () -> Unit = {},
+) {
 
     /** Re-counts unsettled disagreements without starting a run. */
     suspend fun refreshUnresolved() = sync.refreshUnresolved()
@@ -59,6 +72,21 @@ class PositionSyncCoordinator(private val sync: PositionSync) {
 
     /** Held for the duration of a run, so only one happens at a time. */
     private val turn = Mutex()
+
+    /**
+     * How many runs in a row have asked to be carried on.
+     *
+     * A run only asks when it got somewhere and still owes work, so in
+     * principle the chain stops itself. This is the backstop for the day
+     * that reasoning is wrong somewhere: a mistake in the accounting
+     * would otherwise be a sync every fifteen seconds for as long as the
+     * phone is on, which is somebody's battery and somebody's data.
+     * Reaching the cap leaves the rest to the next app start or refresh,
+     * exactly as it was before any of this existed — and either of those
+     * starts the count over, since the cap is a guard against a run that
+     * keeps asking for itself, not a limit on how much a reader may sync.
+     */
+    private var carriedOn = 0
 
     /** Guards the bookkeeping below, and is never held across a sync. */
     private val state = Mutex()
@@ -116,6 +144,10 @@ class PositionSyncCoordinator(private val sync: PositionSync) {
         }
     }
 
+    private companion object {
+        const val MAX_CARRY_ONS = 25
+    }
+
     private class Running(
         val scope: SyncScope,
         val startedAt: Long,
@@ -134,11 +166,16 @@ class PositionSyncCoordinator(private val sync: PositionSync) {
      * going leaves its snapshot behind, since that run is doing its own
      * fetching and is already known to have started late enough to
      * answer honestly.
+     *
+     * [carryingOn] marks the follow-up a previous run asked for. Only
+     * those count against the cap on consecutive carry-ons: anything
+     * else is somebody asking for a sync, and the chain starts over.
      */
     suspend fun request(
         scope: SyncScope,
         requestedAt: Long = System.currentTimeMillis(),
         snapshot: SyncSnapshot? = null,
+        carryingOn: Boolean = false,
     ): SyncOutcome {
         val joinable = state.withLock {
             inFlight?.takeIf { canSatisfy(it, scope, requestedAt) }?.result
@@ -164,7 +201,7 @@ class PositionSyncCoordinator(private val sync: PositionSync) {
             // work happens changes; only the job does, which is what keeps
             // the run alive after the caller has walked away.
             CoroutineScope(currentCoroutineContext() + Job()).launch {
-                lead(scope, snapshot, slot)
+                lead(scope, snapshot, slot, carryingOn)
             }
         }
         return slot.await()
@@ -175,12 +212,14 @@ class PositionSyncCoordinator(private val sync: PositionSync) {
         scope: SyncScope,
         snapshot: SyncSnapshot?,
         slot: CompletableDeferred<SyncOutcome>,
+        carryingOn: Boolean = false,
     ) {
         try {
             turn.withLock {
                 state.withLock {
                     queued.remove(scope)
                     inFlight = Running(scope, System.currentTimeMillis(), slot)
+                    if (!carryingOn) carriedOn = 0
                 }
                 val outcome = try {
                     when (scope) {
@@ -194,6 +233,11 @@ class PositionSyncCoordinator(private val sync: PositionSync) {
                 }
                 clearInFlight(slot)
                 slot.complete(outcome)
+                if (outcome != SyncOutcome.Incomplete) {
+                    carriedOn = 0
+                } else if (carriedOn++ < MAX_CARRY_ONS) {
+                    carryOn()
+                }
             }
         } catch (e: CancellationException) {
             // Only reachable if the run itself is stopped, which now takes

--- a/app/src/main/kotlin/com/chmouel/liseur/sync/PositionSyncWorker.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/sync/PositionSyncWorker.kt
@@ -36,7 +36,7 @@ class PositionSyncWorker(
         // keeps the common case off the network for longer than it needs.
         val scope = bookUrl?.let { SyncScope.Book(it) } ?: SyncScope.Full
 
-        return when (val outcome = coordinator.request(scope)) {
+        return when (val outcome = coordinator.request(scope, carryingOn = isBootstrap())) {
             // Retry schedules a backed-off run, so it is only for things
             // that might work later. A phone with no calibre-web account
             // has nothing to sync now and will have nothing in an hour,
@@ -51,22 +51,84 @@ class PositionSyncWorker(
             is SyncOutcome.Partial ->
                 if (outcome.reason.worthRetrying) Result.retry() else Result.failure()
 
-            SyncOutcome.Success, SyncOutcome.NotApplicable -> Result.success()
+            // The follow-up is not scheduled here. Every way of asking
+            // for a sync goes through the coordinator, and only one of
+            // them is this worker, so the coordinator is where carrying
+            // on belongs — a connection made from Settings has just as
+            // much right to finish itself as one made from a refresh.
+            //
+            // Not a retry either way: a retry is backed off and shares
+            // the failure's escalating delay, and the whole point here
+            // is to carry on promptly.
+            SyncOutcome.Incomplete,
+            SyncOutcome.Success,
+            SyncOutcome.NotApplicable,
+            -> Result.success()
         }
     }
 
+    /**
+     * Whether this run is the follow-up a previous one asked for.
+     *
+     * Only those count against the cap on consecutive carry-ons, so a
+     * reader who refreshes after a long chain has stopped is not held to
+     * a budget somebody else's bootstrap spent.
+     */
+    private fun isBootstrap(): Boolean = inputData.getBoolean(KEY_CARRYING_ON, false)
+
     companion object {
         const val KEY_BOOK_URL = "book_url"
+        private const val KEY_CARRYING_ON = "carrying_on"
         private const val FULL_SYNC = "position-sync"
         private const val PERIODIC_SYNC = "position-sync-periodic"
+
+        /**
+         * The follow-up run for a connection still finding its feet.
+         *
+         * Its own unique name, so that chaining a bootstrap neither
+         * disturbs a book's own queued sync nor inherits the exponential
+         * backoff that belongs to failures.
+         */
+        private const val BOOTSTRAP_SYNC = "position-sync-bootstrap"
+
+        /**
+         * How long to wait before carrying on with a connection that has
+         * more books to name.
+         *
+         * Long enough not to read as a tight loop against the server,
+         * short enough that a reader who has just connected an account
+         * watches the shelf fill rather than going away and coming back.
+         */
+        private const val BOOTSTRAP_DELAY_SECONDS = 15L
 
         private val onNetwork = Constraints.Builder()
             .setRequiredNetworkType(NetworkType.CONNECTED)
             .build()
 
+        /**
+         * Carries on with a connection that has more books to name.
+         *
+         * Appended rather than kept, because the run asking for this is
+         * very often the previous follow-up: WorkManager would see its
+         * own name still running and drop the request, and a library
+         * needing three passes would stop after two. Appending queues
+         * the next pass behind the one asking for it, and the chain ends
+         * when a run stops reporting a shortfall.
+         */
+        fun continueBootstrap(context: Context) {
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                BOOTSTRAP_SYNC,
+                ExistingWorkPolicy.APPEND_OR_REPLACE,
+                OneTimeWorkRequestBuilder<PositionSyncWorker>()
+                    .setConstraints(onNetwork)
+                    .setInputData(Data.Builder().putBoolean(KEY_CARRYING_ON, true).build())
+                    .setInitialDelay(BOOTSTRAP_DELAY_SECONDS, TimeUnit.SECONDS)
+                    .build(),
+            )
+        }
+
         /** Sends one book's position, for the moment it is closed. */
-        fun pushBook(context: Context, bookUrl: String) {
-            enqueueBook(context, bookUrl, ExistingWorkPolicy.APPEND_OR_REPLACE, expedited = true)
+        fun pushBook(context: Context, bookUrl: String) {            enqueueBook(context, bookUrl, ExistingWorkPolicy.APPEND_OR_REPLACE, expedited = true)
         }
 
         /** Retries a failed foreground send without resetting existing backoff. */

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryViewModel.kt
@@ -533,7 +533,7 @@ class LibraryViewModel(
             val settings = baseValues[6] as AppSettings
             @Suppress("UNCHECKED_CAST")
             val readAtList = baseValues[7] as List<BookReadAt>
-            val readAt = readAtList.associate { it.bookUrl to it.updatedAt }
+            val readAt = readAtList.associate { it.bookUrl to it.readAt }
             @Suppress("UNCHECKED_CAST")
             val progressionList = baseValues[8] as List<BookProgression>
             val progressions = progressionList

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/MigrationTest.kt
@@ -1032,10 +1032,104 @@ class MigrationTest {
         }
     }
 
+    @Test
+    fun `imported reading keeps the time it was read, and local reading does not move`() {
+        // Both pull paths write updated_at and synced_at with the same
+        // instant; a page turn here moves only updated_at. That is what
+        // tells an imported position from one read on this device, and
+        // only the imported one may be refiled under the other device's
+        // clock.
+        helper.createDatabase(TEST_DB, 48).use { old ->
+            old.execSQL(
+                """
+                INSERT INTO reading_progress
+                    (book_url, locator_json, total_progression, updated_at, synced_at,
+                     remote_updated_at, local_revision, acked_revision)
+                VALUES ('liseur-sync:imported', '{}', 0.5, 5000, 5000, 1000, 1, 1)
+                """.trimIndent(),
+            )
+            // Read here after the last pull: updated_at moved on its own.
+            old.execSQL(
+                """
+                INSERT INTO reading_progress
+                    (book_url, locator_json, total_progression, updated_at, synced_at,
+                     remote_updated_at, local_revision, acked_revision)
+                VALUES ('liseur-sync:read-here', '{}', 0.5, 9000, 5000, 1000, 2, 1)
+                """.trimIndent(),
+            )
+            // A peer whose clock runs ahead of ours is not to be trusted
+            // over our own record of when we wrote the row down.
+            old.execSQL(
+                """
+                INSERT INTO reading_progress
+                    (book_url, locator_json, total_progression, updated_at, synced_at,
+                     remote_updated_at, local_revision, acked_revision)
+                VALUES ('liseur-sync:clock-ahead', '{}', 0.5, 5000, 5000, 9999, 1, 1)
+                """.trimIndent(),
+            )
+        }
+
+        helper.runMigrationsAndValidate(TEST_DB, LATEST, true, *LiseurDatabase.MIGRATIONS).use { db ->
+            db.query(
+                "SELECT book_url, read_at FROM reading_progress ORDER BY book_url",
+            ).use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals("liseur-sync:clock-ahead", cursor.getString(0))
+                assertTrue(cursor.isNull(1))
+
+                assertTrue(cursor.moveToNext())
+                assertEquals("liseur-sync:imported", cursor.getString(0))
+                assertEquals(1000L, cursor.getLong(1))
+
+                assertTrue(cursor.moveToNext())
+                assertEquals("liseur-sync:read-here", cursor.getString(0))
+                assertTrue(cursor.isNull(1))
+            }
+        }
+    }
+
+    @Test
+    fun `a position whose provenance was erased keeps the shelf it has`() {
+        // The backfill repairs what it can prove and leaves the rest
+        // exactly as it is. Guessing would be worse than the bug.
+        helper.createDatabase(TEST_DB, 48).use { old ->
+            // Dropping an account clears synced_at on every row, so
+            // there is no equality left to test against.
+            old.execSQL(
+                """
+                INSERT INTO reading_progress
+                    (book_url, locator_json, total_progression, updated_at, synced_at,
+                     remote_updated_at, local_revision, acked_revision)
+                VALUES ('liseur-sync:retired', '{}', 0.5, 5000, NULL, 1000, 1, 1)
+                """.trimIndent(),
+            )
+            // Somebody marked this read elsewhere without opening it,
+            // which moved remote_updated_at past updated_at while
+            // leaving the position where it was. The time a button was
+            // pressed is not the time anybody read anything.
+            old.execSQL(
+                """
+                INSERT INTO reading_progress
+                    (book_url, locator_json, total_progression, updated_at, synced_at,
+                     remote_updated_at, local_revision, acked_revision)
+                VALUES ('liseur-sync:status-only', '{}', 0.5, 5000, 5000, 7000, 1, 1)
+                """.trimIndent(),
+            )
+        }
+
+        helper.runMigrationsAndValidate(TEST_DB, LATEST, true, *LiseurDatabase.MIGRATIONS).use { db ->
+            db.query(
+                "SELECT book_url FROM reading_progress WHERE read_at IS NOT NULL",
+            ).use { cursor ->
+                assertEquals(0, cursor.count)
+            }
+        }
+    }
+
     private companion object {
         const val TEST_DB = "migration-test.db"
 
         /** Kept in step with the `version` on [LiseurDatabase]. */
-        const val LATEST = 48
+        const val LATEST = 49
     }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/data/db/ReadingTimeTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/db/ReadingTimeTest.kt
@@ -1,0 +1,182 @@
+package com.chmouel.liseur.data.db
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * When a book counts as read, against the real SQL.
+ *
+ * A fresh device connected to a sync account imports a whole reading
+ * history at once. If each position is filed under the moment the sync
+ * happened to deliver it, the shelf reads as though every book was
+ * picked up just now — and reads differently again after the next
+ * refresh, since the import arrives in batches. What the shelf wants is
+ * when the reading happened, on whichever device did it.
+ */
+@Config(sdk = [35], application = android.app.Application::class)
+@RunWith(RobolectricTestRunner::class)
+class ReadingTimeTest {
+
+    private lateinit var db: LiseurDatabase
+
+    @Before
+    fun open() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            LiseurDatabase::class.java,
+        ).build()
+    }
+
+    @After
+    fun close() = db.close()
+
+    private val progress get() = db.readingProgressDao()
+
+    private suspend fun add(url: String) = db.bookDao().upsert(
+        Book(
+            url = url,
+            title = url,
+            author = null,
+            coverPath = null,
+            source = null,
+            addedAt = 0,
+            lastOpenedAt = null,
+        ),
+    )
+
+    /** A position arriving from another device, read there at [readThere]. */
+    private suspend fun importAt(url: String, readThere: Long, at: Long, progression: Double) {
+        assertTrue(
+            progress.applyPeerPull(
+                bookUrl = url,
+                expectedRevision = 0,
+                progression = progression,
+                status = "READING",
+                now = at,
+                remoteUpdatedAt = readThere,
+            ),
+        )
+    }
+
+    private suspend fun readAt(): Map<String, Long> =
+        progress.observeReadAt().first().associate { it.bookUrl to it.readAt }
+
+    @Test
+    fun `an imported position is filed under when it was read, not when it arrived`() = runTest {
+        add("old")
+        add("recent")
+
+        // Both arrive in the same sync, in the order the server happened
+        // to mention them, which is the opposite of the reading order.
+        importAt("recent", readThere = 9_000, at = 100_000, progression = 0.3)
+        importAt("old", readThere = 1_000, at = 100_001, progression = 0.7)
+
+        assertEquals(mapOf("old" to 1_000L, "recent" to 9_000L), readAt())
+    }
+
+    @Test
+    fun `the shelf order does not change when a second batch is imported`() = runTest {
+        add("first")
+        add("second")
+
+        importAt("first", readThere = 9_000, at = 100_000, progression = 0.3)
+        val before = readAt()
+
+        // The next refresh names another book and imports its history.
+        add("late")
+        importAt("late", readThere = 2_000, at = 200_000, progression = 0.4)
+
+        val after = readAt()
+        assertEquals(before["first"], after["first"])
+        // Older reading files behind, however late this device heard of it.
+        assertTrue(after.getValue("late") < after.getValue("first"))
+    }
+
+    @Test
+    fun `a peer clock running ahead cannot pin a book to the top of the shelf`() = runTest {
+        add("ahead")
+        importAt("ahead", readThere = 500_000, at = 1_000, progression = 0.2)
+
+        assertEquals(1_000L, readAt().getValue("ahead"))
+    }
+
+    @Test
+    fun `a server that reports no time falls back to now`() = runTest {
+        add("timeless")
+        assertTrue(
+            progress.applyPeerPull(
+                bookUrl = "timeless",
+                expectedRevision = 0,
+                progression = 0.2,
+                status = "READING",
+                now = 4_000,
+                remoteUpdatedAt = null,
+            ),
+        )
+
+        assertEquals(4_000L, readAt().getValue("timeless"))
+    }
+
+    @Test
+    fun `a page turn here is read now, even after an older position was imported`() = runTest {
+        add("carried on")
+        importAt("carried on", readThere = 1_000, at = 100_000, progression = 0.2)
+
+        progress.recordLocal(
+            bookUrl = "carried on",
+            locatorJson = """{"at":0.5}""",
+            progression = 0.5,
+            readingSecondsPerPosition = null,
+            readingPaceSamples = null,
+            readingPaceElapsedMs = null,
+            readingPaceEvidence = null,
+            status = "READING",
+            updatedAt = 120_000,
+        )
+
+        assertEquals(120_000L, readAt().getValue("carried on"))
+    }
+
+    @Test
+    fun `a row holding no reading reports none`() = runTest {
+        add("declined")
+        // A pull that made the row exist and then declined to apply,
+        // because a page was turned here while it was being decided.
+        // Nothing was read, so the shelf must not be told it was.
+        assertTrue(
+            !progress.applyPeerPull(
+                bookUrl = "declined",
+                expectedRevision = 7,
+                progression = 0.2,
+                status = "READING",
+                now = 100_000,
+                remoteUpdatedAt = 1_000,
+            ),
+        )
+
+        assertNull(progress.get("declined")?.totalProgression)
+        assertEquals(emptyMap<String, Long>(), readAt())
+    }
+
+    @Test
+    fun `the book to carry on with is the one read last, not the one imported last`() = runTest {
+        add("left off here")
+        add("finished ages ago")
+
+        importAt("left off here", readThere = 9_000, at = 100_000, progression = 0.3)
+        importAt("finished ages ago", readThere = 1_000, at = 100_001, progression = 0.9)
+
+        assertEquals("left off here", db.bookDao().mostRecentlyOpened()?.url)
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSyncTest.kt
@@ -1901,6 +1901,437 @@ class LiseurSyncPositionSyncTest {
         ),
     )
 
+    @Test
+    fun `a fresh device names its whole catalog in one run and asks once where it stands`() =
+        runTest {
+            // The shelf arriving in batches is what made a refresh
+            // reshuffle it. Every book here came from the server's own
+            // catalog, so naming one costs a request and nothing else —
+            // there is no file to open — and there is no reason to
+            // ration them.
+            connect()
+            val catalog = (1..4).map { "liseur-sync:book-$it" }
+            catalog.forEachIndexed { index, url ->
+                db.bookDao().upsert(
+                    local().copy(
+                        url = url,
+                        title = "Book ${index + 1}",
+                        localUri = null,
+                        lastOpenedAt = null,
+                    ),
+                )
+            }
+            catalog.indices.forEach { resolved(workId = "w-${it + 1}") }
+            // One answer for the lot, rather than one question per book.
+            server.enqueue(
+                json(
+                    """{"ops":[
+                        {"op_id":"h-1","work_id":"w-1","seq":1,"progression":0.1,
+                         "client_ts":"${SyncOps.formatTime(NOW - 4_000)}"},
+                        {"op_id":"h-3","work_id":"w-3","seq":3,"progression":0.9,
+                         "client_ts":"${SyncOps.formatTime(NOW - 1_000)}"}
+                    ],"snapshot_seq":3}
+                    """.trimIndent(),
+                ),
+            )
+            server.enqueue(json("""{"ops":[],"has_more":false,"high_water":3}"""))
+
+            assertEquals(SyncOutcome.Success, sync().syncAll(null))
+
+            // Every book named, in the one run.
+            catalog.forEach {
+                assertNotNull(db.workIdentityDao().alias(it, peer())?.workId)
+            }
+            assertEquals(1, requests().count { it.target.startsWith("/v1/heads") })
+            assertTrue(requests().none { it.target.contains("/positions") })
+            // And every one of them told where it stands, including the
+            // books the server had never heard of.
+            catalog.forEach {
+                assertTrue(db.workIdentityDao().alias(it, peer())!!.seeded)
+            }
+            assertEquals(0.1, db.readingProgressDao().get("liseur-sync:book-1")!!.totalProgression!!, 1e-9)
+            assertEquals(0.9, db.readingProgressDao().get("liseur-sync:book-3")!!.totalProgression!!, 1e-9)
+            assertNull(db.readingProgressDao().get("liseur-sync:book-2")?.totalProgression)
+        }
+
+    @Test
+    fun `history imported in one run keeps the order it was read in`() = runTest {
+        connect()
+        // Two books read a minute and a half apart on another device,
+        // both arriving here in the same batch.
+        val catalog = listOf("liseur-sync:book-a", "liseur-sync:book-b")
+        catalog.forEach { url ->
+            db.bookDao().upsert(local().copy(url = url, title = url, localUri = null, lastOpenedAt = null))
+        }
+        resolved(workId = "w-1")
+        resolved(workId = "w-2")
+        server.enqueue(
+            json(
+                """{"ops":[
+                    {"op_id":"h-1","work_id":"w-1","seq":1,"progression":0.1,
+                     "client_ts":"${SyncOps.formatTime(NOW - 90_000)}"},
+                    {"op_id":"h-2","work_id":"w-2","seq":2,"progression":0.2,
+                     "client_ts":"${SyncOps.formatTime(NOW - 1_000)}"}
+                ],"snapshot_seq":2}
+                """.trimIndent(),
+            ),
+        )
+        server.enqueue(json("""{"ops":[],"has_more":false,"high_water":2}"""))
+
+        assertEquals(SyncOutcome.Success, sync().syncAll(null))
+
+        val readAt = db.readingProgressDao().readAtOnce().associate { it.bookUrl to it.readAt }
+        val whenRead = mapOf("w-1" to NOW - 90_000, "w-2" to NOW - 1_000)
+        catalog.forEach { url ->
+            val workId = db.workIdentityDao().alias(url, peer())!!.workId
+            assertEquals(whenRead.getValue(workId), readAt.getValue(url))
+        }
+        // Not, as it used to be, the moment this device happened to hear
+        // about either of them.
+        assertTrue(readAt.values.none { it == NOW })
+    }
+
+    @Test
+    fun `a run that could not name everything asks for another one`() = runTest {
+        connect()
+        // Local files, which are the ones a run rations: naming each
+        // means reading it off the disk to hash it. More of them than
+        // any sensible budget, so the run has to leave some over.
+        val urls = (1..200).map { "content://sd/book-$it.epub" }
+        urls.forEach { url ->
+            db.bookDao().upsert(local().copy(url = url, title = url, lastOpenedAt = null))
+        }
+        var named = 0
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = when {
+                request.target.startsWith("/v1/works/resolve") ->
+                    json("""{"work_id":"w-${named++}","confidence":"high","created":true}""")
+                request.target.startsWith("/v1/heads") -> json("""{"ops":[],"snapshot_seq":0}""")
+                else -> json("""{"ops":[],"has_more":false,"high_water":0}""")
+            }
+        }
+
+        // Nothing went wrong, and there are still books with no name.
+        assertEquals(SyncOutcome.Incomplete, sync().syncAll(null))
+
+        val got = urls.count { db.workIdentityDao().alias(it, peer()) != null }
+        assertTrue(got > 0)
+        assertTrue(got < urls.size)
+    }
+
+    @Test
+    fun `books left waiting to be told where they stand ask for another run`() = runTest {
+        connect()
+        // Named already, but never seeded — and a server too old to
+        // answer /v1/heads, so they have to be asked one at a time and
+        // the run cannot get through them all. The delta pull will not
+        // rescue them: its cursor passed those answers long ago.
+        val urls = (1..60).map { "liseur-sync:book-$it" }
+        urls.forEachIndexed { index, url ->
+            db.bookDao().upsert(local().copy(url = url, title = url, localUri = null))
+            alias(workId = "w-$index", seeded = false, bookUrl = url)
+        }
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = when {
+                request.target.startsWith("/v1/heads") ->
+                    MockResponse.Builder().code(404).body("""{"error":"unknown"}""").build()
+                request.target.contains("/positions") -> json("""{"ops":[]}""")
+                else -> json("""{"ops":[],"has_more":false,"high_water":0}""")
+            }
+        }
+
+        assertEquals(SyncOutcome.Incomplete, sync().syncAll(null))
+
+        val seeded = urls.count { db.workIdentityDao().alias(it, peer())!!.seeded }
+        assertTrue(seeded > 0)
+        assertTrue(seeded < urls.size)
+    }
+
+    @Test
+    fun `one book the server will never accept does not strand the rest`() = runTest {
+        connect()
+        // A stale entry among many. Nothing is going to come of asking
+        // about it again, but the books behind it still have no name,
+        // and a refusal that ends the whole bootstrap is how they stay
+        // that way.
+        val urls = (1..60).map { "liseur-sync:book-$it" }
+        urls.forEachIndexed { index, url ->
+            db.bookDao().upsert(local().copy(url = url, title = url, localUri = null))
+            alias(workId = "w-$index", seeded = false, bookUrl = url)
+        }
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = when {
+                request.target.startsWith("/v1/heads") ->
+                    MockResponse.Builder().code(404).body("""{"error":"unknown"}""").build()
+                request.target.contains("/works/w-0/") ->
+                    MockResponse.Builder().code(404).body("""{"error":"unknown_work"}""").build()
+                request.target.contains("/positions") -> json("""{"ops":[]}""")
+                else -> json("""{"ops":[],"has_more":false,"high_water":0}""")
+            }
+        }
+
+        assertEquals(SyncOutcome.Incomplete, sync().syncAll(null))
+
+        assertTrue(urls.any { db.workIdentityDao().alias(it, peer())!!.seeded })
+    }
+
+    @Test
+    fun `a refusal that might pass later stays a failure`() = runTest {
+        connect()
+        // The same shape as the run above, but with a refusal a retry
+        // could get past. That retry will pick the shortfall up along
+        // with everything else, so the run has to keep saying it
+        // failed rather than quietly asking to be carried on instead.
+        val urls = (1..60).map { "liseur-sync:book-$it" }
+        urls.forEachIndexed { index, url ->
+            db.bookDao().upsert(local().copy(url = url, title = url, localUri = null))
+            alias(workId = "w-$index", seeded = false, bookUrl = url)
+        }
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = when {
+                request.target.startsWith("/v1/heads") ->
+                    MockResponse.Builder().code(404).body("""{"error":"unknown"}""").build()
+                request.target.contains("/works/w-0/") ->
+                    MockResponse.Builder().code(503).body("""{"error":"busy"}""").build()
+                request.target.contains("/positions") -> json("""{"ops":[]}""")
+                else -> json("""{"ops":[],"has_more":false,"high_water":0}""")
+            }
+        }
+
+        assertEquals(SyncOutcome.Failure(SyncFailure.ServerError(503)), sync().syncAll(null))
+    }
+
+    @Test
+    fun `a book the server cannot tell apart is only ever asked about once`() = runTest {
+        connect()
+        // More books than a run will hash, every one of which the
+        // server matches to two works. Raising those questions is
+        // getting somewhere the first time. Raising the same ones again
+        // is not, and if it counted the run would keep asking to be
+        // carried on for as long as the phone was on, without the book
+        // left over ever being reached.
+        val urls = (1..30).map { "content://sd/muddle-$it.epub" }
+        urls.forEach { url ->
+            db.bookDao().upsert(local().copy(url = url, title = url, lastOpenedAt = null))
+        }
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = when {
+                request.target.contains("/resolve") ->
+                    MockResponse.Builder().code(409)
+                        .body("""{"error":"ambiguous","works":["w-1","w-2"]}""").build()
+                request.target.startsWith("/v1/heads") -> json("""{"ops":[],"snapshot_seq":0}""")
+                else -> json("""{"ops":[],"has_more":false,"high_water":0}""")
+            }
+        }
+
+        assertEquals(SyncOutcome.Incomplete, sync().syncAll(null))
+        val raised = db.workIdentityDao().ambiguityCount(peer())
+        assertTrue(raised > 0)
+        assertTrue(raised < urls.size)
+
+        // The books left over are reached by the run that follows,
+        // because a question already on file goes to the back of the
+        // queue rather than being asked again ahead of them.
+        assertEquals(SyncOutcome.Incomplete, sync().syncAll(null))
+        assertEquals(urls.size, db.workIdentityDao().ambiguityCount(peer()))
+
+        // Nothing new to say, so nothing to carry on for — even though
+        // there are still books with no name.
+        assertEquals(SyncOutcome.Success, sync().syncAll(null))
+        assertEquals(urls.size, db.workIdentityDao().ambiguityCount(peer()))
+    }
+
+    @Test
+    fun `paying a book's outstanding debt to the server counts as getting somewhere`() = runTest {
+        connect()
+        // Books whose questions are already on file, so re-asking them
+        // is not progress, and enough of them to use up the run.
+        val muddled = (1..30).map { "content://sd/muddle-$it.epub" }
+        muddled.forEach { url ->
+            db.bookDao().upsert(local().copy(url = url, title = url, lastOpenedAt = null))
+            db.workIdentityDao().upsert(
+                com.chmouel.liseur.data.db.WorkAmbiguity(
+                    bookUrl = url,
+                    peerId = peer(),
+                    workIds = "w-1\nw-2",
+                    noticedAt = NOW,
+                ),
+            )
+        }
+        // And one named book that still owes the server its catalog id,
+        // which one request settles for good.
+        val owing = "liseur-sync:owing"
+        db.bookDao().upsert(local().copy(url = owing, title = owing, localUri = null))
+        alias(workId = "w-9", bookUrl = owing)
+        db.workIdentityDao().upsert(
+            db.workIdentityDao().alias(owing, peer())!!.copy(sourceSent = false),
+        )
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = when {
+                request.target.contains("/books/") && request.target.endsWith("/resolve") ->
+                    json("""{"work_id":"w-9","confidence":"high","created":false}""")
+                request.target.contains("/resolve") ->
+                    MockResponse.Builder().code(409)
+                        .body("""{"error":"ambiguous","works":["w-1","w-2"]}""").build()
+                request.target.startsWith("/v1/heads") -> json("""{"ops":[],"snapshot_seq":0}""")
+                else -> json("""{"ops":[],"has_more":false,"high_water":0}""")
+            }
+        }
+
+        // The debt is paid, books are still waiting, so another run is
+        // asked for — even though nothing was newly named.
+        assertEquals(SyncOutcome.Incomplete, sync().syncAll(null))
+        assertTrue(db.workIdentityDao().alias(owing, peer())!!.sourceSent)
+
+        // Paid once. The next run has nothing to show for itself.
+        assertEquals(SyncOutcome.Success, sync().syncAll(null))
+    }
+
+    @Test
+    fun `a question already on file does not starve a book nobody has asked about`() = runTest {
+        connect()
+        // Enough books the server cannot place to use up a run's whole
+        // budget for hashing files, each with its question already
+        // filed. Their titles sort first, so before this was fixed the
+        // run spent itself re-asking them...
+        val muddled = (1..25).map { "content://sd/aaa-$it.epub" }
+        muddled.forEach { url ->
+            db.bookDao().upsert(local().copy(url = url, title = url, lastOpenedAt = null))
+            db.workIdentityDao().upsert(
+                com.chmouel.liseur.data.db.WorkAmbiguity(
+                    bookUrl = url,
+                    peerId = peer(),
+                    workIds = "w-1\nw-2",
+                    noticedAt = NOW,
+                ),
+            )
+        }
+        // ...and the books behind them were never reached at all.
+        val unasked = (1..5).map { "content://sd/zzz-$it.epub" }
+        unasked.forEach { url ->
+            db.bookDao().upsert(local().copy(url = url, title = url, lastOpenedAt = null))
+        }
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = when {
+                request.target.contains("/resolve") ->
+                    MockResponse.Builder().code(409)
+                        .body("""{"error":"ambiguous","works":["w-1","w-2"]}""").build()
+                request.target.startsWith("/v1/heads") -> json("""{"ops":[],"snapshot_seq":0}""")
+                else -> json("""{"ops":[],"has_more":false,"high_water":0}""")
+            }
+        }
+
+        sync().syncAll(null)
+
+        // Every book has now had its question asked, which is only true
+        // if the ones nobody had asked about went first.
+        assertEquals(
+            muddled.size + unasked.size,
+            db.workIdentityDao().ambiguityCount(peer()),
+        )
+    }
+
+    @Test
+    fun `a head nobody can read sends the book back to ask for itself`() = runTest {
+        connect()
+        // Two books named in one run. The account's heads answer holds
+        // the newest record per work, and one of them is unreadable —
+        // an older op behind it still has a position this device can
+        // use, and only the per-book route can see that far back.
+        val catalog = (1..2).map { "liseur-sync:book-$it" }
+        catalog.forEachIndexed { index, url ->
+            db.bookDao().upsert(
+                local().copy(
+                    url = url,
+                    title = "Book ${index + 1}",
+                    localUri = null,
+                    lastOpenedAt = null,
+                ),
+            )
+        }
+        catalog.indices.forEach { resolved(workId = "w-${it + 1}") }
+        server.enqueue(
+            json(
+                """{"ops":[
+                    {"op_id":"h-1","work_id":"w-1","seq":1,"progression":0.1,
+                     "client_ts":"${SyncOps.formatTime(NOW - 4_000)}"},
+                    {"op_id":"h-2","work_id":"w-2","seq":9,"progression":null,
+                     "client_ts":"${SyncOps.formatTime(NOW - 1_000)}"}
+                ],"snapshot_seq":9}
+                """.trimIndent(),
+            ),
+        )
+        server.enqueue(
+            json(
+                """{"ops":[
+                    {"op_id":"o-2","work_id":"w-2","seq":8,"progression":0.5,
+                     "client_ts":"${SyncOps.formatTime(NOW - 2_000)}"}
+                ]}
+                """.trimIndent(),
+            ),
+        )
+        server.enqueue(json("""{"ops":[],"has_more":false,"high_water":9}"""))
+
+        assertEquals(SyncOutcome.Success, sync().syncAll(null))
+
+        // The readable head landed from the batch, and the unreadable
+        // one sent its book to the window behind it rather than being
+        // sealed over with an empty answer.
+        assertEquals(0.1, db.readingProgressDao().get("liseur-sync:book-1")!!.totalProgression!!, 1e-9)
+        assertEquals(0.5, db.readingProgressDao().get("liseur-sync:book-2")!!.totalProgression!!, 1e-9)
+        assertTrue(requests().any { it.target.startsWith("/v1/works/w-2/positions") })
+        assertTrue(requests().none { it.target.startsWith("/v1/works/w-1/positions") })
+        catalog.forEach { assertTrue(db.workIdentityDao().alias(it, peer())!!.seeded) }
+    }
+
+    @Test
+    fun `a name too weak to use is a question already asked`() = runTest {
+        connect()
+        // Books the server named but was not sure enough of to use, so
+        // each is a question waiting on the reader. Asking again could
+        // settle one — another device may have named it since — but not
+        // ahead of a book nobody has asked about at all.
+        val weak = (1..25).map { "content://sd/aaa-$it.epub" }
+        weak.forEachIndexed { index, url ->
+            db.bookDao().upsert(local().copy(url = url, title = url, lastOpenedAt = null))
+            alias(
+                workId = "w-weak-$index",
+                bookUrl = url,
+                confidence = "low",
+                confirmed = false,
+                seeded = true,
+            )
+        }
+        val unasked = (1..5).map { "content://sd/zzz-$it.epub" }
+        unasked.forEach { url ->
+            db.bookDao().upsert(local().copy(url = url, title = url, lastOpenedAt = null))
+        }
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = when {
+                request.target.contains("/resolve") ->
+                    json("""{"work_id":"w-new","confidence":"low","created":true}""")
+                request.target.startsWith("/v1/heads") -> json("""{"ops":[],"snapshot_seq":0}""")
+                else -> json("""{"ops":[],"has_more":false,"high_water":0}""")
+            }
+        }
+
+        sync().syncAll(null)
+
+        // The books nobody had asked about were reached, which is only
+        // true if the weak names went behind them.
+        unasked.forEach { assertNotNull(db.workIdentityDao().alias(it, peer())) }
+    }
+
+    @Test
+    fun `a run with nothing left to name is simply done`() = runTest {
+        connect()
+        db.bookDao().upsert(local())
+        alias()
+        server.enqueue(json("""{"ops":[],"has_more":false,"high_water":0}"""))
+
+        assertEquals(SyncOutcome.Success, sync().syncAll(null))
+    }
+
     private suspend fun alias(
         workId: String = "w-1",
         seeded: Boolean = true,

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/CompositePositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/CompositePositionSyncTest.kt
@@ -124,6 +124,57 @@ class CompositePositionSyncTest {
     }
 
     @Test
+    fun `a peer with more to fetch is heard over one that is finished`() = runTest {
+        // A phone still naming its library, next to a server with
+        // nothing to do. Calling this success leaves the shelf half
+        // built and nothing scheduled to finish it.
+        val settling = FakePeer("settling", outcome = SyncOutcome.Incomplete)
+        val idle = FakePeer("idle", outcome = SyncOutcome.NotApplicable)
+
+        assertEquals(SyncOutcome.Incomplete, composite(settling, idle).syncAll())
+        assertEquals(SyncOutcome.Incomplete, composite(idle, settling).syncAll())
+    }
+
+    @Test
+    fun `a peer with more to fetch is heard over one that is done`() = runTest {
+        val settling = FakePeer("settling", outcome = SyncOutcome.Incomplete)
+        val done = FakePeer("done", outcome = SyncOutcome.Success)
+
+        assertEquals(SyncOutcome.Incomplete, composite(done, settling).syncAll())
+    }
+
+    @Test
+    fun `a failure beside a peer with more to fetch is still a failure`() = runTest {
+        // The retry that follows covers the shortfall too, and a
+        // failure has to keep being one or nothing is retried at all.
+        val settling = FakePeer("settling", outcome = SyncOutcome.Incomplete)
+        val bad = FakePeer("bad", outcome = SyncOutcome.Failure(SyncFailure.Offline))
+
+        assertEquals(SyncOutcome.Partial(SyncFailure.Offline), composite(settling, bad).syncAll())
+    }
+
+    @Test
+    fun `a peer locked out for good does not strand one still naming its library`() = runTest {
+        // Nothing is retried for a reason that will be refused just as
+        // firmly in an hour, so reporting this as partial would only
+        // stop the phone beside it from finishing — for as long as the
+        // other account stayed locked out.
+        val settling = FakePeer("settling", outcome = SyncOutcome.Incomplete)
+        val refused = FakePeer("refused", outcome = SyncOutcome.Failure(SyncFailure.Unauthorised))
+
+        assertEquals(SyncOutcome.Incomplete, composite(settling, refused).syncAll())
+        assertEquals(SyncOutcome.Incomplete, composite(refused, settling).syncAll())
+    }
+
+    @Test
+    fun `a failure worth retrying still wins over a peer with more to fetch`() = runTest {
+        val settling = FakePeer("settling", outcome = SyncOutcome.Incomplete)
+        val flaky = FakePeer("flaky", outcome = SyncOutcome.Partial(SyncFailure.Timeout))
+
+        assertEquals(SyncOutcome.Partial(SyncFailure.Timeout), composite(settling, flaky).syncAll())
+    }
+
+    @Test
     fun `no peers at all is not applicable rather than success`() = runTest {
         assertEquals(SyncOutcome.NotApplicable, CompositePositionSync(emptyList()).syncAll())
     }

--- a/app/src/test/kotlin/com/chmouel/liseur/sync/PositionSyncCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/sync/PositionSyncCoordinatorTest.kt
@@ -113,6 +113,111 @@ class PositionSyncCoordinatorTest {
      * A sync that does nothing until it is told to, so a test can hold a
      * run open and make a second request arrive in the middle of it.
      */
+    @Test
+    fun `a run with more to do asks to be carried on, whoever asked for it`() = runTest {
+        // Connecting an account from Settings has as much right to
+        // finish itself as pulling to refresh does, and neither of them
+        // is the worker. So the carrying on lives here rather than in
+        // any one caller.
+        val sync = FakeSync()
+        sync.outcome = SyncOutcome.Incomplete
+        var carried = 0
+        val coordinator = PositionSyncCoordinator(sync, carryOn = { carried++ })
+
+        assertEquals(SyncOutcome.Incomplete, coordinator.request(SyncScope.Full))
+        advanceUntilIdle()
+
+        assertEquals(1, carried)
+    }
+
+    @Test
+    fun `a run that is done does not ask to be carried on`() = runTest {
+        val sync = FakeSync()
+        var carried = 0
+        val coordinator = PositionSyncCoordinator(sync, carryOn = { carried++ })
+
+        coordinator.request(SyncScope.Full)
+        advanceUntilIdle()
+
+        assertEquals(0, carried)
+    }
+
+    @Test
+    fun `carrying on gives up rather than running for ever`() = runTest {
+        // The run only asks when it got somewhere and still owes work,
+        // so it should stop by itself. If it ever does not, this is
+        // what stops a sync every fifteen seconds for as long as the
+        // phone is on.
+        val sync = FakeSync()
+        sync.outcome = SyncOutcome.Incomplete
+        var carried = 0
+        val coordinator = PositionSyncCoordinator(sync, carryOn = { carried++ })
+
+        repeat(200) {
+            coordinator.request(
+                SyncScope.Full,
+                requestedAt = System.currentTimeMillis() + it,
+                carryingOn = true,
+            )
+            advanceUntilIdle()
+        }
+
+        assertTrue(carried in 1..50)
+    }
+
+    @Test
+    fun `somebody asking for a sync themselves starts the count over`() = runTest {
+        // The cap is a guard against a run that keeps asking for itself.
+        // A reader pulling to refresh long after such a chain gave up is
+        // not spending somebody else's budget.
+        val sync = FakeSync()
+        sync.outcome = SyncOutcome.Incomplete
+        var carried = 0
+        val coordinator = PositionSyncCoordinator(sync, carryOn = { carried++ })
+        repeat(200) {
+            coordinator.request(
+                SyncScope.Full,
+                requestedAt = System.currentTimeMillis() + it,
+                carryingOn = true,
+            )
+            advanceUntilIdle()
+        }
+        val spent = carried
+
+        coordinator.request(SyncScope.Full, requestedAt = System.currentTimeMillis() + 1_000)
+        advanceUntilIdle()
+
+        assertEquals(spent + 1, carried)
+    }
+
+    @Test
+    fun `a run that finishes clears the way for the next connection to catch up`() = runTest {
+        val sync = FakeSync()
+        var carried = 0
+        val coordinator = PositionSyncCoordinator(sync, carryOn = { carried++ })
+        sync.outcome = SyncOutcome.Incomplete
+        repeat(200) {
+            coordinator.request(
+                SyncScope.Full,
+                requestedAt = System.currentTimeMillis() + it,
+                carryingOn = true,
+            )
+            advanceUntilIdle()
+        }
+        val spent = carried
+
+        // Somebody connects a second account later on. The tally that
+        // stopped the last one must not be what stops this one.
+        sync.outcome = SyncOutcome.Success
+        coordinator.request(SyncScope.Full, requestedAt = System.currentTimeMillis() + 1_000)
+        advanceUntilIdle()
+        sync.outcome = SyncOutcome.Incomplete
+        coordinator.request(SyncScope.Full, requestedAt = System.currentTimeMillis() + 2_000)
+        advanceUntilIdle()
+
+        assertEquals(spent + 1, carried)
+    }
+
     private class FakeSync : PositionSync {
         val started = mutableListOf<SyncScope>()
         var gate: CompletableDeferred<Unit>? = null

--- a/docs/adr/0026-imported-reading-keeps-its-own-time.md
+++ b/docs/adr/0026-imported-reading-keeps-its-own-time.md
@@ -1,0 +1,194 @@
+# 26. Imported reading keeps the time it was read
+
+Status: accepted
+GitHub issue: [#180](https://github.com/chmouel/liseur/issues/180)
+
+## Context
+
+A reader connected a fresh install to liseur-sync and found that pulling
+to refresh kept rearranging the Recent shelf and kept changing which
+book the Continue Reading card offered — on a device where nobody had
+opened a book at all.
+
+Two separate things were doing it.
+
+**The shelf was ordering by when this phone heard about the reading.**
+`reading_progress.updated_at` is the column the Recent shelf and the
+Continue Reading card sort by, and every pull path stamped it with the
+local clock. Six months of reading, imported in one afternoon, all read
+as "this afternoon", in whatever order the ops happened to land. The
+originating device's own time did arrive — liseur-sync sends it as an
+op's `client_ts`, Komga sends `readDate`, calibre-web's Kobo sync sends
+`modified` — and it was even stored, in `remote_updated_at`. Nothing
+ordered by it.
+
+**And the import genuinely arrived in batches.** A book with no
+`work_alias` can neither send nor receive, and naming was rationed to 25
+books a run because naming a local file means reading and hashing it.
+Each refresh therefore named the next 25 books, imported their history
+stamped "now", and that batch leapfrogged the one before it. Nothing
+re-ran on its own, which is why the reader had to keep pulling — and why
+the order kept changing when they did.
+
+## Decision
+
+### Two timestamps, because there are two facts
+
+`reading_progress` gains `read_at`:
+
+- **`updated_at`** — when *this device* last wrote the row. It is what
+  goes out as an op's `client_ts` and as kosync's `timestamp`, and it is
+  therefore part of a derived op id and of a byte-identical replay. It
+  does not change meaning.
+- **`read_at`** — when the reading this position records actually
+  happened, on whatever device did it. A pull takes it from the remote
+  time; a page turn here takes the local clock, because a page turn here
+  *is* the reading.
+
+Null means "not known separately", and every read is
+`COALESCE(read_at, updated_at)`, so rows written before this exist
+happily and nothing regresses.
+
+The remote time is clamped to `now`. It is another device's wall clock,
+and one running fast would otherwise pin a book to the top of the shelf
+for as long as the two disagreed. A clock running slow files its reading
+too far back, which is a worse answer than the truth and a much better
+one than "everything was read at import time". There is nothing better
+on the wire: the server stamps `seq`, which orders events but is not a
+time.
+
+Nothing about conflict resolution changes. Revisions decide, as
+`ReadingStateMerge` documents; `read_at` is only for display order.
+
+### `synced_at = updated_at` is what makes the backfill safe
+
+Devices already have shelves in import order, so migration 48 → 49
+backfills. The difficulty is telling a row whose position came from a
+pull from one genuinely read here, and the two columns already say it:
+
+- both pull paths set `updated_at` and `synced_at` to the same `now`, in
+  one statement;
+- a local page turn moves `updated_at` and leaves `synced_at` alone;
+- an acknowledgement moves `synced_at` and leaves `updated_at` alone.
+
+So `synced_at = updated_at` holds exactly for rows whose current
+position was last written by a pull. Those get `read_at =
+remote_updated_at`; everything else keeps a NULL and falls back to
+`updated_at`, which for those rows is already the right answer.
+
+Two alternatives were rejected. `MIN(remote_updated_at, updated_at)`
+demotes a book read here after an old pull, because its
+`remote_updated_at` is stale. And `local_revision > acked_revision`
+looks like a dirty check but is not one: `applyPeerPullIfUnchanged`
+bumps `local_revision` without touching `acked_revision`, because for a
+liseur-sync peer the real acknowledgement lives in `sync_peer_state`, so
+every pulled row reads as dirty.
+
+The backfill repairs only what it can prove, and two kinds of pulled row
+are deliberately left alone. `retireAccountState` clears `synced_at` on
+every row when an account is dropped, so a device that has switched
+accounts has no equality left to test. And a status adopted from the
+server without a position (`setStatusOnly`) moves `remote_updated_at`
+past `updated_at`, which the second guard rejects. Both keep exactly the
+behaviour they have today and correct themselves the next time the book
+is read or pulled — which is a better answer than filing a book under
+the moment somebody pressed a button somewhere else.
+
+### A row with no position reports no reading
+
+`observeReadAt` now excludes rows with neither a progression nor a
+locator. `startIfMissing` and `insertPending` create such rows to make a
+row exist, not to record reading, and a bare one was reporting its own
+creation time — which `Book.recentRank` reads as "being read" and throws
+to the top of the shelf with nothing behind it.
+
+### Naming is rationed by what naming costs
+
+The budget existed because resolving by identifiers hashes the file. A
+book from the server's own catalog resolves through
+`POST /v1/books/{id}/resolve` instead: one request, no file opened. On a
+fresh device connected to liseur-sync that is *every* book, so the
+ration was being spent entirely on the cheap case.
+
+The budget splits: 25 a run for resolves that must read a file, 500 for
+catalog resolves. Candidates are ordered by the most recent of `read_at`
+and `last_opened_at`, so a partial run names the books the reader
+actually wants — the previous ordering was by `last_opened_at`, which on
+a fresh device is null for everything, leaving title order. Books whose
+question is already on file sort behind all of that. They are still
+worth asking about, since another device may have named one since, but
+not out of the same purse as a book nobody has asked about at all: a
+library with more ambiguities than budget would otherwise spend every
+run re-asking the same questions and never reach the books behind them.
+
+Seeding follows. A newly named book asks the server where it stands, and
+one request per book is what made lifting the resolve budget useless. A
+run with several books to seed asks `GET /v1/heads` once instead, takes
+the newest op per work, and lands the lot. It falls back to the per-book
+route for a single book — somebody is waiting on that one answer — and
+for a server that refuses. The cursor is **not** moved: a heads
+bootstrap is a seed, not a pull, and the cursor advances only in the
+transaction that writes the page it covers.
+
+A work whose head comes back unreadable falls back to the per-book route
+too. Heads carries only the newest record per work and device, so there
+is nothing left in that answer to fall back on, while the per-book route
+scans a window and can find a position behind the record this device
+cannot read. Marking such a book seeded on an empty answer would seal
+over a reading that was there to be had, and a seed is only asked for
+once.
+
+### A run that could not finish says so
+
+`SyncOutcome` gains `Incomplete`: everything asked for went well, and
+there is more to fetch. `LiseurSyncPositionSync` returns it when a run
+got somewhere *and* something is still owed — a book with no name, or
+one named but never told where it stands.
+
+Both halves count durable advancement rather than effort. A book named,
+a book whose debt to the server was finally paid, or a book whose
+question reached the reader for the first time all count; re-asking a
+question this device already has an answer to does not, because the next
+run would face exactly what this one faced. A question can be on file as
+an alias awaiting confirmation *or* as an ambiguity, and both have to be
+read, or a book the server cannot tell from another would pass for
+progress every run for ever. That is what makes the chain terminate.
+
+A refusal does not cancel the debt. If it is worth retrying, the backed
+off retry picks the shortfall up with everything else and the run stays
+a failure. If it is not — one stale book among six hundred — the rest of
+the library still gets its follow-up, and the reader is told what failed
+by the status report rather than by the outcome.
+
+Carrying on lives in `PositionSyncCoordinator`, not in the worker. A
+fresh connection is synced from app start, pull to refresh, connecting
+an account and Settings' sync now, and only one of those is the worker;
+every one of them would otherwise have to remember, and one of them
+eventually would not. `CompositePositionSync` folds `Incomplete` over a
+peer that had nothing to do, or the shortfall would vanish behind a
+quiet neighbour, and over a peer that failed for a reason not worth
+retrying: such a reason decides nothing else — a partial run nobody will
+retry and a run carrying on both end the worker without a backoff — so
+letting it through would leave a fresh connection half-named for as long
+as some unrelated account stayed locked out. A failure that *is* worth
+retrying still wins, because its retry covers the shortfall too. The follow-up is appended to its own unique work name
+rather than kept, because the run reporting the shortfall is usually the
+previous follow-up and WorkManager would drop a request colliding with
+its own running name. `FULL_SYNC`'s backoff is untouched.
+
+The coordinator also stops after twenty-five consecutive carry-ons. The
+accounting above should make that unreachable; it is there because a
+mistake in it would otherwise be a sync every fifteen seconds for as
+long as the phone is on.
+
+## Consequences
+
+- Komga and calibre-web get the ordering fix for free: both already
+  supply a remote time, and the change is in `data/db`.
+- A device that has already imported in batches is repaired by the
+  migration rather than needing a reconnect.
+- `read_at` is a display concern. Anything that must agree across
+  devices continues to go through revisions.
+- A fresh device now issues one resolve per catalog book, up to 500, in
+  a single run. A batch resolve route on the server would make that one
+  request; the client works without it, and that is tracked separately.


### PR DESCRIPTION
## Summary

Fixes #180.

On a fresh install connected to Liseur Sync, pulling to refresh kept
reordering the Recent shelf and kept changing the Continue Reading card,
even though nobody had read anything on that device. Two independent
causes, both fixed here.

**The shelf was showing when the reading arrived, not when it happened.**
Every pull stamped `reading_progress.updated_at` — the only column the
shelf orders by — with this phone's clock. The originating device's real
reading time did arrive, in `remote_updated_at`, and nothing ordered by
it. So a library imported at 14:03 read as "all read at 14:03".

**The bootstrap really did arrive in batches.** A book with no name on
the server can neither send nor receive, and a run would name only 25 of
them. Each refresh named the next 25, imported their history stamped
"now", and that batch leapfrogged the last. Nothing re-ran by itself,
which is why the reader had to keep pulling.

## Changes

- New `reading_progress.read_at`: when the reading a position records
  actually happened, on whatever device did it. `updated_at` keeps its
  existing meaning, which push and kosync both depend on.
- Every pull writes the originating device's time, clamped to now so a
  peer's fast clock cannot pin a book to the top for good. This lives in
  `data/db`, so Komga and calibre-web get the same fix.
- Migration 48 → 49 repairs devices already affected. `synced_at =
  updated_at` is the discriminator: it holds exactly for rows whose
  position last came from a pull, so a book genuinely read on this phone
  since is left alone.
- The shelf and Continue Reading order by `read_at`, falling back to
  `updated_at`. A row with neither a progression nor a locator now
  reports no reading at all, instead of throwing an empty book to the top.
- Naming is rationed by what naming costs: 25 a run for resolves that
  must hash a file, 500 for catalog resolves, which are one request and
  no file at all. A question already on file goes to the back of the
  queue, so a library full of ambiguities cannot starve the books
  behind them.
- Seeding asks `GET /v1/heads` once for the lot instead of one request
  per book, falling back per book for a single seed, for an older
  server, and for a work whose head came back unreadable. The cursor is
  not moved: a seed is not a pull.
- New `SyncOutcome.Incomplete` — everything asked for worked, there is
  more to fetch — and `PositionSyncCoordinator` schedules the follow-up,
  so a connection finishes by itself however it was started. It only
  carries on when the run made durable progress, which is what makes the
  chain terminate.
- `docs/adr/0026-imported-reading-keeps-its-own-time.md` and two
  `AGENTS.md` bullets.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [ ] Manually tested on a device or emulator, if applicable

New tests cover the migration both ways, the ordering, the batch seed,
the unreadable head, the naming budget, ambiguity accounting, the
outcome fold, and the carry-on chain terminating.

## Screenshots or recordings

None. The change is the *order* of a shelf on a device syncing for the
first time against an account with reading history on it, and the bug is
that the order moves between refreshes — a still frame shows neither the
old behaviour nor the new one. The reproduction is in the tests instead:
`history imported in one run keeps the order it was read in` and
`a fresh device names its whole catalog in one run`.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
