### PR TITLE
fix: trust user-installed root CAs

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -15,7 +15,12 @@
     entered, and the default host is pinned below as well.
 -->
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true" />
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
     <domain-config cleartextTrafficPermitted="false">
         <domain includeSubdomains="true">wiktionary.org</domain>
     </domain-config>


### PR DESCRIPTION
## Summary

Fixes #196.

Liseur was only trusting Android's system certificate store, so a CA installed in the user trust store, like a Caddy internal CA, was rejected before the app reached the server.

## Changes

- add Android user trust anchors to the app network security config
- keep the existing cleartext exception for local self-hosted server cases
- leave HTTPS validation enabled

## Testing

- [x] `./gradlew assembleDebug`
- [ ] `./gradlew testDebugUnitTest`
- [ ] `./gradlew lintDebug`
- [ ] Manually tested on a device or emulator, if applicable

## Screenshots or recordings

- N/A

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [ ] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
