### PR TITLE
feat: choose the first offered colour for passage notes

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
@@ -179,7 +179,9 @@ enum class DefinitionTarget(val id: String) {
  *   Wiktionary works, so a reader can pick their own language's edition or
  *   a mirror instead of the default.
  * @param highlightPalette Which colours the bar over a selected passage
- *   offers, and the configured default for a plain highlight.
+ *   offers, and the configured default for a plain highlight. A passage note
+ *   uses the first colour in that bar's stable order, or the default when
+ *   the bar is empty.
  */
 data class AppSettings(
     val themeMode: ThemeMode = ThemeMode.Default,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/AppSettings.kt
@@ -179,7 +179,7 @@ enum class DefinitionTarget(val id: String) {
  *   Wiktionary works, so a reader can pick their own language's edition or
  *   a mirror instead of the default.
  * @param highlightPalette Which colours the bar over a selected passage
- *   offers, and which one a mark made without picking gets.
+ *   offers, and the configured default for a plain highlight.
  */
 data class AppSettings(
     val themeMode: ThemeMode = ThemeMode.Default,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -1018,9 +1018,15 @@ fun ReaderScreen(
     // one it would drop.
     LaunchedEffect(navigator) {
         val nav = navigator ?: return@LaunchedEffect
-        nav.currentLocator.collect {
-            tappedSelection = null
-            moves.onPosition(it.restorePoint(), SystemClock.elapsedRealtime())
+        nav.currentLocator.collect { locator ->
+            val tapped = tappedSelection
+            if (
+                tapped != null &&
+                (!effectiveScrollingNow || locator.href != tapped.locator.href)
+            ) {
+                tappedSelection = null
+            }
+            moves.onPosition(locator.restorePoint(), SystemClock.elapsedRealtime())
         }
     }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -509,6 +509,11 @@ fun ReaderScreen(
     // A tapped mark has no platform selection. A late CLEARED from the
     // web view must not dismiss the controls we just opened for it.
     var tappedSelection by remember { mutableStateOf<ActiveSelection?>(null) }
+    // When the popup for it opened, so the locator collector below can
+    // tell Readium's trailing scroll debounce (ADR 6: up to a hundred
+    // milliseconds of stillness before it lands) from the reader
+    // scrolling again with the popup already open.
+    var tappedAt by remember { mutableStateOf(0L) }
     val annotationsNow by rememberUpdatedState(annotations)
     var noteFor by remember { mutableStateOf<ActiveSelection?>(null) }
     var bookNoteEditor by remember { mutableStateOf<BookNoteEditor?>(null) }
@@ -1020,11 +1025,19 @@ fun ReaderScreen(
         val nav = navigator ?: return@LaunchedEffect
         nav.currentLocator.collect { locator ->
             val tapped = tappedSelection
-            if (
-                tapped != null &&
-                (!effectiveScrollingNow || locator.href != tapped.locator.href)
-            ) {
-                tappedSelection = null
+            if (tapped != null) {
+                // A scroll that had already stopped before the tap can
+                // still land its debounced report just after: within
+                // the grace window that is the same stillness ADR 6
+                // describes, not the reader moving on, so it is not
+                // mistaken for one. Past it, this is exactly what
+                // paginated movement already does: any emission ends
+                // the tap, because the rect it was drawn at is never
+                // re-measured and a real scroll would leave it behind.
+                val settling = effectiveScrollingNow &&
+                    locator.href == tapped.locator.href &&
+                    SystemClock.elapsedRealtime() - tappedAt < TAPPED_SETTLE_GRACE_MS
+                if (!settling) tappedSelection = null
             }
             moves.onPosition(locator.restorePoint(), SystemClock.elapsedRealtime())
         }
@@ -1419,6 +1432,7 @@ fun ReaderScreen(
                     nav.clearSelection()
                     selection = null
                     tappedSelection = ActiveSelection(locator, rect, annotation)
+                    tappedAt = SystemClock.elapsedRealtime()
                     chromeVisible = false
                 }
                 return true
@@ -3056,6 +3070,14 @@ private val SEARCH_HIT_TINT = Color(0xFF80CBC4)
 
 private const val POPUP_HEIGHT_PX = 160f
 private const val POPUP_GAP_PX = 24f
+
+/**
+ * How long after a tap a same-resource locator emission is still read
+ * as the trailing report of a scroll that had already stopped, not the
+ * reader moving on. ADR 6 documents the debounce it is covering: up to
+ * a hundred milliseconds of stillness before Readium lands one.
+ */
+private const val TAPPED_SETTLE_GRACE_MS = 250L
 
 /** Bundle of in-book search actions passed down to the reader chrome. */
 class ReaderSearchActions(

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -199,7 +199,9 @@ import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.withContext
+import org.readium.r2.navigator.DecorableNavigator
 import org.readium.r2.navigator.Decoration
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.navigator.epub.EpubPreferences
@@ -504,6 +506,10 @@ fun ReaderScreen(
     // started. This gives it a window onto the current value.
     val noteShowing by rememberUpdatedState(footnote != null)
     var selection by remember { mutableStateOf<ActiveSelection?>(null) }
+    // A tapped mark has no platform selection. A late CLEARED from the
+    // web view must not dismiss the controls we just opened for it.
+    var tappedSelection by remember { mutableStateOf<ActiveSelection?>(null) }
+    val annotationsNow by rememberUpdatedState(annotations)
     var noteFor by remember { mutableStateOf<ActiveSelection?>(null) }
     var bookNoteEditor by remember { mutableStateOf<BookNoteEditor?>(null) }
     var defineWord by remember { mutableStateOf<String?>(null) }
@@ -842,7 +848,7 @@ fun ReaderScreen(
                 // Chrome up means the scrubber is on the page, and a
                 // drag across it is a seek, not a turn.
                 !chromeDrawn() && !effectiveScrollingNow && reflowableTextNow &&
-                    !isPinching() && selection == null &&
+                    !isPinching() && selection == null && tappedSelection == null &&
                     viewedImageNow == null && !openingImageNow
             },
             interactive = { !eInkNow },
@@ -1013,6 +1019,7 @@ fun ReaderScreen(
     LaunchedEffect(navigator) {
         val nav = navigator ?: return@LaunchedEffect
         nav.currentLocator.collect {
+            tappedSelection = null
             moves.onPosition(it.restorePoint(), SystemClock.elapsedRealtime())
         }
     }
@@ -1329,11 +1336,14 @@ fun ReaderScreen(
     // about the platform's own magnifier and selection handles, which an
     // app hosting a web view has no say over at all.
     LaunchedEffect(navigator, selectionEvents) {
+        tappedSelection = null
         val nav = navigator ?: run {
             selection = null
             return@LaunchedEffect
         }
-        selectionEvents.collectSettledSelection(
+        selectionEvents.onEach {
+            if (it == SelectionEvent.CHANGED) tappedSelection = null
+        }.collectSettledSelection(
             settleMs = SELECTION_SETTLE_MS,
             read = { nav.currentSelection() },
             onSelection = { current ->
@@ -1373,6 +1383,43 @@ fun ReaderScreen(
     LaunchedEffect(navigator, annotations) {
         val nav = navigator ?: return@LaunchedEffect
         nav.applyDecorations(annotations.toDecorations(), DECORATION_GROUP)
+        tappedSelection = tappedSelection?.let { active ->
+            annotations.firstOrNull { it.id == active.existing?.id }?.let {
+                active.copy(existing = it)
+            }
+        }
+    }
+
+    DisposableEffect(navigator) {
+        val nav = navigator
+        val listener = object : DecorableNavigator.Listener {
+            override fun onDecorationActivated(event: DecorableNavigator.OnActivatedEvent): Boolean {
+                // Readium calls this from its JavaScript bridge thread.
+                effectScope.launch {
+                    if (nav == null || navigatorNow !== nav || isPinching()) return@launch
+                    val annotation = annotationsNow.firstOrNull { it.id == event.decoration.id }
+                        ?: return@launch
+                    val locator = annotation.locator() ?: return@launch
+                    // Decoration bounds belong to the inset publication
+                    // view; the popup is placed in the reader's root.
+                    val origin = IntArray(2)
+                    nav.publicationView.getLocationInWindow(origin)
+                    val rect = event.rect?.let {
+                        RectF(it).apply {
+                            offset(origin[0] - boxInWindow.x, origin[1] - boxInWindow.y)
+                        }
+                    }
+                    onSelectionDismissed()
+                    nav.clearSelection()
+                    selection = null
+                    tappedSelection = ActiveSelection(locator, rect, annotation)
+                    chromeVisible = false
+                }
+                return true
+            }
+        }
+        nav?.addDecorationListener(DECORATION_GROUP, listener)
+        onDispose { nav?.removeDecorationListener(listener) }
     }
 
     // Tracked rather than read: the setting arrives with the book, and
@@ -1414,6 +1461,7 @@ fun ReaderScreen(
         !goToPercent &&
         footnote == null &&
         selection == null &&
+        tappedSelection == null &&
         noteFor == null &&
         defineWord == null &&
         jumpBack == null &&
@@ -2696,6 +2744,7 @@ fun ReaderScreen(
         onSelectionDismissed()
         navigator?.clearSelection()
         selection = null
+        tappedSelection = null
     }
 
     // Not composed at all while a picture is open, rather than hidden the
@@ -2705,7 +2754,7 @@ fun ReaderScreen(
     // of buttons a screen reader could still operate — and draw them over
     // the picture besides. The selection itself is untouched and comes
     // back with the bar when the picture is dismissed.
-    selection?.takeIf { viewedImage == null }?.let { active ->
+    (tappedSelection ?: selection)?.takeIf { viewedImage == null }?.let { active ->
         SelectionPopup(
             offset = active.popupOffset(),
             activeTint = active.existing?.tint?.let(HighlightTint::fromName),

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -818,8 +818,8 @@ class ReaderViewModel(
      *
      * Read eagerly because a mark can be made before anything has
      * collected it — the bar is drawn from the reader's first selection
-     * — and because [annotation] and [addNote] take the default colour
-     * from its value rather than from a constant.
+     * — and because [annotation] and [addNote] take their new-mark colours
+     * from its value rather than from constants.
      */
     val highlightPalette: StateFlow<HighlightPalette> = appSettings.settings
         .map { it.highlightPalette }
@@ -1419,7 +1419,7 @@ class ReaderViewModel(
             annotation(locator, AnnotationKind.NOTE).copy(
                 id = existing?.id ?: UUID.randomUUID().toString(),
                 note = note,
-                tint = existing?.tint ?: highlightPalette.value.default.name,
+                tint = existing?.tint ?: highlightPalette.value.passageNoteTint.name,
                 createdAt = existing?.createdAt ?: System.currentTimeMillis(),
             ),
         )
@@ -1662,7 +1662,7 @@ class ReaderViewModel(
     fun toggleHighlightTint(tint: HighlightTint) =
         viewModelScope.launch { appSettings.toggleHighlightTint(tint) }
 
-    /** Which colour a mark made without picking one comes out in. */
+    /** Which colour a plain Highlight, or an empty palette's Note, comes out in. */
     fun setHighlightDefaultTint(tint: HighlightTint) =
         viewModelScope.launch { appSettings.setHighlightDefaultTint(tint) }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/HighlightPalette.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/HighlightPalette.kt
@@ -1,8 +1,8 @@
 package com.chmouel.liseur.reader.annotations
 
 /**
- * Which colours a passage may be marked in, and which one is meant when
- * no colour was picked.
+ * Which colours a passage may be marked in, and which one a plain highlight
+ * gets when no colour was picked.
  *
  * [HighlightTint] has six entries because that is what liseur-sync's
  * palette is, and a colour arriving from another device must have a
@@ -37,6 +37,16 @@ data class HighlightPalette(
 
     /** Whether the bar has no colours to offer and needs a plain action instead. */
     val isEmpty: Boolean = shown.isEmpty()
+
+    /**
+     * The tint for a new note attached to a passage.
+     *
+     * Notes follow the first colour the reader currently offers. An empty
+     * palette has no first colour, so it falls back to the separately chosen
+     * default to keep note creation possible.
+     */
+    val passageNoteTint: HighlightTint
+        get() = shown.firstOrNull() ?: default
 
     /**
      * The chips to draw for the mark in hand.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -519,7 +519,7 @@
 
     <!-- The colours offered when a passage is marked. -->
     <string name="reader_highlight_colours">Available colours</string>
-    <string name="reader_highlight_colours_help">Tap a colour to offer it when you mark a passage. Hold one to make it the default, which is %1$s: a highlight made without picking gets it, and a note uses the first offered colour.</string>
+    <string name="reader_highlight_colours_help">Tap a colour to offer it when you mark a passage. Hold one to make it the default, which is %1$s: a highlight made without picking gets it, and a note uses the first colour in the bar's order.</string>
     <string name="reader_highlight_colours_none">No colours are offered, so marking a passage highlights it in %1$s. Tap a colour to bring the choice back.</string>
     <string name="reader_highlight_state_offered">Offered</string>
     <string name="reader_highlight_state_offered_default">Offered, and the default</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -519,7 +519,7 @@
 
     <!-- The colours offered when a passage is marked. -->
     <string name="reader_highlight_colours">Available colours</string>
-    <string name="reader_highlight_colours_help">Tap a colour to offer it when you mark a passage. Hold one to make it the default, which is %1$s: notes get it, and so does a highlight made without picking.</string>
+    <string name="reader_highlight_colours_help">Tap a colour to offer it when you mark a passage. Hold one to make it the default, which is %1$s: a highlight made without picking gets it, and a note uses the first offered colour.</string>
     <string name="reader_highlight_colours_none">No colours are offered, so marking a passage highlights it in %1$s. Tap a colour to bring the choice back.</string>
     <string name="reader_highlight_state_offered">Offered</string>
     <string name="reader_highlight_state_offered_default">Offered, and the default</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -519,7 +519,7 @@
 
     <!-- The colours offered when a passage is marked. -->
     <string name="reader_highlight_colours">Available colours</string>
-    <string name="reader_highlight_colours_help">Tap a colour to offer it when you mark a passage. Hold one to make it the default, which is %1$s: a highlight made without picking gets it, and a note uses the first colour in the bar's order.</string>
+    <string name="reader_highlight_colours_help">Tap a colour to offer it when you mark a passage. Hold one to make it the default, which is %1$s: a highlight made without picking gets it, and a note uses the first colour in the bar\'s order.</string>
     <string name="reader_highlight_colours_none">No colours are offered, so marking a passage highlights it in %1$s. Tap a colour to bring the choice back.</string>
     <string name="reader_highlight_state_offered">Offered</string>
     <string name="reader_highlight_state_offered_default">Offered, and the default</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/annotations/HighlightPaletteTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/annotations/HighlightPaletteTest.kt
@@ -52,6 +52,26 @@ class HighlightPaletteTest {
     }
 
     @Test
+    fun `a passage note uses the first offered colour`() {
+        val palette = HighlightPalette(
+            offered = setOf(HighlightTint.BLUE, HighlightTint.GREEN),
+            default = HighlightTint.PURPLE,
+        )
+
+        assertEquals(HighlightTint.GREEN, palette.passageNoteTint)
+    }
+
+    @Test
+    fun `a passage note falls back to the configured default when none are offered`() {
+        val palette = HighlightPalette(
+            offered = emptySet(),
+            default = HighlightTint.ORANGE,
+        )
+
+        assertEquals(HighlightTint.ORANGE, palette.passageNoteTint)
+    }
+
+    @Test
     fun `adding a colour leaves the others where they were`() {
         val three = HighlightPalette()
         val four = three.toggled(HighlightTint.PINK)

--- a/docs/adr/0026-a-configurable-highlight-palette.md
+++ b/docs/adr/0026-a-configurable-highlight-palette.md
@@ -26,8 +26,9 @@ selection by everybody.
 ## Decision
 
 Which colours the bar offers is the reader's to set: any subset of the
-six, and **yellow, green and blue by default**. Which colour a mark gets
-when none was picked is theirs to set too.
+six, and **yellow, green and blue by default**. Which colour a plain
+Highlight gets when none was picked is theirs to set too. A Note attached
+to selected passage text follows the first offered colour instead.
 
 `HighlightPalette` holds both, and holds the whole of the rule:
 
@@ -43,10 +44,17 @@ colour slots it in beside its neighbours and leaves the others where
 they were**, so a reader who marks by position rather than by name keeps
 their muscle memory when they change their mind.
 
-The default need not be offered. It is what a note gets, and what the
-plain Highlight action uses when nothing is ticked, so it has to mean
-something even when it is nowhere on the bar. Making it offer itself
-would be the setting quietly overruling a tick the reader made.
+The default need not be offered. It is what the plain Highlight action
+uses when nothing is ticked, and the fallback for a passage Note when no
+colours are offered, so it has to mean something even when it is nowhere
+on the bar. Making it offer itself would be the setting quietly
+overruling a tick the reader made.
+
+A Note attached to selected passage text gets the first offered colour in
+the palette's stable order. Removing yellow from the offered set therefore
+also removes yellow as the automatic Note colour, even if yellow remains
+the configured default. If the reader offers no colours at all, the Note
+falls back to that configured default so the action remains available.
 
 ### Nothing about a mark changes
 
@@ -76,8 +84,10 @@ way back.
 An empty set is a legal answer, and it does not mean "you may no longer
 highlight". The chips are replaced by a plain **Highlight** action that
 marks in the default colour — one word where six circles were, which is
-what a reader who never changes colour actually wants. A bar with no way
-to mark a passage would be a regression wearing a setting's clothes.
+what a reader who never changes colour actually wants. A passage **Note**
+also uses the default in this case because there is no offered colour to
+choose. A bar with no way to mark a passage would be a regression wearing
+a setting's clothes.
 
 Choosing none is stored, and it is not the same as never having chosen.
 `HighlightPalette.of` gives the three defaults for an absent set and an


### PR DESCRIPTION
## Summary

Passage notes now use the first colour currently shown in the highlight bar. Plain highlights keep using the configured default, and notes fall back to that default when no colours are offered. Tapping an existing highlight or note opens its selection popup so it can be edited.

## Changes

- Use the first colour in the bar's stable order for new notes attached to selected text.
- Keep the configured default for plain highlights and empty palettes.
- Let readers tap existing decorations to edit them.
- Update the reader setting text, ADR, and palette tests.

## Testing

- [x] `./gradlew :app:testDebugUnitTest --tests 'com.chmouel.liseur.reader.annotations.HighlightPaletteTest'`
- [ ] `./gradlew testDebugUnitTest`
- [ ] `./gradlew lintDebug` (blocked locally by unrelated unstaged changes in `LiseurModalBottomSheet.kt`)
- [ ] `./gradlew assembleDebug`
- [ ] Manually tested on a device or emulator, if applicable. No emulator was running, and the attached device is a physical phone that was not modified.

## Screenshots or recordings

Not included. The available device is a physical phone, and no app installation or screenshot capture was performed.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
