### PR TITLE
feat: curl the page under the finger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -404,12 +404,38 @@ emulator.
   and electronic paper overrules the reader's choice with `NONE` in that
   one lambda rather than anywhere else. The endpaper is drawn over the
   book rather than navigated to, so only `LIFT` animates its arrival.
-  A sideways drag answers to the same setting: `PageTurnDrag` claims it
-  under `LIFT` and `NONE` and routes it through the same
-  `PageTurner.turn` a tap uses, leaving `SLIDE` to Readium, which is
-  what that motion already is. `R2WebView` moves the columns in its own
+  A sideways drag answers to the same setting, but not by turning the
+  page the way a tap does: under `LIFT` and `NONE` it curls the
+  departing page off the book under the finger, and it can be pulled
+  halfway and put back. `SLIDE` is left to Readium, which is that
+  motion already, and so is electronic paper — a curl dragged across
+  e-paper is the trail of half-erased pages the lift is refused for, and
+  `turnStyle` cannot say so, since a forced `NONE` reads like a chosen
+  one. That is why the claim asks a separate `interactive` predicate.
+  `R2WebView` moves the columns in its own
   native gesture code, which a JavaScript `preventDefault()` cannot
   stop, so the drag is claimed and consumed in `ReaderScreen`'s
   `PointerEventPass.Initial` loop instead — the same route the image
   viewer uses.
