### PR TITLE
fix: ask to reach servers on the home network

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -207,6 +207,32 @@ persisted grant, so a stale grant does not reproduce the failure there.
 The fallback in `LocalLibraryRepository.addFolder` and the message that
 goes with it are for the devices where it does.
 
+### Checking the local network permission
+
+Android 17 blocks an app targeting SDK 37 from reaching addresses on the
+phone's own network until the reader allows it, and it blocks below the
+HTTP client: a LAN server does not refuse a connection, it swallows it
+until the timeout. That is #195, and ADR-0028 explains the shape of the
+answer.
+
+What the system holds is worth reading directly:
+
+```bash
+adb shell dumpsys package com.chmouel.liseur | grep -i local_network
+```
+
+An image older than API 37 can be made to behave like one, which is the
+only way to see the failure without an Android 17 device:
+
+```bash
+adb shell am compat enable RESTRICT_LOCAL_NETWORK com.chmouel.liseur.dev
+adb shell am compat reset RESTRICT_LOCAL_NETWORK com.chmouel.liseur.dev
+```
+
+Note that granting any permission in the `NEARBY_DEVICES` group grants
+this one with it, so a phone that has been asked about nearby devices
+for another reason will not show the prompt.
+
 ### Why the reading stats say "Counting this device only"
 
 The dashboard combines every device that has signed in to liseur-sync,

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,16 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <!--
+        Android 17 blocks traffic to and from the local network for every
+        app targeting it, below the HTTP client and without an error: a
+        connection to a server on the reader's own network simply hangs
+        until it times out. A self-hosted library is the ordinary case
+        here, so it is asked for at connect time, and only of a reader
+        whose address is actually local.
+    -->
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
+
+    <!--
         Android 11 and later hide installed apps from each other unless they
         are asked for by name or by what they can do. Without this, looking a
         word up finds no dictionary however many are installed, and the

--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -30,6 +30,8 @@ import com.chmouel.liseur.data.remote.DeviceIdentityRepository
 import com.chmouel.liseur.data.remote.BookUploadRepository
 import com.chmouel.liseur.data.remote.UploadPrompts
 import com.chmouel.liseur.data.remote.CompositePositionSync
+import com.chmouel.liseur.data.remote.AndroidLocalNetworkAccess
+import com.chmouel.liseur.data.remote.LocalNetworkGuardedSync
 import com.chmouel.liseur.data.liseursync.LiseurSyncAnnotations
 import com.chmouel.liseur.data.liseursync.LiseurSyncCatalogClient
 import com.chmouel.liseur.data.liseursync.LiseurSyncDeleteClient
