### PR TITLE
Mark liseur-desktop as abandoned in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ servers and dictionary sources you configure. See the
 
 ## Related Projects
 
-- [liseur-desktop](https://github.com/chmouel/liseur-desktop): Desktop version of Liseur (may be lagging compared to the android app).
 - [liseur-sync](https://github.com/chmouel/liseur-sync): Lightweight self-hosted library and sync server. Watched folders, browse, download, positions and reading stats. This will give you the best "kindle/just work" experience compared to the other sync servers.
+~- [liseur-desktop](https://github.com/chmouel/liseur-desktop): Desktop version of Liseur (abandoned).~
 
 ## Development
 


### PR DESCRIPTION
Updated README to indicate liseur-desktop is abandoned.

## Summary

<!-- What does this change do, and why? Link related issues with "Fixes #123". -->

## Changes

-

## Testing

- [ ] `./gradlew testDebugUnitTest`
- [ ] `./gradlew lintDebug`
- [ ] `./gradlew assembleDebug`
- [ ] Manually tested on a device or emulator, if applicable

## Screenshots or recordings

<!-- Include before/after visuals for UI changes. Remove personal information. -->

## Checklist

- [ ] I have kept this change focused and documented any user-facing behaviour.
- [ ] I have added or updated tests where needed.
- [ ] I have checked that dependencies remain FOSS and available from allowed repositories.
- [ ] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
