### PR TITLE
Ignore blank notes during sync

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/AnnotationWire.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/AnnotationWire.kt
@@ -266,7 +266,7 @@ object AnnotationWire {
         if (excerpt.toByteArray().size > MAX_EXCERPT_BYTES) return null
         if (body.toByteArray().size > MAX_BODY_BYTES) return null
         if (body.isNotEmpty() && kind == KIND_BOOKMARK) return null
-        if (body.isEmpty() && kind == KIND_NOTE) return null
+        if (body.isBlank() && kind == KIND_NOTE) return null
 
         return Record(
             id = id,
@@ -371,26 +371,25 @@ object AnnotationWire {
         val bookNote = record.kind == KIND_NOTE
         val locator = record.locator?.let { runCatching { JSONObject(it) }.getOrNull() }
         val locations = locator?.optJSONObject("locations")
+        val note = record.body.takeIf { it.isNotBlank() }
+        val existingNote = existing?.note?.takeIf { it.isNotBlank() }
         val kind = when {
             bookNote -> AnnotationKind.BOOK_NOTE
             record.kind == KIND_BOOKMARK -> AnnotationKind.BOOKMARK
-            record.body.isNotEmpty() -> AnnotationKind.NOTE
+            note != null -> AnnotationKind.NOTE
             else -> AnnotationKind.HIGHLIGHT
         }
-        val note = record.body.takeIf { it.isNotEmpty() }
         val noteCreatedAt = if (note == null) {
             null
         } else {
-            existing?.noteCreatedAt ?: if (existing?.note == null) {
-                record.clientTsMicros / 1000
-            } else {
-                existing.createdAt
-            }
+            existing?.noteCreatedAt?.takeIf { existingNote != null }
+                ?: existing?.createdAt?.takeIf { existingNote != null }
+                ?: (record.clientTsMicros / 1000)
         }
         val noteUpdatedAt = when {
             note == null -> null
-            existing?.note == null -> null
-            existing.note == note -> existing.noteUpdatedAt
+            existingNote == null -> null
+            existingNote == note -> existing?.noteUpdatedAt
             else -> record.clientTsMicros
         }
         return BookAnnotation(

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/AnnotationWire.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/AnnotationWire.kt
@@ -266,11 +266,12 @@ object AnnotationWire {
         if (color.isNotEmpty() && kind != KIND_HIGHLIGHT) return null
 
         val excerpt = json.optString("excerpt")
-        val body = json.optString("body")
+        val rawBody = json.optString("body")
         if (excerpt.toByteArray().size > MAX_EXCERPT_BYTES) return null
-        if (body.toByteArray().size > MAX_BODY_BYTES) return null
+        if (rawBody.toByteArray().size > MAX_BODY_BYTES) return null
+        val body = rawBody.takeIf { it.isNotBlank() }.orEmpty()
         if (body.isNotEmpty() && kind == KIND_BOOKMARK) return null
-        if (body.isBlank() && kind == KIND_NOTE) return null
+        if (body.isEmpty() && kind == KIND_NOTE) return null
 
         return Record(
             id = id,

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/AnnotationWire.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/AnnotationWire.kt
@@ -95,10 +95,7 @@ object AnnotationWire {
         // the limit the server refuses it, which is recorded against the
         // fingerprint and shown in a log — a stalled mark rather than a
         // silently halved one.
-        val body = when (kind) {
-            KIND_BOOKMARK -> ""
-            else -> annotation.note.orEmpty()
-        }
+        val body = body(annotation, kind)
         if (kind == KIND_NOTE && body.isEmpty()) return null
         val color = when (kind) {
             KIND_HIGHLIGHT -> color(annotation.tint)
@@ -173,7 +170,7 @@ object AnnotationWire {
             },
             if (anchored) truncate(annotation.text.orEmpty(), MAX_EXCERPT_BYTES) else "",
             if (kind == KIND_HIGHLIGHT) color(annotation.tint) else "",
-            if (kind == KIND_BOOKMARK) "" else annotation.note.orEmpty(),
+            body(annotation, kind),
             clientTs(annotation.updatedAt),
         )
         return sha256(parts.joinToString("\u0000"))
@@ -197,6 +194,13 @@ object AnnotationWire {
         val lower = tint?.lowercase(Locale.ROOT).orEmpty()
         return if (lower in COLORS) lower else ""
     }
+
+    private fun body(annotation: BookAnnotation, kind: String?): String =
+        if (kind == KIND_BOOKMARK) {
+            ""
+        } else {
+            annotation.note?.takeIf { it.isNotBlank() }.orEmpty()
+        }
 
     /**
      * Whether an id is one this device can hold at all.
@@ -389,7 +393,7 @@ object AnnotationWire {
         val noteUpdatedAt = when {
             note == null -> null
             existingNote == null -> null
-            existingNote == note -> existing?.noteUpdatedAt
+            existingNote == note -> existing.noteUpdatedAt
             else -> record.clientTsMicros
         }
         return BookAnnotation(

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/AnnotationWireTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/AnnotationWireTest.kt
@@ -137,7 +137,11 @@ class AnnotationWireTest {
 
     @Test
     fun `a blank standalone note is refused`() {
-        assertNull(AnnotationWire.record(server(kind = "note", locator = "", body = "   ")))
+        assertNull(
+            AnnotationWire.record(
+                server(kind = "note", locator = "", body = "   ", color = ""),
+            ),
+        )
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/AnnotationWireTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/AnnotationWireTest.kt
@@ -141,6 +141,25 @@ class AnnotationWireTest {
     }
 
     @Test
+    fun `a blank body is normalized before conflict comparison`() {
+        val local = AnnotationWire.item(mark(note = null), WORK, 0, null)!!
+        val remote = AnnotationWire.record(server(body = "   "))!!
+
+        assertEquals("", remote.body)
+        assertTrue(AnnotationWire.sameContent(local.json, remote))
+    }
+
+    @Test
+    fun `a blank bookmark body is treated as absent`() {
+        val record = AnnotationWire.record(
+            server(kind = "bookmark", body = "   ", color = ""),
+        )
+
+        assertNotNull(record)
+        assertEquals("", record!!.body)
+    }
+
+    @Test
     fun `a bookmark carries neither colour nor words`() {
         val item = AnnotationWire.item(
             mark(kind = AnnotationKind.BOOKMARK, note = "ignored", tint = "YELLOW"),

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/AnnotationWireTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/AnnotationWireTest.kt
@@ -75,6 +75,45 @@ class AnnotationWireTest {
     }
 
     @Test
+    fun `a blank highlight body is not a note`() {
+        val existing = mark(
+            kind = AnnotationKind.NOTE,
+            note = "   ",
+            noteCreatedAt = 1_700_000_000_000,
+            noteUpdatedAt = 1_700_000_100_000_000,
+        )
+        val record = AnnotationWire.record(server(kind = "highlight", body = "   "))!!
+
+        val landed = AnnotationWire.toAnnotation(record, BOOK, existing)
+
+        assertEquals(AnnotationKind.HIGHLIGHT.name, landed.kind)
+        assertNull(landed.note)
+        assertNull(landed.noteCreatedAt)
+        assertNull(landed.noteUpdatedAt)
+    }
+
+    @Test
+    fun `a real body replacing a blank legacy note starts now`() {
+        val existing = mark(
+            kind = AnnotationKind.NOTE,
+            note = "   ",
+            noteCreatedAt = null,
+            createdAt = 1_600_000_000_000,
+        )
+        val record = AnnotationWire.record(server(body = "new thought"))!!
+
+        val landed = AnnotationWire.toAnnotation(record, BOOK, existing)
+
+        assertEquals(MICROS / 1000, landed.noteCreatedAt)
+        assertNull(landed.noteUpdatedAt)
+    }
+
+    @Test
+    fun `a blank standalone note is refused`() {
+        assertNull(AnnotationWire.record(server(kind = "note", locator = "", body = "   ")))
+    }
+
+    @Test
     fun `a bookmark carries neither colour nor words`() {
         val item = AnnotationWire.item(
             mark(kind = AnnotationKind.BOOKMARK, note = "ignored", tint = "YELLOW"),
@@ -539,6 +578,7 @@ class AnnotationWireTest {
             tint: String? = "YELLOW",
             noteCreatedAt: Long? = null,
             noteUpdatedAt: Long? = null,
+            createdAt: Long = 1_709_294_400_000,
             updatedAt: Long = MICROS,
         ) = BookAnnotation(
             id = id,
@@ -551,7 +591,7 @@ class AnnotationWireTest {
             chapter = "Chapter One",
             position = 12,
             totalProgression = 0.25,
-            createdAt = 1_709_294_400_000,
+            createdAt = createdAt,
             noteCreatedAt = noteCreatedAt,
             noteUpdatedAt = noteUpdatedAt,
             updatedAt = updatedAt,

--- a/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/AnnotationWireTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/liseursync/AnnotationWireTest.kt
@@ -55,6 +55,33 @@ class AnnotationWireTest {
     }
 
     @Test
+    fun `a blank passage note is sent as a plain highlight`() {
+        val note = mark(kind = AnnotationKind.NOTE, note = "   ")
+        val highlight = note.copy(kind = AnnotationKind.HIGHLIGHT.name, note = null)
+
+        val sent = JSONObject(AnnotationWire.item(note, WORK, 0, null)!!.json)
+
+        assertEquals("highlight", sent.getString("kind"))
+        assertFalse(sent.has("body"))
+        assertEquals(
+            AnnotationWire.fingerprint(highlight, WORK),
+            AnnotationWire.fingerprint(note, WORK),
+        )
+    }
+
+    @Test
+    fun `a blank book note is not sent`() {
+        assertNull(
+            AnnotationWire.item(
+                mark(kind = AnnotationKind.BOOK_NOTE, locator = "", note = "   "),
+                WORK,
+                0,
+                null,
+            ),
+        )
+    }
+
+    @Test
     fun `a highlight with a body comes back as a note`() {
         val record = AnnotationWire.record(
             server(kind = "highlight", body = "worth arguing with"),


### PR DESCRIPTION
## Summary

Prevents blank text received during annotation sync from appearing as a note or changing its dates.

## Changes

- Treat whitespace-only annotation bodies as absent.
- Reject standalone notes with no written content.
- Start a real note at the incoming write time when it replaces blank legacy data.
- Add regression tests for these cases.

## Testing

- [x] `./gradlew testDebugUnitTest --tests 'com.chmouel.liseur.data.liseursync.AnnotationWireTest'`
- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [ ] `./gradlew assembleDebug`
- [ ] Manually tested on a device or emulator, if applicable

## Screenshots or recordings

Not applicable. This changes annotation sync parsing without changing the layout.

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