+- The curl is a turn that has already happened: `beginDraggedTurn`
+  photographs the page and jumps the navigator with `animated = false`,
+  and `PageCurl`/`PageCurlOverlay` draw the snapshot over it with
+  `drawBitmapMesh`. Putting it back is `nav.go(from)`, exact, so a
+  boundary the tentative turn crossed is crossed back to the same spot;
+  the ViewModel sees a turn and a turn back, as it does for a tap and a
+  tap back. Keep it off what cannot be undone: `turn` and `stepChapter`
+  refuse while a dragged turn is live, and the last page is probed
+  before the photograph, since the endpaper finishes the book and must
+  never be tentative. A refused curl falls back to the swipe. The
+  snapshot is of the *publication view*, not the window, so both
+  overlays are placed at that view's bounds rather than stretched over
+  the screen, and neither is taken while the chrome is still fading in
+  or out, or the toolbar is photographed onto the page.
+- A turn in the hand is put back at `ON_PAUSE`, never at teardown: a
+  rotation swaps the navigator, and driving the one being let go of
+  throws once its fragments have lost their views. Disposal only drops
+  the page and forgets the turn. Anything that ends a curl from outside
+  the gesture — leaving, a rotation, a window resize — goes through
+  `PageTurnDrag.abandon`, which puts the page back without animating,
+  since an animation wants a next frame there may not be one of.
 - Bundled fonts must be under open licenses (OFL): Literata et al.

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ EMULATOR ?= $(if $(wildcard $(SDK_DIR)/emulator/emulator),$(SDK_DIR)/emulator/em
 SCRCPY ?= scrcpy
 AVD ?= liseur_phone_api36
 SERIAL ?= emulator-5554
-PHONE ?= ca682d4b
+PHONE ?= $(SERIAL)
 ADB_TARGET := -s $(SERIAL)
 ADB_PHONE_TARGET := -s $(PHONE)
 PACKAGE := com.chmouel.liseur
@@ -125,8 +125,8 @@ reset: run-bg
 # The side-by-side build. Everything above installs over whatever carries
 # the production package name, which on a phone is somebody's library; the
 # targets below carry their own package name and cannot reach it. The
-# device is still chosen with SERIAL= like everywhere else, and still
-# defaults to the emulator.
+# device is chosen with PHONE=, which falls back to SERIAL= like
+# everywhere else, and so defaults to the emulator.
 dev:
 	$(GRADLE) assembleDev
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ EMULATOR ?= $(if $(wildcard $(SDK_DIR)/emulator/emulator),$(SDK_DIR)/emulator/em
 SCRCPY ?= scrcpy
 AVD ?= liseur_phone_api36
 SERIAL ?= emulator-5554
+PHONE ?= ca682d4b
 ADB_TARGET := -s $(SERIAL)
+ADB_PHONE_TARGET := -s $(PHONE)
 PACKAGE := com.chmouel.liseur
 ACTIVITY := $(PACKAGE)/.MainActivity
 DEBUG_APK := app/build/outputs/apk/debug/app-debug.apk
@@ -129,23 +131,23 @@ dev:
 	$(GRADLE) assembleDev
 
 dev-install: dev
-	$(ADB) install -r '$(DEV_APK)'
+	$(ADB) $(ADB_PHONE_TARGET) install -r '$(DEV_APK)'
 
 dev-run: dev-install
-	$(ADB)  shell am start -n '$(DEV_ACTIVITY)'
+	$(ADB) $(ADB_PHONE_TARGET) shell am start -n '$(DEV_ACTIVITY)'
 
 dev-uninstall:
-	$(ADB)  uninstall '$(DEV_PACKAGE)'
+	$(ADB) $(ADB_PHONE_TARGET) uninstall '$(DEV_PACKAGE)'
 
 # Filtered by pid rather than by tag: the app logs under a dozen of them,
 # and the pid is the one thing that says "this build and not the other".
 dev-logcat:
-	@pid=$$($(ADB)  shell pidof '$(DEV_PACKAGE)' 2>/dev/null | tr -d '\r' | awk '{print $$1}'); \
+	@pid=$$($(ADB) $(ADB_PHONE_TARGET) shell pidof '$(DEV_PACKAGE)' 2>/dev/null | tr -d '\r' | awk '{print $$1}'); \
 	if [ -z "$$pid" ]; then \
 		printf 'error: %s is not running; start it with make dev-run\n' '$(DEV_PACKAGE)' >&2; \
 		exit 1; \
 	fi; \
-	$(ADB)  logcat --pid="$$pid"
+	$(ADB) $(ADB_PHONE_TARGET) logcat --pid="$$pid"
 
 screenshots:
 	./hack/screenshots

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
@@ -65,9 +66,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.pointer.util.VelocityTracker
+import androidx.compose.ui.input.pointer.util.addPointerInputChange
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalViewConfiguration
@@ -128,6 +134,9 @@ import com.chmouel.liseur.reader.chrome.AdvancedSheet
 import com.chmouel.liseur.reader.chrome.AutoScrollSpeed
 import com.chmouel.liseur.reader.chrome.AutoScrollTicker
 import com.chmouel.liseur.reader.chrome.JumpBackPill
+import com.chmouel.liseur.reader.chrome.PageCurl
+import com.chmouel.liseur.reader.chrome.PageCurlOverlay
+import com.chmouel.liseur.reader.chrome.PageCurlState
 import com.chmouel.liseur.reader.chrome.PageTurnDrag
 import com.chmouel.liseur.reader.chrome.PageTurnEffectState
 import com.chmouel.liseur.reader.chrome.PageTurnOverlay
@@ -378,7 +387,11 @@ fun ReaderScreen(
     var navigator by remember { mutableStateOf<EpubNavigatorFragment?>(null) }
     val navigatorNow by rememberUpdatedState(navigator)
     val readingThemeNow by rememberUpdatedState(readingTheme)
+    var boxInWindow by remember { mutableStateOf(Offset.Zero) }
+    var boxSize by remember { mutableStateOf(IntSize.Zero) }
     var chromeVisible by remember { mutableStateOf(false) }
+    val chromeTransition = remember { MutableTransitionState(false) }
+    val chromeDrawn = { chromeTransition.currentState || chromeTransition.targetState || !chromeTransition.isIdle }
     var showToc by remember { mutableStateOf(false) }
     var searchFor by remember { mutableStateOf<String?>(null) }
     var goToPage by remember { mutableStateOf(false) }
@@ -756,6 +769,7 @@ fun ReaderScreen(
     val eInk = LocalEInk.current
     val eInkNow by rememberUpdatedState(eInk)
     var showingEnd by remember { mutableStateOf(false) }
+    chromeTransition.targetState = chromeVisible && !showingEnd
     val showingEndNow by rememberUpdatedState(showingEnd)
     var endpaperRtl by remember { mutableStateOf(false) }
     val pageTurnEffect = remember { PageTurnEffectState(effectScope) }
@@ -766,7 +780,9 @@ fun ReaderScreen(
     // of half-erased pages. The instant jump is what e-paper wants
     // anyway, and it overrules whatever is set here rather than being
     // one more thing to set. Taps and drags read the style from here, so
-    // the two ways of turning a page cannot disagree about it.
+    // the two ways of turning a page cannot disagree about which drags
+    // are Readium's; the curl a drag draws under the other styles is
+    // refused on e-paper separately, since NONE cannot say why it is set.
     val turnStyle: () -> PageTurnStyle = {
         if (eInkNow) PageTurnStyle.NONE else prefsFlow.value.pageTurnStyle
     }
@@ -774,7 +790,7 @@ fun ReaderScreen(
         PageTurner(
             effect = pageTurnEffect,
             style = turnStyle,
-            isEffectSuppressed = { chromeVisibleNow },
+            isEffectSuppressed = chromeDrawn,
             // Vertical text is scrolled whatever the setting says, so
             // this is the derived answer and not the preference: a
             // sideways-scrolled book asked to turn a page would be asked
@@ -814,6 +830,7 @@ fun ReaderScreen(
         pinchStart.value != null || pinchHeld ||
             SystemClock.uptimeMillis() - pinchSettledAt.longValue < PinchResize.GUARD_MS
     }
+    val pageCurl = remember { PageCurlState(effectScope) }
     val pageTurnDrag = remember {
         PageTurnDrag(
             style = turnStyle,
@@ -824,16 +841,87 @@ fun ReaderScreen(
                 // reach, as it does for every other way of turning it.
                 // Chrome up means the scrubber is on the page, and a
                 // drag across it is a seek, not a turn.
-                !chromeVisibleNow && !effectiveScrollingNow && reflowableTextNow &&
+                !chromeDrawn() && !effectiveScrollingNow && reflowableTextNow &&
                     !isPinching() && selection == null &&
                     viewedImageNow == null && !openingImageNow
             },
+            interactive = { !eInkNow },
             isRtl = {
                 navigatorNow?.overflow?.value?.readingProgression == ReadingProgression.RTL
             },
             density = { view.resources.displayMetrics.density },
+            width = { navigatorNow?.publicationView?.width?.toFloat() ?: view.width.toFloat() },
             onTurnPage = pageTurner::turn,
+            curl = object : PageTurnDrag.Curl {
+                // The turn in hand. Set when the navigator has jumped and
+                // the snapshot is up, cleared when the page has left or
+                // lain back down; nothing here leaves the main thread.
+                var turn: PageTurner.DraggedTurn? = null
+
+                override fun begin(forward: Boolean, grabY: Float, onReady: (Boolean) -> Unit) {
+                    pageTurner.beginDraggedTurn(forward) { started ->
+                        if (started == null) {
+                            onReady(false)
+                            return@beginDraggedTurn
+                        }
+                        turn = started
+                        val pageLocation = IntArray(2)
+                        navigatorNow?.publicationView?.getLocationInWindow(pageLocation)
+                        pageCurl.begin(
+                            bitmap = started.page,
+                            grabY = grabY - (pageLocation[1] - boxInWindow.y),
+                            movesLeft = started.forward != started.rtl,
+                            paper = readingThemeNow.background.toArgb(),
+                        )
+                        onReady(true)
+                    }
+                }
+
+                override fun follow(travel: Float, dy: Float) {
+                    pageCurl.follow(travel, dy, pageCurl.page?.height?.toFloat() ?: view.height.toFloat())
+                }
+
+                override fun finish(velocity: Float) {
+                    val done = turn ?: return
+                    turn = null
+                    pageCurl.finish(
+                        width = done.page.width.toFloat(),
+                        height = done.page.height.toFloat(),
+                        radius = PageCurl.RADIUS_DP * view.resources.displayMetrics.density,
+                        velocity = velocity,
+                    ) { pageTurner.finishDraggedTurn(done) }
+                }
+
+                override fun restore(velocity: Float) {
+                    val undone = turn ?: return
+                    turn = null
+                    pageCurl.restore(velocity) {
+                        // The book goes back under a page that is already
+                        // flat, so the moment it jumps is the moment the
+                        // snapshot can go: the two look the same.
+                        pageTurner.cancelDraggedTurn(undone)
+                        pageCurl.drop()
+                    }
+                }
+
+                override fun abandon() {
+                    turn = null
+                    pageCurl.drop()
+                    // Covers a photograph still being taken as well, so
+                    // it is asked even when there is no turn in hand.
+                    pageTurner.abandonDraggedTurn()
+                }
+            },
         )
+    }
+
+    // A snapshot is a photograph of a page that was this size. Rotating
+    // the phone or resizing the window leaves it a picture of somewhere
+    // else, and the finger is no longer over what it took hold of, so
+    // the turn is given up rather than drawn stretched. The activity
+    // handles these changes itself, so nothing else would notice.
+    LaunchedEffect(boxSize) {
+        if (pageCurl.isRunning) pageTurnDrag.abandon()
     }
 
     LaunchedEffect(showingEnd) {
@@ -1622,6 +1710,17 @@ fun ReaderScreen(
     DisposableEffect(lifecycle) {
         val observer = LifecycleEventObserver { _, event ->
             if (event != Lifecycle.Event.ON_PAUSE) return@LifecycleEventObserver
+            // A page still in the hand has already turned the book
+            // underneath. It is put back here because here is the last
+            // moment the navigator can be driven at all: after this its
+            // fragments lose their views, and a turn nobody committed
+            // would be saved as the place the reader left off. The
+            // origin is published as well as navigated to, since the
+            // navigator's own answer arrives on a later frame that a
+            // closing reader is not obliged to have.
+            val putBack = pageTurner.draggedFrom
+            pageTurnDrag.abandon()
+            putBack?.let { onLocatorChanged(it, NavigatorPositionEvent.LOCAL_JUMP) }
             heldPlace.current()?.let {
                 onLocatorChanged(it, NavigatorPositionEvent.LOCAL_JUMP)
             }
@@ -1660,6 +1759,13 @@ fun ReaderScreen(
         onDispose {
             if (nav != null) listeners?.forEach(nav::removeInputListener)
             pageTurner.navigator = null
+            // After the navigator, deliberately: a rotation swaps it,
+            // and the one being let go of has already lost its views,
+            // so this drops the held page and forgets the turn without
+            // trying to drive anything. Putting the book back is the
+            // ON_PAUSE observer's job, while there is still a navigator
+            // able to do it.
+            pageTurnDrag.abandon()
             pageTurner.window = null
             pageTurner.publication = null
             onPageTurnerChanged(null)
@@ -1755,7 +1861,6 @@ fun ReaderScreen(
      * finger lifted before the document replied leaves a job in flight
      * whose answer must not open a viewer over the next page.
      */
-    var boxInWindow by remember { mutableStateOf(Offset.Zero) }
     val longPressMs = LocalViewConfiguration.current.longPressTimeoutMillis
     val publicationNow by rememberUpdatedState(publication)
 
@@ -1931,9 +2036,13 @@ fun ReaderScreen(
         Modifier
             .fillMaxSize()
             .background(readingTheme.background)
-            .onGloballyPositioned { boxInWindow = it.positionInWindow() }
+            .onGloballyPositioned {
+                boxInWindow = it.positionInWindow()
+                boxSize = it.size
+            }
             .pointerInput(Unit) {
                 val slop = viewConfiguration.touchSlop
+                val velocity = VelocityTracker()
                 awaitPointerEventScope {
                     while (true) {
                         val event = awaitPointerEvent(PointerEventPass.Initial)
@@ -1986,6 +2095,7 @@ fun ReaderScreen(
                                 touch.claim.begin(touch.startedAt)
                                 pinchHeld = false
                                 pageTurnDrag.reset()
+                                velocity.resetTracking()
                                 probeUnderFinger(down[0].position)
                             }
 
@@ -1993,18 +2103,20 @@ fun ReaderScreen(
                                 touch.moved = true
                         }
                         /*
-                         * A sideways drag under Lift or None is a page
-                         * turn in the style the reader chose, and it is
-                         * taken here because there is nowhere else to
-                         * take it: the columns are moved by the web
-                         * view's own native gesture code, which neither
-                         * the page's scripts nor the navigator can call
-                         * off. Consuming the touch is what stops them,
-                         * the way the image viewer stops the long press
-                         * that opened it from also reaching the page.
+                         * A sideways drag under Lift or None curls the
+                         * page off under the finger, and it is taken here
+                         * because there is nowhere else to take it: the
+                         * columns are moved by the web view's own native
+                         * gesture code, which neither the page's scripts
+                         * nor the navigator can call off. Consuming the
+                         * touch is what stops them, the way the image
+                         * viewer stops the long press that opened it from
+                         * also reaching the page. Under Slide the drag is
+                         * Readium's own, which is that motion already.
                          */
+                        if (down.size == 1) velocity.addPointerInputChange(down[0])
                         if (down.isEmpty()) {
-                            if (pageTurnDrag.release()) {
+                            if (pageTurnDrag.release(velocity.calculateVelocity().x)) {
                                 event.changes.forEach { it.consume() }
                                 continue
                             }
@@ -2015,7 +2127,13 @@ fun ReaderScreen(
                             // without travelling would otherwise never be
                             // seen at all.
                             val travelled = down[0].position - touch.downAt
-                            if (pageTurnDrag.offer(down.size, travelled.x, travelled.y)) {
+                            val claimed = pageTurnDrag.offer(
+                                pointers = down.size,
+                                dx = travelled.x,
+                                dy = travelled.y,
+                                downY = touch.downAt.y,
+                            )
+                            if (claimed) {
                                 event.changes.forEach { it.consume() }
                                 continue
                             }
@@ -2236,7 +2354,24 @@ fun ReaderScreen(
             }
         }
 
-        PageTurnOverlay(pageTurnEffect)
+        // PixelCopy captures the inset publication view. Keep its exact
+        // size and origin instead of stretching that image over the screen.
+        val pageOverlayBounds = Modifier.layout { measurable, constraints ->
+            val pageView = navigator?.publicationView
+            val location = IntArray(2)
+            pageView?.getLocationInWindow(location)
+            val width = pageView?.width?.coerceAtLeast(1) ?: constraints.maxWidth
+            val height = pageView?.height?.coerceAtLeast(1) ?: constraints.maxHeight
+            val placeable = measurable.measure(Constraints.fixed(width, height))
+            layout(constraints.maxWidth, constraints.maxHeight) {
+                placeable.place(
+                    (location[0] - boxInWindow.x).toInt(),
+                    (location[1] - boxInWindow.y).toInt(),
+                )
+            }
+        }
+        PageTurnOverlay(pageTurnEffect, pageOverlayBounds)
+        PageCurlOverlay(pageCurl, pageOverlayBounds)
 
         // The ribbon is the marker for a page with no chrome on it. The
         // app bar is placed over this corner and hit first, and its
@@ -2384,7 +2519,7 @@ fun ReaderScreen(
                 fadeOut(tween(CHROME_ANIM_MS))
         }
         AnimatedVisibility(
-            visible = chromeVisible && !showingEnd,
+            visibleState = chromeTransition,
             enter = chromeEnter,
             exit = chromeExit,
             modifier = Modifier.align(Alignment.TopCenter).then(behindViewer),

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -884,12 +884,17 @@ fun ReaderScreen(
                 override fun finish(velocity: Float) {
                     val done = turn ?: return
                     turn = null
+                    // Committed the moment the finger says so, not when
+                    // the snapshot has finished leaving: a turn still
+                    // recorded as in hand would be put back by the
+                    // reader leaving or the page changing size.
+                    pageTurner.finishDraggedTurn(done)
                     pageCurl.finish(
                         width = done.page.width.toFloat(),
                         height = done.page.height.toFloat(),
                         radius = PageCurl.RADIUS_DP * view.resources.displayMetrics.density,
                         velocity = velocity,
-                    ) { pageTurner.finishDraggedTurn(done) }
+                    ) { pageTurner.draggedTurnSettled() }
                 }
 
                 override fun restore(velocity: Float) {

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageCurl.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageCurl.kt
@@ -1,0 +1,280 @@
+package com.chmouel.liseur.reader.chrome
+
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.sin
+import kotlin.math.tan
+
+/**
+ * The shape of a page being curled off the one underneath by a finger.
+ *
+ * The page is a sheet lying flat with its ink up. Its leading edge is
+ * pulled in by [travel] pixels, and the sheet folds back over itself
+ * around a cylinder whose radius broadens during the turn and whose
+ * axis lies along the fold. From
+ * the fold outwards a point climbs the near side of the roll (ink still
+ * showing, in shadow as it turns vertical), comes over the top (the
+ * back of the paper now), and lies flat on the back, upside down, over
+ * the part of the page that has not moved. Everything is measured in a
+ * frame where the page always moves towards `u = 0`, and mirrored back
+ * to screen coordinates at the end, so a backward turn and a
+ * right-to-left book are the same arithmetic.
+ *
+ * The fold sits where it has to for the edge, at the row the finger
+ * holds, to land exactly under the finger. That is an inversion rather
+ * than a formula, because while the edge is still on the roll the
+ * distance it has come is `R sin(d/R) - d`, which is solved for `d`;
+ * once it is over the top it is linear. The fold line is tilted by
+ * [tilt] so a page pulled from near a corner curls that corner first,
+ * and the tilt is ramped in with the travel so that no travel is no
+ * curl, whatever the tilt would be. Raised vertices also project away
+ * from the finger's row to give the sheet depth; flat vertices do not.
+ *
+ * The result is a regular grid over the snapshot, as
+ * `Canvas.drawBitmapMesh` wants it, with three colour arrays that
+ * multiply the snapshot: the ink side, masked to the near quarter of
+ * the roll and darkened into the crease; the back, masked to the far
+ * quarter and the tail; and paper for the back, to be drawn over it
+ * from a one-pixel tile. Per-vertex alpha is what draws the back over
+ * the front: a cell that straddles the top of the roll fades between
+ * the two.
+ */
+object PageCurl {
+
+    /** The mesh for one frame, and what the overlay needs to shade around it. */
+    class Mesh(val cols: Int, val rows: Int) {
+        val vertexCount = (cols + 1) * (rows + 1)
+        val vertices = FloatArray(vertexCount * 2)
+        val front = IntArray(vertexCount)
+        val back = IntArray(vertexCount)
+        val paper = IntArray(vertexCount)
+        val highlight = IntArray(vertexCount)
+        var radius = 0f
+
+        /** A point on the fold line, on screen. */
+        var foldX = 0f
+        var foldY = 0f
+
+        /** Unit normal to the fold, on screen, pointing at the page being revealed. */
+        var normalX = 1f
+        var normalY = 0f
+
+        /** How far past the fold, along the normal, the roll's silhouette lies. */
+        var silhouette = 0f
+
+        /** How much of a roll there is to cast a shadow, 0 to 1. */
+        var lift = 0f
+
+        /** Whether anything is curled at all. */
+        var curled = false
+    }
+
+    /**
+     * Fills [out] for a page [width] by [height] whose leading edge has
+     * come in by [travel] (never negative), held at [grabY], moving
+     * towards the left of the screen or not, with the paper's own
+     * colour [paper] for the back.
+     */
+    fun mesh(
+        width: Float,
+        height: Float,
+        travel: Float,
+        grabY: Float,
+        tilt: Float,
+        movesLeft: Boolean,
+        radius: Float,
+        paper: Int,
+        out: Mesh,
+    ) {
+        val t = max(0f, travel)
+        // A sheet first bows broadly, then tightens as it is pulled over.
+        val bendRadius = bendRadius(t, width, radius)
+        out.radius = bendRadius
+        val phi = tilt * tiltRamp(t, width)
+        val cosP = cos(phi)
+        val sinP = sin(phi)
+        val edgeDistance = edgeDistance(t / cosP, bendRadius)
+        val foldU = width - edgeDistance / cosP
+        val halfTurn = (PI * bendRadius).toFloat()
+        val quarterTurn = halfTurn / 2f
+
+        out.curled = t > 0f
+        val edgeTheta = edgeDistance / bendRadius
+        out.lift = min(1f, edgeTheta / (PI / 2).toFloat())
+        out.silhouette = bendRadius * sin(min(edgeTheta, (PI / 2).toFloat()))
+        out.foldX = toScreen(foldU, width, movesLeft)
+        out.foldY = grabY
+        out.normalX = if (movesLeft) cosP else -cosP
+        out.normalY = sinP
+
+        var i = 0
+        for (row in 0..out.rows) {
+            val y = height * row / out.rows
+            for (col in 0..out.cols) {
+                val x = width * col / out.cols
+                val u = if (movesLeft) x else width - x
+                val d = (u - foldU) * cosP + (y - grabY) * sinP
+                var u2 = u
+                var y2 = y
+                var theta = 0f
+                if (d > 0f) {
+                    theta = d / bendRadius
+                    val shift = if (theta < PI) bendRadius * sin(theta) - d else halfTurn - 2f * d
+                    u2 = u + cosP * shift
+                    y2 = y + sinP * shift
+                    // Perspective belongs only to raised paper. The flat
+                    // region and the finger's row retain their exact size.
+                    val depth = bendRadius * (1f - cos(min(theta, PI.toFloat())))
+                    y2 += (y2 - grabY) * depth / (width * 5f)
+                }
+                out.vertices[i * 2] = toScreen(u2, width, movesLeft)
+                out.vertices[i * 2 + 1] = y2
+                val onFront = d <= quarterTurn
+                out.front[i] = if (onFront) grey(1f, 1f - CREASE * (1f - cos(theta))) else 0
+                out.back[i] = if (onFront) 0 else grey(1f, 1f)
+                out.paper[i] = if (onFront) {
+                    0
+                } else {
+                    val over = min(1f, (theta - (PI / 2).toFloat()) / (PI / 2).toFloat())
+                    tinted(paper, PAPER_ALPHA, BACK_SHADE + (1f - BACK_SHADE) * over)
+                }
+                // A small reflected light band makes black paper's bend
+                // visible too; multiplying black by shading cannot do that.
+                val ridge = sin(theta.coerceIn(0f, PI.toFloat()))
+                out.highlight[i] = grey(0.12f * ridge * ridge, 1f)
+                i++
+            }
+        }
+    }
+
+    /**
+     * How far the edge is from the fold, along the fold's normal, when
+     * it has come in by [travel] along that normal. Inverts the roll
+     * while the edge is on it and is linear once it is over the top.
+     */
+    internal fun edgeDistance(travel: Float, radius: Float): Float {
+        if (travel <= 0f) return 0f
+        val halfTurn = (PI * radius).toFloat()
+        if (travel >= halfTurn) return (halfTurn + travel) / 2f
+        // R sin(d/R) - d falls from 0 to -πR over [0, πR]; find where it
+        // equals -travel.
+        var lo = 0f
+        var hi = halfTurn
+        repeat(24) {
+            val mid = (lo + hi) / 2f
+            val came = mid - radius * sin(mid / radius)
+            if (came < travel) lo = mid else hi = mid
+        }
+        return (lo + hi) / 2f
+    }
+
+    internal fun bendRadius(travel: Float, width: Float, radius: Float): Float {
+        val progress = (travel / width).coerceIn(0f, 1f)
+        val bow = sin(PI.toFloat() * progress)
+        return radius * (1f + 1.2f * bow)
+    }
+
+    /**
+     * The travel at which the last of the page has left the screen: the
+     * fold, and the roll in front of it, is off the far side at every
+     * row. The finishing animation runs to here and no further.
+     */
+    fun travelToClear(
+        width: Float,
+        height: Float,
+        grabY: Float,
+        tilt: Float,
+        radius: Float,
+    ): Float {
+        val cosP = cos(tilt)
+        val tanP = tan(tilt)
+        val overhang = max(grabY * tanP, (grabY - height) * tanP)
+        // A leaning roll projects further along the row than its radius;
+        // two radii cover it at any lean the tilt allows.
+        val distance = (width + overhang) * cosP + 2f * radius
+        return cosP * (2f * distance - (PI * radius).toFloat()) + 1f
+    }
+
+    /**
+     * How the fold leans, in radians: towards the corner the finger is
+     * nearer to, and further as the finger drifts down or up the page.
+     */
+    fun tilt(grabY: Float, dy: Float, height: Float): Float {
+        if (height <= 0f) return 0f
+        val fromGrab = (grabY / height - 0.5f) * 2f * GRAB_TILT
+        val fromDrag = (dy / height) * DRAG_TILT
+        return (fromGrab + fromDrag).coerceIn(-MAX_TILT, MAX_TILT)
+    }
+
+    /**
+     * Whether a finger lifting with the edge [travel] pixels in and moving
+     * at [velocity] pixels a second along the turn (negative is back
+     * towards where it started) finishes the turn or puts the page
+     * back. A page pulled well past the middle turns; a short pull
+     * turns only if it was flung; a fling back puts it back however far
+     * it had come.
+     */
+    fun commits(travel: Float, velocity: Float, width: Float, density: Float): Boolean {
+        val fling = FLING_DP_PER_SECOND * density
+        if (velocity <= -fling) return false
+        if (velocity >= fling && travel >= PageTurnDrag.SWIPE_DP * density) return true
+        return travel >= COMMIT_FRACTION * width
+    }
+
+    private fun tiltRamp(travel: Float, width: Float): Float =
+        if (width <= 0f) 0f else min(1f, travel / (TILT_RAMP_FRACTION * width))
+
+    private fun toScreen(u: Float, width: Float, movesLeft: Boolean): Float =
+        if (movesLeft) u else width - u
+
+    private fun grey(alpha: Float, brightness: Float): Int = tinted(WHITE, alpha, brightness)
+
+    private fun tinted(base: Int, alpha: Float, brightness: Float): Int {
+        val a = (alpha.coerceIn(0f, 1f) * 255f + 0.5f).toInt()
+        val b = brightness.coerceIn(0f, 1f)
+        val r = (((base shr 16) and 0xFF) * b + 0.5f).toInt()
+        val g = (((base shr 8) and 0xFF) * b + 0.5f).toInt()
+        val bl = ((base and 0xFF) * b + 0.5f).toInt()
+        return (a shl 24) or (r shl 16) or (g shl 8) or bl
+    }
+
+    /** Alpha of a vertex whose colour is [argb], 0 to 1. */
+    internal fun alphaOf(argb: Int): Float = ((argb ushr 24) and 0xFF) / 255f
+
+    private const val WHITE = 0xFFFFFFFF.toInt()
+
+    /** How dark the ink side gets as it turns up into the crease. */
+    private const val CREASE = 0.45f
+
+    /** How dark the back is where it comes over the top, before it lies flat. */
+    private const val BACK_SHADE = 0.78f
+
+    /** How much the paper hides the ink showing through the back. */
+    private const val PAPER_ALPHA = 0.9f
+
+    /** Past this share of the width, the tilt is fully in. */
+    private const val TILT_RAMP_FRACTION = 0.25f
+
+    /** How far a fresh corner curls ahead of the rest, at most. */
+    private const val GRAB_TILT = (12.0 * PI / 180.0).toFloat()
+
+    /** How far a finger drifting the whole page height leans the fold. */
+    private const val DRAG_TILT = (25.0 * PI / 180.0).toFloat()
+
+    private const val MAX_TILT = (28.0 * PI / 180.0).toFloat()
+
+    /** How far across the page the edge has to come to turn on a slow release. */
+    const val COMMIT_FRACTION = 0.4f
+
+    /** A flick faster than this decides the turn by its direction. */
+    const val FLING_DP_PER_SECOND = 300f
+
+    /** The roll's minimum radius; it broadens in the middle of a turn. */
+    const val RADIUS_DP = 40f
+
+    const val COLUMNS = 64
+    const val ROWS = 32
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageCurlOverlay.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageCurlOverlay.kt
@@ -1,0 +1,266 @@
+package com.chmouel.liseur.reader.chrome
+
+import android.graphics.Bitmap
+import android.graphics.Matrix
+import android.graphics.Paint
+import android.graphics.Path
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+/**
+ * A page being curled off the book by a finger, and finished or put
+ * back when the finger lifts.
+ *
+ * The book underneath has already turned: `PageTurner` jumps the
+ * navigator and hands the snapshot of the departing page here, the way
+ * it does for the lifted turn. What differs is that the snapshot goes
+ * where the finger says rather than where a tween does, and that it
+ * can be pulled back flat, at which point the navigator is sent back
+ * to where it was.
+ *
+ * All of this runs on the main thread from the pointer loop and the
+ * composition; nothing here is shared with another thread.
+ */
+@Stable
+class PageCurlState(private val scope: CoroutineScope) {
+
+    var page by mutableStateOf<ImageBitmap?>(null)
+        private set
+
+    /** Where the finger took hold, down the page. */
+    var grabY by mutableFloatStateOf(0f)
+        private set
+
+    var tilt by mutableFloatStateOf(0f)
+        private set
+
+    var movesLeft by mutableStateOf(true)
+        private set
+
+    var paper by mutableIntStateOf(0)
+        private set
+
+    /** How far in the leading edge has come, in pixels. */
+    var travel by mutableFloatStateOf(0f)
+        private set
+
+    /**
+     * Held for the first frames after the navigator has jumped, with the
+     * snapshot drawn flat, so that a frame in which the web view is
+     * still painting the new page does not show a strip of the old one
+     * where the curl has already begun.
+     */
+    private var settled by mutableStateOf(false)
+    private var running: Job? = null
+
+    val isRunning: Boolean get() = page != null
+
+    /** Whether the finger still has the page. */
+    var held = false
+        private set
+
+    fun begin(bitmap: ImageBitmap, grabY: Float, movesLeft: Boolean, paper: Int) {
+        running?.cancel()
+        this.grabY = grabY
+        this.movesLeft = movesLeft
+        this.paper = paper
+        tilt = 0f
+        travel = 0f
+        settled = false
+        held = true
+        page = bitmap
+        running = scope.launch {
+            repeat(SETTLE_FRAMES) { withFrameNanos { } }
+            settled = true
+        }
+    }
+
+    /** The finger has moved: the edge is [travel] pixels in, and the finger [dy] down. */
+    fun follow(travel: Float, dy: Float, height: Float) {
+        if (!held) return
+        tilt = PageCurl.tilt(grabY, dy, height)
+        this.travel = travel.coerceAtLeast(0f)
+    }
+
+    /** The finger has let go and the page is to leave; [onDone] once it has. */
+    fun finish(width: Float, height: Float, radius: Float, velocity: Float, onDone: () -> Unit) {
+        if (!held) return
+        held = false
+        val clear = PageCurl.travelToClear(width, height, grabY, tilt, radius)
+        settle(to = clear, velocity = velocity) {
+            page = null
+            onDone()
+        }
+    }
+
+    /** The finger has let go and the page is to lie back down; [onFlat] once it has. */
+    fun restore(velocity: Float, onFlat: () -> Unit) {
+        if (!held) return
+        held = false
+        settle(to = 0f, velocity = velocity, then = onFlat)
+    }
+
+    /** The book has gone back to where it was; nothing more to draw. */
+    fun drop() {
+        held = false
+        running?.cancel()
+        page = null
+    }
+
+    private fun settle(to: Float, velocity: Float, then: () -> Unit) {
+        running?.cancel()
+        running = scope.launch {
+            settled = true
+            Animatable(travel).animateTo(
+                targetValue = to,
+                animationSpec = spring(stiffness = SETTLE_STIFFNESS),
+                initialVelocity = velocity,
+            ) {
+                travel = value
+            }
+            then()
+        }
+    }
+
+    /** The travel to draw this frame: none until the frames after the jump have passed. */
+    internal fun drawnTravel(): Float = if (settled) travel else 0f
+
+    private companion object {
+        const val SETTLE_STIFFNESS = 600f
+        const val SETTLE_FRAMES = 2
+    }
+}
+
+/**
+ * Draws the curled snapshot over the live navigator: the fold's shadow
+ * on the page underneath, the ink side of the sheet bent over the roll,
+ * and paper over the part that has turned face down.
+ */
+@Composable
+fun PageCurlOverlay(state: PageCurlState, modifier: Modifier = Modifier) {
+    val page = state.page ?: return
+    val bitmap = page.asAndroidBitmap()
+    val mesh = remember { PageCurl.Mesh(PageCurl.COLUMNS, PageCurl.ROWS) }
+    val paint = remember { Paint(Paint.FILTER_BITMAP_FLAG or Paint.ANTI_ALIAS_FLAG) }
+    val shadowPaint = remember { Paint(Paint.ANTI_ALIAS_FLAG) }
+    val shadow = remember { Path() }
+    // The shadow's gradient runs along the fold's normal, which turns
+    // and stretches every frame while its colours do not. Built once and
+    // moved with a matrix, so that holding a curl still allocates
+    // nothing on the drawing path.
+    val shadowShader = remember {
+        android.graphics.LinearGradient(
+            0f, 0f, 1f, 0f,
+            intArrayOf(android.graphics.Color.BLACK, android.graphics.Color.TRANSPARENT),
+            null,
+            android.graphics.Shader.TileMode.CLAMP,
+        )
+    }
+    val shadowMatrix = remember { Matrix() }
+    // Vertex colours already carry the paper tint, so the tile is plain.
+    val paperTile = remember {
+        Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+            .apply { eraseColor(android.graphics.Color.WHITE) }
+    }
+    Canvas(modifier.fillMaxSize()) {
+        val width = size.width
+        val height = size.height
+        if (width <= 0f || height <= 0f) return@Canvas
+        val radius = PageCurl.RADIUS_DP.dp.toPx()
+        PageCurl.mesh(
+            width = width,
+            height = height,
+            travel = state.drawnTravel(),
+            grabY = state.grabY,
+            tilt = state.tilt,
+            movesLeft = state.movesLeft,
+            radius = radius,
+            paper = state.paper,
+            out = mesh,
+        )
+        drawIntoCanvas { canvas ->
+            val native = canvas.nativeCanvas
+            if (mesh.curled && mesh.lift > 0f) {
+                drawFoldShadow(
+                    native, mesh, width, height, mesh.radius,
+                    shadow, shadowPaint, shadowShader, shadowMatrix,
+                )
+            }
+            native.drawBitmapMesh(bitmap, mesh.cols, mesh.rows, mesh.vertices, 0, mesh.front, 0, paint)
+            if (mesh.curled) {
+                native.drawBitmapMesh(bitmap, mesh.cols, mesh.rows, mesh.vertices, 0, mesh.back, 0, paint)
+                native.drawBitmapMesh(paperTile, mesh.cols, mesh.rows, mesh.vertices, 0, mesh.paper, 0, paint)
+                native.drawBitmapMesh(paperTile, mesh.cols, mesh.rows, mesh.vertices, 0, mesh.highlight, 0, paint)
+            }
+        }
+    }
+}
+
+/**
+ * A soft band of shadow on the page being revealed, along the roll's
+ * silhouette, fading away from it. Drawn as a strip the width of the
+ * roll's reach, tinted by how upright the roll is.
+ */
+private fun drawFoldShadow(
+    canvas: android.graphics.Canvas,
+    mesh: PageCurl.Mesh,
+    width: Float,
+    height: Float,
+    radius: Float,
+    path: Path,
+    paint: Paint,
+    shader: android.graphics.LinearGradient,
+    matrix: Matrix,
+) {
+    val reach = mesh.silhouette + radius * SHADOW_REACH
+    if (reach <= 0f) return
+    val diag = width + height
+    // The strip lies along the fold line (perpendicular to the normal),
+    // from the silhouette outwards along the normal by the reach.
+    val nx = mesh.normalX
+    val ny = mesh.normalY
+    val tx = -ny
+    val ty = nx
+    val sx = mesh.foldX + nx * mesh.silhouette
+    val sy = mesh.foldY + ny * mesh.silhouette
+    path.rewind()
+    path.moveTo(sx + tx * diag, sy + ty * diag)
+    path.lineTo(sx - tx * diag, sy - ty * diag)
+    path.lineTo(sx - tx * diag + nx * reach, sy - ty * diag + ny * reach)
+    path.lineTo(sx + tx * diag + nx * reach, sy + ty * diag + ny * reach)
+    path.close()
+    // The unit gradient runs (0,0) to (1,0); turn it onto the normal,
+    // stretch it to the reach, and put its start on the silhouette.
+    matrix.setSinCos(ny, nx)
+    matrix.preScale(reach, reach)
+    matrix.postTranslate(sx, sy)
+    shader.setLocalMatrix(matrix)
+    paint.shader = shader
+    // How dark the band is rides on the paint, since the shader's
+    // colours are fixed: the roll standing further up casts more.
+    paint.alpha = ((SHADOW_ALPHA * mesh.lift).coerceIn(0f, 1f) * 255f + 0.5f).toInt()
+    canvas.drawPath(path, paint)
+}
+
+private const val SHADOW_ALPHA = 0.28f
+private const val SHADOW_REACH = 0.6f

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnDrag.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnDrag.kt
@@ -102,6 +102,15 @@ class PageTurnDrag(
     private var gesture: Gesture? = null
 
     /**
+     * A gesture whose fingers have left while the page was still being
+     * photographed. It is nobody's gesture any more, but its answer is
+     * still coming, so it is kept here for [reset] and [abandon] to put
+     * down: a swipe that fell back after the reader closed the book
+     * would turn a page nobody is looking at.
+     */
+    private var awaited: Gesture? = null
+
+    /**
      * Offers a gesture in progress: [pointers] fingers are down, and the
      * first landed [downY] down the page and has travelled [dx] across
      * and [dy] down from there. Answers whether the gesture is ours, and
@@ -161,6 +170,7 @@ class PageTurnDrag(
     }
 
     private fun ready(g: Gesture, inHand: Boolean) {
+        if (awaited === g) awaited = null
         if (g.mode != Mode.PENDING) {
             // Put down or forgotten while the page was being photographed.
             if (inHand) curl.restore(0f)
@@ -197,7 +207,7 @@ class PageTurnDrag(
             Mode.SWIPE -> swipe(g)
             Mode.CURL -> letGo(g)
             // Decided when the page comes to hand.
-            Mode.PENDING -> Unit
+            Mode.PENDING -> awaited = g
             Mode.PUT_DOWN -> Unit
         }
         return true
@@ -221,6 +231,7 @@ class PageTurnDrag(
         val g = gesture
         decided = false
         gesture = null
+        putDownAwaited()
         if (g == null) return
         when (g.mode) {
             Mode.CURL -> curl.restore(0f)
@@ -240,9 +251,15 @@ class PageTurnDrag(
         val g = gesture
         decided = false
         gesture = null
+        putDownAwaited()
         // A photograph still being taken finds nothing left to hold.
         if (g != null) g.mode = Mode.PUT_DOWN
         curl.abandon()
+    }
+
+    private fun putDownAwaited() {
+        awaited?.mode = Mode.PUT_DOWN
+        awaited = null
     }
 
     companion object {

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnDrag.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnDrag.kt
@@ -4,46 +4,108 @@ import com.chmouel.liseur.data.settings.PageTurnStyle
 import kotlin.math.abs
 
 /**
- * Makes a sideways drag turn the page the way the reader asked for.
+ * Makes a sideways drag turn the page, and keeps the page under the
+ * finger while it does.
  *
  * Readium's answer to a drag is the seamless slide: the columns follow
- * the finger and snap when it lifts. That is one of the three page-turn
- * styles, not all of them, and a reader who chose the lifted page or the
- * instant jump got the slide back the moment they used a thumb instead
- * of tapping. So under [PageTurnStyle.SLIDE] this stands aside and the
- * drag stays Readium's; under the other two it takes the gesture over
- * and hands it to the same [PageTurner] a tap uses.
+ * the finger and snap when it lifts. That is [PageTurnStyle.SLIDE], and
+ * under it this stands aside and the drag stays Readium's. Under the
+ * other two the drag is taken over, and the page is curled off the book
+ * under the finger instead — held halfway, put back, or let go — so
+ * that a reader who chose the lifted page or the instant jump for a
+ * *tap* still has a page that moves when they move it. The style
+ * governs the tap, the volume key and the D-pad; a finger on the page
+ * is a finger on the page.
  *
- * Taking it over means taking the touches themselves. The columns are
- * moved by `R2WebView`'s own native gesture code — its own slop, its own
- * velocity tracker, its own scroller — which answers to nothing the page
- * or the navigator can say. The only thing above it is the pointer loop
- * in `ReaderScreen`, which sees every touch before the web view does and
- * can consume it, exactly as the image viewer already does. So this is a
- * plain state machine driven from there rather than an `InputListener`.
+ * Taking the drag over means taking the touches themselves. The columns
+ * are moved by `R2WebView`'s own native gesture code — its own slop,
+ * its own velocity tracker, its own scroller — which answers to nothing
+ * the page or the navigator can say. The only thing above it is the
+ * pointer loop in `ReaderScreen`, which sees every touch before the web
+ * view does and can consume it, exactly as the image viewer already
+ * does. So this is a plain state machine driven from there rather than
+ * an `InputListener`, and the curl itself is behind [Curl], so that
+ * everything here is arithmetic.
  *
- * What is left is a swipe: nothing follows the finger, and lifting it
- * after [SWIPE_DP] turns the page. A drag that sets off up or down the
- * page is never claimed, and a second finger arriving hands the gesture
- * back, so scrolling, pinching and stretching a selection are untouched.
+ * The curl is a page turn that has already happened underneath: the
+ * navigator jumps as the drag is claimed and the departing page is
+ * photographed over it. That takes a frame or two, and the finger goes
+ * on moving meanwhile, so the travel is held and handed over when the
+ * page is in hand. Electronic paper leaves the drag to the navigator.
+ * When there is no curl to be had — the last page, whose
+ * turn finishes the book and cannot be tentative; the first page going
+ * back — the drag is a swipe: nothing follows the finger, and lifting
+ * it after [SWIPE_DP] turns the page the way a tap would.
+ *
+ * A drag that sets off up or down the page is never claimed, so
+ * scrolling, pinching and stretching a selection are untouched. A
+ * second finger arriving hands a swipe back to the web view; it cannot
+ * hand a curl back, since the book has already turned, so it puts the
+ * page down instead and the gesture stays consumed until every finger
+ * has left.
  */
 class PageTurnDrag(
     private val style: () -> PageTurnStyle,
     private val canTurn: () -> Boolean,
+    /** Whether the page can be drawn moving at all; false on electronic paper. */
+    private val interactive: () -> Boolean,
     private val isRtl: () -> Boolean,
     private val density: () -> Float,
+    private val width: () -> Float,
     private val onTurnPage: (forward: Boolean) -> Unit,
+    private val curl: Curl,
 ) {
 
+    /** The page under the finger, as the screen draws it. */
+    interface Curl {
+        /**
+         * Photographs the page and turns the book underneath, going
+         * [forward] or not, with the finger [grabY] down the page.
+         * Answers [onReady] once, later, with whether the page is in
+         * hand; false means there is no curl and the drag is a swipe.
+         */
+        fun begin(forward: Boolean, grabY: Float, onReady: (Boolean) -> Unit)
+
+        /** The edge has come [travel] pixels in, and the finger [dy] down from where it landed. */
+        fun follow(travel: Float, dy: Float)
+
+        /** Let go: the page leaves at [velocity] pixels a second. */
+        fun finish(velocity: Float)
+
+        /** Let go: the page lies back down, from [velocity] pixels a second, and the book goes back. */
+        fun restore(velocity: Float)
+
+        /**
+         * Everything stops now: the page goes and the book returns to
+         * where the turn started, with no motion and nothing to wait
+         * for. For a reader that is closing or a page that has changed
+         * size under the finger, where an animation would outlive what
+         * it was animating.
+         */
+        fun abandon()
+    }
+
+    private enum class Mode { SWIPE, PENDING, CURL, PUT_DOWN }
+
+    private class Gesture(val forward: Boolean, val movesLeft: Boolean) {
+        var mode = Mode.SWIPE
+        var dx = 0f
+        var dy = 0f
+        var released = false
+        var velocity = 0f
+
+        /** How far the edge has come along the turn; a finger back past its start is a flat page. */
+        val travel: Float get() = (if (movesLeft) -dx else dx).coerceAtLeast(0f)
+    }
+
     private var decided = false
-    private var claimed = false
-    private var travel = 0f
+    private var gesture: Gesture? = null
 
     /**
      * Offers a gesture in progress: [pointers] fingers are down, and the
-     * first has travelled [dx] across and [dy] down from where it
-     * landed. Answers whether the gesture is ours, and so whether the
-     * caller should consume it.
+     * first landed [downY] down the page and has travelled [dx] across
+     * and [dy] down from there. Answers whether the gesture is ours, and
+     * so whether the caller should consume it.
      *
      * Only worth asking once the finger has passed the touch slop: below
      * it a drag has no direction to read, and the web view has not begun
@@ -51,43 +113,136 @@ class PageTurnDrag(
      *
      * The answer is decided once and then kept until [reset]. A gesture
      * that set off downwards is the web view's for as long as it lasts,
-     * however it curves later, and a second finger settles it for good:
-     * taking a gesture over halfway through would cancel a touch the web
-     * view is already acting on, and turn a page nobody asked to turn.
+     * however it curves later: taking it over halfway through would
+     * cancel a touch the web view is already acting on, and turn a page
+     * nobody asked to turn. The direction is settled at the same moment,
+     * so a finger that comes back flattens the page rather than starting
+     * the other turn.
      */
-    fun offer(pointers: Int, dx: Float, dy: Float): Boolean {
+    fun offer(pointers: Int, dx: Float, dy: Float, downY: Float = 0f): Boolean {
+        val g = gesture
         if (pointers != 1) {
             decided = true
-            claimed = false
-            return false
+            if (g == null) return false
+            return when (g.mode) {
+                // Nothing has moved yet; the web view can have it.
+                Mode.SWIPE -> {
+                    gesture = null
+                    false
+                }
+                Mode.PENDING -> {
+                    g.mode = Mode.PUT_DOWN
+                    true
+                }
+                Mode.CURL -> {
+                    g.mode = Mode.PUT_DOWN
+                    curl.restore(0f)
+                    true
+                }
+                Mode.PUT_DOWN -> true
+            }
         }
         if (!decided) {
             decided = true
-            claimed = style() != PageTurnStyle.SLIDE && canTurn() && sideways(dx, dy)
+            if (style() != PageTurnStyle.SLIDE && interactive() && canTurn() && sideways(dx, dy)) {
+                val rtl = isRtl()
+                val movesLeft = dx < 0f
+                val fresh = Gesture(forward = movesLeft != rtl, movesLeft = movesLeft)
+                gesture = fresh
+                fresh.mode = Mode.PENDING
+                curl.begin(fresh.forward, downY) { inHand -> ready(fresh, inHand) }
+            }
         }
-        if (claimed) travel = dx
-        return claimed
+        val current = gesture ?: return false
+        current.dx = dx
+        current.dy = dy
+        if (current.mode == Mode.CURL) curl.follow(current.travel, dy)
+        return true
+    }
+
+    private fun ready(g: Gesture, inHand: Boolean) {
+        if (g.mode != Mode.PENDING) {
+            // Put down or forgotten while the page was being photographed.
+            if (inHand) curl.restore(0f)
+            return
+        }
+        if (!inHand) {
+            g.mode = Mode.SWIPE
+            if (g.released) swipe(g)
+            return
+        }
+        g.mode = Mode.CURL
+        if (g.released) {
+            letGo(g)
+        } else {
+            curl.follow(g.travel, g.dy)
+        }
     }
 
     /**
-     * The fingers have left. Turns the page if the swipe went far
-     * enough, and answers whether the gesture was ours at all — a
-     * gesture that was, is consumed to the end, so that the lift out of
-     * a swipe is never also read as a tap on the page.
+     * The fingers have left, the first moving at [velocityX] pixels a
+     * second across the screen. Finishes or puts back a curled page,
+     * turns the page after a long enough swipe, and answers whether the
+     * gesture was ours at all — a gesture that was, is consumed to the
+     * end, so that the lift out of it is never also read as a tap on
+     * the page.
      */
-    fun release(): Boolean {
-        if (!claimed) return false
-        val turn = forward(travel, SWIPE_DP * density(), isRtl())
-        reset()
-        turn?.let(onTurnPage)
+    fun release(velocityX: Float = 0f): Boolean {
+        val g = gesture ?: return false
+        g.released = true
+        g.velocity = velocityX
+        gesture = null
+        decided = false
+        when (g.mode) {
+            Mode.SWIPE -> swipe(g)
+            Mode.CURL -> letGo(g)
+            // Decided when the page comes to hand.
+            Mode.PENDING -> Unit
+            Mode.PUT_DOWN -> Unit
+        }
         return true
+    }
+
+    private fun swipe(g: Gesture) {
+        forward(g.dx, SWIPE_DP * density(), isRtl())?.let(onTurnPage)
+    }
+
+    private fun letGo(g: Gesture) {
+        val along = if (g.movesLeft) -g.velocity else g.velocity
+        if (PageCurl.commits(g.travel, along, width(), density())) {
+            curl.finish(along)
+        } else {
+            curl.restore(along)
+        }
     }
 
     /** Forgets a gesture: a fresh touch owes nothing to the last one. */
     fun reset() {
+        val g = gesture
         decided = false
-        claimed = false
-        travel = 0f
+        gesture = null
+        if (g == null) return
+        when (g.mode) {
+            Mode.CURL -> curl.restore(0f)
+            // Answered when the page comes to hand: see [ready].
+            Mode.PENDING -> g.mode = Mode.PUT_DOWN
+            Mode.SWIPE, Mode.PUT_DOWN -> Unit
+        }
+    }
+
+    /**
+     * Gives the gesture up altogether, putting any page back without
+     * animating it. For the reader closing or the page changing size
+     * under the finger: [reset] starts a motion that wants a next
+     * frame, and there may not be one.
+     */
+    fun abandon() {
+        val g = gesture
+        decided = false
+        gesture = null
+        // A photograph still being taken finds nothing left to hold.
+        if (g != null) g.mode = Mode.PUT_DOWN
+        curl.abandon()
     }
 
     companion object {

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnEffect.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnEffect.kt
@@ -163,6 +163,9 @@ class PageTurner(
     /** True between asking for a dragged turn and answering for it. */
     private var beginning = false
 
+    /** True while a committed page is still flying off the screen. */
+    private var settling = false
+
     /**
      * A page turn that has happened underneath and is still in the
      * reader's hand: the navigator is on the new page, and [page] is
@@ -199,7 +202,7 @@ class PageTurner(
         val win = window
         val view = nav?.publicationView
         if (nav == null || win == null || view == null ||
-            isSuspended() || showingEnd() || pendingEnd || dragging != null || beginning ||
+            isSuspended() || showingEnd() || pendingEnd || handTurning ||
             effect.isRunning || isScrolling() || isEffectSuppressed() ||
             view.width <= 0 || view.height <= 0
         ) {
@@ -207,12 +210,18 @@ class PageTurner(
             return
         }
         beginning = true
+        val generation = ++probeGeneration
+        // A photograph that has been overtaken still has to answer, so
+        // that whoever asked for it puts its page down. What it must not
+        // do is speak for the turn that overtook it: those fields belong
+        // to the newer request now.
         val answer = { turn: DraggedTurn? ->
-            beginning = false
-            dragging = turn
+            if (generation == probeGeneration) {
+                beginning = false
+                dragging = turn
+            }
             onReady(turn)
         }
-        val generation = ++probeGeneration
         val from = nav.currentLocator.value
         val start = {
             copyPage(win, view) { bitmap ->
@@ -265,12 +274,30 @@ class PageTurner(
     fun abandonDraggedTurn() {
         probeGeneration++
         beginning = false
+        settling = false
         dragging?.let { cancelDraggedTurn(it) }
     }
 
-    /** The page left with the finger: the turn stands. */
+    /**
+     * The page left with the finger: the turn stands, and cannot be put
+     * back any more. Said as soon as the finger commits, not when the
+     * snapshot has finished flying off: a turn still recorded as in hand
+     * would be cancelled by the reader leaving or the page changing
+     * size, putting the book back on a page they had already turned.
+     *
+     * The motion goes on for a moment after that, and the book stays
+     * [handTurning] until [draggedTurnSettled], so that a key arriving
+     * meanwhile does not turn a second page over the top of it.
+     */
     fun finishDraggedTurn(turn: DraggedTurn) {
-        if (dragging === turn) dragging = null
+        if (dragging !== turn) return
+        dragging = null
+        settling = true
+    }
+
+    /** The snapshot has gone: the book is the reader's again. */
+    fun draggedTurnSettled() {
+        settling = false
     }
 
     /**
@@ -295,7 +322,7 @@ class PageTurner(
      * arriving in that window would invalidate them and then turn a
      * page of its own, leaving the drag to turn a second one on release.
      */
-    private val handTurning: Boolean get() = dragging != null || beginning
+    private val handTurning: Boolean get() = dragging != null || beginning || settling
 
     fun turn(forward: Boolean) {
         if (isSuspended() || handTurning) return

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnEffect.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/PageTurnEffect.kt
@@ -157,8 +157,148 @@ class PageTurner(
      */
     private var probeGeneration = 0L
 
+    /** The turn a finger is performing, while it is. */
+    private var dragging: DraggedTurn? = null
+
+    /** True between asking for a dragged turn and answering for it. */
+    private var beginning = false
+
+    /**
+     * A page turn that has happened underneath and is still in the
+     * reader's hand: the navigator is on the new page, and [page] is
+     * what the old one looked like, for the curl to draw. [from] is
+     * where the reader was, kept exactly so that a cancelled turn puts
+     * them back there and nowhere near it.
+     */
+    class DraggedTurn(
+        val forward: Boolean,
+        val rtl: Boolean,
+        val from: Locator,
+        val page: ImageBitmap,
+    )
+
+    /**
+     * Starts a turn under the finger: photographs the page, jumps the
+     * navigator with no motion of its own, and answers [onReady] with
+     * the turn once both are done — or with null when there is no turn
+     * to be had, which the caller reads as "swipe instead". That is the
+     * case behind an overlay, while another motion is running, in a
+     * scrolled book, before the view has a size, at the first page
+     * going back, and on the last page: the endpaper finishes the book
+     * when it is reached, and a turn that may yet be put back must not
+     * reach it, so the swipe and [turn] take the last page as they
+     * always have.
+     *
+     * Asked from the pointer loop the moment a drag is claimed. The
+     * snapshot and the last-page probe both answer a frame or two
+     * later, and the finger goes on moving meanwhile; the caller holds
+     * the travel until the answer comes.
+     */
+    fun beginDraggedTurn(forward: Boolean, onReady: (DraggedTurn?) -> Unit) {
+        val nav = navigator
+        val win = window
+        val view = nav?.publicationView
+        if (nav == null || win == null || view == null ||
+            isSuspended() || showingEnd() || pendingEnd || dragging != null || beginning ||
+            effect.isRunning || isScrolling() || isEffectSuppressed() ||
+            view.width <= 0 || view.height <= 0
+        ) {
+            onReady(null)
+            return
+        }
+        beginning = true
+        val answer = { turn: DraggedTurn? ->
+            beginning = false
+            dragging = turn
+            onReady(turn)
+        }
+        val generation = ++probeGeneration
+        val from = nav.currentLocator.value
+        val start = {
+            copyPage(win, view) { bitmap ->
+                if (bitmap == null || !probeStillHolds(generation, nav, from)) {
+                    answer(null)
+                    return@copyPage
+                }
+                val token = onMoveIssued(from, null)
+                val moved = if (forward) nav.goForward(false) else nav.goBackward(false)
+                if (!moved) {
+                    onMoveDropped(token)
+                    answer(null)
+                    return@copyPage
+                }
+                val rtl = nav.overflow.value.readingProgression == ReadingProgression.RTL
+                answer(DraggedTurn(forward, rtl, from, bitmap))
+            }
+        }
+        if (forward && isOnLastResource(nav)) {
+            askIfLastContentVisible(nav) { atEnd ->
+                if (atEnd || !probeStillHolds(generation, nav, from)) answer(null) else start()
+            }
+            return
+        }
+        start()
+    }
+
+    /**
+     * Where a turn in the hand started, while one is. The place to put
+     * the reader back if the turn cannot be finished.
+     */
+    val draggedFrom: Locator? get() = dragging?.from
+
+    /**
+     * Gives up a turn a finger was performing, wherever it had got to,
+     * and puts the book back where the turn started.
+     *
+     * Unlike [cancelDraggedTurn] this needs no [DraggedTurn] in hand, so
+     * it can be called by whatever notices that the turn cannot go on:
+     * the reader leaving, the page changing size under a held curl. A
+     * tentative turn left standing would be a page the reader never
+     * asked to turn, saved as their place. A photograph still being
+     * taken is invalidated too, which its own generation check sees.
+     *
+     * The book is only put back while there is still a navigator to put
+     * it back with. Called after the navigator has gone, this forgets
+     * the turn and no more: driving a fragment whose views have been
+     * destroyed throws, and a teardown is not the place to find out.
+     */
+    fun abandonDraggedTurn() {
+        probeGeneration++
+        beginning = false
+        dragging?.let { cancelDraggedTurn(it) }
+    }
+
+    /** The page left with the finger: the turn stands. */
+    fun finishDraggedTurn(turn: DraggedTurn) {
+        if (dragging === turn) dragging = null
+    }
+
+    /**
+     * The page was put back: the navigator returns to where the turn
+     * started. An exact `go` rather than a turn the other way, so that
+     * a boundary the tentative turn crossed is crossed back to the same
+     * spot.
+     */
+    fun cancelDraggedTurn(turn: DraggedTurn) {
+        if (dragging !== turn) return
+        dragging = null
+        val nav = navigator ?: return
+        probeGeneration++
+        val token = onMoveIssued(nav.currentLocator.value, turn.from)
+        if (!nav.go(turn.from, animated = false)) onMoveDropped(token)
+    }
+
+    /**
+     * Whether a finger has the book. True from the moment a drag is
+     * claimed — not merely once the page is in hand — because the
+     * photograph and the last-page probe take a frame or two, and a key
+     * arriving in that window would invalidate them and then turn a
+     * page of its own, leaving the drag to turn a second one on release.
+     */
+    private val handTurning: Boolean get() = dragging != null || beginning
+
     fun turn(forward: Boolean) {
-        if (isSuspended()) return
+        if (isSuspended() || handTurning) return
         if (showingEnd() || pendingEnd) {
             if (!forward && showingEnd()) onLeaveEnd()
             return
@@ -385,7 +525,7 @@ class PageTurner(
      * one that answered when this locator was made.
      */
     fun stepChapter(forward: Boolean): Boolean {
-        if (isSuspended()) return false
+        if (isSuspended() || handTurning) return false
         if (showingEnd() || pendingEnd) {
             if (!forward && showingEnd()) onLeaveEnd()
             return false

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/PageCurlTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/PageCurlTest.kt
@@ -1,0 +1,220 @@
+package com.chmouel.liseur.reader.chrome
+
+import kotlin.math.PI
+import kotlin.math.abs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PageCurlTest {
+
+    private val width = 1000f
+    private val height = 1800f
+    private val radius = 100f
+    private val paper = 0xFFFAF3E0.toInt()
+
+    @Test
+    fun `no travel leaves the page flat and all ink side`() {
+        val mesh = mesh(travel = 0f)
+        assertFalse(mesh.curled)
+        assertEquals(0f, mesh.lift, 0f)
+        forEachVertex(mesh) { i, col, row ->
+            assertEquals(width * col / mesh.cols, mesh.vertices[i * 2], 1e-3f)
+            assertEquals(height * row / mesh.rows, mesh.vertices[i * 2 + 1], 1e-3f)
+            assertEquals(1f, PageCurl.alphaOf(mesh.front[i]), 0f)
+            assertEquals(0f, PageCurl.alphaOf(mesh.back[i]), 0f)
+            assertEquals(0f, PageCurl.alphaOf(mesh.paper[i]), 0f)
+        }
+    }
+
+    @Test
+    fun `the leading edge lands under the finger`() {
+        for (travel in listOf(40f, 200f, 500f, 900f)) {
+            val mesh = mesh(travel = travel, grabY = height / 2)
+            val edge = cornerX(mesh, col = mesh.cols, row = mesh.rows / 2)
+            assertEquals("travel $travel", width - travel, edge, 1f)
+        }
+    }
+
+    @Test
+    fun `the edge lands under the finger in a backward turn too`() {
+        val mesh = mesh(travel = 300f, movesLeft = false)
+        val edge = cornerX(mesh, col = 0, row = mesh.rows / 2)
+        assertEquals(300f, edge, 1f)
+    }
+
+    @Test
+    fun `nothing before the fold moves`() {
+        val mesh = mesh(travel = 300f)
+        forEachVertex(mesh) { i, col, row ->
+            val x = width * col / mesh.cols
+            if (x < mesh.foldX - 1f) {
+                assertEquals(x, mesh.vertices[i * 2], 1e-2f)
+                assertEquals(height * row / mesh.rows, mesh.vertices[i * 2 + 1], 1e-2f)
+            }
+        }
+    }
+
+    @Test
+    fun `the lifted sheet bows in perspective but flat text stays anchored`() {
+        val mesh = mesh(travel = 400f)
+        var bent = false
+        forEachVertex(mesh) { i, col, row ->
+            val x = width * col / mesh.cols
+            val y = height * row / mesh.rows
+            if (x <= mesh.foldX) {
+                assertEquals(x, mesh.vertices[i * 2], 1e-2f)
+                assertEquals(y, mesh.vertices[i * 2 + 1], 1e-2f)
+                assertEquals(0f, PageCurl.alphaOf(mesh.highlight[i]), 0f)
+            } else if (abs(y - height / 2) > 1f) {
+                bent = bent || abs(mesh.vertices[i * 2 + 1] - y) > 1f
+            }
+        }
+        assertTrue(bent)
+        assertTrue(mesh.highlight.any { PageCurl.alphaOf(it) > 0f })
+    }
+
+    @Test
+    fun `the bend broadens mid turn and tightens before leaving`() {
+        val start = PageCurl.bendRadius(0f, width, radius)
+        val middle = PageCurl.bendRadius(width / 2, width, radius)
+        val end = PageCurl.bendRadius(width, width, radius)
+        assertTrue(middle > start * 2f)
+        assertEquals(start, end, 1e-3f)
+    }
+
+    @Test
+    fun `the back of the page shows where it has come over the top`() {
+        val mesh = mesh(travel = 600f)
+        var sawFront = false
+        var sawBack = false
+        forEachVertex(mesh) { i, _, _ ->
+            val front = PageCurl.alphaOf(mesh.front[i])
+            val back = PageCurl.alphaOf(mesh.back[i])
+            val paper = PageCurl.alphaOf(mesh.paper[i])
+            // A vertex is one side or the other, never both and never neither.
+            assertEquals(1f, front + back, 1e-6f)
+            if (front == 1f) sawFront = true else sawBack = true
+            if (back == 1f) assertTrue(paper > 0f) else assertEquals(0f, paper, 0f)
+        }
+        assertTrue(sawFront)
+        assertTrue(sawBack)
+    }
+
+    @Test
+    fun `the ink darkens into the crease and nowhere else`() {
+        val mesh = mesh(travel = 300f)
+        forEachVertex(mesh) { i, col, _ ->
+            val x = width * col / mesh.cols
+            val front = mesh.front[i]
+            if (PageCurl.alphaOf(front) == 0f) return@forEachVertex
+            val brightness = (front and 0xFF) / 255f
+            if (x < mesh.foldX - 1f) {
+                assertEquals(1f, brightness, 1e-2f)
+            } else {
+                assertTrue(brightness <= 1f && brightness > 0.5f)
+            }
+        }
+    }
+
+    @Test
+    fun `the roll flattens once it is well over`() {
+        val mesh = mesh(travel = 900f)
+        // A vertex near the leading edge, past the roll: on the back,
+        // lying flat, so it has moved by exactly the fold's reflection.
+        val i = index(mesh, col = mesh.cols, row = mesh.rows / 2)
+        assertEquals(width - 900f, mesh.vertices[i * 2], 1f)
+        assertEquals(height / 2, mesh.vertices[i * 2 + 1], 1e-2f)
+        assertEquals(1f, mesh.lift, 0f)
+    }
+
+    @Test
+    fun `a page pulled clear has nothing left on screen`() {
+        for (tilt in listOf(0f, 0.3f, -0.3f)) {
+            val travel = PageCurl.travelToClear(width, height, height / 2, tilt, radius)
+            val mesh = mesh(travel = travel, tilt = tilt)
+            forEachVertex(mesh) { i, _, _ ->
+                if (PageCurl.alphaOf(mesh.front[i]) == 1f) {
+                    assertTrue("tilt $tilt", mesh.vertices[i * 2] < 0f)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `the fold leans towards the corner the finger holds`() {
+        assertTrue(PageCurl.tilt(grabY = 100f, dy = 0f, height = height) < 0f)
+        assertTrue(PageCurl.tilt(grabY = height - 100f, dy = 0f, height = height) > 0f)
+        assertEquals(0f, PageCurl.tilt(grabY = height / 2, dy = 0f, height = height), 1e-6f)
+        assertTrue(PageCurl.tilt(grabY = height / 2, dy = 400f, height = height) > 0f)
+    }
+
+    @Test
+    fun `the tilt is capped`() {
+        val cap = (28.0 * PI / 180.0).toFloat()
+        assertEquals(cap, PageCurl.tilt(grabY = height, dy = height * 3, height = height), 1e-6f)
+        assertEquals(-cap, PageCurl.tilt(grabY = 0f, dy = -height * 3, height = height), 1e-6f)
+    }
+
+    @Test
+    fun `the fold does not lean before the page has moved`() {
+        val mesh = mesh(travel = 0f, grabY = 0f, tilt = 0.4f)
+        assertEquals(1f, abs(mesh.normalX), 1e-6f)
+        assertEquals(0f, mesh.normalY, 1e-6f)
+    }
+
+    @Test
+    fun `edge distance inverts the roll`() {
+        val halfTurn = (PI * radius).toFloat()
+        assertEquals(0f, PageCurl.edgeDistance(0f, radius), 0f)
+        // On the roll: d - R sin(d/R) == travel.
+        for (travel in listOf(10f, 100f, 300f)) {
+            val d = PageCurl.edgeDistance(travel, radius)
+            assertTrue(d < halfTurn)
+            assertEquals(travel, d - radius * kotlin.math.sin(d / radius), 0.05f)
+        }
+        // Over the top: linear, and continuous with the roll.
+        assertEquals(halfTurn, PageCurl.edgeDistance(halfTurn, radius), 0.05f)
+        assertEquals(halfTurn + 50f, PageCurl.edgeDistance(halfTurn + 100f, radius), 1e-3f)
+    }
+
+    @Test
+    fun `a page pulled past the middle turns on a slow release`() {
+        assertTrue(PageCurl.commits(travel = 450f, velocity = 0f, width = width, density = 2f))
+        assertFalse(PageCurl.commits(travel = 350f, velocity = 0f, width = width, density = 2f))
+    }
+
+    @Test
+    fun `a short pull turns only when flung`() {
+        assertTrue(PageCurl.commits(travel = 120f, velocity = 800f, width = width, density = 2f))
+        assertFalse(PageCurl.commits(travel = 120f, velocity = 200f, width = width, density = 2f))
+        // Under the swipe distance even a fling is a twitch.
+        assertFalse(PageCurl.commits(travel = 60f, velocity = 800f, width = width, density = 2f))
+    }
+
+    @Test
+    fun `a fling back puts the page back however far it came`() {
+        assertFalse(PageCurl.commits(travel = 900f, velocity = -800f, width = width, density = 2f))
+    }
+
+    private fun mesh(
+        travel: Float,
+        grabY: Float = height / 2,
+        tilt: Float = 0f,
+        movesLeft: Boolean = true,
+    ): PageCurl.Mesh {
+        val mesh = PageCurl.Mesh(cols = 20, rows = 12)
+        PageCurl.mesh(width, height, travel, grabY, tilt, movesLeft, radius, paper, mesh)
+        return mesh
+    }
+
+    private fun index(mesh: PageCurl.Mesh, col: Int, row: Int) = row * (mesh.cols + 1) + col
+
+    private fun cornerX(mesh: PageCurl.Mesh, col: Int, row: Int) =
+        mesh.vertices[index(mesh, col, row) * 2]
+
+    private fun forEachVertex(mesh: PageCurl.Mesh, block: (i: Int, col: Int, row: Int) -> Unit) {
+        for (row in 0..mesh.rows) for (col in 0..mesh.cols) block(index(mesh, col, row), col, row)
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/PageTurnDragTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/PageTurnDragTest.kt
@@ -41,77 +41,322 @@ class PageTurnDragTest {
         assertEquals(true, PageTurnDrag.forward(travel = 60f, threshold = 48f, rtl = true))
     }
 
+    // Swipes: what the drag is when there is no curl to be had.
+
     @Test
     fun `a sideways swipe past the threshold turns one page`() {
-        val turns = mutableListOf<Boolean>()
-        val drag = drag(turns)
-        assertTrue(drag.offer(pointers = 1, dx = -30f, dy = 2f))
-        assertTrue(drag.offer(pointers = 1, dx = -200f, dy = 6f))
-        assertTrue(drag.release())
-        assertEquals(listOf(true), turns)
+        val h = Harness()
+        assertTrue(h.drag.offer(pointers = 1, dx = -30f, dy = 2f))
+        h.curl.ready(false)
+        assertTrue(h.drag.offer(pointers = 1, dx = -200f, dy = 6f))
+        assertTrue(h.drag.release())
+        assertEquals(listOf(true), h.turns)
+        assertEquals(1, h.curl.log.size)
     }
 
     @Test
     fun `a gesture that set off down the page is never claimed later`() {
-        val turns = mutableListOf<Boolean>()
-        val drag = drag(turns)
-        assertFalse(drag.offer(pointers = 1, dx = 2f, dy = -40f))
+        val h = Harness()
+        assertFalse(h.drag.offer(pointers = 1, dx = 2f, dy = -40f))
         // The finger curves until it has gone further across than down.
-        assertFalse(drag.offer(pointers = 1, dx = -200f, dy = -60f))
-        assertFalse(drag.release())
-        assertTrue(turns.isEmpty())
+        assertFalse(h.drag.offer(pointers = 1, dx = -200f, dy = -60f))
+        assertFalse(h.drag.release())
+        assertTrue(h.turns.isEmpty())
     }
 
     @Test
-    fun `a second finger settles the gesture for good`() {
-        val turns = mutableListOf<Boolean>()
-        val drag = drag(turns)
-        assertTrue(drag.offer(pointers = 1, dx = -200f, dy = 4f))
-        assertFalse(drag.offer(pointers = 2, dx = -200f, dy = 4f))
+    fun `a second finger hands a swipe back to the web view`() {
+        val h = Harness()
+        assertTrue(h.drag.offer(pointers = 1, dx = -200f, dy = 4f))
+        h.curl.ready(false)
+        assertFalse(h.drag.offer(pointers = 2, dx = -200f, dy = 4f))
         // One finger leaves, the other keeps moving across the page.
-        assertFalse(drag.offer(pointers = 1, dx = -300f, dy = 4f))
-        assertFalse(drag.release())
-        assertTrue(turns.isEmpty())
+        assertFalse(h.drag.offer(pointers = 1, dx = -300f, dy = 4f))
+        assertFalse(h.drag.release())
+        assertTrue(h.turns.isEmpty())
     }
 
     @Test
     fun `a fresh touch starts over`() {
-        val turns = mutableListOf<Boolean>()
-        val drag = drag(turns)
-        assertFalse(drag.offer(pointers = 2, dx = -200f, dy = 4f))
-        drag.reset()
-        assertTrue(drag.offer(pointers = 1, dx = -200f, dy = 4f))
-        assertTrue(drag.release())
-        assertEquals(listOf(true), turns)
+        val h = Harness()
+        assertFalse(h.drag.offer(pointers = 2, dx = -200f, dy = 4f))
+        h.drag.reset()
+        assertTrue(h.drag.offer(pointers = 1, dx = -200f, dy = 4f))
+        h.curl.ready(false)
+        assertTrue(h.drag.release())
+        assertEquals(listOf(true), h.turns)
     }
 
     @Test
     fun `the slide is left to the navigator`() {
-        val turns = mutableListOf<Boolean>()
-        val drag = drag(turns, style = PageTurnStyle.SLIDE)
-        assertFalse(drag.offer(pointers = 1, dx = -200f, dy = 4f))
-        assertFalse(drag.release())
-        assertTrue(turns.isEmpty())
+        val h = Harness(style = PageTurnStyle.SLIDE)
+        assertFalse(h.drag.offer(pointers = 1, dx = -200f, dy = 4f))
+        assertFalse(h.drag.release())
+        assertTrue(h.turns.isEmpty())
+        assertTrue(h.curl.log.isEmpty())
     }
 
     @Test
     fun `a page that cannot be turned is left alone`() {
-        val turns = mutableListOf<Boolean>()
-        val drag = drag(turns, canTurn = false)
-        assertFalse(drag.offer(pointers = 1, dx = -200f, dy = 4f))
-        assertFalse(drag.release())
-        assertTrue(turns.isEmpty())
+        val h = Harness(canTurn = false)
+        assertFalse(h.drag.offer(pointers = 1, dx = -200f, dy = 4f))
+        assertFalse(h.drag.release())
+        assertTrue(h.turns.isEmpty())
+        assertTrue(h.curl.log.isEmpty())
     }
 
-    private fun drag(
-        turns: MutableList<Boolean>,
+    @Test
+    fun `electronic paper is left to the navigator`() {
+        val h = Harness(interactive = false)
+        assertFalse(h.drag.offer(pointers = 1, dx = -200f, dy = 4f))
+        assertFalse(h.drag.release())
+        assertTrue(h.turns.isEmpty())
+        assertTrue(h.curl.log.isEmpty())
+    }
+
+    // Curls.
+
+    @Test
+    fun `a claimed drag begins a curl in its direction and follows the finger once it is in hand`() {
+        val h = Harness()
+        assertTrue(h.drag.offer(pointers = 1, dx = -30f, dy = 2f, downY = 900f))
+        assertEquals(listOf("begin forward grab=900.0"), h.curl.log)
+        // Travel while the page is being photographed is held, not lost.
+        assertTrue(h.drag.offer(pointers = 1, dx = -80f, dy = 10f))
+        assertEquals(1, h.curl.log.size)
+        h.curl.ready(true)
+        assertEquals("follow 80.0 dy=10.0", h.curl.log.last())
+        assertTrue(h.drag.offer(pointers = 1, dx = -120f, dy = 12f))
+        assertEquals("follow 120.0 dy=12.0", h.curl.log.last())
+    }
+
+    @Test
+    fun `dragging right curls the page back, and in a right-to-left book forward`() {
+        val ltr = Harness()
+        ltr.drag.offer(pointers = 1, dx = 40f, dy = 0f)
+        assertEquals("begin back grab=0.0", ltr.curl.log.single())
+
+        val rtl = Harness(rtl = true)
+        rtl.drag.offer(pointers = 1, dx = 40f, dy = 0f)
+        assertEquals("begin forward grab=0.0", rtl.curl.log.single())
+    }
+
+    @Test
+    fun `a finger back past where it started is a flat page, not the other turn`() {
+        val h = Harness()
+        h.drag.offer(pointers = 1, dx = -30f, dy = 0f)
+        h.curl.ready(true)
+        h.drag.offer(pointers = 1, dx = 50f, dy = 0f)
+        assertEquals("follow 0.0 dy=0.0", h.curl.log.last())
+    }
+
+    @Test
+    fun `letting go past the middle finishes the turn and the page is not turned twice`() {
+        val h = Harness()
+        h.drag.offer(pointers = 1, dx = -30f, dy = 0f)
+        h.curl.ready(true)
+        h.drag.offer(pointers = 1, dx = -500f, dy = 0f)
+        assertTrue(h.drag.release(velocityX = 0f))
+        assertEquals("finish v=-0.0", h.curl.log.last())
+        assertTrue(h.turns.isEmpty())
+    }
+
+    @Test
+    fun `letting go short of the middle puts the page back`() {
+        val h = Harness()
+        h.drag.offer(pointers = 1, dx = -30f, dy = 0f)
+        h.curl.ready(true)
+        h.drag.offer(pointers = 1, dx = -200f, dy = 0f)
+        assertTrue(h.drag.release(velocityX = 0f))
+        assertEquals("restore v=-0.0", h.curl.log.last())
+    }
+
+    @Test
+    fun `a flick finishes a short pull, along the turn`() {
+        val h = Harness()
+        h.drag.offer(pointers = 1, dx = -30f, dy = 0f)
+        h.curl.ready(true)
+        h.drag.offer(pointers = 1, dx = -120f, dy = 0f)
+        assertTrue(h.drag.release(velocityX = -2000f))
+        // The screen velocity is leftwards; along the turn it is positive.
+        assertEquals("finish v=2000.0", h.curl.log.last())
+    }
+
+    @Test
+    fun `a flick back puts the page back however far it came`() {
+        val h = Harness()
+        h.drag.offer(pointers = 1, dx = -30f, dy = 0f)
+        h.curl.ready(true)
+        h.drag.offer(pointers = 1, dx = -800f, dy = 0f)
+        assertTrue(h.drag.release(velocityX = 2000f))
+        assertEquals("restore v=-2000.0", h.curl.log.last())
+    }
+
+    @Test
+    fun `a release before the page is in hand is decided when it is`() {
+        val h = Harness()
+        h.drag.offer(pointers = 1, dx = -30f, dy = 0f)
+        h.drag.offer(pointers = 1, dx = -600f, dy = 0f)
+        assertTrue(h.drag.release())
+        assertEquals(1, h.curl.log.size)
+        h.curl.ready(true)
+        assertEquals("finish v=-0.0", h.curl.log.last())
+    }
+
+    @Test
+    fun `a curl refused after release becomes the swipe it would have been`() {
+        val h = Harness()
+        h.drag.offer(pointers = 1, dx = -200f, dy = 0f)
+        assertTrue(h.drag.release())
+        assertTrue(h.turns.isEmpty())
+        h.curl.ready(false)
+        assertEquals(listOf(true), h.turns)
+    }
+
+    @Test
+    fun `a curl refused while the finger is still down goes on as a swipe`() {
+        val h = Harness()
+        h.drag.offer(pointers = 1, dx = -30f, dy = 0f)
+        h.curl.ready(false)
+        assertTrue(h.drag.offer(pointers = 1, dx = -200f, dy = 0f))
+        assertEquals(1, h.curl.log.size)
+        assertTrue(h.drag.release())
+        assertEquals(listOf(true), h.turns)
+    }
+
+    @Test
+    fun `a second finger puts a curled page down and keeps the gesture to the end`() {
+        val h = Harness()
+        h.drag.offer(pointers = 1, dx = -200f, dy = 0f)
+        h.curl.ready(true)
+        assertTrue(h.drag.offer(pointers = 2, dx = -200f, dy = 0f))
+        assertEquals("restore v=0.0", h.curl.log.last())
+        // The gesture stays ours until every finger has left.
+        assertTrue(h.drag.offer(pointers = 1, dx = -400f, dy = 0f))
+        assertTrue(h.drag.release(velocityX = -3000f))
+        assertEquals("restore v=0.0", h.curl.log.last())
+        assertTrue(h.turns.isEmpty())
+    }
+
+    @Test
+    fun `a second finger before the page is in hand puts it down when it arrives`() {
+        val h = Harness()
+        h.drag.offer(pointers = 1, dx = -200f, dy = 0f)
+        assertTrue(h.drag.offer(pointers = 2, dx = -200f, dy = 0f))
+        assertTrue(h.drag.release())
+        assertEquals(1, h.curl.log.size)
+        h.curl.ready(true)
+        assertEquals("restore v=0.0", h.curl.log.last())
+    }
+
+    @Test
+    fun `a fresh touch over a curl in the air puts it down`() {
+        val h = Harness()
+        h.drag.offer(pointers = 1, dx = -200f, dy = 0f)
+        h.drag.reset()
+        h.curl.ready(true)
+        assertEquals("restore v=0.0", h.curl.log.last())
+    }
+
+    @Test
+    fun `giving up a held curl puts the book back without animating it`() {
+        val h = Harness()
+        h.drag.offer(pointers = 1, dx = -200f, dy = 0f)
+        h.curl.ready(true)
+        h.drag.abandon()
+        assertEquals("abandon", h.curl.log.last())
+        // Nothing is left of the gesture: the lift is not also a turn.
+        assertFalse(h.drag.release(velocityX = -3000f))
+        assertTrue(h.turns.isEmpty())
+    }
+
+    @Test
+    fun `giving up before the page is in hand turns nothing when it arrives`() {
+        val h = Harness()
+        h.drag.offer(pointers = 1, dx = -200f, dy = 0f)
+        h.drag.abandon()
+        assertEquals("abandon", h.curl.log.last())
+        // The photograph was still being taken; its answer finds the
+        // gesture gone and must not start a swipe out of it.
+        assertTrue(h.curl.awaiting)
+        h.curl.ready(false)
+        assertTrue(h.turns.isEmpty())
+    }
+
+    @Test
+    fun `giving up when nothing is happening is harmless`() {
+        val h = Harness()
+        h.drag.abandon()
+        assertEquals(listOf("abandon"), h.curl.log)
+        // The next touch is an ordinary one.
+        assertTrue(h.drag.offer(pointers = 1, dx = -200f, dy = 0f))
+        assertEquals("begin forward grab=0.0", h.curl.log[1])
+    }
+
+    @Test
+    fun `a curl given up after the fingers left is still put back`() {
+        val h = Harness()
+        h.drag.offer(pointers = 1, dx = -200f, dy = 0f)
+        h.curl.ready(true)
+        // Let go short of the commit: the page is settling back.
+        assertTrue(h.drag.release())
+        assertTrue(h.curl.log.last().startsWith("restore"))
+        h.drag.abandon()
+        assertEquals("abandon", h.curl.log.last())
+    }
+
+    private class FakeCurl : PageTurnDrag.Curl {
+        val log = mutableListOf<String>()
+        private var pending: ((Boolean) -> Unit)? = null
+
+        override fun begin(forward: Boolean, grabY: Float, onReady: (Boolean) -> Unit) {
+            log += "begin ${if (forward) "forward" else "back"} grab=$grabY"
+            pending = onReady
+        }
+
+        override fun follow(travel: Float, dy: Float) {
+            log += "follow $travel dy=$dy"
+        }
+
+        override fun finish(velocity: Float) {
+            log += "finish v=$velocity"
+        }
+
+        override fun restore(velocity: Float) {
+            log += "restore v=$velocity"
+        }
+
+        override fun abandon() {
+            log += "abandon"
+        }
+
+        fun ready(inHand: Boolean) {
+            val answer = pending ?: error("no curl was begun")
+            pending = null
+            answer(inHand)
+        }
+
+        /** Whether a photograph asked for has yet to be answered. */
+        val awaiting: Boolean get() = pending != null
+    }
+
+    private class Harness(
         style: PageTurnStyle = PageTurnStyle.LIFT,
         canTurn: Boolean = true,
-    ) = PageTurnDrag(
-        style = { style },
-        canTurn = { canTurn },
-        isRtl = { false },
-        density = { 1f },
-        onTurnPage = { turns += it },
-    )
+        interactive: Boolean = true,
+        rtl: Boolean = false,
+    ) {
+        val turns = mutableListOf<Boolean>()
+        val curl = FakeCurl()
+        val drag = PageTurnDrag(
+            style = { style },
+            canTurn = { canTurn },
+            interactive = { interactive },
+            isRtl = { rtl },
+            density = { 1f },
+            width = { 1000f },
+            onTurnPage = { turns += it },
+            curl = curl,
+        )
+    }
 }

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/PageTurnDragTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/chrome/PageTurnDragTest.kt
@@ -305,6 +305,37 @@ class PageTurnDragTest {
         assertEquals("abandon", h.curl.log.last())
     }
 
+    @Test
+    fun `giving up after the fingers left turns nothing when the page arrives`() {
+        val h = Harness()
+        h.drag.offer(pointers = 1, dx = -200f, dy = 0f)
+        // The fingers leave while the photograph is still being taken,
+        // so the swipe fallback is owed an answer.
+        assertTrue(h.drag.release())
+        h.drag.abandon()
+        h.curl.ready(false)
+        assertTrue(h.turns.isEmpty())
+    }
+
+    @Test
+    fun `a fresh touch after the fingers left drops the swipe still owed`() {
+        val h = Harness()
+        h.drag.offer(pointers = 1, dx = -200f, dy = 0f)
+        assertTrue(h.drag.release())
+        h.drag.reset()
+        h.curl.ready(false)
+        assertTrue(h.turns.isEmpty())
+    }
+
+    @Test
+    fun `a swipe still owed when the fingers left turns the page as usual`() {
+        val h = Harness()
+        h.drag.offer(pointers = 1, dx = -200f, dy = 0f)
+        assertTrue(h.drag.release())
+        h.curl.ready(false)
+        assertEquals(listOf(true), h.turns)
+    }
+
     private class FakeCurl : PageTurnDrag.Curl {
         val log = mutableListOf<String>()
         private var pending: ((Boolean) -> Unit)? = null

--- a/docs/adr/0025-page-turn-styles.md
+++ b/docs/adr/0025-page-turn-styles.md
@@ -84,6 +84,63 @@ reading of the setting — a reader who asked for no motion cannot also
 have the page follow their finger — and **Slide**, which is that
 tracking, is one tap away.
 
+#### Amended: the page follows the finger after all
+
+> Amended by [#176](https://github.com/chmouel/liseur/issues/176). The
+> paragraph above was wrong about what the setting says. A reader who
+> chose the lifted page chose what a *tap* does with it; they did not
+> ask for a thumb that pushes nothing. Losing the tracking was a cost
+> of how the claim was built, and it read on the phone as the gesture
+> having stopped working — the page sits still under the finger and
+> then jumps when it leaves.
+
+So under **Lift** and **None** the drag now curls the departing page off
+the book, and the curl follows the finger: it can be pulled halfway,
+held there, and put back. **Slide** is unchanged and still Readium's
+own drag, which is that tracking already.
+
+The curl is a page turn that has already happened underneath. The
+machinery the rejected alternative below was refused for turns out to
+be the machinery already written for the lift: `PageTurner` photographs
+the page with `PixelCopy` and jumps the navigator with `animated =
+false`, and the snapshot is drawn over the live page. The drag does the
+same, and the difference is only what moves the snapshot — a finger
+rather than a tween — and that it can be put back. Nothing is held at
+touch-down: the snapshot is taken when the drag is claimed, which is
+after the slop and after the direction is read, so a selection or a
+pinch never causes one to be taken at all.
+
+`reader/chrome/PageCurl.kt` is the geometry, and it is arithmetic:
+vertices and per-vertex colours for `Canvas.drawBitmapMesh`, which is
+hardware-accelerated back to API 18 where `drawVertices` only arrives at
+29. The page wraps a cylinder whose radius broadens as the turn opens
+and tightens as it completes, the fold tilts with the row the finger
+grabbed and with how far down it has since travelled, and the back face
+is a second pass of a plain paper tile so the text shows faintly through
+it the way thin paper does. `PageCurlOverlay.kt` draws it and
+`PageTurnDrag` is still the state machine, now with the curl behind an
+interface so that all of it stays testable as numbers.
+
+Releasing commits the turn past about 40% of the width, or on a fling
+toward it; anything less puts the page back, and a fling back cancels
+from anywhere.
+
+**Electronic paper keeps Readium's drag**, as it had before this ADR.
+The reasoning that gives it **None** for a tap is exactly the reasoning
+that refuses it a curl: a photograph dragged across such a panel is a
+trail of half-erased pages, and a curled one is a worse trail. But the
+swipe that stood in for it here was no better a fit — a gesture that
+does nothing until it is released, on the screen least able to explain
+why — and Readium's own drag is what e-paper had before and handles
+itself. Since `turnStyle` overrules e-ink to **None** in one lambda and
+a chosen **None** cannot be told from an imposed one, the claim reads a
+separate `interactive` predicate rather than the style.
+
+The swipe does not go away. It is what a refused curl falls back to:
+the last page, whose turn finishes the book and must not be tentative,
+so it is probed for first; the first page going back; a snapshot that
+could not be taken; anything drawn over the book.
+
 The claim is decided once, on the first move past the touch slop, and
 only for a drag that sets off across the page. That decision then stands
 for the rest of the gesture: a drag that set off downwards stays the web
@@ -139,6 +196,12 @@ away if the drag turns into a selection or a pinch — a lot of machinery
 for a style whose point is that the page comes off the stack, not that
 it follows anything.
 
+> Amended by [#176](https://github.com/chmouel/liseur/issues/176):
+> built, as a curl rather than a lift. The objection was answered by
+> not taking the snapshot at touch-down. It is taken when the drag is
+> claimed, by which time a selection or a pinch has already gone
+> elsewhere, so there is nothing to throw away.
+
 **Interpolating the slide ourselves.** Readium animates its own move; a
 second animation over the top of it would have to agree with the first
 about duration, easing and direction, and would drift the moment the
@@ -166,10 +229,39 @@ affordable.
 #156 also asks for pages-left-in-chapter progress and a partial progress
 bar. Not decided here.
 
+> Amended by [#176](https://github.com/chmouel/liseur/issues/176): a
+> curl that is put back is, underneath, a page turn and a turn back.
+> The navigator has already moved by the time the finger is halfway,
+> and the cancel is an exact `go` to the locator the turn started from
+> — exact rather than a step the other way, so that a resource boundary
+> the tentative turn crossed is crossed back to the same spot and not
+> merely to the same side of it. Everything downstream sees both moves:
+> the position is published twice, the pace estimator drops the
+> backward one, a catch-up offer is dismissed. This is what a tap
+> followed by a tap back already does, and it was accepted rather than
+> given a tentative-move channel of its own, which would have had to
+> reach every reader of a position. The tentative turn is kept off the
+> paths that cannot be undone: `turn` and `stepChapter` do nothing
+> while one is live, and the last page is probed before the page is
+> ever photographed, so the endpaper is never reached by a turn that
+> might yet be put back.
+>
+> A turn still in the hand when the reader leaves is put back at
+> `ON_PAUSE`, and only there. That is the last moment the navigator can
+> be driven at all: disposal is too late, because a rotation swaps the
+> navigator and the one being let go of has already lost its fragments'
+> views, so a `go` from a teardown throws. Disposal therefore drops the
+> held page and forgets the turn without driving anything. The origin is
+> published as a `LOCAL_JUMP` as well as navigated to, since the
+> navigator's own answer arrives on a later frame that a closing reader
+> is not obliged to give it — the same reasoning, and the same observer,
+> as the held scroll position published there already.
+
 *Where:* `data/settings/ReaderPrefs.kt`,
 `data/settings/ReaderPreferencesRepository.kt`,
 `data/settings/AppSettings.kt`, `reader/chrome/PageTurnEffect.kt`,
-`reader/chrome/PageTurnDrag.kt`, `reader/ReaderScreen.kt`,
+`reader/chrome/PageTurnDrag.kt`, `reader/chrome/PageCurl.kt`,
+`reader/chrome/PageCurlOverlay.kt`, `reader/ReaderScreen.kt`,
 `reader/chrome/AdvancedSheet.kt`,
 `ui/reading/ReadingAppearanceControls.kt`, `ui/settings/SettingsRows.kt`,
 `ui/settings/ReadingNavigationScreen.kt`,


### PR DESCRIPTION
## Summary

Dragging sideways in a book now bends the page under your finger, like turning a real one, instead of doing nothing until you let go. Lift it far enough across, or flick it, and the page turns. Pull it back and it settles where it was.

Before this, a drag under the Lift and None page-turn settings only turned the page on release, so nothing followed the finger.

Fixes #176

## Changes

- A sideways drag under the Lift and None page-turn settings curls the page under the finger and completes or cancels on release.
- The Slide setting is unchanged; it was already interactive.
- E-ink screens keep the plain slide, since a curl dragged across e-paper leaves a trail of half-erased pages.
- The page-turn setting still governs taps, volume keys and keyboard turns as before.
- Amends the page-turn styles design record and the contributor notes.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

Checked on an emulator: forward and backward turns, holding the page halfway, pulling it back to cancel, flicking to commit, the first and last pages, rotating and leaving the app mid-turn, and the Slide and e-ink cases. Reading position after leaving mid-turn was confirmed in the database.

## Screenshots or recordings

![The page curled under the finger](https://github.com/user-attachments/assets/acaa5f1a-4a63-4942-9cce-52e55e9717e8)

A recording of a forward and a backward turn:

https://github.com/user-attachments/assets/c2257ac8-5022-42ce-8021-3ece70355e9e

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
