### PR TITLE
Show notes when tapping an annotated passage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,6 +352,14 @@ emulator.
   the three, an *empty* one is a reader who chose none. The default is
   not required to be offered, since notes and that plain Highlight need
   it either way. See `docs/adr/0026-a-configurable-highlight-palette.md`.
+- A tapped mark opens as what it is: a plain highlight gets the
+  `SelectionPopup` bar, a mark carrying a note gets `NoteSheet`, a
+  bottom sheet painted in the reading theme that shows the note and only
+  then the things to do with it. Both ride the same `tappedSelection`
+  state, so the bar's guards (no turn, no auto-scroll, no curl) apply
+  to the sheet without a second copy. A passage selected by hand, even
+  over a noted mark, still gets the bar. Recolouring from the sheet does
+  not close it. See `docs/adr/0027-a-tapped-note-opens-as-a-note.md`.
 - A book only on this device can be sent to liseur-sync, where the
   server allows it: `BookUploader`, `ServerCapabilities.canUpload` (read
   from the `library-upload` scope) and `BookUploadWorker`, whose unique

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -109,6 +109,9 @@ import com.chmouel.liseur.reader.annotations.DECORATION_GROUP
 import com.chmouel.liseur.reader.annotations.HighlightPalette
 import com.chmouel.liseur.reader.annotations.HighlightTint
 import com.chmouel.liseur.reader.annotations.NoteDialog
+import com.chmouel.liseur.reader.annotations.NoteSheet
+import com.chmouel.liseur.reader.annotations.NoteSheetActions
+import com.chmouel.liseur.reader.annotations.NoteText
 import com.chmouel.liseur.reader.annotations.SelectionActions
 import com.chmouel.liseur.reader.annotations.SelectionPopup
 import com.chmouel.liseur.reader.annotations.locator
