### PR TITLE
Show chapter pages in the reader footer

### DIFF
--- a/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPrefs.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/data/settings/ReaderPrefs.kt
@@ -176,6 +176,19 @@ enum class FooterMode(val id: String) {
      * to something true rather than to a stock guess or to nothing.
      */
     SMART("time_chapter"),
+
+    /**
+     * How many pages are left before the next chapter — a figure the
+     * app has from the moment the book opens, with no reading pace to
+     * wait for and nothing in it that moves when the reader speeds up.
+     *
+     * A page here is a Readium position, the unit the footer's own
+     * right edge is already counting in. Counting screens instead
+     * would match what a turn consumes, but it would put two different
+     * meanings of "page" a hand's width apart on the same line, and
+     * the middle one would jump every time the font size did.
+     */
+    PAGES_LEFT_CHAPTER("pages_chapter"),
     TIME_LEFT_BOOK("time_book"),
     CHAPTER_TITLE("chapter"),
     EMPTY("empty"),

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/ReaderViewModel.kt
@@ -74,6 +74,7 @@ import com.chmouel.liseur.reader.progress.GoToDestination
 import com.chmouel.liseur.reader.progress.GoToPagePrompt
 import com.chmouel.liseur.reader.progress.GoToPageResolver
 import com.chmouel.liseur.reader.progress.goToPercent
+import com.chmouel.liseur.reader.progress.pagesLeftInChapter
 import com.chmouel.liseur.reader.footnotes.FootnoteResolver
 import com.chmouel.liseur.reader.progress.ReaderProgress
 import com.chmouel.liseur.reader.progress.ReadingPace
@@ -1337,9 +1338,10 @@ class ReaderViewModel(
         stable ?: return null
         val totalProgression = stable.progression.toFloat()
         val position = stable.position
-        val chapter = publication.readingOrder.indexOfFirstWithHref(locator.href)
-            ?.let(positions::chapterOfResource)
-            ?: positions.chapterAt(position)
+        val chapter = positions.chapterFor(
+            publication.readingOrder.indexOfFirstWithHref(locator.href),
+            position,
+        )
         val chapterEnd = chapter?.lastPosition ?: positions.totalPositions
         return ReaderProgress(
             position = position,
@@ -1348,6 +1350,7 @@ class ReaderViewModel(
             chapterTitle = chapter?.title,
             minutesLeftInChapter = speed.minutesFor(chapterEnd - stable.coordinate),
             minutesLeftInBook = speed.minutesFor(positions.totalPositions - stable.coordinate),
+            positionsLeftInChapter = pagesLeftInChapter(chapter, position),
             isSpeedMeasured = speed.isMeasured,
         )
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReadingProgressUi.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/chrome/ReadingProgressUi.kt
@@ -51,9 +51,9 @@ import com.chmouel.liseur.ui.LocalEInk
 /**
  * The quiet line of text at the bottom of the page, Kindle-style. The
  * percentage read sits on the left and the page number on the right,
- * always; the middle carries the smart slot — time left, the chapter's
- * name — and tapping the footer cycles what that slot shows. Taps
- * never turn the page.
+ * always; the middle carries the smart slot — time left, pages left in
+ * the chapter, the chapter's name — and tapping the footer cycles what
+ * that slot shows. Taps never turn the page.
  */
 @Composable
 fun ReadingFooter(
@@ -68,7 +68,11 @@ fun ReadingFooter(
     Row(
         modifier
             .fillMaxWidth()
-            .clickableWithoutRipple(onCycleMode)
+            .clickableWithoutRipple(
+                onClick = onCycleMode,
+                role = Role.Button,
+                onClickLabel = stringResource(R.string.footer_cycle),
+            )
             .padding(horizontal = 20.dp, vertical = FooterMetrics.VERTICAL_PADDING_DP.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -110,6 +114,17 @@ private fun middleText(progress: ReaderProgress, mode: FooterMode): String? =
             stringResource(R.string.footer_left_in_book, durationText(middle.minutes))
 
         is FooterMiddle.Chapter -> middle.title
+
+        is FooterMiddle.PagesInChapter ->
+            if (middle.pages == 0) {
+                stringResource(R.string.footer_last_page_in_chapter)
+            } else {
+                pluralStringResource(
+                    R.plurals.footer_pages_left_in_chapter,
+                    middle.pages,
+                    middle.pages,
+                )
+            }
 
         null -> null
     }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/progress/BookPositions.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/progress/BookPositions.kt
@@ -30,7 +30,7 @@ data class BookChapter(
  */
 fun pagesLeftInChapter(chapter: BookChapter?, position: Int): Int? {
     chapter ?: return null
-    if (chapter.title == null) return null
+    if (chapter.title.isNullOrBlank()) return null
     if (position !in chapter.firstPosition..chapter.lastPosition) return null
     return chapter.lastPosition - position
 }

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/progress/BookPositions.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/progress/BookPositions.kt
@@ -15,6 +15,27 @@ data class BookChapter(
 )
 
 /**
+ * How many pages remain before the next chapter, or null when there is
+ * no chapter to count to.
+ *
+ * A nameless chapter counts as no chapter. [BookPositions.of] gives
+ * every book at least one, by opening a chapter on the first resource
+ * whether or not anything names it and folding each untitled resource
+ * after it into the one before — which is what keeps a split chapter
+ * whole. A book with no table of contents comes out of that as a
+ * single nameless chapter spanning the whole text, and counting to the
+ * end of it under a label reading "chapter" would be counting to the
+ * end of the book. Its end is where the untitled run stops, not a
+ * boundary the book declared.
+ */
+fun pagesLeftInChapter(chapter: BookChapter?, position: Int): Int? {
+    chapter ?: return null
+    if (chapter.title == null) return null
+    if (position !in chapter.firstPosition..chapter.lastPosition) return null
+    return chapter.lastPosition - position
+}
+
+/**
  * The page-like "positions" Readium computes for a book, grouped by
  * chapter. Positions are numbered from 1 and are stable for a given
  * book, whatever the font size, which makes them a good basis for
@@ -49,6 +70,14 @@ class BookPositions(
     /** The chapter of the resource at [resourceIndex] in the reading order. */
     fun chapterOfResource(resourceIndex: Int): BookChapter? =
         chapterIndexByResource[resourceIndex]?.let(chapters::getOrNull)
+
+    /** The chapter for [position], using the resource only when its range agrees. */
+    fun chapterFor(resourceIndex: Int?, position: Int): BookChapter? {
+        val resourceChapter = resourceIndex?.let(::chapterOfResource)
+        return resourceChapter
+            ?.takeIf { position in it.firstPosition..it.lastPosition }
+            ?: chapterAt(position)
+    }
 
     /** The locator to jump to for [position], numbered from 1. */
     fun locatorAt(position: Int): Locator? =
@@ -263,7 +292,15 @@ data class StableBookProgress(
     val progression: Double,
 )
 
-/** Where the reader is in the book, and how much is left to read. */
+/**
+ * Where the reader is in the book, and how much is left to read.
+ *
+ * [positionsLeftInChapter] is null when there is no chapter to count
+ * to. The time estimates fall back to the end of the book in that
+ * case, which is a fair guess for a figure that is a guess anyway; a
+ * count labelled "in chapter" cannot do the same without quietly
+ * counting something else. See [pagesLeftInChapter].
+ */
 data class ReaderProgress(
     val position: Int,
     val totalPositions: Int,
@@ -271,6 +308,7 @@ data class ReaderProgress(
     val chapterTitle: String?,
     val minutesLeftInChapter: Int,
     val minutesLeftInBook: Int,
+    val positionsLeftInChapter: Int?,
     val isSpeedMeasured: Boolean,
 ) {
     val percent: Int get() = (totalProgression * 100).toInt().coerceIn(0, 100)

--- a/app/src/main/kotlin/com/chmouel/liseur/reader/progress/FooterMiddle.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/reader/progress/FooterMiddle.kt
@@ -7,6 +7,14 @@ sealed interface FooterMiddle {
     data class TimeInChapter(val minutes: Int) : FooterMiddle
     data class TimeInBook(val minutes: Int) : FooterMiddle
     data class Chapter(val title: String) : FooterMiddle
+
+    /**
+     * Pages left before the next chapter. Zero is kept rather than
+     * turned into nothing: the reader is on the chapter's last page,
+     * which is worth saying, and how to word it is the footer's
+     * business rather than this decision's.
+     */
+    data class PagesInChapter(val pages: Int) : FooterMiddle
 }
 
 /**
@@ -17,6 +25,11 @@ sealed interface FooterMiddle {
  * cannot yet stand behind is replaced by something true, not by a
  * stock guess and not by a blank. A chapter with no name leaves the
  * slot empty rather than inventing one.
+ *
+ * [FooterMode.PAGES_LEFT_CHAPTER] counts Readium positions, and says
+ * nothing at all when the chapter is unknown: counting to the end of
+ * the book under a label that says "chapter" is worse than an empty
+ * slot.
  */
 fun footerMiddle(progress: ReaderProgress, mode: FooterMode): FooterMiddle? = when (mode) {
     FooterMode.SMART ->
@@ -25,6 +38,9 @@ fun footerMiddle(progress: ReaderProgress, mode: FooterMode): FooterMiddle? = wh
         } else {
             progress.chapterTitle?.let(FooterMiddle::Chapter)
         }
+
+    FooterMode.PAGES_LEFT_CHAPTER ->
+        progress.positionsLeftInChapter?.let(FooterMiddle::PagesInChapter)
 
     FooterMode.TIME_LEFT_BOOK -> FooterMiddle.TimeInBook(progress.minutesLeftInBook)
 

--- a/app/src/main/kotlin/com/chmouel/liseur/ui/reading/ReadingAppearanceControls.kt
+++ b/app/src/main/kotlin/com/chmouel/liseur/ui/reading/ReadingAppearanceControls.kt
@@ -669,6 +669,7 @@ val ColumnMode.label: Int
 val FooterMode.label: Int
     get() = when (this) {
         FooterMode.SMART -> R.string.footer_mode_smart
+        FooterMode.PAGES_LEFT_CHAPTER -> R.string.footer_mode_pages_chapter
         FooterMode.TIME_LEFT_BOOK -> R.string.footer_mode_time_book
         FooterMode.CHAPTER_TITLE -> R.string.footer_mode_chapter
         FooterMode.EMPTY -> R.string.footer_mode_empty

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,6 +118,12 @@
 
     <string name="footer_left_in_chapter">%s left in chapter</string>
     <string name="footer_left_in_book">%s left in book</string>
+    <plurals name="footer_pages_left_in_chapter">
+        <item quantity="one">%d page left in chapter</item>
+        <item quantity="other">%d pages left in chapter</item>
+    </plurals>
+    <string name="footer_last_page_in_chapter">Last page in chapter</string>
+    <string name="footer_cycle">Change what the footer shows</string>
     <string name="footer_page">Page %1$d of %2$d</string>
     <string name="footer_page_compact">%1$d of %2$d</string>
     <string name="footer_percent">%d%%</string>
@@ -605,6 +611,7 @@
     <string name="reader_auto_scroll_slower">Slower</string>
     <string name="reader_auto_scroll_faster">Faster</string>
     <string name="footer_mode_smart">Time left, or the chapter</string>
+    <string name="footer_mode_pages_chapter">Pages left in chapter</string>
     <string name="footer_mode_time_book">Time left in book</string>
     <string name="footer_mode_chapter">Chapter title</string>
     <string name="footer_mode_empty">Nothing in the middle</string>

--- a/app/src/test/kotlin/com/chmouel/liseur/data/settings/FooterModeTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/data/settings/FooterModeTest.kt
@@ -50,6 +50,7 @@ class FooterModeTest {
         assertEquals(FooterMode.Default, FooterMode.fromId(null))
         assertEquals(FooterMode.Default, FooterMode.fromId("something else"))
         assertEquals(FooterMode.TIME_LEFT_BOOK, FooterMode.fromId("time_book"))
+        assertEquals(FooterMode.PAGES_LEFT_CHAPTER, FooterMode.fromId("pages_chapter"))
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/progress/BookPositionsTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/progress/BookPositionsTest.kt
@@ -3,6 +3,7 @@ package com.chmouel.liseur.reader.progress
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.readium.r2.shared.publication.Locator
@@ -37,10 +38,11 @@ class BookPositionsTest {
     private fun positions(
         resources: List<List<Locator>>,
         chapters: List<BookChapter> = emptyList(),
+        chapterIndexByResource: Map<Int, Int> = emptyMap(),
     ) = BookPositions(
         locators = resources.flatten(),
         chapters = chapters,
-        chapterIndexByResource = emptyMap(),
+        chapterIndexByResource = chapterIndexByResource,
         positionsByResource = resources,
     )
 
@@ -212,6 +214,64 @@ class BookPositionsTest {
         val target = book.locatorAtOrBeforeProgression(0.85)!!
         assertEquals(3, target.locations.position)
         assertEquals(0.85, book.resolve(target)!!.progression, 0.0001)
+    }
+
+    @Test
+    fun `chapter lookup uses the resource chapter when the position agrees`() {
+        val first = BookChapter("One", firstPosition = 1, lastPosition = 2)
+        val second = BookChapter("Two", firstPosition = 3, lastPosition = 4)
+        val book = positions(
+            resources = listOf(
+                listOf(locator("same.xhtml", 0.0, 1), locator("same.xhtml", 1.0, 2)),
+                listOf(locator("same.xhtml", 0.0, 3), locator("same.xhtml", 1.0, 4)),
+            ),
+            chapters = listOf(first, second),
+            chapterIndexByResource = mapOf(0 to 0, 1 to 1),
+        )
+
+        assertEquals(first, book.chapterFor(resourceIndex = 0, position = 2))
+    }
+
+    @Test
+    fun `chapter lookup falls back when the resource chapter range disagrees`() {
+        val first = BookChapter("One", firstPosition = 1, lastPosition = 2)
+        val second = BookChapter("Two", firstPosition = 3, lastPosition = 4)
+        val book = positions(
+            resources = listOf(
+                listOf(locator("same.xhtml", 0.0, 1), locator("same.xhtml", 1.0, 2)),
+                listOf(locator("same.xhtml", 0.0, 3), locator("same.xhtml", 1.0, 4)),
+            ),
+            chapters = listOf(first, second),
+            chapterIndexByResource = mapOf(0 to 0, 1 to 1),
+        )
+
+        assertEquals(second, book.chapterFor(resourceIndex = 0, position = 3))
+    }
+
+    @Test
+    fun `chapter lookup falls back without a resource chapter`() {
+        val chapter = BookChapter("Only", firstPosition = 1, lastPosition = 2)
+        val book = positions(
+            resources = listOf(
+                listOf(locator("chapter.xhtml", 0.0, 1), locator("chapter.xhtml", 1.0, 2)),
+            ),
+            chapters = listOf(chapter),
+        )
+
+        assertEquals(chapter, book.chapterFor(resourceIndex = null, position = 1))
+    }
+
+    @Test
+    fun `chapter lookup returns nothing outside every chapter`() {
+        val chapter = BookChapter("Only", firstPosition = 1, lastPosition = 2)
+        val book = positions(
+            resources = listOf(
+                listOf(locator("chapter.xhtml", 0.0, 1), locator("chapter.xhtml", 1.0, 2)),
+            ),
+            chapters = listOf(chapter),
+        )
+
+        assertNull(book.chapterFor(resourceIndex = null, position = 3))
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/progress/FooterMiddleTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/progress/FooterMiddleTest.kt
@@ -20,6 +20,7 @@ class FooterMiddleTest {
         chapterTitle = "The Sign of Four",
         minutesLeftInChapter = 12,
         minutesLeftInBook = 340,
+        positionsLeftInChapter = 17,
         isSpeedMeasured = true,
     )
 
@@ -61,6 +62,47 @@ class FooterMiddleTest {
     @Test
     fun `a nameless chapter leaves the title mode empty`() {
         assertNull(footerMiddle(progress.copy(chapterTitle = null), FooterMode.CHAPTER_TITLE))
+    }
+
+    @Test
+    fun `pages left is shown before any pace is measured`() {
+        // The whole point of the mode: it needs no reading speed.
+        assertEquals(
+            FooterMiddle.PagesInChapter(17),
+            footerMiddle(progress.copy(isSpeedMeasured = false), FooterMode.PAGES_LEFT_CHAPTER),
+        )
+    }
+
+    @Test
+    fun `the chapter's last page is kept as a count of zero`() {
+        // Wording it is the footer's business; dropping it here would
+        // blank the slot on the one page of the chapter that has
+        // something plain to say.
+        assertEquals(
+            FooterMiddle.PagesInChapter(0),
+            footerMiddle(progress.copy(positionsLeftInChapter = 0), FooterMode.PAGES_LEFT_CHAPTER),
+        )
+    }
+
+    @Test
+    fun `an unknown chapter counts nothing rather than counting the book`() {
+        assertNull(
+            footerMiddle(
+                progress.copy(positionsLeftInChapter = null),
+                FooterMode.PAGES_LEFT_CHAPTER,
+            ),
+        )
+    }
+
+    @Test
+    fun `smart still falls back to the title, not to pages`() {
+        // Pages left is a mode the reader asks for by name. Smart
+        // promises time, and degrades to something that is not a
+        // number at all rather than to a different number.
+        assertEquals(
+            FooterMiddle.Chapter("The Sign of Four"),
+            footerMiddle(progress.copy(isSpeedMeasured = false), FooterMode.SMART),
+        )
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/progress/PagesLeftInChapterTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/progress/PagesLeftInChapterTest.kt
@@ -54,6 +54,7 @@ class PagesLeftInChapterTest {
         // the end of that is counting to the end of the book, which is
         // not what the label says.
         assertNull(pagesLeftInChapter(chapter.copy(title = null), 40))
+        assertNull(pagesLeftInChapter(chapter.copy(title = "   "), 40))
     }
 
     @Test

--- a/app/src/test/kotlin/com/chmouel/liseur/reader/progress/PagesLeftInChapterTest.kt
+++ b/app/src/test/kotlin/com/chmouel/liseur/reader/progress/PagesLeftInChapterTest.kt
@@ -1,0 +1,63 @@
+package com.chmouel.liseur.reader.progress
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * How many pages the footer says are left before the next chapter.
+ *
+ * The count is only as trustworthy as the boundary it counts to, and
+ * the book is the one that draws that boundary. Where it has drawn
+ * none, there is nothing to count to and the footer says so by saying
+ * nothing.
+ */
+class PagesLeftInChapterTest {
+
+    private val chapter = BookChapter(
+        title = "The Sign of Four",
+        firstPosition = 40,
+        lastPosition = 58,
+    )
+
+    @Test
+    fun `counts the positions after the current one`() {
+        assertEquals(18, pagesLeftInChapter(chapter, 40))
+        assertEquals(1, pagesLeftInChapter(chapter, 57))
+    }
+
+    @Test
+    fun `the chapter's last position has none left`() {
+        assertEquals(0, pagesLeftInChapter(chapter, 58))
+    }
+
+    @Test
+    fun `a position outside the chapter's range counts nothing`() {
+        // Readium's resource lookup and the position range can disagree on
+        // a resource that shares its href with another one in the reading
+        // order. Claiming the last page of that wrong chapter is false,
+        // whichever side of the range the position falls on.
+        assertNull(pagesLeftInChapter(chapter, 61))
+        assertNull(pagesLeftInChapter(chapter, 39))
+    }
+
+    @Test
+    fun `a one-position chapter is its own last page`() {
+        val single = BookChapter(title = "Colophon", firstPosition = 7, lastPosition = 7)
+        assertEquals(0, pagesLeftInChapter(single, 7))
+    }
+
+    @Test
+    fun `a nameless chapter counts nothing`() {
+        // A book with no table of contents comes out of BookPositions
+        // as one untitled chapter spanning the whole text. Counting to
+        // the end of that is counting to the end of the book, which is
+        // not what the label says.
+        assertNull(pagesLeftInChapter(chapter.copy(title = null), 40))
+    }
+
+    @Test
+    fun `no chapter at all counts nothing`() {
+        assertNull(pagesLeftInChapter(null, 40))
+    }
+}

--- a/docs/adr/0029-what-a-page-is-in-the-footer.md
+++ b/docs/adr/0029-what-a-page-is-in-the-footer.md
@@ -1,0 +1,146 @@
+# 29. What a page is in the footer
+
+Date: 2026-09-11
+
+## Status
+
+Accepted
+
+## Context
+
+The reading footer's middle slot counted time and only time: time left
+in the chapter, time left in the book, the chapter's name, or nothing.
+Every one of those either waits for a reading pace to be measured or
+says nothing about distance at all. A reader deciding whether to start
+the next chapter before putting the phone down has no figure to act on.
+
+Libby answers that question outright, with pages remaining until the
+next chapter. It is available the moment the book opens, and it does not
+move when the reader speeds up or slows down. #172 asked for the same.
+
+Before any of it could be written, "a page" had to mean something, and
+there are two candidates that disagree.
+
+A **Readium position** is a fixed slice of a resource, roughly a
+thousand characters, computed once per book and unchanged by anything
+the reader does afterwards.
+
+A **screen** is what a turn actually consumes: however much text the
+current font size, margins and column count leave room for. It is what
+the reader's thumb counts.
+
+They are not close to each other. A book at a large font size has
+several screens to a position; at a small one, the other way about.
+
+## Decision
+
+A page in the footer is a Readium position.
+
+### One unit per row
+
+The footer already draws `42 of 300` on its right edge, and that 300 is
+`BookPositions.totalPositions` — positions. So is the page the go-to
+dialog asks for when a book declares no printed page list, the page the
+scrubber previews, and the page the jump-back and catch-up pills name.
+The app has one notion of a page and it is this one.
+
+Counting screens in the middle of the footer would put two different
+meanings of "page" a hand's width apart on the same line of text, moving
+at different rates, with nothing to tell the reader they are different.
+That is not a better number; it is a number that makes the one beside it
+untrustworthy.
+
+### A figure that stays still
+
+A count of screens changes when the font size changes, when the margins
+change, when the device is rotated, and when a tablet switches to two
+columns. Every one of those is a thing a reader does while reading. A
+number that says 8 and then says 14 because the text got bigger is read
+as a bug before it is read as arithmetic.
+
+Positions do not move. The count answers the reader's question — how
+much of this chapter is left — in a unit that means the same thing at
+the start of the chapter and at the end of it.
+
+### What it costs to compute
+
+A position count is subtraction on numbers `ReaderViewModel.progressAt()`
+already holds: the chapter's last position and the current one. No
+JavaScript, nothing to measure, nothing to re-measure.
+
+A screen count would need `scrollWidth / innerWidth` from the web view
+per resource, re-run on every typography change and every rotation, with
+the answer arriving asynchronously after the turn that prompted it. And
+it would still be incomplete: a chapter in this app can span several
+resources — `BookPositions` folds an untitled resource into the chapter
+before it, because split chapters are the ordinary case in EPUB — and
+the screens of a resource Readium has not laid out yet cannot be
+counted. Those would have to be estimated from positions anyway, so the
+"exact" count would be exact only for the part of the chapter already on
+screen.
+
+## Consequences
+
+A turn does not always consume exactly one of the pages being counted.
+Read at a large font size, the number will come down more slowly than
+the turns. This is not new: it is already true of the page number on the
+footer's right edge, and of the page the go-to dialog accepts. The
+change inherits the discrepancy rather than introducing it.
+
+`ReaderProgress` carries `positionsLeftInChapter` as a nullable, and
+`pagesLeftInChapter()` decides when it is null. The time estimates fall
+back to the end of the book when no chapter resolves, which is fair for
+a figure that is a guess either way; a count printed under the words "in
+chapter" cannot do the same without quietly counting something else.
+
+A **nameless chapter counts as no chapter**. `BookPositions.of()` gives
+every book at least one, by opening a chapter on the first resource
+whether or not anything names it and folding each untitled resource
+after it into the one before — which is what keeps a chapter split
+across several files whole. A book with no table of contents comes out
+of that as a single untitled chapter spanning the whole text, so
+counting to its end would be counting to the end of the book with the
+word "chapter" on it. The end of an untitled run is not a boundary the
+book declared, so the slot stays empty, as it already does for the
+chapter-title mode.
+
+Zero left is the chapter's last page, and the figure survives as zero
+into the footer so it can be worded there — "Last page in chapter" —
+rather than being dropped and blanking the slot on the one page of the
+chapter with something plain to say.
+
+When Readium's resource lookup and the stable position disagree about
+which chapter the reader is in, the count is absent. This can happen
+when the reading order contains the same href more than once: the href
+can resolve to one resource's chapter while the stable position belongs
+to another. Reporting zero there would falsely claim the reader is on
+that chapter's last position. Zero is reserved for a position actually
+equal to the chapter's `lastPosition`.
+
+`FooterMode.SMART` is untouched. It promises time and degrades to the
+chapter's name, which is not a number at all; degrading to a different
+number would be the second meaning of "page" arriving by another door.
+
+## Known limitation
+
+A chapter here is a run of reading-order resources, so several table-of-
+contents entries pointing at fragments of one XHTML file collapse into
+one chapter, and the count runs to the end of the file rather than to
+the next heading. That is the chapter model the whole app already uses
+— the time left in the chapter, the scrubber's ticks and the chapter
+title read the same ranges — and this figure inherits it rather than
+introducing it. Chapter boundaries resolved from the contents entries'
+own locators would fix all four at once, and would be a change to
+`BookPositions`, not to the footer.
+
+## Alternatives considered
+
+**Pages left in the book.** The existing time-left-in-book mode already
+covers that shape of question, and it is further from what was asked
+for.
+
+**A hybrid: screens for the loaded resource, positions scaled for the
+rest of the chapter.** Exact where it can be and estimated where it
+cannot, which means the number changes character partway through a
+chapter without saying so, and still moves with the font size. All of
+the cost of screens and most of the imprecision of positions.

--- a/docs/adr/0029-what-a-page-is-in-the-footer.md
+++ b/docs/adr/0029-what-a-page-is-in-the-footer.md
@@ -109,13 +109,14 @@ into the footer so it can be worded there — "Last page in chapter" —
 rather than being dropped and blanking the slot on the one page of the
 chapter with something plain to say.
 
-When Readium's resource lookup and the stable position disagree about
-which chapter the reader is in, the count is absent. This can happen
-when the reading order contains the same href more than once: the href
-can resolve to one resource's chapter while the stable position belongs
-to another. Reporting zero there would falsely claim the reader is on
-that chapter's last position. Zero is reserved for a position actually
-equal to the chapter's `lastPosition`.
+Readium's resource lookup and the stable position can disagree about
+which chapter the reader is in. This can happen when the reading order
+contains the same href more than once: the href can resolve to one
+resource's chapter while the stable position belongs to another. In
+that case the stable position wins, and the footer counts against the
+chapter containing it. The count is absent only when no final named
+chapter contains the position. Zero is reserved for a position actually
+equal to that chapter's `lastPosition`.
 
 `FooterMode.SMART` is untouched. It promises time and degrades to the
 chapter's name, which is not a number at all; degrading to a different


### PR DESCRIPTION
## Summary

Adds a reader footer mode for #172 that shows how many Readium positions are left in the current chapter.

## Changes

- Adds a "Pages left in chapter" footer mode.
- Leaves the middle slot empty when the app cannot name a real chapter.
- Uses the chapter that matches the saved reading position when an EPUB repeats the same reading-order href.
- Documents why the footer counts Readium positions rather than screen turns.

## Testing

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew assembleDebug`
- [x] Manually tested on a device or emulator, if applicable

## Screenshots or recordings

| Reader footer |
|---------------|
| ![Reader footer showing 2 pages left in chapter](https://github.com/user-attachments/assets/4ba31dfa-196e-4872-98ce-814a3379b414) |

## Checklist

- [x] I have kept this change focused and documented any user-facing behaviour.
- [x] I have added or updated tests where needed.
- [x] I have checked that dependencies remain FOSS and available from allowed repositories.
- [x] I have not included private data, credentials, copyrighted book files, or generated build artifacts.
