### PR TITLE
fix: show every server type when the picker opens

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerKindPicker.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/settings/ServerKindPicker.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -82,6 +83,13 @@ internal fun ServerKindRow(
  * it says whether your place in a book will follow you there. Grimmory
  * cannot carry one at all, and that is worth knowing before typing a
  * password rather than after.
+ *
+ * It opens expanded rather than half-way. A Material sheet's default
+ * resting height is about half the window, which fitted four kinds and
+ * hid the fifth below a fold with nothing to mark it, so OPDS read as
+ * unsupported (issue #179). Scrolling is not the same as being seen.
+ * The scroll stays for a short screen or a large font size, where the
+ * sheet is capped at the window and the list runs on inside it.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -90,7 +98,10 @@ internal fun ServerKindSheet(
     onPick: (ServerKind) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    LiseurModalBottomSheet(onDismissRequest = onDismiss) {
+    LiseurModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    ) {
         Column(
             Modifier
                 .verticalScroll(rememberScrollState())

--- a/docs/adr/0013-server-kind-picker.md
+++ b/docs/adr/0013-server-kind-picker.md
@@ -142,3 +142,21 @@ artwork under their name.
 This is a licensing fact about one upstream project, not a rule about
 the picker. If Komga relicenses the icon, `ServerKindLogo` gains a
 branch and loses one.
+
+## Addendum: the fifth kind did have a layout consequence
+
+[Issue #179](https://github.com/chmouel/liseur/issues/179). The decision
+above says a fifth kind is "a `when` branch and three strings with no
+layout consequence at all", on the grounds that the sheet scrolls. The
+Custom/OPDS kind showed that up. A Material sheet's default resting
+height is about half the window, which held four rows on a normal phone
+and put the fifth under the fold with nothing to mark it, so readers
+took OPDS for unsupported.
+
+The sheet now opens expanded (`skipPartiallyExpanded = true`), which is
+what `SeriesPickerSheet` and `DefinitionSheet` already do. The scroll is
+still there and still does the job the decision asked of it, on a short
+screen or at a large font size. What was wrong was the assumption that
+being scrollable to is the same as being seen. A sixth kind is a `when`
+branch and three strings again, and this time the claim holds until the
+list outgrows a whole screen rather than half of one.


### PR DESCRIPTION
## Summary

The server kind sheet opened at Material's default resting height, about
half the window. Four kinds fitted; the fifth, Custom/OPDS, sat below the
fold with nothing to mark it, so readers took OPDS for unsupported.

`ServerKindSheet` now passes `skipPartiallyExpanded = true`, the same
thing `SeriesPickerSheet` and `DefinitionSheet` already do, so the sheet
opens at its content height.

Fixes #179

## Changes

- `ServerKindSheet` opens expanded rather than half-way. The existing
  `verticalScroll` is untouched, so a short screen or a large font size
  still scrolls inside a sheet capped at the window.
- ADR 0013 gains an addendum. It claimed a fifth kind would have "no
  layout consequence at all" because the sheet scrolls; being scrollable
  to turned out not to be the same as being seen.

The e-paper branch of `LiseurModalBottomSheet` draws a `Popup` that
ignores `sheetState` and already sizes itself to its content, so it never
had this and is not touched.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

Checked on `liseur_phone_api36` at the default text size and at 1.5x. At
1.5x the sheet fills the screen with Custom half in view at the fold,
which cues the scroll, and scrolling reaches it.

## Screenshots or recordings

| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/efafa753-2a01-4c1b-8b8d-441ce1d792d1) | ![after](https://github.com/user-attachments/assets/361de60c-be88-4a94-91c3-81b7153dffff) |

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.