@@ -2774,54 +2777,99 @@ fun ReaderScreen(
     // of buttons a screen reader could still operate — and draw them over
     // the picture besides. The selection itself is untouched and comes
     // back with the bar when the picture is dismissed.
-    (tappedSelection ?: selection)?.takeIf { viewedImage == null }?.let { active ->
-        SelectionPopup(
-            offset = active.popupOffset(),
-            activeTint = active.existing?.tint?.let(HighlightTint::fromName),
-            palette = highlightPalette,
-            actions = remember(active, dictionary) {
-                SelectionActions(
-                    onHighlight = { tint ->
-                        onAnnotationAction.highlight(active.locator, tint, active.existing?.id)
-                        dismissSelection()
-                    },
-                    onNote = {
-                        noteFor = active
-                        dismissSelection()
-                    },
-                    onSearch = {
-                        searchFor = active.text
-                        dismissSelection()
-                    },
-                    onLookUp = {
-                        when (dictionary.target) {
-                            DefinitionTarget.BUILT_IN -> defineWord = active.text
-                            DefinitionTarget.EXTERNAL_APP -> {
-                                context.lookUpExternally(active.text, dictionary.baseUrl)
-                            }
-                        }
-                        dismissSelection()
-                    },
-                    onShare = {
-                        context.shareText(active.text, publication.metadata.title)
-                        dismissSelection()
-                    },
-                    onDelete = active.existing?.let { existing ->
-                        {
+    //
+    // A tapped mark that carries a note opens as the note, not as the bar:
+    // the reader put words there, and seeing them is what the tap was
+    // for. The sheet is modal and has its own scrim, so unlike the bar it
+    // is not placed by the selection's rectangle. A passage the reader
+    // selected by hand over such a mark still gets the bar: they were
+    // reaching for the words, not the note.
+    val notedTap = tappedSelection?.takeIf { !it.existing?.note.isNullOrBlank() }
+    notedTap
+        ?.takeIf { viewedImage == null }
+        ?.let { active ->
+            val existing = active.existing ?: return@let
+            NoteSheet(
+                annotation = existing,
+                passage = active.text,
+                theme = readingTheme,
+                palette = highlightPalette,
+                actions = remember(active) {
+                    NoteSheetActions(
+                        onEdit = {
+                            noteFor = active
+                            dismissSelection()
+                        },
+                        onRecolour = { tint ->
+                            onAnnotationAction.highlight(active.locator, tint, existing.id)
+                        },
+                        onShare = {
+                            context.shareText(
+                                NoteText.share(active.text, existing.note),
+                                publication.metadata.title,
+                            )
+                            dismissSelection()
+                        },
+                        onDelete = {
                             onAnnotationAction.remove(existing)
                             dismissSelection()
-                        }
-                    },
-                )
-            },
-            onDismiss = {
-                // The bar and the selection go together: leaving the page
-                // selected keeps the platform's handles alive and drawing
-                // over words the reader has finished with.
-                dismissSelection()
-            },
-        )
-    }
+                        },
+                    )
+                },
+                onDismiss = ::dismissSelection,
+            )
+        }
+
+    (tappedSelection ?: selection)
+        ?.takeIf { viewedImage == null && notedTap == null }
+        ?.let { active ->
+            SelectionPopup(
+                offset = active.popupOffset(),
+                activeTint = active.existing?.tint?.let(HighlightTint::fromName),
+                palette = highlightPalette,
+                actions = remember(active, dictionary) {
+                    SelectionActions(
+                        onHighlight = { tint ->
+                            onAnnotationAction.highlight(active.locator, tint, active.existing?.id)
+                            dismissSelection()
+                        },
+                        onNote = {
+                            noteFor = active
+                            dismissSelection()
+                        },
+                        onSearch = {
+                            searchFor = active.text
+                            dismissSelection()
+                        },
+                        onLookUp = {
+                            when (dictionary.target) {
+                                DefinitionTarget.BUILT_IN -> defineWord = active.text
+                                DefinitionTarget.EXTERNAL_APP -> {
+                                    context.lookUpExternally(active.text, dictionary.baseUrl)
+                                }
+                            }
+                            dismissSelection()
+                        },
+                        onShare = {
+                            context.shareText(active.text, publication.metadata.title)
+                            dismissSelection()
+                        },
+                        onDelete = active.existing?.let { existing ->
+                            {
+                                onAnnotationAction.remove(existing)
+                                dismissSelection()
+                            }
+                        },
+                    )
+                },
+                onDismiss = {
+                    // The bar and the selection go together: leaving the page
+                    // selected keeps the platform's handles alive and drawing
+                    // over words the reader has finished with.
+                    dismissSelection()
+                },
+            )
+        }
 
     defineWord?.let { word ->
         DefinitionSheet(

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderScreen.kt
@@ -2789,9 +2789,10 @@ fun ReaderScreen(
         ?.takeIf { viewedImage == null }
         ?.let { active ->
             val existing = active.existing ?: return@let
+            val passage = existing.text?.takeIf { it.isNotBlank() } ?: active.text
             NoteSheet(
                 annotation = existing,
-                passage = active.text,
+                passage = passage,
                 theme = readingTheme,
                 palette = highlightPalette,
                 actions = remember(active) {
@@ -2805,7 +2806,7 @@ fun ReaderScreen(
                         },
                         onShare = {
                             context.shareText(
-                                NoteText.share(active.text, existing.note),
+                                NoteText.share(passage, existing.note),
                                 publication.metadata.title,
                             )
                             dismissSelection()

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/NoteSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/NoteSheet.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -95,6 +96,7 @@ fun NoteSheet(
         Column(
             Modifier
                 .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
                 .padding(horizontal = 24.dp)
                 .padding(bottom = 16.dp),
         ) {
@@ -157,17 +159,22 @@ fun NoteSheet(
                     .fillMaxWidth()
                     .padding(top = 16.dp),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
             ) {
-                palette.chipsFor(tint).forEach { chip ->
-                    TintChip(
-                        tint = chip,
-                        selected = chip == tint,
-                        onClick = { actions.onRecolour(chip) },
-                        ringColor = ink,
-                    )
+                Row(
+                    Modifier
+                        .weight(1f)
+                        .horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    palette.chipsFor(tint).forEach { chip ->
+                        TintChip(
+                            tint = chip,
+                            selected = chip == tint,
+                            onClick = { actions.onRecolour(chip) },
+                            ringColor = ink,
+                        )
+                    }
                 }
-                Spacer(Modifier.weight(1f))
                 IconButton(onClick = actions.onShare) {
                     Icon(
                         Icons.Outlined.Share,

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/NoteSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/NoteSheet.kt
@@ -1,0 +1,223 @@
+package com.chmouel.liseur.reader.annotations
+
+import android.content.Context
+import android.text.format.DateUtils
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.chmouel.liseur.R
+import com.chmouel.liseur.data.db.BookAnnotation
+import com.chmouel.liseur.data.settings.ReaderTheme
+import com.chmouel.liseur.ui.LiseurModalBottomSheet
+import com.chmouel.liseur.ui.LocalEInk
+
+/** What the reader can do with a note they have opened. */
+class NoteSheetActions(
+    val onEdit: () -> Unit,
+    val onRecolour: (HighlightTint) -> Unit,
+    val onShare: () -> Unit,
+    val onDelete: () -> Unit,
+)
+
+/**
+ * A note, opened to be read.
+ *
+ * Tapping a plain highlight brings up the bar of things to do with it.
+ * A mark that carries a note is different: the reader put words there,
+ * and the first thing they want on tapping it is to see them, not a row
+ * of buttons with the note hidden behind one. So this is a sheet — the
+ * passage, quoted, with the mark's colour running down its side, and the
+ * note under it in full — and the things to do with it come after.
+ *
+ * It is painted in the reading theme rather than in Material colours,
+ * for the reason the footnote card is: it sits over the page, and a
+ * white sheet over a black page at night is a lamp in the face.
+ *
+ * Recolouring does not close it. The stripe changes where the reader is
+ * looking, which is the confirmation; closing would send them back to
+ * the page to check.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NoteSheet(
+    annotation: BookAnnotation,
+    passage: String,
+    theme: ReaderTheme,
+    palette: HighlightPalette,
+    actions: NoteSheetActions,
+    onDismiss: () -> Unit,
+) {
+    val eInk = LocalEInk.current
+    val ink = theme.foreground
+    // A wash under half ink dithers to grey on electronic paper; there the
+    // quieter text is simply the ink.
+    val quiet = if (eInk) ink else ink.copy(alpha = 0.7f)
+    val faint = if (eInk) ink else ink.copy(alpha = 0.55f)
+    val tint = HighlightTint.fromName(annotation.tint)
+
+    LiseurModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = theme.background,
+        contentColor = ink,
+    ) {
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 16.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.annotation_note_sheet_title),
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = faint,
+            )
+
+            if (passage.isNotBlank()) {
+                Row(
+                    Modifier
+                        .padding(top = 12.dp)
+                        .heightIn(max = 160.dp)
+                        .height(IntrinsicSize.Min),
+                ) {
+                    Spacer(
+                        Modifier
+                            .width(4.dp)
+                            .fillMaxHeight()
+                            .clip(RoundedCornerShape(2.dp))
+                            .background(tint.color),
+                    )
+                    SelectionContainer {
+                        Text(
+                            text = passage.trim(),
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontStyle = FontStyle.Italic,
+                            color = quiet,
+                            modifier = Modifier
+                                .padding(start = 14.dp)
+                                .verticalScroll(rememberScrollState()),
+                        )
+                    }
+                }
+            }
+
+            SelectionContainer {
+                Text(
+                    text = annotation.note.orEmpty().trim(),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = ink,
+                    modifier = Modifier
+                        .padding(top = 16.dp)
+                        .heightIn(max = 280.dp)
+                        .verticalScroll(rememberScrollState()),
+                )
+            }
+
+            Text(
+                text = stamps(annotation),
+                style = MaterialTheme.typography.labelSmall,
+                color = faint,
+                modifier = Modifier.padding(top = 12.dp),
+            )
+
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                palette.chipsFor(tint).forEach { chip ->
+                    TintChip(
+                        tint = chip,
+                        selected = chip == tint,
+                        onClick = { actions.onRecolour(chip) },
+                        ringColor = ink,
+                    )
+                }
+                Spacer(Modifier.weight(1f))
+                IconButton(onClick = actions.onShare) {
+                    Icon(
+                        Icons.Outlined.Share,
+                        contentDescription = stringResource(R.string.annotation_share),
+                        tint = quiet,
+                    )
+                }
+                IconButton(onClick = actions.onDelete) {
+                    Icon(
+                        Icons.Outlined.Delete,
+                        contentDescription = stringResource(R.string.annotation_delete),
+                        tint = quiet,
+                    )
+                }
+                TextButton(onClick = actions.onEdit) {
+                    Icon(
+                        Icons.Outlined.Edit,
+                        contentDescription = null,
+                        tint = ink,
+                        modifier = Modifier.padding(end = 6.dp),
+                    )
+                    Text(stringResource(R.string.annotation_note_edit), color = ink)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * When the note was made, and when it was last changed if that was a
+ * later sitting. The chapter comes first when the mark kept one, because
+ * that is how the reader remembers where a thought came from.
+ *
+ * The times read "at 8:59" today and "on 5 Sept" after that: a note is
+ * a thing written, and a written thing has a date rather than an age.
+ */
+@Composable
+private fun stamps(annotation: BookAnnotation): String {
+    val context = LocalContext.current
+    val parts = mutableListOf<String>()
+    annotation.chapter?.takeIf { it.isNotBlank() }?.let(parts::add)
+    parts += stringResource(R.string.annotation_note_added, dated(context, annotation.createdAt))
+    if (NoteText.edited(annotation.createdAt, annotation.updatedAt)) {
+        parts += stringResource(
+            R.string.annotation_note_edited,
+            dated(context, annotation.updatedAt / 1000),
+        )
+    }
+    return parts.joinToString(" \u00B7 ")
+}
+
+private fun dated(context: Context, atMs: Long): CharSequence =
+    DateUtils.getRelativeTimeSpanString(context, atMs, true)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/NoteText.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/NoteText.kt
@@ -1,0 +1,30 @@
+package com.chmouel.liseur.reader.annotations
+
+import java.util.concurrent.TimeUnit
+
+/** What a note says about itself, worked out without a screen. */
+object NoteText {
+    /**
+     * Whether a note was reworked after it was written.
+     *
+     * A mark's two stamps are not in the same unit: `created_at` is in
+     * milliseconds and `updated_at` in microseconds, since the latter goes
+     * to liseur-sync verbatim. Saving a note stamps it a moment after
+     * creating it, so anything inside a minute is the same sitting.
+     */
+    fun edited(createdAtMs: Long, updatedAtMicros: Long): Boolean {
+        if (updatedAtMicros <= 0L) return false
+        val updatedAtMs = TimeUnit.MICROSECONDS.toMillis(updatedAtMicros)
+        return updatedAtMs - createdAtMs > TimeUnit.MINUTES.toMillis(1)
+    }
+
+    /**
+     * The passage and the note as one thing to hand to another app: the
+     * words first, quoted, and what the reader made of them underneath.
+     */
+    fun share(passage: String?, note: String?): String {
+        val quoted = passage?.trim()?.takeIf { it.isNotEmpty() }?.let { "\u201C$it\u201D" }
+        val body = note?.trim()?.takeIf { it.isNotEmpty() }
+        return listOfNotNull(quoted, body).joinToString("\n\n")
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/SelectionPopup.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/annotations/SelectionPopup.kt
@@ -140,7 +140,12 @@ fun SelectionPopup(
 }
 
 @Composable
-private fun TintChip(tint: HighlightTint, selected: Boolean, onClick: () -> Unit) {
+internal fun TintChip(
+    tint: HighlightTint,
+    selected: Boolean,
+    onClick: () -> Unit,
+    ringColor: Color = MaterialTheme.colorScheme.onSurface,
+) {
     val label = stringResource(tint.label)
     Row(
         Modifier
@@ -150,11 +155,7 @@ private fun TintChip(tint: HighlightTint, selected: Boolean, onClick: () -> Unit
             .background(tint.color)
             .border(
                 width = if (selected) 2.dp else 0.dp,
-                color = if (selected) {
-                    MaterialTheme.colorScheme.onSurface
-                } else {
-                    Color.Transparent
-                },
+                color = if (selected) ringColor else Color.Transparent,
                 shape = CircleShape,
             )
             .clickable(onClick = onClick),

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/LiseurModalBottomSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/LiseurModalBottomSheet.kt
@@ -90,7 +90,7 @@ fun LiseurModalBottomSheet(
             contentColor = contentColor,
             tonalElevation = 0.dp,
             shadowElevation = 0.dp,
-            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+            border = BorderStroke(1.dp, contentColor.copy(alpha = 0.3f)),
             modifier = modifier
                 .windowInsetsPadding(
                     WindowInsets.safeDrawing

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/LiseurModalBottomSheet.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/LiseurModalBottomSheet.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
@@ -34,6 +35,11 @@ import androidx.compose.ui.window.PopupProperties
  * dimmed text behind as ghosting when it closes. The sheet itself is already
  * opaque; dropping the scrim and its lift leaves only the region containing
  * the controls to change. The popup appears in its final position immediately.
+ *
+ * [containerColor] and [contentColor] are Material's by default. A sheet
+ * that sits over the page itself — a note, say — passes the reading
+ * theme's instead, for the same reason the footnote card does: a white
+ * sheet over a black page at night is a lamp in the face.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -41,6 +47,8 @@ fun LiseurModalBottomSheet(
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
     sheetState: SheetState = rememberModalBottomSheetState(),
+    containerColor: Color = MaterialTheme.colorScheme.surface,
+    contentColor: Color = MaterialTheme.colorScheme.onSurface,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     val eInk = LocalEInk.current
@@ -49,6 +57,11 @@ fun LiseurModalBottomSheet(
             onDismissRequest = onDismissRequest,
             modifier = modifier,
             sheetState = sheetState,
+            containerColor = containerColor,
+            contentColor = contentColor,
+            dragHandle = {
+                BottomSheetDefaults.DragHandle(color = contentColor.copy(alpha = 0.4f))
+            },
             content = content,
         )
         return
@@ -73,8 +86,8 @@ fun LiseurModalBottomSheet(
     ) {
         Surface(
             shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
-            color = MaterialTheme.colorScheme.surface,
-            contentColor = MaterialTheme.colorScheme.onSurface,
+            color = containerColor,
+            contentColor = contentColor,
             tonalElevation = 0.dp,
             shadowElevation = 0.dp,
             border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
@@ -87,7 +100,10 @@ fun LiseurModalBottomSheet(
                 .fillMaxWidth(),
         ) {
             Column(Modifier.navigationBarsPadding()) {
-                BottomSheetDefaults.DragHandle(Modifier.align(Alignment.CenterHorizontally))
+                BottomSheetDefaults.DragHandle(
+                    color = contentColor.copy(alpha = 0.4f),
+                    modifier = Modifier.align(Alignment.CenterHorizontally),
+                )
                 content()
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -389,7 +389,6 @@
     <string name="annotation_note_edit">Edit</string>
     <string name="annotation_note_added">Added %1$s</string>
     <string name="annotation_note_edited">Edited %1$s</string>
-    <string name="annotation_note_close">Close note</string>
     <string name="annotation_add_book_note">Add a book note</string>
     <string name="annotation_book_note_title">Book note</string>
     <string name="annotation_book_note_hint">What do you want to remember about this book?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -385,6 +385,11 @@
     <string name="annotation_note">Note</string>
     <string name="annotation_note_title">Note</string>
     <string name="annotation_note_hint">What did this make you think?</string>
+    <string name="annotation_note_sheet_title">Your note</string>
+    <string name="annotation_note_edit">Edit</string>
+    <string name="annotation_note_added">Added %1$s</string>
+    <string name="annotation_note_edited">Edited %1$s</string>
+    <string name="annotation_note_close">Close note</string>
     <string name="annotation_add_book_note">Add a book note</string>
     <string name="annotation_book_note_title">Book note</string>
     <string name="annotation_book_note_hint">What do you want to remember about this book?</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/annotations/NoteTextTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/annotations/NoteTextTest.kt
@@ -1,0 +1,48 @@
+package com.chmouel.liseur.reader.annotations
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NoteTextTest {
+    private val createdMs = 1_700_000_000_000L
+
+    @Test
+    fun `a note saved in the same sitting is not edited`() {
+        val updatedMicros = (createdMs + 3_000L) * 1000
+        assertFalse(NoteText.edited(createdMs, updatedMicros))
+    }
+
+    @Test
+    fun `a note reworked later is edited`() {
+        val updatedMicros = (createdMs + 2 * 60 * 60 * 1000L) * 1000
+        assertTrue(NoteText.edited(createdMs, updatedMicros))
+    }
+
+    @Test
+    fun `an unstamped row is not edited`() {
+        assertFalse(NoteText.edited(createdMs, 0L))
+    }
+
+    @Test
+    fun `microseconds are not mistaken for milliseconds`() {
+        // The same instant in both units must read as the same sitting.
+        assertFalse(NoteText.edited(createdMs, createdMs * 1000))
+    }
+
+    @Test
+    fun `share quotes the passage and puts the note under it`() {
+        assertEquals(
+            "\u201Cthe artist\u201D\n\nA good word for it.",
+            NoteText.share("  the artist ", "A good word for it.\n"),
+        )
+    }
+
+    @Test
+    fun `share leaves out what is missing`() {
+        assertEquals("\u201Cthe artist\u201D", NoteText.share("the artist", "  "))
+        assertEquals("only the note", NoteText.share(null, "only the note"))
+        assertEquals("", NoteText.share(null, null))
+    }
+}

--- a/docs/adr/0027-a-tapped-note-opens-as-a-note.md
+++ b/docs/adr/0027-a-tapped-note-opens-as-a-note.md
@@ -1,0 +1,58 @@
+# 27. A tapped note opens as a note
+
+Status: accepted
+
+## Context
+
+Since a highlight could be edited by tapping it, every tapped mark
+brought up `SelectionPopup`: the row of colour chips, Note, Define,
+Search, Share and Delete, placed over the passage. That bar is right for
+a plain highlight, where the only thing to know about the mark is its
+colour and the chips show it.
+
+A mark with a note is a different object. The reader put words there,
+and the thing they want on tapping it is to read them. The bar hid the
+note behind its "Note" button, and that button opened the *editor* — a
+Material dialog with a text field and a keyboard — when what was asked
+for was to look, not to write.
+
+## Decision
+
+A tapped mark that carries a note opens `NoteSheet` instead of the bar.
+A mark with no note, and any passage the reader selects by hand — even
+over a noted mark — still gets the bar, because a hand selection was
+reaching for the words.
+
+The sheet is a bottom sheet painted in the reading theme, for the reason
+`FootnoteCard` is: it sits over the page, and a white sheet over a black
+page at night is a lamp in the face. `LiseurModalBottomSheet` learned to
+take a container and content colour for it; every other sheet keeps
+Material's.
+
+It shows the passage, quoted and italic, with the mark's colour as a
+stripe down its side; the note in full; where and when it was written,
+and when it was reworked if that was a later sitting. Under those come
+the colour chips, Share, Delete and Edit. Edit is the existing
+`NoteDialog`; nothing about how a note is stored, identified or synced
+changes.
+
+Recolouring does not close the sheet. The stripe changes where the
+reader is looking, which is the confirmation; closing would send them
+back to the page to check. The annotation list refresh already carries
+the new colour into the open sheet.
+
+Share sends the passage first, quoted, and the note under it — the bar
+shares the passage alone, because there is nothing else to share.
+
+## Consequences
+
+- The sheet reuses the same `tappedSelection` state the bar does, so
+  every guard the bar earned — no page turn, no auto-scroll, no curl
+  while it is up; cleared on a position change, a hand selection, a
+  navigator swap or an image opening — applies to it unchanged.
+- The two stamps on a mark are in different units (`created_at` in
+  milliseconds, `updated_at` in microseconds, since the latter goes to
+  liseur-sync verbatim). `NoteText.edited` is where that is reconciled,
+  once, and it treats anything inside a minute as one sitting.
+- On electronic paper the sheet's quiet text is plain ink rather than a
+  wash, since a wash under half ink dithers to grey.


### PR DESCRIPTION
## Summary

Open a tapped passage note in a reading-themed bottom sheet so readers can read and manage the note without losing the passage context.

## Changes

- Show a note sheet when tapping an annotated passage with a note.
- Keep plain highlights on the existing selection popup.
- Add the note sheet text and action strings.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [ ] `./gradlew assembleDebug`
- [x] Manually tested on an emulator.

## Screenshots or recordings

![Note sheet opened from a tapped annotated passage](https://github.com/user-attachments/assets/df835c92-dd33-4da2-914f-65d3e3219a07)

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