@@ -229,6 +231,12 @@ class AppContainer(context: Context) {
      */
     val syncReporting = SyncReporting()
 
+    /**
+     * What the phone will and will not let the app reach, and the way
+     * to ask it for more.
+     */
+    val localNetwork = AndroidLocalNetworkAccess(context)
+
     val koboSync = KoboSyncRepository(
         serverDao = database.remoteServerDao(),
         bookDao = database.bookDao(),
@@ -400,10 +408,27 @@ class AppContainer(context: Context) {
      * the position too — and the kosync partner after it. The composite
      * runs them in turn, so the coordinator's ordering rules hold across
      * both without being written twice.
+     *
+     * Each is wrapped against a phone that is blocking the network its
+     * server lives on, separately rather than together: a public
+     * catalog and a kosync server on the LAN is an ordinary pairing,
+     * and one of them being out of reach is no reason to stop syncing
+     * with the other.
      */
     val positionSync = PositionSyncCoordinator(
         CompositePositionSync(
-            listOf(RoutedPositionSync(remoteRouter), kosyncSync),
+            listOf(
+                LocalNetworkGuardedSync(
+                    delegate = RoutedPositionSync(remoteRouter),
+                    access = localNetwork,
+                    reporting = syncReporting,
+                ),
+                LocalNetworkGuardedSync(
+                    delegate = kosyncSync,
+                    access = localNetwork,
+                    reporting = syncReporting,
+                ),
+            ),
         ),
         carryOn = { PositionSyncWorker.continueBootstrap(context.applicationContext) },
     )

--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -460,6 +460,7 @@ class AppContainer(context: Context) {
                 ?.takeIf { !localNetwork.blocks(server.baseUrl) }
         },
         coordinator = positionSync,
+        reconnectOn = localNetwork.grants,
         requestBook = ::requestBookSync,
         reportFailure = { identity, reason ->
             if (database.remoteServerDao().get()?.let(LiveIdentity::from) == identity) {

--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -511,6 +511,7 @@ class AppContainer(context: Context) {
         bookRemoval = bookRemoval,
         inTransaction = { work -> database.withTransaction { work() } },
         networkAvailability = networkAvailability,
+        localNetwork = localNetwork,
     )
 
     val seriesExtras = SeriesExtrasRepository(

--- a/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/AppContainer.kt
@@ -449,7 +449,15 @@ class AppContainer(context: Context) {
         scope = applicationScope,
         accounts = database.remoteServerDao().observe(),
         sourceFor = { server ->
-            remoteRouter.liveFor(server.kind).takeIf { server.credentials != null }
+            // A live connection is one more socket to the same machine
+            // the position sync dials, so it answers to the same block:
+            // opening it while the permission is refused buys a retry
+            // loop of timeouts and no events. It reports nothing —
+            // the guarded sync already says the account is blocked —
+            // and the next connection picks up a grant.
+            remoteRouter.liveFor(server.kind)
+                .takeIf { server.credentials != null }
+                ?.takeIf { !localNetwork.blocks(server.baseUrl) }
         },
         coordinator = positionSync,
         requestBook = ::requestBookSync,

--- a/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/MainActivity.kt
@@ -570,6 +570,10 @@ private fun ServerAccountRoute(
         onKosyncRegisterChange = viewModel::setKosyncRegister,
         onKosyncConnect = viewModel::connectKosync,
         onKosyncDisconnect = viewModel::disconnectKosync,
+        onLocalNetworkRequestLaunched = viewModel::onLocalNetworkRequestLaunched,
+        onLocalNetworkResult = viewModel::onLocalNetworkResult,
+        onAskLocalNetworkAgain = viewModel::askLocalNetworkAgain,
+        onRefreshLocalNetworkAccess = viewModel::refreshLocalNetworkAccess,
         onBack = onBack,
     )
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/data/calibre/KoboSyncRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/calibre/KoboSyncRepository.kt
@@ -79,6 +79,14 @@ class KoboSyncRepository(
      * store, which is its own incremental protocol and already asks for
      * only what has changed. Any snapshot is dropped.
      */
+    /**
+     * The server's address, and only while there is a token to reach it
+     * with. Without one the run answers "not applicable" before it
+     * dials, so there is no address to be blocked on.
+     */
+    override suspend fun dialledAddress(): String? =
+        serverDao.get()?.takeIf { it.koboToken != null }?.baseUrl
+
     override suspend fun syncAll(snapshot: SyncSnapshot?): SyncOutcome = run(book = null)
 
     /** Reconciles one book, for the moments someone is waiting on it. */

--- a/app/src/main/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepository.kt
@@ -93,6 +93,13 @@ class KomgaSyncRepository(
     private val inTransaction: suspend (suspend () -> Unit) -> Unit = { it() },
 ) : PositionSync {
 
+    /**
+     * The server's address, and only while its credential can still be
+     * read back. See [KoboSyncRepository.dialledAddress].
+     */
+    override suspend fun dialledAddress(): String? =
+        serverDao.get()?.takeIf { it.credentials != null }?.baseUrl
+
     override suspend fun syncAll(snapshot: SyncSnapshot?): SyncOutcome =
         run(book = null, snapshot = snapshot)
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSync.kt
@@ -106,6 +106,14 @@ class KosyncPositionSync(
 
     override val peerId: String get() = PeerPositionSync.KOSYNC
 
+    /**
+     * The pairing's address, and only when a run would use it.
+     * [account] is the same test [run] opens with, so an ineligible
+     * server or a credential this Keystore cannot open answers null
+     * here exactly as it answers "not applicable" there.
+     */
+    override suspend fun dialledAddress(): String? = account()?.baseUrl
+
     override suspend fun syncAll(snapshot: SyncSnapshot?): SyncOutcome = run(book = null)
 
     override suspend fun syncBook(bookUrl: String): SyncOutcome = run(book = bookUrl)

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncPositionSync.kt
@@ -98,6 +98,13 @@ class LiseurSyncPositionSync(
     private val inTransaction: suspend (suspend () -> Unit) -> Unit = { it() },
 ) : PositionSync {
 
+    /**
+     * The server's address, and only while its token can still be read
+     * back. See [com.chmouel.liseur.data.calibre.KoboSyncRepository.dialledAddress].
+     */
+    override suspend fun dialledAddress(): String? =
+        server()?.takeIf { it.credentials != null }?.baseUrl
+
     override suspend fun syncAll(snapshot: SyncSnapshot?): SyncOutcome = run(book = null)
 
     override suspend fun syncBook(bookUrl: String): SyncOutcome = run(book = bookUrl)

--- a/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncServerSetup.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/liseursync/LiseurSyncServerSetup.kt
@@ -267,6 +267,10 @@ class LiseurSyncServerSetup(
                 SetupFailure.WrongServer
             SyncFailure.Offline, SyncFailure.Timeout ->
                 SetupFailure.Unreachable("No answer", httpMayWork = false)
+            // Setup asks the permission gate before it dials, so this
+            // reason cannot arrive here; the branch still has to exist.
+            SyncFailure.LocalNetworkBlocked ->
+                SetupFailure.Unreachable("No answer", httpMayWork = false)
 
             is SyncFailure.ServerError ->
                 if (reason.code == TOO_MANY) {

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAccess.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAccess.kt
@@ -66,6 +66,13 @@ interface LocalNetworkAccess {
          * the manifest declares.
          */
         const val PERMISSION = "android.permission.ACCESS_LOCAL_NETWORK"
+
+        /** A phone that gates nothing, which is every phone below 17. */
+        val Unrestricted = object : LocalNetworkAccess {
+            override val required = false
+            override val granted = true
+            override suspend fun blocks(url: String?) = false
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAccess.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAccess.kt
@@ -55,8 +55,13 @@ interface LocalNetworkAccess {
      */
     val grants: Flow<Long> get() = flowOf(0L)
 
-    /** Look again, after the reader has answered a permission prompt. */
-    fun recheck() = Unit
+    /**
+     * Look again, after the reader has answered a permission prompt.
+     *
+     * Answers whether the answer actually moved, so a caller can tell a
+     * grant from a resume that changed nothing.
+     */
+    fun recheck(): Boolean = false
 
     companion object {
         /**
@@ -97,11 +102,12 @@ class AndroidLocalNetworkAccess(
      * grant on a phone that was never going to block anything, must not
      * tear down a healthy connection to reopen it unchanged.
      */
-    override fun recheck() {
+    override fun recheck(): Boolean {
         val now = granted
-        if (lastGranted == now) return
+        if (lastGranted == now) return false
         lastGranted = now
         _grants.value = _grants.value + 1
+        return true
     }
 
     override val granted: Boolean

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAccess.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAccess.kt
@@ -1,0 +1,106 @@
+package com.chmouel.liseur.data.remote
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
+import java.net.InetAddress
+
+/**
+ * Whether the phone will let the app reach a given address, and what it
+ * is called when it will not.
+ *
+ * Android 17 blocks local network traffic for every app targeting it
+ * until the reader allows it, and blocks it below the HTTP client and
+ * without an error: a connection to a server on the reader's own
+ * network hangs until it times out. Liseur's readers self-host, so this
+ * is not an edge case for them — but plenty of them reach their library
+ * over the open internet, where the permission is neither needed nor
+ * welcome. So it is asked for only where the address is actually local.
+ *
+ * Everything here answers false below Android 17, where nothing is
+ * blocked and nothing may be asked.
+ */
+interface LocalNetworkAccess {
+
+    /** Whether this phone gates the local network at all. */
+    val required: Boolean
+
+    /** Whether the reader has already allowed it. */
+    val granted: Boolean
+
+    /**
+     * Whether connecting to [url] would be blocked as things stand.
+     *
+     * Null or blank is not an address and cannot be blocked — a
+     * connection with no kosync partner, say, is asked about with
+     * exactly that.
+     */
+    suspend fun blocks(url: String?): Boolean
+
+    companion object {
+        /**
+         * Spelled out rather than taken from `Manifest.permission`,
+         * which would inline a constant from an SDK above `minSdk` and
+         * read as a call nothing older can make. It is the same string
+         * the manifest declares.
+         */
+        const val PERMISSION = "android.permission.ACCESS_LOCAL_NETWORK"
+    }
+}
+
+/** The real thing, reading the phone's permission and its routes. */
+class AndroidLocalNetworkAccess(
+    context: Context,
+    private val sdkInt: Int = Build.VERSION.SDK_INT,
+) : LocalNetworkAccess {
+
+    private val context = context.applicationContext
+
+    override val required: Boolean get() = sdkInt >= Build.VERSION_CODES.CINNAMON_BUN
+
+    override val granted: Boolean
+        get() = !required ||
+            context.checkSelfPermission(LocalNetworkAccess.PERMISSION) ==
+            PackageManager.PERMISSION_GRANTED
+
+    override suspend fun blocks(url: String?): Boolean {
+        if (!required || granted) return false
+        if (url.isNullOrBlank()) return false
+        return LocalNetworkAddress.isLocal(url, onLink = ::onLink)
+    }
+
+    /**
+     * Whether an address sits on one of this phone's own links.
+     *
+     * Every network is consulted, not only the default one, because a
+     * library on Wi-Fi is still on Wi-Fi while cellular carries the
+     * rest. VPN transports are left out: Android's restriction does not
+     * reach what a tunnel carries, and a tailnet address must not raise
+     * a prompt for a permission it never needed.
+     *
+     * This is not a routing table and does not pretend to be one. It
+     * can name an address local that the socket would in fact have
+     * reached another way, and the cost of that is one dialog on a
+     * screen the reader opened to connect a server. The cost of the
+     * other direction is the fifteen seconds of silence this whole file
+     * exists to prevent.
+     */
+    private fun onLink(host: String): Boolean {
+        // The routes are read through APIs newer than `minSdk`, and are
+        // only ever worth reading where the restriction exists at all.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.CINNAMON_BUN) return false
+        val address = runCatching { InetAddress.getByName(host) }.getOrNull() ?: return false
+        val manager = context.getSystemService(ConnectivityManager::class.java) ?: return false
+        return manager.allNetworks.any { network ->
+            val capabilities = manager.getNetworkCapabilities(network)
+            if (capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) != false) {
+                return@any false
+            }
+            manager.getLinkProperties(network)?.routes.orEmpty().any {
+                !it.hasGateway() && it.matches(address)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAccess.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAccess.kt
@@ -6,6 +6,10 @@ import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
 import java.net.InetAddress
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flowOf
 
 /**
  * Whether the phone will let the app reach a given address, and what it
@@ -39,6 +43,21 @@ interface LocalNetworkAccess {
      */
     suspend fun blocks(url: String?): Boolean
 
+    /**
+     * Bumped when the answer to [blocks] may have changed, so a
+     * connection that outlives one question can ask it again.
+     *
+     * A background sync asks afresh every run and needs none of this.
+     * A live notification stream is opened once and held for as long as
+     * the app is on screen, so a reader who allows the permission from
+     * the connected card would otherwise wait out the rest of that
+     * session with the stream still down.
+     */
+    val grants: Flow<Long> get() = flowOf(0L)
+
+    /** Look again, after the reader has answered a permission prompt. */
+    fun recheck() = Unit
+
     companion object {
         /**
          * Spelled out rather than taken from `Manifest.permission`,
@@ -58,7 +77,25 @@ class AndroidLocalNetworkAccess(
 
     private val context = context.applicationContext
 
+    private val _grants = MutableStateFlow(0L)
+
+    override val grants = _grants.asStateFlow()
+
+    private var lastGranted: Boolean = granted
+
     override val required: Boolean get() = sdkInt >= Build.VERSION_CODES.CINNAMON_BUN
+
+    /**
+     * Only an answer that actually changed is announced. A denial, or a
+     * grant on a phone that was never going to block anything, must not
+     * tear down a healthy connection to reopen it unchanged.
+     */
+    override fun recheck() {
+        val now = granted
+        if (lastGranted == now) return
+        lastGranted = now
+        _grants.value = _grants.value + 1
+    }
 
     override val granted: Boolean
         get() = !required ||

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAddress.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAddress.kt
@@ -1,0 +1,169 @@
+package com.chmouel.liseur.data.remote
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.InetAddress
+
+/**
+ * Whether an address is one Android counts as being on the local
+ * network, and so one the app may not reach without permission.
+ *
+ * A narrower question than [PrivateAddress]'s, and a different one. That
+ * object asks whether an address is somewhere only the reader's own
+ * network can reach, which is about what is safe to send in the clear
+ * and what a catalog may point the phone at. This asks what the
+ * platform will drop, and the platform's answer is not a table: it is
+ * the directly connected routes of the networks the phone is on, and it
+ * excludes whatever a VPN carries.
+ *
+ * So the judgement has two halves. The fixed half is everything
+ * [PrivateAddress] knows, plus broadcast and multicast. The live half is
+ * [onLink], a predicate over the phone's own routes, which
+ * `LocalNetworkAccess` fills in and the tests supply directly. Both are
+ * needed: a home server on a global IPv6 address in the phone's own /64
+ * is on-link and blocked, and no list of private ranges will ever say
+ * so.
+ *
+ * Carrier-grade NAT space, `100.64.0.0/10`, is deliberately absent from
+ * the fixed half. That is where a Tailscale address lives; that traffic
+ * goes down the tunnel and needs no permission, and asking for one
+ * would be asking for nothing. An ISP that hands `100.64` out on the
+ * LAN still gets asked about — through [onLink], which is the honest
+ * reason.
+ *
+ * Loopback answers false throughout. The restriction exempts it, so a
+ * reader pointed at `localhost` must not be asked a question about
+ * their network.
+ */
+object LocalNetworkAddress {
+
+    /** What can be said about an address without going to the network. */
+    enum class Verdict {
+        /** Local for certain: a literal in range, or an mDNS name. */
+        LOCAL,
+
+        /** Not local, or not reachable at all. */
+        NOT_LOCAL,
+
+        /** A name, which has to be resolved before it can be judged. */
+        RESOLVE,
+    }
+
+    /** Resolving a name to the addresses it stands for, as text. */
+    fun interface Resolver {
+        fun addresses(host: String): List<String>
+    }
+
+    private val system = Resolver { host ->
+        runCatching { InetAddress.getAllByName(host).mapNotNull { it.hostAddress } }
+            .getOrDefault(emptyList())
+    }
+
+    /**
+     * Whether one host — normally a literal, resolved or typed — is on
+     * the local network.
+     */
+    fun hostIsLocal(host: String, onLink: (String) -> Boolean = { false }): Boolean {
+        val cleaned = clean(host)
+        if (cleaned.isEmpty()) return false
+        if (isLoopback(cleaned)) return false
+        if (PrivateAddress.matchesHost(cleaned)) return true
+        if (isBroadcastOrMulticast(cleaned)) return true
+        return isLiteral(cleaned) && onLink(cleaned)
+    }
+
+    /**
+     * What the address says about itself, before anything is dialled or
+     * looked up.
+     *
+     * An mDNS name answers [Verdict.LOCAL] without a lookup, and must:
+     * resolving a `.local` name *is* mDNS, which is itself blocked
+     * without the permission, so asking that way could only ever
+     * answer no.
+     */
+    fun literalVerdict(url: String, onLink: (String) -> Boolean = { false }): Verdict {
+        val host = hostOf(url) ?: return Verdict.NOT_LOCAL
+        if (isLoopback(host)) return Verdict.NOT_LOCAL
+        if (host == "localhost" || host.endsWith(".localhost")) return Verdict.NOT_LOCAL
+        if (host.endsWith(".local") || host.endsWith(".internal")) return Verdict.LOCAL
+        if (isLiteral(host)) {
+            return if (hostIsLocal(host, onLink)) Verdict.LOCAL else Verdict.NOT_LOCAL
+        }
+        return Verdict.RESOLVE
+    }
+
+    /**
+     * Whether connecting to [url] means touching the local network.
+     *
+     * A name is resolved — a DNS lookup, which the restriction exempts,
+     * so it works from behind the block — and *any* address it stands
+     * for being local is enough. A name that resolves to nothing is not
+     * local; it is about to fail as an unknown host either way.
+     *
+     * This is a preflight, and the client will resolve again when it
+     * dials. A record that rotates under the phone can put a different
+     * address on the wire than the one judged here. The cost of being
+     * wrong is one timed-out attempt in front of a reader who is being
+     * told what to do about it, which is a better trade than teaching
+     * the HTTP client to share a resolver.
+     */
+    suspend fun isLocal(
+        url: String,
+        onLink: (String) -> Boolean = { false },
+        resolver: Resolver = system,
+    ): Boolean = when (literalVerdict(url, onLink)) {
+        Verdict.LOCAL -> true
+        Verdict.NOT_LOCAL -> false
+        Verdict.RESOLVE -> {
+            val host = hostOf(url)
+            withContext(Dispatchers.IO) {
+                host?.let { resolver.addresses(it) }.orEmpty().any { hostIsLocal(it, onLink) }
+            }
+        }
+    }
+
+    /**
+     * The host an address will actually be dialled at.
+     *
+     * Taken from [RemoteUrl.normaliseBase], because the form takes
+     * `books.lan:8083` with no scheme and every setup client adds one
+     * before dialling; reading the typed text as a URL answers null and
+     * would call a LAN address public. The setup clients disagree about
+     * defaults and paths, never about the host, so one normalisation
+     * serves them all.
+     */
+    private fun hostOf(url: String): String? {
+        val base = RemoteUrl.normaliseBase(url) ?: return null
+        val authority = base.substringAfter("://")
+            .substringBefore('/')
+            .substringBefore('?')
+            .substringAfterLast('@')
+        val host = if (authority.startsWith("[")) {
+            authority.drop(1).substringBefore(']')
+        } else {
+            authority.substringBefore(':')
+        }
+        return clean(host).takeIf { it.isNotEmpty() }
+    }
+
+    /** Lowercased, unbracketed, and without an IPv6 zone. */
+    private fun clean(host: String): String =
+        host.lowercase().trim('[', ']').substringBefore('%').trim()
+
+    private fun isLoopback(host: String): Boolean {
+        if (':' in host) return host.replace(":", "").trimStart('0').let { it.isEmpty() || it == "1" }
+        return host.substringBefore('.').toIntOrNull() == 127
+    }
+
+    private fun isLiteral(host: String): Boolean =
+        ':' in host || host.split('.').let { parts ->
+            parts.size == 4 && parts.all { part -> part.toIntOrNull()?.let { it in 0..255 } == true }
+        }
+
+    private fun isBroadcastOrMulticast(host: String): Boolean {
+        if (':' in host) return host.startsWith("ff")
+        if (host == "255.255.255.255") return true
+        val first = host.substringBefore('.').toIntOrNull() ?: return false
+        return first in 224..239
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAddress.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAddress.kt
@@ -150,9 +150,23 @@ object LocalNetworkAddress {
     private fun clean(host: String): String =
         host.lowercase().trim('[', ']').substringBefore('%').trim()
 
+    /**
+     * Loopback, in any of the spellings this app can be handed.
+     *
+     * The IPv4-mapped form matters: `[::ffff:127.0.0.1]` is 127.0.0.1
+     * with a longer name, loopback is exempt from the restriction, and
+     * reading it as an ordinary private address would raise a prompt
+     * for a connection that was never going to be blocked. The
+     * all-zeros test is anchored on the last group, because `1::` is a
+     * global address that the digits alone would have called loopback.
+     */
     private fun isLoopback(host: String): Boolean {
-        if (':' in host) return host.replace(":", "").trimStart('0').let { it.isEmpty() || it == "1" }
-        return host.substringBefore('.').toIntOrNull() == 127
+        if (':' !in host) return host.substringBefore('.').toIntOrNull() == 127
+        val tail = host.substringAfterLast(':')
+        if ('.' in tail) return tail.substringBefore('.').toIntOrNull() == 127
+        val groups = host.split(':')
+        if (groups.last().trimStart('0') != "1") return false
+        return groups.dropLast(1).all { it.trimStart('0').isEmpty() }
     }
 
     private fun isLiteral(host: String): Boolean =

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAddress.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAddress.kt
@@ -178,7 +178,7 @@ object LocalNetworkAddress {
     }
 
     private fun isV4Loopback(host: String): Boolean =
-        host.split('.').let { it.size == 4 && it.first().toIntOrNull() == 127 }
+        isLiteral(host) && ':' !in host && host.substringBefore('.').toInt() == 127
 
     private fun isLiteral(host: String): Boolean =
         ':' in host || host.split('.').let { parts ->

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAddress.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAddress.kt
@@ -146,28 +146,39 @@ object LocalNetworkAddress {
         return clean(host).takeIf { it.isNotEmpty() }
     }
 
-    /** Lowercased, unbracketed, and without an IPv6 zone. */
+    /**
+     * Lowercased, unbracketed, without an IPv6 zone, and without the
+     * root label.
+     *
+     * `books.local.` is `books.local` fully spelled out, and reading
+     * the trailing dot as part of the name would send an mDNS address
+     * off to be resolved — by mDNS, which is the thing being blocked.
+     */
     private fun clean(host: String): String =
-        host.lowercase().trim('[', ']').substringBefore('%').trim()
+        host.lowercase().trim('[', ']').substringBefore('%').trim().removeSuffix(".")
 
     /**
      * Loopback, in any of the spellings this app can be handed.
      *
-     * The IPv4-mapped form matters: `[::ffff:127.0.0.1]` is 127.0.0.1
-     * with a longer name, loopback is exempt from the restriction, and
-     * reading it as an ordinary private address would raise a prompt
-     * for a connection that was never going to be blocked. The
-     * all-zeros test is anchored on the last group, because `1::` is a
-     * global address that the digits alone would have called loopback.
+     * The IPv4-mapped forms matter: `[::ffff:127.0.0.1]` and
+     * `[::ffff:7f00:1]` are both 127.0.0.1 with a longer name, a
+     * dual-stack lookup hands the first of those back for `localhost`
+     * on plenty of setups, loopback is exempt from the restriction,
+     * and reading either as an ordinary private address would raise a
+     * prompt for a connection that was never going to be blocked. So
+     * the literal is parsed rather than matched as text — by
+     * [PrivateAddress], which already has that parser, so there is
+     * only ever one of them.
      */
     private fun isLoopback(host: String): Boolean {
-        if (':' !in host) return host.substringBefore('.').toIntOrNull() == 127
-        val tail = host.substringAfterLast(':')
-        if ('.' in tail) return tail.substringBefore('.').toIntOrNull() == 127
-        val groups = host.split(':')
-        if (groups.last().trimStart('0') != "1") return false
-        return groups.dropLast(1).all { it.trimStart('0').isEmpty() }
+        if (':' !in host) return isV4Loopback(host)
+        PrivateAddress.mappedV4(host)?.let { return isV4Loopback(it) }
+        val groups = PrivateAddress.expandV6(host) ?: return false
+        return groups.last() == 1 && groups.dropLast(1).all { it == 0 }
     }
+
+    private fun isV4Loopback(host: String): Boolean =
+        host.split('.').let { it.size == 4 && it.first().toIntOrNull() == 127 }
 
     private fun isLiteral(host: String): Boolean =
         ':' in host || host.split('.').let { parts ->

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkGuardedSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkGuardedSync.kt
@@ -24,6 +24,13 @@ package com.chmouel.liseur.data.remote
  * was never going to be dialled must not manufacture a failure. The
  * peer answers it from the same state its own run consults, so the two
  * cannot drift apart.
+ *
+ * That address is the whole test, and asking one book's [canSync] as
+ * well would be a mistake: a book the peer does not carry is not a book
+ * the peer declines to dial about. A page turn in a side-loaded book on
+ * a catalog account still opens the connection, discovers there is no
+ * matching remote book, and returns nothing — so it still spends the
+ * timeout, and the guard has to reach it.
  */
 class LocalNetworkGuardedSync(
     private val delegate: PeerPositionSync,
@@ -37,7 +44,7 @@ class LocalNetworkGuardedSync(
         if (blocked()) refuse() else delegate.syncAll(snapshot)
 
     override suspend fun syncBook(bookUrl: String): SyncOutcome =
-        if (delegate.canSync(bookUrl) && blocked()) refuse() else delegate.syncBook(bookUrl)
+        if (blocked()) refuse() else delegate.syncBook(bookUrl)
 
     /**
      * A preview is one reader asking one book a question, so it answers
@@ -45,7 +52,7 @@ class LocalNetworkGuardedSync(
      * let a glance at one book overwrite what the last real run did.
      */
     override suspend fun previewBook(bookUrl: String): PreviewOutcome =
-        if (delegate.canSync(bookUrl) && blocked()) {
+        if (blocked()) {
             PreviewOutcome.Failed(SyncFailure.LocalNetworkBlocked)
         } else {
             delegate.previewBook(bookUrl)

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkGuardedSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkGuardedSync.kt
@@ -59,28 +59,20 @@ class LocalNetworkGuardedSync(
         }
 
     /**
-     * Settling a conflict sends the answer to the server, so it is
-     * guarded too.
+     * Keeping this device's position sends it to the server, so it is
+     * guarded; taking the server's is not.
      *
-     * Both of these are reached from the reader's own tap, and both
-     * already answer `Failed(Offline)` when there is no network at all.
-     * A blocked one is the same thing said differently: the write is
-     * not going to arrive, and a timeout the reader watches is the
-     * worst way to tell them so. The status line is left alone, as it
-     * is for a preview.
+     * The asymmetry is the two operations', not this class's. Taking
+     * the server's position applies an answer an earlier run already
+     * brought back and wrote down, and touches nothing but this
+     * phone's database — which is why it works on a plane, and must go
+     * on working behind a blocked network for the same reason. Keeping
+     * this device's dials, and already answers `Failed(Offline)` when
+     * there is no network at all; a blocked one is that said
+     * differently, and a timeout the reader sits and watches is the
+     * worst way to say it. The status line is left alone, as it is for
+     * a preview: one book being settled is not a run.
      */
-    override suspend fun takeRemotePosition(
-        bookUrl: String,
-        atRevision: Long,
-        peerId: String?,
-        expectedAccountKey: String?,
-    ): ResolveOutcome =
-        if (blocked()) {
-            ResolveOutcome.Failed(SyncFailure.LocalNetworkBlocked)
-        } else {
-            delegate.takeRemotePosition(bookUrl, atRevision, peerId, expectedAccountKey)
-        }
-
     override suspend fun keepLocalPosition(bookUrl: String, peerId: String?): ResolveOutcome =
         if (blocked()) {
             ResolveOutcome.Failed(SyncFailure.LocalNetworkBlocked)

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkGuardedSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkGuardedSync.kt
@@ -51,6 +51,36 @@ class LocalNetworkGuardedSync(
             delegate.previewBook(bookUrl)
         }
 
+    /**
+     * Settling a conflict sends the answer to the server, so it is
+     * guarded too.
+     *
+     * Both of these are reached from the reader's own tap, and both
+     * already answer `Failed(Offline)` when there is no network at all.
+     * A blocked one is the same thing said differently: the write is
+     * not going to arrive, and a timeout the reader watches is the
+     * worst way to tell them so. The status line is left alone, as it
+     * is for a preview.
+     */
+    override suspend fun takeRemotePosition(
+        bookUrl: String,
+        atRevision: Long,
+        peerId: String?,
+        expectedAccountKey: String?,
+    ): ResolveOutcome =
+        if (blocked()) {
+            ResolveOutcome.Failed(SyncFailure.LocalNetworkBlocked)
+        } else {
+            delegate.takeRemotePosition(bookUrl, atRevision, peerId, expectedAccountKey)
+        }
+
+    override suspend fun keepLocalPosition(bookUrl: String, peerId: String?): ResolveOutcome =
+        if (blocked()) {
+            ResolveOutcome.Failed(SyncFailure.LocalNetworkBlocked)
+        } else {
+            delegate.keepLocalPosition(bookUrl, peerId)
+        }
+
     private suspend fun blocked(): Boolean = access.blocks(delegate.dialledAddress())
 
     private fun refuse(): SyncOutcome {

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkGuardedSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/LocalNetworkGuardedSync.kt
@@ -1,0 +1,60 @@
+package com.chmouel.liseur.data.remote
+
+/**
+ * A partner that will not be dialled while the phone is blocking the
+ * network it lives on.
+ *
+ * Android 17 drops local network traffic below the HTTP client, so a
+ * LAN server does not refuse a connection — it swallows it until the
+ * timeout. Left alone, every scheduled run spends that timeout, fails
+ * for a reason worth retrying, and comes back to spend it again. A
+ * worker cannot put a permission prompt in front of anyone, so the
+ * useful thing it can do is stop and say why.
+ *
+ * Wrapped around each peer rather than around the composite, because a
+ * public catalog paired with a kosync server in the spare room has one
+ * blocked partner and one perfectly healthy one, and refusing the whole
+ * run would silence the healthy one and file the failure under nobody's
+ * name.
+ *
+ * [PeerPositionSync.dialledAddress] answers null when this peer has
+ * nothing to do anyway — a connection that does not sync positions, a
+ * kosync partner stranded on an account that no longer uses it, a
+ * credential that cannot be read back — because a stored address that
+ * was never going to be dialled must not manufacture a failure. The
+ * peer answers it from the same state its own run consults, so the two
+ * cannot drift apart.
+ */
+class LocalNetworkGuardedSync(
+    private val delegate: PeerPositionSync,
+    private val access: LocalNetworkAccess,
+    private val reporting: SyncReporting,
+) : PeerPositionSync by delegate {
+
+    override val peerId: String get() = delegate.peerId
+
+    override suspend fun syncAll(snapshot: SyncSnapshot?): SyncOutcome =
+        if (blocked()) refuse() else delegate.syncAll(snapshot)
+
+    override suspend fun syncBook(bookUrl: String): SyncOutcome =
+        if (delegate.canSync(bookUrl) && blocked()) refuse() else delegate.syncBook(bookUrl)
+
+    /**
+     * A preview is one reader asking one book a question, so it answers
+     * and nothing more. Writing the account's status from here would
+     * let a glance at one book overwrite what the last real run did.
+     */
+    override suspend fun previewBook(bookUrl: String): PreviewOutcome =
+        if (delegate.canSync(bookUrl) && blocked()) {
+            PreviewOutcome.Failed(SyncFailure.LocalNetworkBlocked)
+        } else {
+            delegate.previewBook(bookUrl)
+        }
+
+    private suspend fun blocked(): Boolean = access.blocks(delegate.dialledAddress())
+
+    private fun refuse(): SyncOutcome {
+        reporting.report(PositionSyncStatus.Failed(SyncFailure.LocalNetworkBlocked), peerId)
+        return SyncOutcome.Failure(SyncFailure.LocalNetworkBlocked)
+    }
+}

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/PeerPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/PeerPositionSync.kt
@@ -18,6 +18,23 @@ interface PeerPositionSync : PositionSync {
     /** A stable, account-independent name for this partner. */
     val peerId: String
 
+    /**
+     * The address a run started now would dial, or null when it would
+     * not dial at all.
+     *
+     * Null is the whole of "this partner has nothing to do": no server
+     * connected, a kind that does not sync positions, a pairing
+     * stranded on an account that no longer uses it, a credential that
+     * cannot be read back. It answers from the same state the run
+     * itself consults, because the two disagreeing is how a peer that
+     * was going to answer "not applicable" is made to fail instead.
+     *
+     * It exists for [LocalNetworkGuardedSync], which has to know
+     * whether a run was going to touch the network *before* it decides
+     * that the network is out of reach.
+     */
+    suspend fun dialledAddress(): String?
+
     companion object {
         /** The server the library browses and downloads from. */
         const val CATALOG = "catalog"

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/PeerPositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/PeerPositionSync.kt
@@ -18,23 +18,6 @@ interface PeerPositionSync : PositionSync {
     /** A stable, account-independent name for this partner. */
     val peerId: String
 
-    /**
-     * The address a run started now would dial, or null when it would
-     * not dial at all.
-     *
-     * Null is the whole of "this partner has nothing to do": no server
-     * connected, a kind that does not sync positions, a pairing
-     * stranded on an account that no longer uses it, a credential that
-     * cannot be read back. It answers from the same state the run
-     * itself consults, because the two disagreeing is how a peer that
-     * was going to answer "not applicable" is made to fail instead.
-     *
-     * It exists for [LocalNetworkGuardedSync], which has to know
-     * whether a run was going to touch the network *before* it decides
-     * that the network is out of reach.
-     */
-    suspend fun dialledAddress(): String?
-
     companion object {
         /** The server the library browses and downloads from. */
         const val CATALOG = "catalog"
@@ -59,6 +42,12 @@ interface PeerPositionSync : PositionSync {
  * is paid in the background.
  */
 class CompositePositionSync(private val peers: List<PeerPositionSync>) : PositionSync {
+
+    /** The first partner that would dial, if any would. */
+    override suspend fun dialledAddress(): String? {
+        for (peer in peers) peer.dialledAddress()?.let { return it }
+        return null
+    }
 
     override suspend fun syncAll(snapshot: SyncSnapshot?): SyncOutcome =
         fold(peers.map { it.syncAll(snapshot) })

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/PositionSync.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/PositionSync.kt
@@ -242,6 +242,24 @@ sealed interface PreviewOutcome {
  */
 interface PositionSync {
     /**
+     * The address a run started now would dial, or null when it would
+     * not dial at all.
+     *
+     * Null is the whole of "this partner has nothing to do": no server
+     * connected, a kind that does not sync positions, a pairing
+     * stranded on an account that no longer uses it, a token or a
+     * credential that cannot be read back. Every implementation answers
+     * from the state its own run opens with, because the two
+     * disagreeing is how a partner that was going to answer "not
+     * applicable" is made to fail instead.
+     *
+     * It exists for [LocalNetworkGuardedSync], which has to know
+     * whether a run was going to touch the network *before* it decides
+     * that the network is out of reach.
+     */
+    suspend fun dialledAddress(): String?
+
+    /**
      * Reconciles every book that has a position on either side.
      *
      * [snapshot] is a catalog walk that has just been done, offered so a

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/PrivateAddress.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/PrivateAddress.kt
@@ -71,13 +71,17 @@ object PrivateAddress {
      * The IPv4 address inside an IPv4-mapped or IPv4-compatible IPv6
      * literal, in dotted form, or null if this is not one.
      *
+     * Public because the local-network classifier asks the same
+     * question about loopback that this object asks about private
+     * space, and the IPv6 parsing belongs in one place.
+     *
      * Both spellings are accepted: the trailing dotted quad that
      * `::ffff:192.168.1.1` uses, and the two hex groups of
      * `::ffff:c0a8:0101`. The `::ffff:` prefix may itself be written
      * out as `0:0:0:0:0:ffff:`, so the groups are counted rather than
      * matched as text.
      */
-    private fun mappedV4(host: String): String? {
+    fun mappedV4(host: String): String? {
         val expanded = expandV6(host) ?: return null
         if (expanded.size != 8) return null
         if (expanded.take(5).any { it != 0 }) return null
@@ -90,7 +94,7 @@ object PrivateAddress {
     }
 
     /** The eight 16-bit groups of an IPv6 literal, or null if it is not one. */
-    private fun expandV6(host: String): List<Int>? {
+    fun expandV6(host: String): List<Int>? {
         var text = host
         var trailing = emptyList<Int>()
         val dotted = text.substringAfterLast(':', "")

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/PrivateAddress.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/PrivateAddress.kt
@@ -27,17 +27,29 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
  * that needs the check to happen against the address actually dialled,
  * at connect time. That is worth doing and is not done here; this
  * answers the cheap and common shape, where the address is a literal.
+ *
+ * It is also not the authority on what Android will let the app reach.
+ * That is a wider and less fixed question — the routes of the network
+ * the phone is on, minus whatever a VPN carries — and it is
+ * [LocalNetworkAddress]'s, which builds on this rather than repeating
+ * it.
  */
 object PrivateAddress {
 
     fun matches(url: String): Boolean = url.toHttpUrlOrNull()?.let(::matches) ?: false
 
-    fun matches(url: HttpUrl): Boolean {
-        val host = url.host.lowercase().trim('[', ']')
-        if (host == "localhost" || host.endsWith(".localhost")) return true
-        if (host.endsWith(".local") || host.endsWith(".internal")) return true
-        if (':' in host) return isPrivateV6(host)
-        return isPrivateV4(host)
+    fun matches(url: HttpUrl): Boolean = matchesHost(url.host)
+
+    /**
+     * The same judgement about a bare host, for a caller that has one
+     * rather than a URL — a name's resolved addresses, say.
+     */
+    fun matchesHost(host: String): Boolean {
+        val cleaned = host.lowercase().trim('[', ']')
+        if (cleaned == "localhost" || cleaned.endsWith(".localhost")) return true
+        if (cleaned.endsWith(".local") || cleaned.endsWith(".internal")) return true
+        if (':' in cleaned) return isPrivateV6(cleaned)
+        return isPrivateV4(cleaned)
     }
 
     private fun isPrivateV6(host: String): Boolean {

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepository.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepository.kt
@@ -70,6 +70,7 @@ class RemoteCatalogRepository(
     private val inTransaction: suspend (suspend () -> Unit) -> Unit = { it() },
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
     private val networkAvailability: NetworkAvailability = NetworkAvailability { true },
+    private val localNetwork: LocalNetworkAccess = LocalNetworkAccess.Unrestricted,
 ) {
     private val _status = MutableStateFlow<CatalogStatus>(CatalogStatus.Idle)
     val status: StateFlow<CatalogStatus> = _status.asStateFlow()
@@ -139,6 +140,14 @@ class RemoteCatalogRepository(
             // reports nothing looks like a gesture that did not register.
             if (!networkAvailability.isAvailable()) {
                 _status.value = CatalogStatus.Failed(SyncFailure.Offline)
+                return CatalogRefresh.None
+            }
+            // Same reasoning, one rung further in: a server on a network
+            // the phone is blocking swallows the connection rather than
+            // refusing it, so a pull-to-refresh that is not stopped here
+            // is fifteen seconds of spinner and a puzzling timeout.
+            if (localNetwork.blocks(server.baseUrl)) {
+                _status.value = CatalogStatus.Failed(SyncFailure.LocalNetworkBlocked)
                 return CatalogRefresh.None
             }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteRouter.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteRouter.kt
@@ -45,6 +45,17 @@ class RemoteRouter(
 
     suspend fun positionSync(): PositionSync? = kind()?.let(positions::get)
 
+    /**
+     * Where the connected server's position sync would be dialled, when
+     * it has one.
+     *
+     * One read of the connected row answers both halves, so a server
+     * that changed in between cannot have its kind taken from one
+     * account and its address from the next.
+     */
+    suspend fun positionSyncAddress(): String? =
+        serverDao.get()?.takeIf { positions[it.kind] != null }?.baseUrl
+
     fun liveFor(kind: ServerKind): LiveChanges? = live[kind]
 
     /** The deleter for a server already in hand, when the kind has one. */
@@ -75,6 +86,8 @@ class RemoteRouter(
 class RoutedPositionSync(private val router: RemoteRouter) : PeerPositionSync {
 
     override val peerId: String get() = PeerPositionSync.CATALOG
+
+    override suspend fun dialledAddress(): String? = router.positionSyncAddress()
 
     override suspend fun syncAll(snapshot: SyncSnapshot?): SyncOutcome =
         router.positionSync()?.syncAll(snapshot) ?: SyncOutcome.NotApplicable

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteRouter.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/RemoteRouter.kt
@@ -45,17 +45,6 @@ class RemoteRouter(
 
     suspend fun positionSync(): PositionSync? = kind()?.let(positions::get)
 
-    /**
-     * Where the connected server's position sync would be dialled, when
-     * it has one.
-     *
-     * One read of the connected row answers both halves, so a server
-     * that changed in between cannot have its kind taken from one
-     * account and its address from the next.
-     */
-    suspend fun positionSyncAddress(): String? =
-        serverDao.get()?.takeIf { positions[it.kind] != null }?.baseUrl
-
     fun liveFor(kind: ServerKind): LiveChanges? = live[kind]
 
     /** The deleter for a server already in hand, when the kind has one. */
@@ -87,7 +76,7 @@ class RoutedPositionSync(private val router: RemoteRouter) : PeerPositionSync {
 
     override val peerId: String get() = PeerPositionSync.CATALOG
 
-    override suspend fun dialledAddress(): String? = router.positionSyncAddress()
+    override suspend fun dialledAddress(): String? = router.positionSync()?.dialledAddress()
 
     override suspend fun syncAll(snapshot: SyncSnapshot?): SyncOutcome =
         router.positionSync()?.syncAll(snapshot) ?: SyncOutcome.NotApplicable

--- a/app/src/main/kotlin/com/chmouel/liseur/data/remote/SyncFailure.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/remote/SyncFailure.kt
@@ -62,6 +62,18 @@ sealed interface SyncFailure {
     data object StaleIdentity : SyncFailure
 
     /**
+     * The phone is refusing to let the app reach this server at all.
+     *
+     * Android 17 blocks the local network until the reader allows it,
+     * and does so below the HTTP client: without this, a LAN server
+     * times out on every scheduled run, backs off and tries again for
+     * as long as it takes the reader to wander into Settings. Nothing
+     * changes until they are asked, and they cannot be asked from a
+     * worker, so it is not worth retrying.
+     */
+    data object LocalNetworkBlocked : SyncFailure
+
+    /**
      * Whether asking again later stands a chance. A refused sign-in will
      * be refused just as firmly in ten minutes, so retrying it only
      * spends battery.
@@ -70,7 +82,7 @@ sealed interface SyncFailure {
         get() = when (this) {
             Offline, Timeout, Malformed, StaleIdentity -> true
             is ServerError -> code >= 500
-            Unauthorised, Forbidden, NotFound, InsecureTransport -> false
+            Unauthorised, Forbidden, NotFound, InsecureTransport, LocalNetworkBlocked -> false
         }
 
     /** A short tag for the log. Never contains a URL or a token. */
@@ -85,6 +97,7 @@ sealed interface SyncFailure {
             Malformed -> "malformed response"
             InsecureTransport -> "https required"
             StaleIdentity -> "stale identity"
+            LocalNetworkBlocked -> "local network blocked"
         }
 }
 

--- a/app/src/main/kotlin/com/chmouel/liseur/sync/LiveSyncConnector.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/sync/LiveSyncConnector.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.launch
 class LiveSyncConnector(
     private val scope: CoroutineScope,
     accounts: Flow<RemoteServer?>,
-    private val sourceFor: (RemoteServer) -> LiveChanges?,
+    private val sourceFor: suspend (RemoteServer) -> LiveChanges?,
     private val coordinator: PositionSyncCoordinator,
     private val requestBook: (String) -> Unit,
     private val graceMillis: Long = 15_000,

--- a/app/src/main/kotlin/com/chmouel/liseur/sync/LiveSyncConnector.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/sync/LiveSyncConnector.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.launch
 
@@ -32,6 +33,7 @@ class LiveSyncConnector(
     private val sourceFor: suspend (RemoteServer) -> LiveChanges?,
     private val coordinator: PositionSyncCoordinator,
     private val requestBook: (String) -> Unit,
+    reconnectOn: Flow<Long> = flowOf(0L),
     private val graceMillis: Long = 15_000,
     private val retryJitter: () -> Double = { Random.nextDouble() },
     private val reportFailure: suspend (LiveIdentity, SyncFailure) -> Unit = { _, _ -> },
@@ -43,9 +45,19 @@ class LiveSyncConnector(
 
     init {
         scope.launch {
-            combine(active, accounts) { foreground, server -> server.takeIf { foreground } }
-                .distinctUntilChangedBy { it?.let(LiveIdentity::from) }
-                .collectLatest { server ->
+            // The reconnect signal is in the distinct key but not in
+            // `LiveIdentity`: what it stands for is the phone's answer
+            // about reaching this server changing under a connection
+            // that was opened once and held, which is a reason to open
+            // it again and not a different account.
+            combine(active, accounts, reconnectOn) { foreground, server, generation ->
+                server.takeIf { foreground }?.let { it to generation }
+            }
+                .distinctUntilChangedBy { open ->
+                    open?.let { (server, generation) -> LiveIdentity.from(server) to generation }
+                }
+                .collectLatest { open ->
+                    val server = open?.first
                     val identity = server?.let(LiveIdentity::from)
                     coordinator.liveAccount(identity)
                     if (server != null && identity != null) {

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/SyncFailureMessages.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/SyncFailureMessages.kt
@@ -18,5 +18,6 @@ fun SyncFailure.messageRes(): Int = when (this) {
     SyncFailure.Malformed -> R.string.server_sync_malformed
     SyncFailure.InsecureTransport -> R.string.server_sync_insecure
     SyncFailure.StaleIdentity -> R.string.server_sync_stale_identity
+    SyncFailure.LocalNetworkBlocked -> R.string.server_sync_local_network
     is SyncFailure.ServerError -> R.string.server_sync_server_error
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/library/LibraryScreen.kt
@@ -1624,6 +1624,7 @@ private fun CatalogFailureNotice(
         // A catalog fetch never produces this one; the notice still has
         // to answer for it.
         SyncFailure.StaleIdentity -> R.string.catalog_failed_server_error
+        SyncFailure.LocalNetworkBlocked -> R.string.catalog_failed_local_network
         is SyncFailure.ServerError -> R.string.catalog_failed_server_error
     }
     Surface(

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountScreen.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountScreen.kt
@@ -1,7 +1,13 @@
 package com.chmouel.liseur.ui.settings
 
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
 import android.text.format.DateUtils
 import android.text.format.Formatter
+import androidx.activity.compose.LocalActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
@@ -61,6 +67,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -81,6 +89,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import com.chmouel.liseur.R
 import com.chmouel.liseur.data.calibre.BulkBatch
 import com.chmouel.liseur.data.calibre.BulkDownloadEstimate
@@ -88,6 +97,7 @@ import com.chmouel.liseur.data.calibre.BulkStopReason
 import com.chmouel.liseur.data.calibre.SpaceVerdict
 import com.chmouel.liseur.data.calibre.StorageUse
 import com.chmouel.liseur.data.db.RemoteServer
+import com.chmouel.liseur.data.remote.LocalNetworkAccess
 import com.chmouel.liseur.data.remote.PositionSyncStatus
 import com.chmouel.liseur.data.remote.ServerKind
 import com.chmouel.liseur.data.remote.SyncIdentity
@@ -132,10 +142,24 @@ fun ServerAccountScreen(
     onKosyncRegisterChange: (Boolean) -> Unit,
     onKosyncConnect: () -> Unit,
     onKosyncDisconnect: () -> Unit,
+    onLocalNetworkRequestLaunched: (Long) -> Unit,
+    onLocalNetworkResult: (Boolean) -> Unit,
+    onAskLocalNetworkAgain: () -> Unit,
+    onRefreshLocalNetworkAccess: () -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    val localNetwork = rememberLocalNetworkPrompt(
+        request = state.localNetworkRequest,
+        asked = state.localNetworkAsked,
+        onLaunched = onLocalNetworkRequestLaunched,
+        onResult = onLocalNetworkResult,
+    )
+    LifecycleResumeEffect(Unit) {
+        onRefreshLocalNetworkAccess()
+        onPauseOrDispose { }
+    }
 
     Scaffold(
         modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -189,6 +213,7 @@ fun ServerAccountScreen(
                         onKosyncUsernameChange = onKosyncUsernameChange,
                         onKosyncPasswordChange = onKosyncPasswordChange,
                         onConnect = onConnect,
+                        prompt = localNetwork,
                     )
                 } else {
                     ConnectedCard(
@@ -211,6 +236,13 @@ fun ServerAccountScreen(
                         onCancelDownloadAll = onCancelDownloadAll,
                         onDismissBatch = onDismissBatch,
                     )
+                    if (state.localNetworkBlocked) {
+                        LocalNetworkNotice(
+                            text = stringResource(R.string.server_local_network_blocked),
+                            prompt = localNetwork,
+                            onAskAgain = onAskLocalNetworkAgain,
+                        )
+                    }
                     if (server.kind == ServerKind.LISEUR_SYNC) {
                         if (state.confirmations.isNotEmpty()) {
                             SameBookCard(state.confirmations, onAnswerConfirmation)
@@ -243,6 +275,7 @@ fun ServerAccountScreen(
                         onRegisterChange = onKosyncRegisterChange,
                         onConnect = onKosyncConnect,
                         onDisconnect = onKosyncDisconnect,
+                        prompt = localNetwork,
                     )
                 }
                 val secretNote = when (server?.kind ?: state.kind) {
@@ -511,6 +544,7 @@ private fun ConnectForm(
     onKosyncUsernameChange: (String) -> Unit,
     onKosyncPasswordChange: (String) -> Unit,
     onConnect: (Boolean) -> Unit,
+    prompt: LocalNetworkPrompt,
 ) {
     var picking by rememberSaveable { mutableStateOf(false) }
     val uriHandler = LocalUriHandler.current
@@ -651,7 +685,7 @@ private fun ConnectForm(
             // A two-address form needs each failure next to the address
             // that caused it. Left at the foot of the form, a catalog
             // refusal reads as a complaint about the sync server.
-            ConnectError(state = state, onConnect = onConnect)
+            ConnectError(state = state, onConnect = onConnect, prompt = prompt)
 
             SectionLabel(stringResource(R.string.server_custom_kosync_section))
             OutlinedTextField(
@@ -692,10 +726,18 @@ private fun ConnectForm(
             )
             FieldHelp(stringResource(R.string.server_custom_kosync_help))
             state.kosyncError?.let {
-                Notice(
-                    text = stringResource(it.kosyncMessageRes()),
-                    tone = NoticeTone.PROBLEM,
-                )
+                if (it == AccountError.LOCAL_NETWORK_BLOCKED) {
+                    LocalNetworkNotice(
+                        text = stringResource(it.kosyncMessageRes()),
+                        prompt = prompt,
+                        onAskAgain = { onConnect(false) },
+                    )
+                } else {
+                    Notice(
+                        text = stringResource(it.kosyncMessageRes()),
+                        tone = NoticeTone.PROBLEM,
+                    )
+                }
             }
         }
         ServerKind.KOMGA -> {
@@ -733,7 +775,7 @@ private fun ConnectForm(
     }
 
     if (state.kind != ServerKind.CUSTOM) {
-        ConnectError(state = state, onConnect = onConnect)
+        ConnectError(state = state, onConnect = onConnect, prompt = prompt)
     }
 
     Button(
@@ -781,8 +823,20 @@ private fun ConnectForm(
  * about it: retrying an unreachable https address over http.
  */
 @Composable
-private fun ConnectError(state: ServerAccountUiState, onConnect: (Boolean) -> Unit) {
+private fun ConnectError(
+    state: ServerAccountUiState,
+    onConnect: (Boolean) -> Unit,
+    prompt: LocalNetworkPrompt,
+) {
     val error = state.error ?: return
+    if (error == AccountError.LOCAL_NETWORK_BLOCKED) {
+        LocalNetworkNotice(
+            text = stringResource(error.messageRes(state.kind)),
+            prompt = prompt,
+            onAskAgain = { onConnect(false) },
+        )
+        return
+    }
     Notice(
         text = stringResource(error.messageRes(state.kind)),
         tone = NoticeTone.PROBLEM,
@@ -1109,6 +1163,7 @@ private fun KosyncSection(
     onRegisterChange: (Boolean) -> Unit,
     onConnect: () -> Unit,
     onDisconnect: () -> Unit,
+    prompt: LocalNetworkPrompt,
 ) {
     ServerSection(title = stringResource(R.string.kosync_section)) {
         val peer = state.kosync
@@ -1206,10 +1261,18 @@ private fun KosyncSection(
             ),
         )
         state.kosyncError?.let { error ->
-            Notice(
-                text = stringResource(error.kosyncMessageRes()),
-                tone = NoticeTone.PROBLEM,
-            )
+            if (error == AccountError.LOCAL_NETWORK_BLOCKED) {
+                LocalNetworkNotice(
+                    text = stringResource(error.kosyncMessageRes()),
+                    prompt = prompt,
+                    onAskAgain = onConnect,
+                )
+            } else {
+                Notice(
+                    text = stringResource(error.kosyncMessageRes()),
+                    tone = NoticeTone.PROBLEM,
+                )
+            }
         }
         Button(
             onClick = onConnect,
@@ -1237,6 +1300,7 @@ private fun AccountError.kosyncMessageRes(): Int = when (this) {
     AccountError.WRONG_SERVER -> R.string.kosync_error_not_kosync
     AccountError.INSECURE_TRANSPORT -> R.string.server_sync_insecure
     AccountError.RATE_LIMITED -> R.string.server_error_rate_limited
+    AccountError.LOCAL_NETWORK_BLOCKED -> R.string.server_error_local_network
     else -> R.string.server_error_unreachable
 }
 
@@ -1480,6 +1544,83 @@ internal fun Notice(text: String, tone: NoticeTone) {
     }
 }
 
+/**
+ * What to offer a reader whose phone is blocking the local network,
+ * and how to get there.
+ *
+ * The prompt itself is launched from here, from an effect keyed on the
+ * pending request, and the ViewModel is told it has been launched
+ * *before* it goes up: a rotation while the system dialog is on screen
+ * rebuilds this effect, and a second dialog behind the first is not
+ * something the reader can make sense of.
+ */
+@Composable
+private fun rememberLocalNetworkPrompt(
+    request: LocalNetworkRequest?,
+    asked: Boolean,
+    onLaunched: (Long) -> Unit,
+    onResult: (Boolean) -> Unit,
+): LocalNetworkPrompt {
+    val context = LocalContext.current
+    val activity = LocalActivity.current
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+        onResult,
+    )
+    LaunchedEffect(request?.id, request?.launched) {
+        if (request != null && !request.launched) {
+            onLaunched(request.id)
+            launcher.launch(LocalNetworkAccess.PERMISSION)
+        }
+    }
+    // Asked and told never to ask again is the one case worth sending
+    // somebody to the settings app for. Before anything has been asked
+    // the platform answers the same false, which is why nothing here
+    // reads it until an ask has happened.
+    val settingsOnly = asked &&
+        activity?.shouldShowRequestPermissionRationale(LocalNetworkAccess.PERMISSION) == false
+    return LocalNetworkPrompt(settingsOnly) {
+        context.startActivity(
+            Intent(
+                Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                Uri.fromParts("package", context.packageName, null),
+            ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        )
+    }
+}
+
+@Immutable
+private class LocalNetworkPrompt(
+    /** Whether asking again is pointless and only settings will do. */
+    val settingsOnly: Boolean,
+    val openSettings: () -> Unit,
+)
+
+/**
+ * The notice for a blocked local network, with the one thing to do
+ * about it: ask again, or go to the settings page that can still say
+ * yes.
+ */
+@Composable
+private fun LocalNetworkNotice(
+    text: String,
+    prompt: LocalNetworkPrompt,
+    onAskAgain: () -> Unit,
+) {
+    Notice(text, NoticeTone.PROBLEM)
+    TextButton(onClick = { if (prompt.settingsOnly) prompt.openSettings() else onAskAgain() }) {
+        Text(
+            stringResource(
+                if (prompt.settingsOnly) {
+                    R.string.server_local_network_settings
+                } else {
+                    R.string.server_local_network_retry
+                },
+            ),
+        )
+    }
+}
+
 private fun AccountError.messageRes(kind: ServerKind): Int = when (this) {
     AccountError.BAD_CREDENTIALS -> when (kind) {
         ServerKind.CALIBRE -> R.string.server_error_credentials
@@ -1504,6 +1645,7 @@ private fun AccountError.messageRes(kind: ServerKind): Int = when (this) {
     AccountError.INSECURE_TRANSPORT -> R.string.server_sync_insecure
     AccountError.INSUFFICIENT_SCOPES -> R.string.server_error_scopes_liseur_sync
     AccountError.RATE_LIMITED -> R.string.server_error_rate_limited
+    AccountError.LOCAL_NETWORK_BLOCKED -> R.string.server_error_local_network
 }
 
 /** Plain words for how the last position sync went. */

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountViewModel.kt
@@ -14,6 +14,7 @@ import com.chmouel.liseur.data.db.WorkIdentityDao
 import com.chmouel.liseur.data.kosync.KosyncAccountRepository
 import com.chmouel.liseur.data.kosync.KosyncSetupOutcome
 import com.chmouel.liseur.data.remote.PeerPositionSync
+import com.chmouel.liseur.data.remote.LocalNetworkAccess
 import com.chmouel.liseur.data.remote.RemoteAccountRepository
 import com.chmouel.liseur.data.calibre.BookDownloadRepository
 import com.chmouel.liseur.data.calibre.BulkBatch
@@ -36,6 +37,7 @@ import com.chmouel.liseur.domain.displayTitle
 import com.chmouel.liseur.sync.PositionSyncCoordinator
 import com.chmouel.liseur.sync.SyncScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -54,6 +56,46 @@ enum class AccountError {
     INSECURE_TRANSPORT,
     INSUFFICIENT_SCOPES,
     RATE_LIMITED,
+
+    /** The phone is blocking the network the server lives on. */
+    LOCAL_NETWORK_BLOCKED,
+}
+
+/**
+ * Something waiting on the reader's answer to a permission prompt.
+ *
+ * The whole of what was submitted travels with it, because the prompt
+ * stands between the button and the connection and the form underneath
+ * it stays live: re-reading the fields afterwards would connect with a
+ * password half-retyped in the meantime. It is also what makes resuming
+ * possible at all, since [ServerAccountViewModel.connect] and its
+ * siblings set the busy flag they themselves refuse to start under.
+ *
+ * [launched] is the prompt having been put up, which is not the same as
+ * it having been answered. A rotation while the dialog is on screen
+ * builds the screen again, and without this the new one would put up a
+ * second dialog; the result of the first still finds its way home.
+ */
+data class LocalNetworkRequest(
+    val id: Long,
+    val action: Action,
+    /** The form exactly as it was submitted, for the paths that connect. */
+    val submitted: ServerAccountUiState? = null,
+    val allowHttp: Boolean = false,
+    /** Whether a refusal belongs against the sync address, not the catalog one. */
+    val blockedKosync: Boolean = false,
+    val launched: Boolean = false,
+) {
+    enum class Action {
+        /** The connect form, whichever kind it is filled in for. */
+        CONNECT,
+
+        /** A kosync partner being paired on its own. */
+        KOSYNC,
+
+        /** An account already connected, whose permission went away. */
+        SAVED,
+    }
 }
 
 /** Which way a reader proves who they are to a liseur-sync server. */
@@ -120,6 +162,18 @@ data class ServerAccountUiState(
     val kosyncError: AccountError? = null,
     /** How the kosync partner's own last run went, apart from the summary. */
     val kosyncStatus: PositionSyncStatus = PositionSyncStatus.Idle,
+    /** A permission prompt this screen is waiting on, if any. */
+    val localNetworkRequest: LocalNetworkRequest? = null,
+    /**
+     * Whether the permission has been asked for on this screen yet.
+     *
+     * `shouldShowRequestPermissionRationale` answers false in two
+     * opposite situations — nothing ever asked, and asked and refused
+     * for good — so it means nothing until something has been asked.
+     */
+    val localNetworkAsked: Boolean = false,
+    /** Whether the connected account's own addresses are out of reach. */
+    val localNetworkBlocked: Boolean = false,
 )
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -133,10 +187,15 @@ class ServerAccountViewModel(
     private val identityDao: WorkIdentityDao,
     private val bookDao: BookDao,
     private val kosyncAccount: KosyncAccountRepository,
+    private val localNetwork: LocalNetworkAccess,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(ServerAccountUiState())
     val state: StateFlow<ServerAccountUiState> = _state.asStateFlow()
+
+    private var lastLocalNetworkRequest = 0L
+
+    private var localNetworkCheck: Job? = null
 
     init {
         viewModelScope.launch {
@@ -155,6 +214,7 @@ class ServerAccountViewModel(
                             ?: state.kosyncUrl,
                     )
                 }
+                recheckLocalNetwork(server, peer)
             }
         }
         viewModelScope.launch {
@@ -277,23 +337,31 @@ class ServerAccountViewModel(
         }
         _state.update { it.copy(kosyncConnecting = true, kosyncError = null) }
         viewModelScope.launch {
-            val outcome = kosyncAccount.connect(
-                url = current.kosyncUrl,
-                username = current.kosyncUsername,
-                password = current.kosyncPassword,
-                register = current.kosyncRegister,
-            )
-            _state.update {
-                when (outcome) {
-                    KosyncSetupOutcome.Success ->
-                        it.copy(kosyncConnecting = false, kosyncPassword = "")
-                    is KosyncSetupOutcome.Failure ->
-                        it.copy(kosyncConnecting = false, kosyncError = outcome.reason.toUiError())
-                }
+            if (localNetwork.blocks(current.kosyncUrl.trim())) {
+                park(LocalNetworkRequest.Action.KOSYNC, current, blockedKosync = true)
+                return@launch
             }
-            if (outcome == KosyncSetupOutcome.Success) {
-                positionSync.request(SyncScope.Full)
+            runKosyncConnect(current)
+        }
+    }
+
+    private suspend fun runKosyncConnect(current: ServerAccountUiState) {
+        val outcome = kosyncAccount.connect(
+            url = current.kosyncUrl,
+            username = current.kosyncUsername,
+            password = current.kosyncPassword,
+            register = current.kosyncRegister,
+        )
+        _state.update {
+            when (outcome) {
+                KosyncSetupOutcome.Success ->
+                    it.copy(kosyncConnecting = false, kosyncPassword = "")
+                is KosyncSetupOutcome.Failure ->
+                    it.copy(kosyncConnecting = false, kosyncError = outcome.reason.toUiError())
             }
+        }
+        if (outcome == KosyncSetupOutcome.Success) {
+            positionSync.request(SyncScope.Full)
         }
     }
 
@@ -327,56 +395,69 @@ class ServerAccountViewModel(
         val current = _state.value
         if (current.connecting) return
         if (!current.readyToConnect()) return
-        _state.update { it.copy(connecting = true, error = null) }
+        _state.update { it.copy(connecting = true, error = null, kosyncError = null) }
 
         viewModelScope.launch {
-            if (current.kind == ServerKind.CUSTOM) {
-                connectCustom(current, allowHttp)
+            val blocked = blockedForConnect(current)
+            if (blocked != null) {
+                park(LocalNetworkRequest.Action.CONNECT, current, allowHttp, blocked)
                 return@launch
             }
-            val result = when (current.kind) {
-                ServerKind.CALIBRE -> repository.connectCalibre(
+            runConnect(current, allowHttp)
+        }
+    }
+
+    /**
+     * The connection itself, over what was submitted rather than over
+     * whatever the form holds now.
+     */
+    private suspend fun runConnect(current: ServerAccountUiState, allowHttp: Boolean) {
+        if (current.kind == ServerKind.CUSTOM) {
+            connectCustom(current, allowHttp)
+            return
+        }
+        val result = when (current.kind) {
+            ServerKind.CALIBRE -> repository.connectCalibre(
+                url = current.url,
+                username = current.username.trim(),
+                password = current.password,
+                allowHttp = allowHttp,
+            )
+            ServerKind.KOMGA -> repository.connectKomga(
+                url = current.url,
+                apiKey = current.apiKey.trim(),
+                allowHttp = allowHttp,
+            )
+            ServerKind.GRIMMORY -> repository.connectGrimmory(
+                url = current.url,
+                username = current.username.trim(),
+                password = current.password,
+                allowHttp = allowHttp,
+            )
+            ServerKind.LISEUR_SYNC -> when (current.liseurSyncSignIn) {
+                LiseurSyncSignIn.PASSWORD -> repository.connectLiseurSync(
                     url = current.url,
                     username = current.username.trim(),
                     password = current.password,
                     allowHttp = allowHttp,
                 )
-                ServerKind.KOMGA -> repository.connectKomga(
+                LiseurSyncSignIn.TOKEN -> repository.connectLiseurSyncToken(
                     url = current.url,
-                    apiKey = current.apiKey.trim(),
+                    token = current.deviceToken,
                     allowHttp = allowHttp,
                 )
-                ServerKind.GRIMMORY -> repository.connectGrimmory(
-                    url = current.url,
-                    username = current.username.trim(),
-                    password = current.password,
-                    allowHttp = allowHttp,
-                )
-                ServerKind.LISEUR_SYNC -> when (current.liseurSyncSignIn) {
-                    LiseurSyncSignIn.PASSWORD -> repository.connectLiseurSync(
-                        url = current.url,
-                        username = current.username.trim(),
-                        password = current.password,
-                        allowHttp = allowHttp,
-                    )
-                    LiseurSyncSignIn.TOKEN -> repository.connectLiseurSyncToken(
-                        url = current.url,
-                        token = current.deviceToken,
-                        allowHttp = allowHttp,
-                    )
-                }
             }
-            if (result is SetupResult.Success) {
-                fetchCatalogAndPositions()
-                appSettings.setAccountLostToRestore(false)
-            }
-            _state.update {
-                when (result) {
-                    is SetupResult.Success ->
-                        it.copy(connecting = false, password = "", apiKey = "", deviceToken = "")
-                    is SetupResult.Failure ->
-                        it.copy(connecting = false, error = result.reason.toUiError())
-                }
+        }
+        if (result is SetupResult.Success) {
+            fetchCatalogAndPositions()
+            appSettings.setAccountLostToRestore(false)
+        }
+        _state.update {
+            when (result) {
+                is SetupResult.Success ->
+                    it.copy(connecting = false, password = "", apiKey = "", deviceToken = "")
+                is SetupResult.Failure ->
+                    it.copy(connecting = false, error = result.reason.toUiError())
             }
         }
     }
@@ -391,6 +472,151 @@ class ServerAccountViewModel(
             }
             _state.update { it.copy(connecting = false) }
         }
+    }
+
+    /**
+     * Which of a submitted form's addresses the phone will not let this
+     * app reach, or null if it will reach all of them.
+     *
+     * Both of a Custom connection are asked about: its catalog and its
+     * sync server are two machines, and either of them may be the one
+     * in the spare room. The answer says which, so a refusal lands
+     * under the field it belongs to.
+     */
+    private suspend fun blockedForConnect(current: ServerAccountUiState): Boolean? = when {
+        localNetwork.blocks(current.url.trim()) -> false
+        current.kind == ServerKind.CUSTOM &&
+            localNetwork.blocks(current.kosyncUrl.trim()) -> true
+        else -> null
+    }
+
+    /** Holds an action still, and asks the screen to put the prompt up. */
+    private fun park(
+        action: LocalNetworkRequest.Action,
+        submitted: ServerAccountUiState? = null,
+        allowHttp: Boolean = false,
+        blockedKosync: Boolean = false,
+    ) {
+        _state.update {
+            it.copy(
+                localNetworkRequest = LocalNetworkRequest(
+                    id = ++lastLocalNetworkRequest,
+                    action = action,
+                    submitted = submitted,
+                    allowHttp = allowHttp,
+                    blockedKosync = blockedKosync,
+                ),
+            )
+        }
+    }
+
+    /**
+     * The prompt for [id] is on screen.
+     *
+     * Marked before it is shown rather than after it is answered, so a
+     * screen rebuilt by a rotation while the dialog is up finds the
+     * asking already done.
+     */
+    fun onLocalNetworkRequestLaunched(id: Long) {
+        _state.update {
+            val request = it.localNetworkRequest
+            if (request?.id != id || request.launched) it
+            else it.copy(localNetworkRequest = request.copy(launched = true))
+        }
+    }
+
+    /** Asks for the permission again for an account already connected. */
+    fun askLocalNetworkAgain() {
+        if (_state.value.localNetworkRequest != null) return
+        park(LocalNetworkRequest.Action.SAVED)
+    }
+
+    /**
+     * What the reader said.
+     *
+     * The request is spent before anything is done with it, so a
+     * duplicate callback — or a screen that comes back and reports the
+     * same answer again — cannot connect twice.
+     */
+    fun onLocalNetworkResult(granted: Boolean) {
+        val request = _state.value.localNetworkRequest ?: return
+        _state.update { it.copy(localNetworkRequest = null, localNetworkAsked = true) }
+        viewModelScope.launch {
+            if (granted) resume(request) else refuse(request)
+        }
+    }
+
+    private suspend fun resume(request: LocalNetworkRequest) = when (request.action) {
+        LocalNetworkRequest.Action.CONNECT ->
+            request.submitted?.let { runConnect(it, request.allowHttp) } ?: Unit
+        LocalNetworkRequest.Action.KOSYNC ->
+            request.submitted?.let { runKosyncConnect(it) } ?: Unit
+        LocalNetworkRequest.Action.SAVED -> {
+            refreshLocalNetworkAccess()
+            positionSync.request(SyncScope.Full, System.currentTimeMillis())
+            Unit
+        }
+    }
+
+    private fun refuse(request: LocalNetworkRequest) {
+        _state.update {
+            when (request.action) {
+                LocalNetworkRequest.Action.CONNECT -> if (request.blockedKosync) {
+                    it.copy(connecting = false, kosyncError = AccountError.LOCAL_NETWORK_BLOCKED)
+                } else {
+                    it.copy(connecting = false, error = AccountError.LOCAL_NETWORK_BLOCKED)
+                }
+                LocalNetworkRequest.Action.KOSYNC -> it.copy(
+                    kosyncConnecting = false,
+                    kosyncError = AccountError.LOCAL_NETWORK_BLOCKED,
+                )
+                LocalNetworkRequest.Action.SAVED -> it.copy(localNetworkBlocked = true)
+            }
+        }
+    }
+
+    /**
+     * Whether the connected account has anywhere it can no longer
+     * reach.
+     *
+     * Both of the server's addresses, because a Custom connection
+     * catalogs at one and syncs at another; and the kosync partner's
+     * only when the connected server is one the pairing belongs to. A
+     * pairing stranded by an account switch is shown so that it can be
+     * disconnected, and nothing will dial it — asking for a permission
+     * on its behalf would be a prompt for a machine this account never
+     * talks to. That is the test [com.chmouel.liseur.data.kosync.KosyncPositionSync]
+     * applies before it runs, kept in step with it here.
+     *
+     * Recomputed whenever the stored account changes, not only on
+     * resume: the row arrives from Room after the screen is built, and
+     * a check that ran before it landed would find nothing stored,
+     * answer "not blocked", and leave a reader on Android 17 with the
+     * original timeout and no way to grant anything. Each run replaces
+     * the one before it, so a slow lookup cannot land on top of a
+     * newer answer.
+     */
+    private fun recheckLocalNetwork(server: RemoteServer?, peer: KosyncPeer?) {
+        localNetworkCheck?.cancel()
+        localNetworkCheck = viewModelScope.launch {
+            val addresses = listOfNotNull(
+                server?.baseUrl,
+                server?.catalogUrl,
+                peer?.baseUrl?.takeIf { server?.kind?.hostsKosyncPeer == true },
+            ).distinct()
+            val blocked = addresses.any { localNetwork.blocks(it) }
+            _state.update { it.copy(localNetworkBlocked = blocked) }
+        }
+    }
+
+    /**
+     * The same question asked again on resume, so coming back from the
+     * system settings page clears the notice without the reader doing
+     * anything else.
+     */
+    fun refreshLocalNetworkAccess() {
+        val current = _state.value
+        recheckLocalNetwork(current.server, current.kosync)
     }
 
     /**
@@ -581,6 +807,7 @@ class ServerAccountViewModel(
                     identityDao = container.database.workIdentityDao(),
                     bookDao = container.database.bookDao(),
                     kosyncAccount = container.kosyncAccount,
+                    localNetwork = container.localNetwork,
                 )
             }
         }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountViewModel.kt
@@ -541,6 +541,10 @@ class ServerAccountViewModel(
     fun onLocalNetworkResult(granted: Boolean) {
         val request = _state.value.localNetworkRequest ?: return
         _state.update { it.copy(localNetworkRequest = null, localNetworkAsked = true) }
+        // A background run asks afresh every time, but a live
+        // notification stream is opened once and held, so it is told
+        // the answer has moved.
+        localNetwork.recheck()
         viewModelScope.launch {
             if (granted) resume(request) else refuse(request)
         }
@@ -615,6 +619,9 @@ class ServerAccountViewModel(
      * anything else.
      */
     fun refreshLocalNetworkAccess() {
+        // Called on resume, which is how a grant made in the system
+        // settings app gets back here at all.
+        localNetwork.recheck()
         val current = _state.value
         recheckLocalNetwork(current.server, current.kosync)
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountViewModel.kt
@@ -606,7 +606,14 @@ class ServerAccountViewModel(
             val addresses = listOfNotNull(
                 server?.baseUrl,
                 server?.catalogUrl,
-                peer?.baseUrl?.takeIf { server?.kind?.hostsKosyncPeer == true },
+                // Both halves matter and both have bitten: a pairing
+                // the connected account does not use is never dialled,
+                // and neither is one whose stored key this Keystore
+                // cannot read back -- a database restored onto another
+                // phone. Granting the permission would not help either.
+                peer?.baseUrl?.takeIf {
+                    server?.kind?.hostsKosyncPeer == true && peer.credentials != null
+                },
             ).distinct()
             val blocked = addresses.any { localNetwork.blocks(it) }
             _state.update { it.copy(localNetworkBlocked = blocked) }
@@ -630,6 +637,19 @@ class ServerAccountViewModel(
         // the app's own foreground refresh is debounced, and a trip to
         // the settings app is well inside that minute.
         if (moved && localNetwork.granted) {
+            // And the refusal it left on the form is spent. Otherwise
+            // the notice stays up offering the settings page a reader
+            // has just come back from -- the rationale API answers
+            // false after a grant as readily as before the first ask,
+            // so the button cannot tell on its own -- and the way out
+            // is to notice that Connect works now.
+            _state.update {
+                it.copy(
+                    error = it.error.takeUnless { e -> e == AccountError.LOCAL_NETWORK_BLOCKED },
+                    kosyncError = it.kosyncError
+                        .takeUnless { e -> e == AccountError.LOCAL_NETWORK_BLOCKED },
+                )
+            }
             viewModelScope.launch {
                 positionSync.request(SyncScope.Full, System.currentTimeMillis())
             }

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerAccountViewModel.kt
@@ -621,9 +621,19 @@ class ServerAccountViewModel(
     fun refreshLocalNetworkAccess() {
         // Called on resume, which is how a grant made in the system
         // settings app gets back here at all.
-        localNetwork.recheck()
+        val moved = localNetwork.recheck()
         val current = _state.value
         recheckLocalNetwork(current.server, current.kosync)
+        // And a grant made over there deserves the same sync a grant
+        // made in the prompt gets. Without it the account keeps the
+        // stale blocked failure until a page turn or a manual Sync now:
+        // the app's own foreground refresh is debounced, and a trip to
+        // the settings app is well inside that minute.
+        if (moved && localNetwork.granted) {
+            viewModelScope.launch {
+                positionSync.request(SyncScope.Full, System.currentTimeMillis())
+            }
+        }
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -233,6 +233,10 @@
     <string name="server_error_rate_limited">Too many attempts. Wait a moment and try again.</string>
     <string name="server_error_unreachable">The server did not answer. Check the address and that you are online.</string>
     <string name="server_error_https">The server did not answer over a secure connection.</string>
+    <string name="server_error_local_network">Android is blocking Liseur from reaching servers on this network. Allow it access to nearby devices to connect.</string>
+    <string name="server_local_network_blocked">Android is blocking Liseur from reaching this server on your network. Allow it access to nearby devices.</string>
+    <string name="server_local_network_retry">Allow access</string>
+    <string name="server_local_network_settings">Open app settings</string>
     <string name="server_no_download_right">This account is not allowed to download books. Ask whoever runs the server to tick \"Allow Downloads\" for your user in calibre-web, then check again.</string>
     <string name="server_no_download_right_komga">This API key is not allowed to download books. Ask whoever runs the server to give your account the file download role, then check again.</string>
     <string name="server_no_download_right_custom">This catalog is not offering any books to download.</string>
@@ -287,6 +291,7 @@
     <string name="server_sync_insecure">This server refuses to take credentials over plain HTTP. Use an https:// address.</string>
     <string name="server_sync_malformed">The server answered with something unexpected; positions will sync later.</string>
     <string name="server_sync_stale_identity">The server’s book identity changed; sync will retry.</string>
+    <string name="server_sync_local_network">Android is blocking Liseur from reaching this server on your network, so positions did not sync.</string>
     <string name="server_sync_server_error">The server ran into trouble; positions will sync later.</string>
     <string name="server_sync_never">Reading positions have not synced yet.</string>
     <string name="server_sync_last">Reading positions synced %1$s</string>
@@ -692,6 +697,7 @@
     <string name="catalog_failed_malformed">Your server answered with something unexpected. Showing the saved catalog.</string>
     <string name="catalog_failed_insecure">This server needs an https:// address. Showing the saved catalog.</string>
     <string name="catalog_failed_server_error">Your server ran into trouble. Showing the saved catalog.</string>
+    <string name="catalog_failed_local_network">Android is blocking Liseur from reaching servers on this network. Showing the saved catalog.</string>
     <string name="catalog_retry">Try again</string>
     <string name="catalog_reconnect">Reconnect</string>
     <string name="state_finished">Finished</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepositoryTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/komga/KomgaSyncRepositoryTest.kt
@@ -136,6 +136,25 @@ class KomgaSyncRepositoryTest {
         )
     }
 
+    /**
+     * A database restored onto another phone arrives with ciphertext
+     * this Keystore cannot open, and the run answers "not applicable"
+     * before it dials. Naming an address anyway would let the local
+     * network guard fail a run that was never going to touch the
+     * network.
+     */
+    @Test
+    fun `a server whose credential cannot be read names no address`() = runTest {
+        assertNull(sync.dialledAddress())
+        connect()
+        assertEquals("http://127.0.0.1:${server.port}", sync.dialledAddress())
+
+        CredentialCipher.keyForTesting =
+            javax.crypto.KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
+
+        assertNull(sync.dialledAddress())
+    }
+
     @Test
     fun `an offline run says so without waiting on a connection`() = runTest {
         connect()

--- a/app/src/test/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/kosync/KosyncPositionSyncTest.kt
@@ -123,6 +123,22 @@ class KosyncPositionSyncTest {
         assertEquals(0, server.requestCount)
     }
 
+    /**
+     * The address the local network guard judges comes from the same
+     * test the run opens with, so a pairing left behind by an account
+     * switch names no address to be blocked on — and a blocked phone
+     * cannot turn a run that was going to do nothing into a failure.
+     */
+    @Test
+    fun `a stranded pairing names no address to dial`() = runTest {
+        pair(baseUrl = "http://192.168.1.20:8081")
+
+        assertNull(sync(connectedKind = ServerKind.KOMGA).dialledAddress())
+        assertNull(sync(connectedKind = null).dialledAddress())
+        assertEquals("http://192.168.1.20:8081", sync().dialledAddress())
+        assertEquals(0, server.requestCount)
+    }
+
     // -- Which books a pairing speaks about ---------------------------------
 
     /**

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/CompositePositionSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/CompositePositionSyncTest.kt
@@ -32,6 +32,8 @@ class CompositePositionSyncTest {
         var resolved = 0
         var conflictsRead = 0
 
+        override suspend fun dialledAddress(): String? = null
+
         override suspend fun syncAll(snapshot: SyncSnapshot?): SyncOutcome {
             fullRuns++
             return outcome

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAddressTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAddressTest.kt
@@ -90,6 +90,24 @@ class LocalNetworkAddressTest {
      * trailing dot as part of it would send an mDNS address off to be
      * resolved by mDNS, which is what the permission is blocking.
      */
+    /**
+     * A name is not an address because it starts with a number. Reading
+     * `127.books.home.local` as loopback would exempt a server on the
+     * reader's own network from the one check that gets them prompted.
+     */
+    @Test
+    fun `a name that begins with 127 is still a name`() = runTest {
+        assertTrue(
+            LocalNetworkAddress.isLocal("http://127.books.home.local:8083", resolver = refusing),
+        )
+        assertTrue(
+            LocalNetworkAddress.isLocal(
+                "http://127.books.example.com:8083",
+                resolver = { listOf("192.168.1.20") },
+            ),
+        )
+    }
+
     @Test
     fun `a name written out to the root label is the same name`() = runTest {
         assertTrue(LocalNetworkAddress.isLocal("http://books.local.:8083", resolver = refusing))

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAddressTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAddressTest.kt
@@ -56,6 +56,30 @@ class LocalNetworkAddressTest {
     }
 
     /**
+     * `::ffff:127.0.0.1` is 127.0.0.1 with a longer name, and reading
+     * it as an ordinary private address would ask for a permission
+     * that the connection was never going to need. `1::` is the
+     * opposite mistake: a global address that a digits-only test calls
+     * loopback, and then never judges at all.
+     */
+    @Test
+    fun `loopback is still loopback in its longer spellings`() = runTest {
+        assertFalse(
+            LocalNetworkAddress.isLocal("http://[::ffff:127.0.0.1]:8083", resolver = refusing),
+        )
+        assertFalse(
+            LocalNetworkAddress.isLocal("http://[0:0:0:0:0:0:0:1]:8083", resolver = refusing),
+        )
+        assertTrue(
+            LocalNetworkAddress.isLocal(
+                "http://[1::]:8083",
+                onLink = { true },
+                resolver = refusing,
+            ),
+        )
+    }
+
+    /**
      * A tailnet address is carried by a tunnel, which the restriction
      * does not reach. An ISP that hands the same range out on the LAN
      * is a different matter, and the routes are what tell them apart.

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAddressTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAddressTest.kt
@@ -70,6 +70,12 @@ class LocalNetworkAddressTest {
         assertFalse(
             LocalNetworkAddress.isLocal("http://[0:0:0:0:0:0:0:1]:8083", resolver = refusing),
         )
+        // The same address in hex, which is what a resolver returns as
+        // readily as the dotted form.
+        assertFalse(
+            LocalNetworkAddress.isLocal("http://[::ffff:7f00:1]:8083", resolver = refusing),
+        )
+        assertFalse(LocalNetworkAddress.isLocal("http://127.1.2.3:8083", resolver = refusing))
         assertTrue(
             LocalNetworkAddress.isLocal(
                 "http://[1::]:8083",
@@ -77,6 +83,17 @@ class LocalNetworkAddressTest {
                 resolver = refusing,
             ),
         )
+    }
+
+    /**
+     * A name spelled out to its root is the same name. Reading the
+     * trailing dot as part of it would send an mDNS address off to be
+     * resolved by mDNS, which is what the permission is blocking.
+     */
+    @Test
+    fun `a name written out to the root label is the same name`() = runTest {
+        assertTrue(LocalNetworkAddress.isLocal("http://books.local.:8083", resolver = refusing))
+        assertFalse(LocalNetworkAddress.isLocal("http://localhost.:8083", resolver = refusing))
     }
 
     /**

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAddressTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/LocalNetworkAddressTest.kt
@@ -1,0 +1,160 @@
+package com.chmouel.liseur.data.remote
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Which addresses cost a reader a permission prompt.
+ *
+ * Getting this wrong is expensive in both directions: too eager and a
+ * reader whose library is on the open internet is asked to let the app
+ * see their home network for no reason, too shy and they wait out a
+ * timeout with nothing to show for it. The route predicate and the
+ * resolver are both injected, so none of this touches a network or an
+ * emulator.
+ */
+class LocalNetworkAddressTest {
+
+    private val nothingOnLink: (String) -> Boolean = { false }
+
+    private fun resolving(vararg answers: Pair<String, List<String>>) =
+        LocalNetworkAddress.Resolver { host -> answers.toMap()[host].orEmpty() }
+
+    private val refusing = LocalNetworkAddress.Resolver {
+        error("nothing here should be resolved")
+    }
+
+    @Test
+    fun `private literals are local`() = runTest {
+        assertTrue(LocalNetworkAddress.isLocal("192.168.1.20", resolver = refusing))
+        assertTrue(LocalNetworkAddress.isLocal("http://10.0.0.5:8083", resolver = refusing))
+        assertTrue(LocalNetworkAddress.isLocal("https://172.16.4.1/opds", resolver = refusing))
+        assertTrue(LocalNetworkAddress.isLocal("http://[fd00::1]:8083", resolver = refusing))
+        assertTrue(LocalNetworkAddress.isLocal("http://[fe80::1]", resolver = refusing))
+    }
+
+    @Test
+    fun `broadcast and multicast are local`() = runTest {
+        assertTrue(LocalNetworkAddress.isLocal("255.255.255.255", resolver = refusing))
+        assertTrue(LocalNetworkAddress.isLocal("224.0.0.251", resolver = refusing))
+        assertTrue(LocalNetworkAddress.isLocal("http://[ff02::fb]", resolver = refusing))
+    }
+
+    @Test
+    fun `an interface zone does not hide a link-local address`() = runTest {
+        assertTrue(LocalNetworkAddress.isLocal("http://[fe80::1%25wlan0]:8083", resolver = refusing))
+    }
+
+    @Test
+    fun `loopback is exempt and must not raise a prompt`() = runTest {
+        assertFalse(LocalNetworkAddress.isLocal("http://127.0.0.1:8083", resolver = refusing))
+        assertFalse(LocalNetworkAddress.isLocal("http://[::1]:8083", resolver = refusing))
+        assertFalse(LocalNetworkAddress.isLocal("http://localhost:8083", resolver = refusing))
+    }
+
+    /**
+     * A tailnet address is carried by a tunnel, which the restriction
+     * does not reach. An ISP that hands the same range out on the LAN
+     * is a different matter, and the routes are what tell them apart.
+     */
+    @Test
+    fun `carrier-grade NAT is judged by the routes and not by the range`() = runTest {
+        assertFalse(LocalNetworkAddress.isLocal("100.64.0.1", resolver = refusing))
+        assertTrue(
+            LocalNetworkAddress.isLocal(
+                "100.64.0.1",
+                onLink = { it == "100.64.0.1" },
+                resolver = refusing,
+            ),
+        )
+    }
+
+    /** The reported bug with a different address in it. */
+    @Test
+    fun `a global address in the phone's own prefix is local`() = runTest {
+        val address = "2001:db8:1::10"
+        assertFalse(LocalNetworkAddress.isLocal("http://[$address]", resolver = refusing))
+        assertTrue(
+            LocalNetworkAddress.isLocal(
+                "http://[$address]",
+                onLink = { it == address },
+                resolver = refusing,
+            ),
+        )
+    }
+
+    @Test
+    fun `a scheme-less address with a port is still read as a literal`() {
+        assertEquals(
+            LocalNetworkAddress.Verdict.LOCAL,
+            LocalNetworkAddress.literalVerdict("192.168.1.20:8083"),
+        )
+        assertEquals(
+            LocalNetworkAddress.Verdict.LOCAL,
+            LocalNetworkAddress.literalVerdict("HTTP://192.168.1.20/opds"),
+        )
+        assertEquals(
+            LocalNetworkAddress.Verdict.RESOLVE,
+            LocalNetworkAddress.literalVerdict("books.example.com:8083"),
+        )
+    }
+
+    /**
+     * Resolving a `.local` name is mDNS, which is the very thing the
+     * permission gates, so asking that way could only answer no.
+     */
+    @Test
+    fun `an mDNS name answers without a lookup`() = runTest {
+        assertEquals(
+            LocalNetworkAddress.Verdict.LOCAL,
+            LocalNetworkAddress.literalVerdict("http://books.local:8083"),
+        )
+        assertTrue(LocalNetworkAddress.isLocal("http://books.local:8083", resolver = refusing))
+        assertTrue(LocalNetworkAddress.isLocal("http://books.internal", resolver = refusing))
+    }
+
+    @Test
+    fun `a public name resolving into public space is not local`() = runTest {
+        val resolver = resolving("books.example.com" to listOf("203.0.113.10"))
+        assertFalse(LocalNetworkAddress.isLocal("https://books.example.com", resolver = resolver))
+    }
+
+    @Test
+    fun `a public name resolving into private space is local`() = runTest {
+        val resolver = resolving("books.example.com" to listOf("192.168.1.20"))
+        assertTrue(LocalNetworkAddress.isLocal("https://books.example.com", resolver = resolver))
+    }
+
+    @Test
+    fun `one local answer among several is enough`() = runTest {
+        val resolver = resolving(
+            "books.example.com" to listOf("203.0.113.10", "2001:db8::1", "10.1.2.3"),
+        )
+        assertTrue(LocalNetworkAddress.isLocal("https://books.example.com", resolver = resolver))
+    }
+
+    @Test
+    fun `a name that resolves to nothing is not local`() = runTest {
+        assertFalse(
+            LocalNetworkAddress.isLocal("https://nowhere.example.com", resolver = resolving()),
+        )
+    }
+
+    @Test
+    fun `an address the app could never dial is not local`() = runTest {
+        assertFalse(LocalNetworkAddress.isLocal("", resolver = refusing))
+        assertFalse(LocalNetworkAddress.isLocal("   ", resolver = refusing))
+        assertFalse(LocalNetworkAddress.isLocal("http://", resolver = refusing))
+    }
+
+    @Test
+    fun `a host on its own is judged the same way as a URL`() {
+        assertTrue(LocalNetworkAddress.hostIsLocal("192.168.1.20"))
+        assertTrue(LocalNetworkAddress.hostIsLocal("FD00::1"))
+        assertFalse(LocalNetworkAddress.hostIsLocal("203.0.113.10"))
+        assertFalse(LocalNetworkAddress.hostIsLocal(""))
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/LocalNetworkGuardedSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/LocalNetworkGuardedSyncTest.kt
@@ -50,15 +50,22 @@ class LocalNetworkGuardedSyncTest {
 
         override suspend fun preservedConflict(bookUrl: String, peerId: String?): SyncPreview? = null
 
+        var resolutions = 0
+
         override suspend fun takeRemotePosition(
             bookUrl: String,
             atRevision: Long,
             peerId: String?,
             expectedAccountKey: String?,
-        ): ResolveOutcome = ResolveOutcome.Done
+        ): ResolveOutcome {
+            resolutions++
+            return ResolveOutcome.Done
+        }
 
-        override suspend fun keepLocalPosition(bookUrl: String, peerId: String?): ResolveOutcome =
-            ResolveOutcome.Done
+        override suspend fun keepLocalPosition(bookUrl: String, peerId: String?): ResolveOutcome {
+            resolutions++
+            return ResolveOutcome.Done
+        }
 
         override suspend fun refreshUnresolved() = Unit
 
@@ -69,6 +76,27 @@ class LocalNetworkGuardedSyncTest {
         override val required = true
         override val granted = false
         override suspend fun blocks(url: String?) = url != null && url in blocked
+    }
+
+    /**
+     * Settling a conflict writes the answer to the server, so it is
+     * refused too rather than left to sit on a timeout the reader is
+     * watching. The status line is not touched: this is one book being
+     * settled, not a run.
+     */
+    @Test
+    fun `settling a conflict is refused rather than dialled`() = runTest {
+        val peer = FakePeer(PeerPositionSync.CATALOG)
+        val reporting = SyncReporting()
+        val guarded = guard(peer, reporting, "http://192.168.1.20:8083")
+
+        val kept = guarded.keepLocalPosition("book", null)
+        val taken = guarded.takeRemotePosition("book", 1L, null, null)
+
+        assertEquals(ResolveOutcome.Failed(SyncFailure.LocalNetworkBlocked), kept)
+        assertEquals(ResolveOutcome.Failed(SyncFailure.LocalNetworkBlocked), taken)
+        assertEquals(0, peer.resolutions)
+        assertEquals(PositionSyncStatus.Idle, reporting.statusOf(PeerPositionSync.CATALOG))
     }
 
     private fun guard(

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/LocalNetworkGuardedSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/LocalNetworkGuardedSyncTest.kt
@@ -212,15 +212,27 @@ class LocalNetworkGuardedSyncTest {
         assertEquals(PositionSyncStatus.Idle, reporting.statusOf(PeerPositionSync.KOSYNC))
     }
 
+    /**
+     * A book the peer does not carry is not a book the peer declines to
+     * dial about: a page turn in a side-loaded book on a catalog
+     * account still opens the connection before it finds there is no
+     * matching remote book. So the address decides, not the book.
+     */
     @Test
-    fun `a book this peer does not carry passes straight through`() = runTest {
+    fun `a book this peer does not carry is still refused`() = runTest {
         val reporting = SyncReporting()
         val peer = FakePeer(PeerPositionSync.CATALOG, syncable = false)
         val guarded = guard(peer, reporting, "http://192.168.1.20:8083")
 
-        assertEquals(SyncOutcome.Success, guarded.syncBook("book://one"))
-        assertEquals(listOf("book://one"), peer.syncedBooks)
-        assertEquals(PreviewOutcome.NotSynced, guarded.previewBook("book://one"))
+        assertEquals(
+            SyncOutcome.Failure(SyncFailure.LocalNetworkBlocked),
+            guarded.syncBook("book://one"),
+        )
+        assertEquals(emptyList<String>(), peer.syncedBooks)
+        assertEquals(
+            PreviewOutcome.Failed(SyncFailure.LocalNetworkBlocked),
+            guarded.previewBook("book://one"),
+        )
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/LocalNetworkGuardedSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/LocalNetworkGuardedSyncTest.kt
@@ -1,0 +1,212 @@
+package com.chmouel.liseur.data.remote
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * A partner the phone will not let the app reach.
+ *
+ * The point of guarding each peer rather than the whole run is that a
+ * public catalog and a LAN sync server are an ordinary pairing here,
+ * and the healthy half has to go on working. The point of guarding at
+ * all is that a worker cannot put a permission prompt in front of
+ * anybody, so the useful thing it can do is stop spending a timeout
+ * every ten minutes.
+ */
+class LocalNetworkGuardedSyncTest {
+
+    private class FakePeer(
+        override val peerId: String,
+        var syncable: Boolean = true,
+        var outcome: SyncOutcome = SyncOutcome.Success,
+        var preview: PreviewOutcome = PreviewOutcome.NotSynced,
+        var address: String? = null,
+    ) : PeerPositionSync {
+        var fullRuns = 0
+        val syncedBooks = mutableListOf<String>()
+        var previews = 0
+
+        override suspend fun dialledAddress(): String? = address
+
+        override suspend fun syncAll(snapshot: SyncSnapshot?): SyncOutcome {
+            fullRuns++
+            return outcome
+        }
+
+        override suspend fun syncBook(bookUrl: String): SyncOutcome {
+            syncedBooks += bookUrl
+            return outcome
+        }
+
+        override suspend fun canSync(bookUrl: String) = syncable
+
+        override suspend fun previewBook(bookUrl: String): PreviewOutcome {
+            previews++
+            return preview
+        }
+
+        override suspend fun preservedConflict(bookUrl: String, peerId: String?): SyncPreview? = null
+
+        override suspend fun takeRemotePosition(
+            bookUrl: String,
+            atRevision: Long,
+            peerId: String?,
+            expectedAccountKey: String?,
+        ): ResolveOutcome = ResolveOutcome.Done
+
+        override suspend fun keepLocalPosition(bookUrl: String, peerId: String?): ResolveOutcome =
+            ResolveOutcome.Done
+
+        override suspend fun refreshUnresolved() = Unit
+
+        override suspend fun identity(): SyncIdentity? = null
+    }
+
+    private class FakeAccess(private val blocked: Set<String>) : LocalNetworkAccess {
+        override val required = true
+        override val granted = false
+        override suspend fun blocks(url: String?) = url != null && url in blocked
+    }
+
+    private fun guard(
+        peer: FakePeer,
+        reporting: SyncReporting,
+        address: String?,
+        blocked: Set<String> = setOfNotNull(address),
+    ): LocalNetworkGuardedSync {
+        peer.address = address
+        return LocalNetworkGuardedSync(peer, FakeAccess(blocked), reporting)
+    }
+
+    @Test
+    fun `a blocked peer is refused rather than dialled`() = runTest {
+        val peer = FakePeer(PeerPositionSync.CATALOG)
+        val reporting = SyncReporting()
+        val guarded = guard(peer, reporting, "http://192.168.1.20:8083")
+
+        val outcome = guarded.syncAll(null)
+
+        assertEquals(SyncOutcome.Failure(SyncFailure.LocalNetworkBlocked), outcome)
+        assertEquals(0, peer.fullRuns)
+    }
+
+    /**
+     * Asking again in ten minutes cannot change the answer, so the
+     * worker must not keep asking.
+     */
+    @Test
+    fun `the refusal is not worth retrying`() {
+        assertFalse(SyncFailure.LocalNetworkBlocked.worthRetrying)
+    }
+
+    @Test
+    fun `the failure is filed under the blocked peer's own name`() = runTest {
+        val reporting = SyncReporting()
+        val guarded = guard(FakePeer(PeerPositionSync.KOSYNC), reporting, "http://192.168.1.9")
+
+        guarded.syncAll(null)
+
+        assertEquals(
+            PositionSyncStatus.Failed(SyncFailure.LocalNetworkBlocked),
+            reporting.statusOf(PeerPositionSync.KOSYNC),
+        )
+        assertEquals(PositionSyncStatus.Idle, reporting.statusOf(PeerPositionSync.CATALOG))
+    }
+
+    @Test
+    fun `a healthy partner beside a blocked one still syncs`() = runTest {
+        val reporting = SyncReporting()
+        val healthy = FakePeer(PeerPositionSync.KOSYNC)
+        val blocked = guard(
+            FakePeer(PeerPositionSync.CATALOG),
+            reporting,
+            "http://192.168.1.20:8083",
+        )
+        val composite = CompositePositionSync(listOf(blocked, healthy))
+
+        val outcome = composite.syncAll(null)
+
+        assertTrue(outcome is SyncOutcome.Partial)
+        assertEquals(1, healthy.fullRuns)
+    }
+
+    /** The catalog is first in the list, so the other order is a case too. */
+    @Test
+    fun `a blocked partner second folds the same way`() = runTest {
+        val reporting = SyncReporting()
+        val healthy = FakePeer(PeerPositionSync.CATALOG)
+        val blocked = guard(FakePeer(PeerPositionSync.KOSYNC), reporting, "http://10.0.0.9")
+        val composite = CompositePositionSync(listOf(healthy, blocked))
+
+        val outcome = composite.syncAll(null)
+
+        assertTrue(outcome is SyncOutcome.Partial)
+        assertEquals(1, healthy.fullRuns)
+    }
+
+    @Test
+    fun `a book is refused too, but a preview leaves the status alone`() = runTest {
+        val reporting = SyncReporting()
+        val peer = FakePeer(PeerPositionSync.CATALOG)
+        val guarded = guard(peer, reporting, "http://192.168.1.20:8083")
+
+        assertEquals(
+            SyncOutcome.Failure(SyncFailure.LocalNetworkBlocked),
+            guarded.syncBook("book://one"),
+        )
+        assertEquals(
+            PreviewOutcome.Failed(SyncFailure.LocalNetworkBlocked),
+            guarded.previewBook("book://one"),
+        )
+        assertEquals(0, peer.previews)
+        assertEquals(
+            "a preview must not overwrite what the last real run said",
+            PositionSyncStatus.Failed(SyncFailure.LocalNetworkBlocked),
+            reporting.statusOf(PeerPositionSync.CATALOG),
+        )
+    }
+
+    /**
+     * A stored address that was never going to be dialled must not
+     * manufacture a failure for a run that would have skipped it.
+     */
+    @Test
+    fun `a peer with nothing to do passes straight through`() = runTest {
+        val reporting = SyncReporting()
+        val peer = FakePeer(PeerPositionSync.KOSYNC)
+        val guarded = guard(peer, reporting, address = null, blocked = setOf("http://10.0.0.9"))
+
+        assertEquals(SyncOutcome.Success, guarded.syncAll(null))
+        assertEquals(1, peer.fullRuns)
+        assertEquals(PositionSyncStatus.Idle, reporting.statusOf(PeerPositionSync.KOSYNC))
+    }
+
+    @Test
+    fun `a book this peer does not carry passes straight through`() = runTest {
+        val reporting = SyncReporting()
+        val peer = FakePeer(PeerPositionSync.CATALOG, syncable = false)
+        val guarded = guard(peer, reporting, "http://192.168.1.20:8083")
+
+        assertEquals(SyncOutcome.Success, guarded.syncBook("book://one"))
+        assertEquals(listOf("book://one"), peer.syncedBooks)
+        assertEquals(PreviewOutcome.NotSynced, guarded.previewBook("book://one"))
+    }
+
+    @Test
+    fun `a public address is dialled as usual`() = runTest {
+        val reporting = SyncReporting()
+        val peer = FakePeer(PeerPositionSync.CATALOG)
+        val guarded = guard(
+            peer,
+            reporting,
+            "https://books.example.com",
+            blocked = setOf("http://192.168.1.20:8083"),
+        )
+
+        assertEquals(SyncOutcome.Success, guarded.syncAll(null))
+        assertEquals(1, peer.fullRuns)
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/LocalNetworkGuardedSyncTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/LocalNetworkGuardedSyncTest.kt
@@ -79,13 +79,15 @@ class LocalNetworkGuardedSyncTest {
     }
 
     /**
-     * Settling a conflict writes the answer to the server, so it is
-     * refused too rather than left to sit on a timeout the reader is
-     * watching. The status line is not touched: this is one book being
-     * settled, not a run.
+     * Keeping this device's position writes it to the server, so it is
+     * refused rather than left to sit on a timeout the reader is
+     * watching. Taking the server's applies an answer an earlier run
+     * already wrote down and touches nothing but this phone, so it goes
+     * through — the same reason it works on a plane. Neither touches
+     * the status line: this is one book being settled, not a run.
      */
     @Test
-    fun `settling a conflict is refused rather than dialled`() = runTest {
+    fun `sending an answer is refused but accepting one still works`() = runTest {
         val peer = FakePeer(PeerPositionSync.CATALOG)
         val reporting = SyncReporting()
         val guarded = guard(peer, reporting, "http://192.168.1.20:8083")
@@ -94,8 +96,8 @@ class LocalNetworkGuardedSyncTest {
         val taken = guarded.takeRemotePosition("book", 1L, null, null)
 
         assertEquals(ResolveOutcome.Failed(SyncFailure.LocalNetworkBlocked), kept)
-        assertEquals(ResolveOutcome.Failed(SyncFailure.LocalNetworkBlocked), taken)
-        assertEquals(0, peer.resolutions)
+        assertEquals(ResolveOutcome.Done, taken)
+        assertEquals(1, peer.resolutions)
         assertEquals(PositionSyncStatus.Idle, reporting.statusOf(PeerPositionSync.CATALOG))
     }
 

--- a/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepositoryTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/remote/RemoteCatalogRepositoryTest.kt
@@ -159,7 +159,10 @@ class RemoteCatalogRepositoryTest {
         ): List<RemoteBook> = emptyList()
     }
 
-    private fun repository(catalog: CatalogSource) = RemoteCatalogRepository(
+    private fun repository(
+        catalog: CatalogSource,
+        localNetwork: LocalNetworkAccess = LocalNetworkAccess.Unrestricted,
+    ) = RemoteCatalogRepository(
         router = RemoteRouter(
             serverDao = db.remoteServerDao(),
             catalogs = mapOf(
@@ -181,6 +184,7 @@ class RemoteCatalogRepositoryTest {
             db.annotationDao(),
             db.annotationSyncDao(),
         ),
+        localNetwork = localNetwork,
     )
 
     /** A book DAO that keeps count of what a refresh asked it to do. */
@@ -604,6 +608,34 @@ class RemoteCatalogRepositoryTest {
         repository.refresh()
 
         assertEquals(CatalogStatus.Failed(SyncFailure.Timeout), repository.status.value)
+    }
+
+    /**
+     * A server on a network the phone is blocking swallows the
+     * connection rather than refusing it, so a pull-to-refresh that
+     * dialled anyway would be fifteen seconds of spinner and then a
+     * timeout that blames the server.
+     */
+    @Test
+    fun `a server on a blocked network is named, not dialled`() = runTest {
+        connect()
+        var dialled = 0
+        val repository = repository(
+            catalog = FakeCatalog { dialled++; throw IOException("never reached") },
+            localNetwork = object : LocalNetworkAccess {
+                override val required = true
+                override val granted = false
+                override suspend fun blocks(url: String?) = url == "https://books.example"
+            },
+        )
+
+        repository.refresh()
+
+        assertEquals(
+            CatalogStatus.Failed(SyncFailure.LocalNetworkBlocked),
+            repository.status.value,
+        )
+        assertEquals(0, dialled)
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/ReaderCatchUpTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/ReaderCatchUpTest.kt
@@ -33,6 +33,8 @@ class ReaderCatchUpTest {
         var revision = answer.localRevision ?: 0
         val adoptions = mutableListOf<Long>()
 
+        override suspend fun dialledAddress(): String? = null
+
         override suspend fun previewBook(bookUrl: String): PreviewOutcome {
             pending = answer
             return PreviewOutcome.Ready(answer)

--- a/app/src/test/kotlin/com/chmouel/liseur/sync/LiveSyncConnectorTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/sync/LiveSyncConnectorTest.kt
@@ -257,6 +257,7 @@ class LiveSyncConnectorTest {
     }
 
     private object NoSync : PositionSync {
+        override suspend fun dialledAddress(): String? = null
         override suspend fun syncAll(snapshot: SyncSnapshot?): SyncOutcome = error("No full sync from events")
         override suspend fun syncBook(bookUrl: String): SyncOutcome = error("No inline book sync")
         override suspend fun canSync(bookUrl: String) = false

--- a/app/src/test/kotlin/com/chmouel/liseur/sync/LiveSyncConnectorTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/sync/LiveSyncConnectorTest.kt
@@ -29,6 +29,38 @@ import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class LiveSyncConnectorTest {
+    /**
+     * A live connection is one more socket to the machine the position
+     * sync dials, so when the phone is blocking the local network the
+     * connector must not open one: the event stream would time out and
+     * be retried for as long as the app is in the foreground.
+     */
+    @Test
+    fun `a source refused before it is opened is not connected or retried`() = runTest {
+        val accounts = MutableStateFlow<RemoteServer?>(account())
+        val source = Source()
+        var blocked = true
+        val connector = LiveSyncConnector(
+            backgroundScope,
+            accounts,
+            { source.takeIf { !blocked } },
+            PositionSyncCoordinator(NoSync),
+            {},
+        )
+        connector.foreground()
+        runCurrent()
+        advanceTimeBy(600_000)
+        runCurrent()
+        assertEquals(0, source.opens)
+
+        // And the block is not remembered: the next account the
+        // connector is handed is asked about again.
+        blocked = false
+        accounts.value = account(baseUrl = "https://books.example.org")
+        runCurrent()
+        assertEquals(1, source.opens)
+    }
+
     @Test
     fun `unauthorised refresh reports auth and stops a still healthy event stream`() = runTest {
         val accounts = MutableStateFlow<RemoteServer?>(account())
@@ -275,8 +307,8 @@ class LiveSyncConnectorTest {
         override suspend fun identity(): SyncIdentity? = null
     }
 
-    private fun account() = RemoteServer(
-        kind = ServerKind.LISEUR_SYNC, baseUrl = "http://localhost",
+    private fun account(baseUrl: String = "http://localhost") = RemoteServer(
+        kind = ServerKind.LISEUR_SYNC, baseUrl = baseUrl,
         username = "reader", passwordCipher = null, apiKeyCipher = null,
         accountId = "device", userId = null, koboTokenCipher = null,
         canDownload = true, addedAt = 1, catalogSyncedAt = null,

--- a/app/src/test/kotlin/com/chmouel/liseur/sync/LiveSyncConnectorTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/sync/LiveSyncConnectorTest.kt
@@ -40,12 +40,14 @@ class LiveSyncConnectorTest {
         val accounts = MutableStateFlow<RemoteServer?>(account())
         val source = Source()
         var blocked = true
+        val grants = MutableStateFlow(0L)
         val connector = LiveSyncConnector(
             backgroundScope,
             accounts,
             { source.takeIf { !blocked } },
             PositionSyncCoordinator(NoSync),
             {},
+            reconnectOn = grants,
         )
         connector.foreground()
         runCurrent()
@@ -53,10 +55,11 @@ class LiveSyncConnectorTest {
         runCurrent()
         assertEquals(0, source.opens)
 
-        // And the block is not remembered: the next account the
-        // connector is handed is asked about again.
+        // And allowing it does not wait for the account to change or
+        // for a trip to the home screen longer than the grace period:
+        // the gate says the answer has moved and the stream opens.
         blocked = false
-        accounts.value = account(baseUrl = "https://books.example.org")
+        grants.value = 1L
         runCurrent()
         assertEquals(1, source.opens)
     }

--- a/app/src/test/kotlin/com/chmouel/liseur/sync/PositionSyncCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/sync/PositionSyncCoordinatorTest.kt
@@ -232,6 +232,8 @@ class PositionSyncCoordinatorTest {
 
         val snapshots = mutableListOf<SyncSnapshot?>()
 
+        override suspend fun dialledAddress(): String? = null
+
         override suspend fun syncAll(snapshot: SyncSnapshot?): SyncOutcome {
             snapshots += snapshot
             return run(SyncScope.Full)

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/settings/ServerAccountLocalNetworkTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/settings/ServerAccountLocalNetworkTest.kt
@@ -1,0 +1,518 @@
+package com.chmouel.liseur.ui.settings
+
+import androidx.room.Room
+import androidx.work.Configuration
+import androidx.work.WorkManager
+import androidx.test.core.app.ApplicationProvider
+import com.chmouel.liseur.data.calibre.BookDownloadRepository
+import com.chmouel.liseur.data.calibre.CredentialCipher
+import com.chmouel.liseur.data.db.LiseurDatabase
+import com.chmouel.liseur.data.kosync.KosyncAccountRepository
+import com.chmouel.liseur.data.kosync.KosyncCredentials
+import com.chmouel.liseur.data.kosync.KosyncPairing
+import com.chmouel.liseur.data.kosync.KosyncProbe
+import com.chmouel.liseur.data.db.KosyncPeer
+import com.chmouel.liseur.data.db.RemoteServer
+import com.chmouel.liseur.data.kosync.ProvedKosyncPairing
+import com.chmouel.liseur.data.library.BookRemoval
+import com.chmouel.liseur.data.remote.LocalNetworkAccess
+import com.chmouel.liseur.data.remote.PositionSync
+import com.chmouel.liseur.data.remote.PreviewOutcome
+import com.chmouel.liseur.data.remote.RemoteCatalogRepository
+import com.chmouel.liseur.data.remote.ResolveOutcome
+import com.chmouel.liseur.data.remote.RemoteCredentials
+import com.chmouel.liseur.data.remote.RemoteAccountRepository
+import com.chmouel.liseur.data.remote.RemoteRouter
+import com.chmouel.liseur.data.remote.ServerCapabilities
+import com.chmouel.liseur.data.remote.ServerKind
+import com.chmouel.liseur.data.remote.ServerSetup
+import com.chmouel.liseur.data.remote.SetupResult
+import com.chmouel.liseur.data.remote.SyncIdentity
+import com.chmouel.liseur.data.remote.SyncOutcome
+import com.chmouel.liseur.data.remote.SyncPreview
+import com.chmouel.liseur.data.remote.SyncReporting
+import com.chmouel.liseur.data.remote.SyncSnapshot
+import com.chmouel.liseur.data.settings.AppSettingsRepository
+import com.chmouel.liseur.sync.PositionSyncCoordinator
+import javax.crypto.KeyGenerator
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Connecting to a server the phone is blocking.
+ *
+ * The whole point of parking a connection is that it can be resumed
+ * exactly once, with what was submitted rather than with what the form
+ * holds by the time the reader has finished with the system dialog. The
+ * ways that goes wrong — a second prompt after a rotation, a second
+ * connection from a repeated callback, credentials read back out of a
+ * form the reader edited underneath it — are all here.
+ */
+@Config(sdk = [35], application = android.app.Application::class)
+@RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class ServerAccountLocalNetworkTest {
+
+    private lateinit var db: LiseurDatabase
+    private val connects = mutableListOf<Triple<String, String, Boolean>>()
+    private val kosyncPairings = mutableListOf<String>()
+    private var blocked = mutableSetOf<String>()
+    private var permitted = false
+
+    @Before
+    fun open() {
+        CredentialCipher.keyForTesting =
+            KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
+        // Inline executors throughout: a connection that hops onto
+        // Room's own threads finishes whenever they get to it, and
+        // these tests are about what the ViewModel did by the time the
+        // reader's answer came back.
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            LiseurDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .setQueryExecutor { it.run() }
+            .setTransactionExecutor { it.run() }
+            .build()
+        // The download repository asks for it as it is built. Nothing
+        // here enqueues anything; it only has to exist.
+        runCatching {
+            WorkManager.initialize(
+                ApplicationProvider.getApplicationContext(),
+                Configuration.Builder().setExecutor { it.run() }.build(),
+            )
+        }
+    }
+
+    @After
+    fun close() {
+        db.close()
+        CredentialCipher.keyForTesting = null
+    }
+
+    /** A test with the main dispatcher running on its own scheduler. */
+    private fun scenario(body: suspend TestScope.() -> Unit) = runTest {
+        Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        try {
+            body()
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test
+    fun `a public address connects without asking anything`() = scenario {
+        blocked += "http://192.168.1.20:8083"
+        val model = model()
+        model.setUrl("https://books.example.com")
+        model.setUsername("ada")
+        model.setPassword("secret")
+
+        model.connect()
+
+        assertNull(model.state.value.localNetworkRequest)
+        assertEquals(1, connects.size)
+    }
+
+    @Test
+    fun `a phone that does not gate the network connects straight through`() = scenario {
+        blocked += "http://192.168.1.20:8083"
+        val model = model(gated = false)
+        model.setUrl("http://192.168.1.20:8083")
+        model.setUsername("ada")
+        model.setPassword("secret")
+
+        model.connect()
+
+        assertNull(model.state.value.localNetworkRequest)
+        assertEquals(1, connects.size)
+    }
+
+    @Test
+    fun `a local address parks the connection instead of dialling it`() = scenario {
+        blocked += "http://192.168.1.20:8083"
+        val model = connecting()
+
+        val request = model.state.value.localNetworkRequest
+        assertNotNull(request)
+        assertEquals(LocalNetworkRequest.Action.CONNECT, request!!.action)
+        assertFalse(request.blockedKosync)
+        assertTrue(model.state.value.connecting)
+        assertEquals(0, connects.size)
+    }
+
+    /**
+     * The form is live behind the dialog. Reading it again on the way
+     * back would connect with whatever is in it now.
+     */
+    @Test
+    fun `a grant connects once, with what was submitted`() = scenario {
+        blocked += "http://192.168.1.20:8083"
+        val model = connecting()
+        val id = model.state.value.localNetworkRequest!!.id
+        model.onLocalNetworkRequestLaunched(id)
+        model.setUsername("somebody else")
+        model.setPassword("another password")
+
+        model.onLocalNetworkResult(granted = true)
+
+        assertEquals(1, connects.size)
+        assertEquals(Triple("http://192.168.1.20:8083", "ada", false), connects.single())
+        assertNull(model.state.value.localNetworkRequest)
+        assertTrue(model.state.value.localNetworkAsked)
+    }
+
+    @Test
+    fun `a repeated answer does not connect twice`() = scenario {
+        blocked += "http://192.168.1.20:8083"
+        val model = connecting()
+        model.onLocalNetworkRequestLaunched(model.state.value.localNetworkRequest!!.id)
+
+        model.onLocalNetworkResult(granted = true)
+        model.onLocalNetworkResult(granted = true)
+
+        assertEquals(1, connects.size)
+    }
+
+    /**
+     * A rotation while the system dialog is up rebuilds the effect that
+     * launched it. The request has to survive; only the launching is
+     * spent.
+     */
+    @Test
+    fun `an acknowledged request is not launched again`() = scenario {
+        blocked += "http://192.168.1.20:8083"
+        val model = connecting()
+        val id = model.state.value.localNetworkRequest!!.id
+
+        model.onLocalNetworkRequestLaunched(id)
+        model.onLocalNetworkRequestLaunched(id)
+
+        val request = model.state.value.localNetworkRequest
+        assertNotNull(request)
+        assertTrue(request!!.launched)
+        assertEquals(id, request.id)
+
+        model.onLocalNetworkResult(granted = true)
+        assertEquals(1, connects.size)
+    }
+
+    @Test
+    fun `a refusal stops the attempt and says why`() = scenario {
+        blocked += "http://192.168.1.20:8083"
+        val model = connecting()
+        model.onLocalNetworkRequestLaunched(model.state.value.localNetworkRequest!!.id)
+
+        model.onLocalNetworkResult(granted = false)
+
+        assertEquals(0, connects.size)
+        assertFalse(model.state.value.connecting)
+        assertEquals(AccountError.LOCAL_NETWORK_BLOCKED, model.state.value.error)
+        assertNull(model.state.value.localNetworkRequest)
+    }
+
+    /**
+     * A Custom connection is two servers, and either of them may be the
+     * one in the spare room.
+     */
+    @Test
+    fun `a custom connection asks about its sync address too`() = scenario {
+        blocked += "http://192.168.1.9:8080"
+        val model = model()
+        model.setKind(ServerKind.CUSTOM)
+        model.setUrl("https://books.example.com/opds")
+        model.setKosyncUrl("http://192.168.1.9:8080")
+        model.setKosyncUsername("ada")
+        model.setKosyncPassword("pw")
+
+        model.connect()
+
+        val request = model.state.value.localNetworkRequest
+        assertNotNull(request)
+        assertTrue(request!!.blockedKosync)
+
+        model.onLocalNetworkRequestLaunched(request.id)
+        model.onLocalNetworkResult(granted = false)
+
+        assertEquals(AccountError.LOCAL_NETWORK_BLOCKED, model.state.value.kosyncError)
+        assertNull(model.state.value.error)
+        // Neither half of a Custom connection is dialled when one of
+        // them is out of reach: it is one connection, not two.
+        assertEquals(0, connects.size)
+        assertEquals(0, kosyncPairings.size)
+    }
+
+    @Test
+    fun `pairing a kosync partner on its own parks the same way`() = scenario {
+        blocked += "http://192.168.1.9:8080"
+        val model = model()
+        model.setKosyncUrl("http://192.168.1.9:8080")
+        model.setKosyncUsername("ada")
+        model.setKosyncPassword("pw")
+
+        model.connectKosync()
+
+        val request = model.state.value.localNetworkRequest
+        assertNotNull(request)
+        assertEquals(LocalNetworkRequest.Action.KOSYNC, request!!.action)
+        assertTrue(model.state.value.kosyncConnecting)
+        assertNull(model.state.value.kosyncError)
+
+        model.onLocalNetworkRequestLaunched(request.id)
+        model.onLocalNetworkResult(granted = true)
+
+        // Nothing is listening on that address, so the pairing is out
+        // on the wire and will fail there. What matters is that it got
+        // that far: the request is spent, the attempt is still running
+        // and nothing on this side refused it.
+        assertNull(model.state.value.localNetworkRequest)
+        assertTrue(model.state.value.localNetworkAsked)
+        assertTrue(model.state.value.kosyncConnecting)
+        assertNull(model.state.value.kosyncError)
+    }
+
+    @Test
+    fun `a refused kosync pairing reports against the sync address`() = scenario {
+        blocked += "http://192.168.1.9:8080"
+        val model = model()
+        model.setKosyncUrl("http://192.168.1.9:8080")
+        model.setKosyncUsername("ada")
+        model.setKosyncPassword("pw")
+        model.connectKosync()
+        model.onLocalNetworkRequestLaunched(model.state.value.localNetworkRequest!!.id)
+
+        model.onLocalNetworkResult(granted = false)
+
+        assertEquals(AccountError.LOCAL_NETWORK_BLOCKED, model.state.value.kosyncError)
+        assertFalse(model.state.value.kosyncConnecting)
+    }
+
+    /**
+     * The account is not in hand when the screen is built: Room
+     * delivers it a moment later. A check that only ran when the
+     * screen resumed would look before it landed, find nothing stored,
+     * and leave the reader with the timeout and nothing to press.
+     */
+    @Test
+    fun `a stored local account raises the notice on its own`() = scenario {
+        blocked += "http://192.168.1.20:8083"
+        db.remoteServerDao().upsert(server(baseUrl = "http://192.168.1.20:8083"))
+
+        val model = model()
+
+        assertTrue(model.state.value.localNetworkBlocked)
+    }
+
+    /**
+     * A pairing left behind by an account switch is shown so that it
+     * can be disconnected, and nothing will ever dial it. Asking for a
+     * permission on its behalf would be a prompt for a machine this
+     * account does not talk to.
+     */
+    @Test
+    fun `a stranded kosync pairing raises no notice`() = scenario {
+        blocked += "http://192.168.1.9:8080"
+        db.remoteServerDao().upsert(
+            server(baseUrl = "https://books.example.com", kind = ServerKind.KOMGA),
+        )
+        db.kosyncPeerDao().upsert(
+            KosyncPeer(
+                baseUrl = "http://192.168.1.9:8080",
+                username = "ada",
+                keyCipher = KosyncPeer.seal(KosyncCredentials.keyFor("pw")),
+                addedAt = 1L,
+            ),
+        )
+
+        val model = model()
+
+        assertFalse(model.state.value.localNetworkBlocked)
+    }
+
+    /** The same pairing under a server that does use it. */
+    @Test
+    fun `a kosync partner the account uses raises the notice`() = scenario {
+        blocked += "http://192.168.1.9:8080"
+        db.remoteServerDao().upsert(
+            server(baseUrl = "https://books.example.com", kind = ServerKind.CUSTOM),
+        )
+        db.kosyncPeerDao().upsert(
+            KosyncPeer(
+                baseUrl = "http://192.168.1.9:8080",
+                username = "ada",
+                keyCipher = KosyncPeer.seal(KosyncCredentials.keyFor("pw")),
+                addedAt = 1L,
+            ),
+        )
+
+        val model = model()
+
+        assertTrue(model.state.value.localNetworkBlocked)
+    }
+
+    private fun server(baseUrl: String, kind: ServerKind = ServerKind.CALIBRE) = RemoteServer(
+        kind = kind,
+        baseUrl = baseUrl,
+        catalogUrl = baseUrl,
+        username = "ada",
+        passwordCipher = null,
+        apiKeyCipher = null,
+        accountId = null,
+        userId = null,
+        koboTokenCipher = null,
+        canDownload = true,
+        addedAt = 1L,
+        catalogSyncedAt = null,
+        positionSyncedAt = null,
+        syncToken = null,
+    )
+
+    private fun connecting(): ServerAccountViewModel {
+        val model = model()
+        model.setUrl("http://192.168.1.20:8083")
+        model.setUsername("ada")
+        model.setPassword("secret")
+        model.connect()
+        return model
+    }
+
+    private fun model(gated: Boolean = true): ServerAccountViewModel {
+        val bookRemoval = BookRemoval(
+            db.bookDao(),
+            db.readingSessionDao(),
+            db.syncPeerStateDao(),
+            db.workIdentityDao(),
+            db.readingProgressDao(),
+            db.annotationDao(),
+            db.annotationSyncDao(),
+        )
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        val scope = CoroutineScope(UnconfinedTestDispatcher())
+        val account = RemoteAccountRepository(
+            dao = db.remoteServerDao(),
+            bookDao = db.bookDao(),
+            progressDao = db.readingProgressDao(),
+            bookRemoval = bookRemoval,
+            seriesExtraDao = db.seriesExtraDao(),
+            peerStateDao = db.syncPeerStateDao(),
+            kosync = { ScriptedPairing() },
+            setups = ServerKind.entries.associateWith { Recording() },
+        )
+        val router = RemoteRouter(
+            serverDao = db.remoteServerDao(),
+            catalogs = emptyMap(),
+            files = emptyMap(),
+            positions = emptyMap(),
+        )
+        return ServerAccountViewModel(
+            repository = account,
+            downloads = BookDownloadRepository(context, db.bookDao(), bookRemoval, scope),
+            reporting = SyncReporting(),
+            positionSync = PositionSyncCoordinator(NoSync()),
+            catalog = RemoteCatalogRepository(
+                router = router,
+                serverDao = db.remoteServerDao(),
+                bookDao = db.bookDao(),
+                bookRemoval = bookRemoval,
+                scope = scope,
+            ),
+            appSettings = AppSettingsRepository(context),
+            identityDao = db.workIdentityDao(),
+            bookDao = db.bookDao(),
+            kosyncAccount = KosyncAccountRepository(db.kosyncPeerDao(), db.syncPeerStateDao()),
+            localNetwork = FakeAccess(gated),
+        )
+    }
+
+    /** A gate whose answers the test writes rather than the platform. */
+    private inner class FakeAccess(gated: Boolean) : LocalNetworkAccess {
+        override val required = gated
+        override val granted get() = !required || permitted
+        override suspend fun blocks(url: String?) =
+            required && !permitted && url != null && url in blocked
+    }
+
+    /** Nothing to sync: these tests never get that far. */
+    private class NoSync : PositionSync {
+        override suspend fun syncAll(snapshot: SyncSnapshot?) = SyncOutcome.Success
+        override suspend fun syncBook(bookUrl: String) = SyncOutcome.Success
+        override suspend fun canSync(bookUrl: String) = false
+        override suspend fun previewBook(bookUrl: String) = PreviewOutcome.NotSynced
+        override suspend fun preservedConflict(bookUrl: String, peerId: String?): SyncPreview? = null
+        override suspend fun takeRemotePosition(
+            bookUrl: String,
+            atRevision: Long,
+            peerId: String?,
+            expectedAccountKey: String?,
+        ) = ResolveOutcome.Done
+
+        override suspend fun keepLocalPosition(bookUrl: String, peerId: String?) =
+            ResolveOutcome.Done
+
+        override suspend fun refreshUnresolved() = Unit
+        override suspend fun identity(): SyncIdentity? = null
+    }
+
+    private inner class Recording : ServerSetup {
+        override suspend fun connect(
+            rawUrl: String,
+            credentials: RemoteCredentials,
+            allowHttp: Boolean,
+        ): SetupResult {
+            val username = (credentials as? RemoteCredentials.Basic)?.username.orEmpty()
+            connects += Triple(rawUrl, username, allowHttp)
+            return SetupResult.Success(
+                ServerCapabilities(
+                    baseUrl = rawUrl,
+                    canDownload = true,
+                    accountId = null,
+                    displayName = "The Shelf",
+                ),
+            )
+        }
+    }
+
+    private inner class ScriptedPairing : KosyncPairing {
+        private val real = KosyncAccountRepository(db.kosyncPeerDao(), db.syncPeerStateDao())
+
+        override suspend fun verify(
+            url: String,
+            username: String,
+            password: String,
+        ): KosyncProbe {
+            kosyncPairings += url
+            return KosyncProbe.Proved(
+                ProvedKosyncPairing(
+                    KosyncPeer(
+                        baseUrl = if ("://" in url) url else "https://$url",
+                        username = username,
+                        keyCipher = KosyncPeer.seal(KosyncCredentials.keyFor(password)),
+                        addedAt = 0L,
+                    ),
+                ),
+            )
+        }
+
+        override suspend fun adopt(pairing: ProvedKosyncPairing) = real.adopt(pairing)
+
+        override suspend fun forget() = real.forget()
+    }
+}

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/settings/ServerAccountLocalNetworkTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/settings/ServerAccountLocalNetworkTest.kt
@@ -452,6 +452,7 @@ class ServerAccountLocalNetworkTest {
 
     /** Nothing to sync: these tests never get that far. */
     private class NoSync : PositionSync {
+        override suspend fun dialledAddress(): String? = null
         override suspend fun syncAll(snapshot: SyncSnapshot?) = SyncOutcome.Success
         override suspend fun syncBook(bookUrl: String) = SyncOutcome.Success
         override suspend fun canSync(bookUrl: String) = false

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/settings/ServerAccountLocalNetworkTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/settings/ServerAccountLocalNetworkTest.kt
@@ -261,6 +261,31 @@ class ServerAccountLocalNetworkTest {
         assertEquals(0, kosyncPairings.size)
     }
 
+    /**
+     * A denial that has become permanent sends the reader to the system
+     * settings page, and coming back from it having allowed the
+     * permission has to spend the refusal it left behind. The button
+     * under the notice cannot work this out for itself: the rationale
+     * API answers false after a grant as readily as before the first
+     * ask, so the notice would sit there offering the page the reader
+     * has just come back from.
+     */
+    @Test
+    fun `a grant from the settings page clears the refusal it left behind`() = scenario {
+        blocked += "http://192.168.1.20:8083"
+        val model = connecting()
+        model.onLocalNetworkRequestLaunched(model.state.value.localNetworkRequest!!.id)
+        model.onLocalNetworkResult(granted = false)
+        assertEquals(AccountError.LOCAL_NETWORK_BLOCKED, model.state.value.error)
+
+        permitted = true
+        model.refreshLocalNetworkAccess()
+        runCurrent()
+
+        assertNull(model.state.value.error)
+        assertFalse(model.state.value.connecting)
+    }
+
     @Test
     fun `pairing a kosync partner on its own parks the same way`() = scenario {
         blocked += "http://192.168.1.9:8080"
@@ -370,6 +395,31 @@ class ServerAccountLocalNetworkTest {
                 baseUrl = "http://192.168.1.9:8080",
                 username = "ada",
                 keyCipher = KosyncPeer.seal(KosyncCredentials.keyFor("pw")),
+                addedAt = 1L,
+            ),
+        )
+
+        val model = model()
+
+        assertFalse(model.state.value.localNetworkBlocked)
+    }
+
+    /**
+     * A database restored onto another phone brings the pairing row but
+     * not a key this Keystore can open, so the run answers "not
+     * applicable" before it dials and no permission would change that.
+     */
+    @Test
+    fun `a kosync pairing whose key cannot be read raises no notice`() = scenario {
+        blocked += "http://192.168.1.9:8080"
+        db.remoteServerDao().upsert(
+            server(baseUrl = "https://books.example.com", kind = ServerKind.CUSTOM),
+        )
+        db.kosyncPeerDao().upsert(
+            KosyncPeer(
+                baseUrl = "http://192.168.1.9:8080",
+                username = "ada",
+                keyCipher = "not something this phone sealed",
                 addedAt = 1L,
             ),
         )

--- a/app/src/test/kotlin/com/chmouel/liseur/ui/settings/ServerAccountLocalNetworkTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/ui/settings/ServerAccountLocalNetworkTest.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
@@ -322,6 +323,37 @@ class ServerAccountLocalNetworkTest {
     }
 
     /**
+     * A permanent denial sends the reader to the system settings app,
+     * so the grant comes back through resume rather than through a
+     * permission result. It has to be worth as much: without a sync
+     * the account keeps the stale blocked failure until a page turn or
+     * a manual Sync now, and the app's own foreground refresh is
+     * debounced well past a trip to the settings app and back.
+     */
+    @Test
+    fun `a grant made in the settings app clears the notice and syncs`() = scenario {
+        blocked += "http://192.168.1.20:8083"
+        db.remoteServerDao().upsert(server(baseUrl = "http://192.168.1.20:8083"))
+        val sync = NoSync()
+
+        val model = model(sync = sync)
+        assertTrue(model.state.value.localNetworkBlocked)
+        assertEquals(0, sync.fullRuns)
+
+        permitted = true
+        model.refreshLocalNetworkAccess()
+        runCurrent()
+
+        assertFalse(model.state.value.localNetworkBlocked)
+        assertEquals(1, sync.fullRuns)
+
+        // A resume that changed nothing is not a reason to sync again.
+        model.refreshLocalNetworkAccess()
+        runCurrent()
+        assertEquals(1, sync.fullRuns)
+    }
+
+    /**
      * A pairing left behind by an account switch is shown so that it
      * can be disconnected, and nothing will ever dial it. Asking for a
      * permission on its behalf would be a prompt for a machine this
@@ -394,7 +426,7 @@ class ServerAccountLocalNetworkTest {
         return model
     }
 
-    private fun model(gated: Boolean = true): ServerAccountViewModel {
+    private fun model(gated: Boolean = true, sync: NoSync = NoSync()): ServerAccountViewModel {
         val bookRemoval = BookRemoval(
             db.bookDao(),
             db.readingSessionDao(),
@@ -426,7 +458,7 @@ class ServerAccountLocalNetworkTest {
             repository = account,
             downloads = BookDownloadRepository(context, db.bookDao(), bookRemoval, scope),
             reporting = SyncReporting(),
-            positionSync = PositionSyncCoordinator(NoSync()),
+            positionSync = PositionSyncCoordinator(sync),
             catalog = RemoteCatalogRepository(
                 router = router,
                 serverDao = db.remoteServerDao(),
@@ -448,12 +480,26 @@ class ServerAccountLocalNetworkTest {
         override val granted get() = !required || permitted
         override suspend fun blocks(url: String?) =
             required && !permitted && url != null && url in blocked
+
+        private var lastGranted = granted
+
+        override fun recheck(): Boolean {
+            val now = granted
+            if (lastGranted == now) return false
+            lastGranted = now
+            return true
+        }
     }
 
-    /** Nothing to sync: these tests never get that far. */
+    /** Nothing to sync, but it does say when it was asked. */
     private class NoSync : PositionSync {
+        var fullRuns = 0
+
         override suspend fun dialledAddress(): String? = null
-        override suspend fun syncAll(snapshot: SyncSnapshot?) = SyncOutcome.Success
+        override suspend fun syncAll(snapshot: SyncSnapshot?): SyncOutcome {
+            fullRuns++
+            return SyncOutcome.Success
+        }
         override suspend fun syncBook(bookUrl: String) = SyncOutcome.Success
         override suspend fun canSync(bookUrl: String) = false
         override suspend fun previewBook(bookUrl: String) = PreviewOutcome.NotSynced

--- a/docs/adr/0028-local-network-permission.md
+++ b/docs/adr/0028-local-network-permission.md
@@ -1,0 +1,225 @@
+# 28. Local network permission
+
+Status: accepted
+
+## Context
+
+A reader on Android 17 could not reach their calibre-web server on their
+own LAN. Connecting timed out; the same server over the internet was
+fine (#195).
+
+Android 17 makes Local Network Protections mandatory for apps targeting
+SDK 37, which Liseur does. An app holding only `INTERNET` has its
+traffic to and from local network addresses dropped inside the
+networking stack, below OkHttp. A TCP connection to a LAN address does
+not get refused — it hangs until the timeout. Apps targeting 36 or below
+keep an implicit grant, so nothing changed for anyone on an older
+phone, and every Android 17 device running 0.15.0 had this.
+
+The permission is `android.permission.ACCESS_LOCAL_NETWORK`, in the
+`NEARBY_DEVICES` group — hence the reporter's guess that Liseur needed
+"Nearby devices", which is the group label the system prompt shows.
+
+## Decision
+
+Declare the permission, and ask for it only of a reader whose server is
+actually on their own network.
+
+### Asked conditionally
+
+Liseur's readers self-host, and a good number chose this app for the
+reasons that make an unexplained "allow Liseur to find devices on your
+network" prompt unwelcome. An address on the open internet will never
+need it, and a reader who only ever reaches their library that way is
+never asked.
+
+### Asked before the connection, not after its timeout
+
+A reader who waits fifteen seconds for a timeout and is *then* asked a
+question has already been told the app is broken. Every connect path
+checks its addresses first and parks.
+
+Four addresses can each be the local one, and they are asked about
+separately: the catalog address, a Custom connection's second (kosync)
+address, a kosync partner paired on its own, and — for an account
+already connected — whichever of those is stored. A public catalog with
+a sync server in the spare room is an ordinary setup here, and so is
+its opposite.
+
+### Judged by two halves, neither of which is `PrivateAddress`
+
+`PrivateAddress` answers a narrower question: whether plain HTTP is
+defensible, whether a catalog link is a probe nobody asked for.
+Android's idea of a local address is wider, and it is not knowable from
+a table — it is the directly connected routes of the networks the phone
+is on, and it excludes what a VPN carries.
+
+So `LocalNetworkAddress` has a fixed half — everything `PrivateAddress`
+knows, plus IPv4 broadcast and IPv4 and IPv6 multicast — and a live
+half, a route predicate that `AndroidLocalNetworkAccess` fills in from
+`ConnectivityManager`. `PrivateAddress` is reused rather than copied, so
+the IPv6 parsing has one home, and it gained a `matchesHost` for the
+purpose.
+
+Both halves earn their place. A home server on a global IPv6 address in
+the phone's own /64 is on-link and blocked, and no list of private
+ranges will ever say so — that is the reported bug with a different
+address in it. And carrier-grade NAT space, `100.64.0.0/10`, is
+deliberately *not* in the fixed set: that is where a Tailscale address
+lives, that traffic goes down the tunnel and needs no permission, so a
+table entry would prompt a tailnet reader for nothing. An ISP that hands
+`100.64` out on the LAN still gets the prompt, through the route, which
+is the honest reason.
+
+VPN transports are left out of the live half because Android's
+restriction does not reach what a tunnel carries. Routes are read across
+every non-VPN network rather than the default one alone, so a Wi-Fi
+library stays reachable while cellular is default.
+
+### Two inaccuracies, both accepted, both erring the same way
+
+A VPN carrying a private range can raise a prompt Android would not have
+needed; and the routes are read across every network rather than the one
+a socket will actually leave by. Deciding either correctly means
+resolving the route a connection will take, which is a routing engine
+this app has no business containing. Asking a question that turns out to
+have been unnecessary costs one dialog, on a screen the reader opened to
+connect a server. Not asking costs the fifteen seconds of silence that
+opened #195.
+
+### The address that will be dialled, not the text that was typed
+
+The form takes `books.lan:8083` without a scheme, and every setup client
+normalises before dialling. Feeding raw form text to `toHttpUrlOrNull()`
+returns null, the gate says "not local", and the reader gets the same
+timeout they reported. So the host comes out of
+`RemoteUrl.normaliseBase`, which is safe for all four addresses: the
+normalisers disagree about paths and defaults, never about the host.
+
+An IPv6 literal has to be bracketed, because that is what
+`normaliseBase` and OkHttp both require. A bare one is not an address
+this app takes anywhere; making it one is a separate change.
+
+### A name is resolved, but `.local` never is
+
+A literal answers on its own. So does a `.local` or `.internal` name —
+and it must, because resolving a `.local` name is mDNS, which is itself
+blocked without the permission, so asking that way could only ever
+answer no. Everything else is a DNS lookup, which the restriction
+exempts, and every address that comes back is judged: one local answer
+among several is enough. A name that resolves to nothing is not local;
+it is about to fail as an unknown host anyway.
+
+This is a preflight, and OkHttp resolves again when it dials. A rotating
+record, split-horizon DNS, or outright rebinding can put a different
+address on the wire than the one judged here. That time-of-check /
+time-of-use gap is accepted rather than closed by sharing a resolver
+with the HTTP client: the cost of being wrong is one timeout and a
+notice saying what to do about it, on a screen the reader is already
+looking at.
+
+### A denial is re-askable
+
+Android 17 ships a reset counter precisely so an app can ask again after
+explaining itself, and a reader who dismissed the prompt by reflex and
+then pressed Connect again means to be asked. So the first Connect
+always launches the prompt, and only afterwards does
+`shouldShowRequestPermissionRationale` decide what to offer — it answers
+false in two opposite situations, before anything has been asked and
+after a denial that will not be asked about again, so reading it first
+would send a reader who has simply never been asked off to the settings
+app. The app-settings intent is reserved for the denial that has become
+permanent, and for a grant revoked later.
+
+The parked request carries an immutable snapshot of what was submitted,
+and is marked as launched *before* the dialog goes up and spent *before*
+the answer is acted on. A rotation while the system dialog is on screen
+therefore cannot raise a second one, and a duplicate callback cannot
+connect twice. Resuming re-reads nothing from the form, which is live
+behind the dialog.
+
+### The notice on a connected account follows the stored account
+
+An account already connected gets a notice rather than a prompt out of
+nowhere, and the question behind it — has this account anywhere it can
+no longer reach — is answered from the stored row every time that row
+changes, not once when the screen resumes. Room delivers the account a
+moment after the screen is built, so a check that only ran on resume
+would look before it landed, find nothing stored, and leave a reader
+who upgraded to Android 17 with the timeout and nothing to press. Each
+run replaces the one before it, so a slow lookup cannot land on top of
+a newer answer.
+
+Which addresses count is the same question the background guard asks,
+and it gets the same answer: both of the server's, because a Custom
+connection catalogs at one and syncs at another, and the kosync
+partner's only when the connected server is one the pairing belongs to.
+A pairing stranded by an account switch is kept on screen so that it can
+be disconnected, and nothing will ever dial it; asking for a permission
+on its behalf would be a prompt for a machine this account does not talk
+to.
+
+### Refused per partner in the background
+
+A worker cannot put a prompt in front of anybody, and a revoked
+permission would leave position sync timing out on every scheduled run,
+backing off, and trying again until the reader happened to open
+Settings. `SyncFailure.LocalNetworkBlocked` is not worth retrying, on
+the rule `Unauthorised` already lives by.
+
+But it is refused per partner, not per run. `PositionSyncCoordinator`
+sees one `PositionSync` and must go on seeing one; underneath,
+`CompositePositionSync` holds a catalog peer and a kosync peer, and a
+public catalog paired with a LAN sync server has one blocked partner and
+one healthy one. Each peer is wrapped separately where they are
+assembled, so the refusal carries its own `peerId` into `SyncReporting`
+and `fold()` — which already turns one peer's failure beside another's
+success into `Partial` — needed no change.
+
+The decorator reports its own status, because the concrete syncs do and
+a decorator that only returned a failure would leave the status line
+saying Idle while nothing synced. `previewBook` returns a failure and
+writes nothing: one reader asking one book a question must not overwrite
+what the account's last real run did. And it asks whether the peer had
+anything to do at all before it asks about the permission, so a
+stored-but-idle LAN address cannot manufacture a failure for a run that
+was never going to touch it.
+
+That question is put to the peer rather than answered beside it.
+`PeerPositionSync.dialledAddress()` is the address a run started now
+would dial, and null is the whole of "nothing to do": no server
+connected, a kind that does not sync positions, a pairing stranded on an
+account that no longer uses it, a credential this Keystore can no longer
+open. Each peer answers from the state its own run opens with —
+`KosyncPositionSync` from the very `account()` its run calls first — so
+the two cannot drift. Written as a lambda at the assembly point instead,
+it drifted immediately: a kosync pairing left behind by an account
+switch has a row and an address, its run answers "not applicable", and
+the guard would have failed every scheduled run on behalf of a partner
+the connected account does not use. Judging it there would also have
+meant a `when (kind)` over which credential each kind of catalog needs,
+at exactly the kind of call site the router exists to keep them out of.
+
+Downloads and uploads are left alone. They fail in front of a reader who
+can be told, and the notice on the connected card is what explains them.
+
+### `NEARBY_WIFI_DEVICES` is not declared
+
+That spelling matters only to Android 16's adb-enabled preview of the
+same restriction, and it would put a scarier line on the F-Droid and
+Play listings for a case nobody reaches by accident.
+
+## Consequences
+
+- A new `uses-permission` line appears on the F-Droid and Play listings.
+  It is legitimate and the reproducible build is unaffected: no
+  dependency, no build setting.
+- The permission does not widen what the app may reach. `PrivateAddress`
+  still governs cleartext, and `OpdsScope` still refuses a catalog's
+  unsolicited private link: granting this does not make a feed's link to
+  `192.168.1.1` followable.
+- Nothing about what is stored changes, so the backup and data
+  extraction rules are untouched. Play's data-safety declarations are
+  edited in the console and are worth revisiting.
+- Readers on Android 16 and below see no difference at all: every
+  check answers "not blocked" below SDK 37.

--- a/docs/adr/0028-local-network-permission.md
+++ b/docs/adr/0028-local-network-permission.md
@@ -185,20 +185,28 @@ anything to do at all before it asks about the permission, so a
 stored-but-idle LAN address cannot manufacture a failure for a run that
 was never going to touch it.
 
-That question is put to the peer rather than answered beside it.
-`PeerPositionSync.dialledAddress()` is the address a run started now
-would dial, and null is the whole of "nothing to do": no server
-connected, a kind that does not sync positions, a pairing stranded on an
-account that no longer uses it, a credential this Keystore can no longer
-open. Each peer answers from the state its own run opens with —
-`KosyncPositionSync` from the very `account()` its run calls first — so
+That question is put to the partner rather than answered beside it.
+`PositionSync.dialledAddress()` is the address a run started now would
+dial, and null is the whole of "nothing to do": no server connected, a
+kind that does not sync positions, a pairing stranded on an account that
+no longer uses it, a token or a credential this Keystore can no longer
+open. Every implementation answers from the state its own run opens with
+— `KosyncPositionSync` from the very `account()` its run calls first,
+each catalog provider from the credential its own first lines check — so
 the two cannot drift. Written as a lambda at the assembly point instead,
 it drifted immediately: a kosync pairing left behind by an account
 switch has a row and an address, its run answers "not applicable", and
 the guard would have failed every scheduled run on behalf of a partner
-the connected account does not use. Judging it there would also have
+the connected account does not use. Answering it there would also have
 meant a `when (kind)` over which credential each kind of catalog needs,
 at exactly the kind of call site the router exists to keep them out of.
+
+Settling a conflict is guarded as well, because `keepLocalPosition` and
+`takeRemotePosition` both write to the server. They already answer
+"failed, offline" when there is no network at all; a blocked one is the
+same thing said differently, and a timeout the reader sits and watches
+is the worst possible way to say it. Like a preview, they leave the
+account's status line alone: one book being settled is not a run.
 
 Downloads and uploads are left alone. They fail in front of a reader who
 can be told, and the notice on the connected card is what explains them.

--- a/docs/adr/0028-local-network-permission.md
+++ b/docs/adr/0028-local-network-permission.md
@@ -228,6 +228,14 @@ status line: one book being settled is not a run.
 Downloads and uploads are left alone. They fail in front of a reader who
 can be told, and the notice on the connected card is what explains them.
 
+A catalog refresh is not left alone, though it is also in front of the
+reader: it is a pull on the library screen, which is where somebody who
+has just upgraded their phone meets this for the first time. Dialling
+anyway buys fifteen seconds of spinner and then a timeout that blames
+the server, so `RemoteCatalogRepository.refresh()` asks the same
+question one rung further in than the offline check, in the same place
+and for the same reason.
+
 The live notification stream is not a sync, but it is another socket to
 the same machine, so it answers to the same block. `LiveSyncConnector`
 is handed no source at all for a blocked account rather than one that

--- a/docs/adr/0028-local-network-permission.md
+++ b/docs/adr/0028-local-network-permission.md
@@ -248,7 +248,12 @@ Where a background run asks the question afresh every time, that
 connection is opened once and held, so it is told when the answer moves:
 `LocalNetworkAccess.recheck()` is called after a permission result and
 on resume, and announces only an answer that actually changed, so a
-denial does not tear down a healthy stream. The connector takes that
+denial does not tear down a healthy stream. That same answer is what
+makes a grant given in the system settings app — which is where a
+permanent denial has to be undone, and which comes back through resume
+rather than through a permission result — worth as much as one given in
+the prompt: it asks for a sync too, rather than leaving the account
+showing a stale blocked failure until the next page turn. The connector takes that
 signal as a third input and puts it in the key it deduplicates on —
 *not* in `LiveIdentity`, which stands for the account and its
 credentials. Without it a reader who allowed the permission from the

--- a/docs/adr/0028-local-network-permission.md
+++ b/docs/adr/0028-local-network-permission.md
@@ -110,6 +110,19 @@ exempts, and every address that comes back is judged: one local answer
 among several is enough. A name that resolves to nothing is not local;
 it is about to fail as an unknown host anyway.
 
+Both a name and a literal are read in the spelling the network uses
+rather than the one a reader is likely to type. A trailing root label is
+dropped, so `books.local.` is the mDNS name it plainly is and not
+something to look up; and an IPv4 address wearing an IPv6 coat is parsed
+rather than matched as text, because `::ffff:127.0.0.1` and
+`::ffff:7f00:1` are both loopback, a dual-stack lookup hands the first
+of them back for `localhost` on plenty of setups, and loopback is exempt
+— so reading either as an ordinary private address would raise a prompt
+for a connection that was never going to be blocked. That parsing is
+[`PrivateAddress`](../../app/src/main/kotlin/com/chmouel/liseur/data/remote/PrivateAddress.kt)'s,
+reused rather than copied, so there is only ever one IPv6 parser to get
+wrong.
+
 This is a preflight, and OkHttp resolves again when it dials. A rotating
 record, split-horizon DNS, or outright rebinding can put a different
 address on the wire than the one judged here. That time-of-check /
@@ -210,6 +223,15 @@ account's status line alone: one book being settled is not a run.
 
 Downloads and uploads are left alone. They fail in front of a reader who
 can be told, and the notice on the connected card is what explains them.
+
+The live notification stream is not a sync, but it is another socket to
+the same machine, so it answers to the same block. `LiveSyncConnector`
+is handed no source at all for a blocked account rather than one that
+would open, time out and be retried for as long as the app is in the
+foreground. It reports nothing: the guarded sync has already said the
+account is blocked, and the live stream is a hint that a full sync would
+be worth running. Nothing is remembered, so a grant takes effect at the
+next connection.
 
 ### `NEARBY_WIFI_DEVICES` is not declared
 

--- a/docs/adr/0028-local-network-permission.md
+++ b/docs/adr/0028-local-network-permission.md
@@ -230,8 +230,20 @@ is handed no source at all for a blocked account rather than one that
 would open, time out and be retried for as long as the app is in the
 foreground. It reports nothing: the guarded sync has already said the
 account is blocked, and the live stream is a hint that a full sync would
-be worth running. Nothing is remembered, so a grant takes effect at the
-next connection.
+be worth running.
+
+Where a background run asks the question afresh every time, that
+connection is opened once and held, so it is told when the answer moves:
+`LocalNetworkAccess.recheck()` is called after a permission result and
+on resume, and announces only an answer that actually changed, so a
+denial does not tear down a healthy stream. The connector takes that
+signal as a third input and puts it in the key it deduplicates on —
+*not* in `LiveIdentity`, which stands for the account and its
+credentials. Without it a reader who allowed the permission from the
+connected card would have waited out the rest of that foreground session
+with the stream still down, since granting changes neither the account
+nor the foreground state and the background grace period swallows a trip
+to the settings app.
 
 ### `NEARBY_WIFI_DEVICES` is not declared
 

--- a/docs/adr/0028-local-network-permission.md
+++ b/docs/adr/0028-local-network-permission.md
@@ -214,12 +214,16 @@ the connected account does not use. Answering it there would also have
 meant a `when (kind)` over which credential each kind of catalog needs,
 at exactly the kind of call site the router exists to keep them out of.
 
-Settling a conflict is guarded as well, because `keepLocalPosition` and
-`takeRemotePosition` both write to the server. They already answer
-"failed, offline" when there is no network at all; a blocked one is the
-same thing said differently, and a timeout the reader sits and watches
-is the worst possible way to say it. Like a preview, they leave the
-account's status line alone: one book being settled is not a run.
+Half of settling a conflict is guarded as well. `keepLocalPosition`
+sends this device's answer to the server, and already says "failed,
+offline" when there is no network at all; a blocked one is that said
+differently, and a timeout the reader sits and watches is the worst
+possible way to say it. `takeRemotePosition` is not guarded, because it
+sends nothing: it applies a position an earlier run already brought back
+and wrote down, and touches nothing but this phone's database. That is
+why it works on a plane, and it must go on working behind a blocked
+network for exactly the same reason. Neither touches the account's
+status line: one book being settled is not a run.
 
 Downloads and uploads are left alone. They fail in front of a reader who
 can be told, and the notice on the connected card is what explains them.

--- a/docs/adr/0028-local-network-permission.md
+++ b/docs/adr/0028-local-network-permission.md
@@ -253,7 +253,12 @@ makes a grant given in the system settings app — which is where a
 permanent denial has to be undone, and which comes back through resume
 rather than through a permission result — worth as much as one given in
 the prompt: it asks for a sync too, rather than leaving the account
-showing a stale blocked failure until the next page turn. The connector takes that
+showing a stale blocked failure until the next page turn, and it spends
+the refusal left on the connect form. The notice under the form cannot
+work that second part out for itself, because
+`shouldShowRequestPermissionRationale` answers false after a grant as
+readily as before the first ask, so it would go on offering the settings
+page the reader has just come back from. The connector takes that
 signal as a third input and puts it in the key it deduplicates on —
 *not* in `LiveIdentity`, which stands for the account and its
 credentials. Without it a reader who allowed the permission from the


### PR DESCRIPTION
## Summary

Fixes #195.

Android 17 turned on Local Network Protections for every app targeting
SDK 37, which Liseur does. An app holding only `INTERNET` has its
traffic to and from local addresses dropped inside the networking
stack, below OkHttp, so a calibre-web server in the next room never
refuses a connection — it swallows it until the timeout. That is what
was reported: the LAN server times out, the same server over the
internet is fine. Every Android 17 device running 0.15.0 has this.

The permission is `ACCESS_LOCAL_NETWORK`, in the `NEARBY_DEVICES`
group, which is where the reporter's guess about "Nearby devices" came
from. It is now declared and asked for — but only of a reader whose
server is actually on their own network. Liseur's readers self-host,
and a good number of them chose this app for the reasons that make an
unexplained "allow Liseur to find devices on your network" prompt
unwelcome. A public address never raises it.

The ask comes before the connection rather than after it fails. A
reader who waits fifteen seconds for a timeout and is *then* asked a
question has already been told the app is broken.

## Changes

- **Declared `ACCESS_LOCAL_NETWORK`** and request it at runtime. Not
  `NEARBY_WIFI_DEVICES`: that spelling only matters to Android 16's
  adb-enabled preview, and it would put a scarier line on the F-Droid
  and Play listings.
- **`LocalNetworkAddress`** decides whether an address is local. The
  fixed half is `PrivateAddress` plus IPv4 broadcast and IPv4/IPv6
  multicast; the live half asks `ConnectivityManager` for the
  directly-connected non-VPN routes, because a home server on a global
  IPv6 address in the phone's own /64 is on-link and blocked, and no
  table of private ranges will ever say so. `100.64.0.0/10` is
  deliberately *not* in the table — that is where a Tailscale address
  lives, and it goes down a tunnel Android does not block.
- **Four addresses are judged separately**: the catalog, a Custom
  connection's second address, a kosync partner paired on its own, and
  whatever a connected account already has stored. A public catalog
  with a sync server in the spare room is an ordinary setup here, and
  so is its opposite.
- **A denial is re-askable.** The first Connect always launches the
  prompt; only afterwards does `shouldShowRequestPermissionRationale`
  decide between "Try again" and "Open app settings", because it
  answers false both before anything has been asked and after a
  permanent denial.
- **Background sync stops and says why** instead of spending a timeout
  on every scheduled run. The refusal is per partner, so one blocked
  server does not silence a healthy one, and each partner is asked
  whether it would dial at all — a pairing stranded by an account
  switch, or one whose stored password this phone can no longer read,
  names no address and is left alone.
- **A catalog refresh and the live notification stream** are stopped
  the same way. A pull on the library screen is where somebody who has
  just upgraded their phone meets this first, and the live stream is
  held open for as long as the app is on screen, so opening it blocked
  buys a retry loop of timeouts. Sending this device's position to
  settle a conflict is refused too; *accepting* the other device's is
  not, because that applies an answer an earlier run already wrote down
  and touches nothing but this phone — which is why it works on a plane.
- **Allowing it takes effect at once.** A grant made in the system
  settings page — the only way back from a permanent denial — clears the
  notice, spends the refusal left on the form, asks for a sync, and
  reopens the live stream, none of which it used to do.
- ADR `docs/adr/0028-local-network-permission.md` records the
  reasoning, including the two places this errs on purpose.

```mermaid
flowchart LR
  A["Connect pressed"] --> B{"Android 17<br/>and not granted?"}
  B -- no --> D["Dial"]
  B -- yes --> C{"Address local?"}
  C -- "public name or address" --> D
  C -- "literal in range,<br/>on-link, or .local" --> E["Park, ask"]
  E -- granted --> D
  E -- denied --> F["Say why,<br/>offer a way back"]
```

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

Ten rounds of automated review found eight real defects in this change
and all eight are fixed, each with a test. Six of them were the same
mistake in different clothes: *having a stored address is not the same
as being about to dial it*.

No Android 17 system image exists here, so the screenshot below was
taken on API 36 with the version gate forced on locally (a change not
in this branch). That makes the platform refuse a permission it does
not know, which lands on the denial state — the notice and its action
are the real ones. The system prompt itself, and the classifier against
a real blocked socket, still want confirming on an Android 17 device;
I have asked the reporter.

## Screenshots or recordings

The notice a reader sees when the permission is not granted and the
address they typed is on their own network:

![local-network-notice.png](https://github.com/user-attachments/assets/0366ce9e-b4b4-4c47-ae4c-7d4951b86173)

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.

